### PR TITLE
CI: Add deploy pipeline for Etebase server

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,0 +1,69 @@
+name: Deploy Etebase Server (production)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'server/**'
+      - 'Dockerfile.server'
+      - '.github/workflows/deploy-server.yml'
+
+concurrency:
+  group: deploy-server-production
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build & Push to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push server image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.server
+          push: true
+          tags: |
+            ghcr.io/silent-suite/silentsuite-server:latest
+            ghcr.io/silent-suite/silentsuite-server:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to VPS
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            docker pull ghcr.io/silent-suite/silentsuite-server:latest
+            docker tag ghcr.io/silent-suite/silentsuite-server:latest etebase-etebase:latest
+            cd ~/etebase
+            docker compose up -d --force-recreate etebase
+            echo "Etebase server deployed successfully"

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,0 +1,47 @@
+FROM python:3.12-alpine AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_NO_CACHE_DIR=1
+
+# Install build dependencies
+RUN apk add --no-cache \
+    gcc musl-dev libffi-dev make \
+    postgresql-dev
+
+COPY server/requirements.txt /requirements.txt
+RUN pip install --no-cache-dir -r /requirements.txt
+
+# --- Production stage ---
+FROM python:3.12-alpine
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTHONUNBUFFERED=1
+
+# Runtime dependencies only
+RUN apk add --no-cache libpq libffi
+
+# Copy installed packages from builder
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Create non-root user
+RUN addgroup -S etebase && adduser -S etebase -G etebase
+
+# Copy application code
+COPY server/ /app
+
+# Create data directories
+RUN mkdir -p /data /data/media /data/static && \
+    chown -R etebase:etebase /app /data
+
+WORKDIR /app
+
+# Run as non-root
+USER etebase
+
+EXPOSE 3735
+
+CMD ["uvicorn", "etebase_server.asgi:application", \
+     "--host", "0.0.0.0", "--port", "3735", \
+     "--workers", "2", "--proxy-headers", \
+     "--forwarded-allow-ips", "*"]


### PR DESCRIPTION
Adds CI/CD for the Etebase sync server, matching the existing web deploy pattern.

**What's new:**
- `Dockerfile.server` — multi-stage Python 3.12-alpine build (identical to current VPS Dockerfile)
- `deploy-server.yml` — GitHub Actions: build → push to GHCR → SSH deploy

**Triggers on push to main:**
- `server/**`
- `Dockerfile.server`
- `.github/workflows/deploy-server.yml`

**VPS docker-compose already updated** to pull from `ghcr.io/silent-suite/silentsuite-server:latest` instead of building locally.

**After merge:**
- First push will create the GHCR package — needs to be made public (org packages settings)
- Django 5.2 upgrade (PR #7) will auto-deploy on next server/ change