### PR TITLE
feat(server): upgrade Django 4.2 → 5.2 LTS

### DIFF
--- a/server/etebase_server/settings.py
+++ b/server/etebase_server/settings.py
@@ -21,8 +21,6 @@ BASE_DIR = os.path.dirname(SOURCE_DIR)
 
 AUTH_USER_MODEL = "myauth.User"
 
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
@@ -120,8 +118,6 @@ LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 
 USE_I18N = True
-
-USE_L10N = True
 
 USE_TZ = True
 

--- a/server/requirements.in/base.txt
+++ b/server/requirements.in/base.txt
@@ -1,4 +1,4 @@
-django>=4.0,<5.0
+django>=5.2,<6.0
 msgpack
 pynacl
 fastapi>=0.104

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -25,7 +25,7 @@ click==8.1.7
     # via
     #   typer
     #   uvicorn
-django==4.2.14
+django==5.2.12
     # via -r requirements.in/base.txt
 dnspython==2.6.1
     # via email-validator


### PR DESCRIPTION
## Summary
Upgrades Django from 4.2 (EOL April 2026) to 5.2 LTS (supported until April 2029).

## Changes
- Update django pin from `>=4.0,<5.0` to `>=5.2,<6.0` (resolves to 5.2.12)
- Remove `USE_L10N = True` (removed in Django 5.0, behavior now always-on)
- Remove duplicate `DEFAULT_AUTO_FIELD` definition (line 24, kept line 49)
- Regenerate `requirements.txt` via pip-compile

## Risk Assessment
Low complexity — codebase uses Django primarily as ORM + admin layer. No deprecated views, middleware, template tags, or REST framework patterns.

**Key test:** BinaryField round-trips for encryption keys and encrypted content must behave identically.

## Migration Plan
Full analysis at `_bmad-output/implementation-artifacts/django-5.2-migration-plan.md`