### PR TITLE
feat: graceful degradation — billing fallback + non-blocking read-only mode (B3, A4-A5)

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -4,7 +4,7 @@ import { ProtectedRoute } from '@/app/components/protected-route'
 import { Sidebar } from '@/app/components/sidebar'
 import { Header } from '@/app/components/header'
 import { BottomNav } from '@/app/components/bottom-nav'
-import { ReadOnlyOverlay } from '@/app/components/read-only-overlay'
+import { ReadOnlyBanner, DegradedModeBanner } from '@/app/components/read-only-overlay'
 import { PendingSyncBanner } from '@/app/components/PendingSyncBanner'
 import { SyncProvider } from '@/app/providers/sync-provider'
 import { NotificationProvider } from '@/app/providers/notification-provider'
@@ -12,12 +12,8 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { isSelfHosted } from '@/app/lib/self-hosted'
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  const readOnly = useAuthStore((s) => {
-    if (isSelfHosted) return false
-    if (s.user?.isAdmin) return false
-    const status = s.subscriptionStatus
-    return status === 'cancelled' || status === 'expired' || status === 'none'
-  })
+  const readOnly = useAuthStore((s) => s.isReadOnly())
+  const degraded = useAuthStore((s) => s.isDegraded())
 
   return (
     <ProtectedRoute>
@@ -34,13 +30,14 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             <Sidebar />
             <div className="flex flex-1 flex-col min-w-0">
               <Header />
+              {!isSelfHosted && degraded && <DegradedModeBanner />}
+              {!isSelfHosted && readOnly && <ReadOnlyBanner />}
               <PendingSyncBanner />
               <main id="main-content" className="relative z-0 flex-1 overflow-auto p-3 pb-20 md:p-4 md:pb-4 page-transition">
                 {children}
               </main>
             </div>
             <BottomNav />
-            {!isSelfHosted && readOnly && <ReadOnlyOverlay />}
           </div>
         </NotificationProvider>
       </SyncProvider>

--- a/apps/web/app/components/__tests__/read-only-overlay.test.tsx
+++ b/apps/web/app/components/__tests__/read-only-overlay.test.tsx
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import { ReadOnlyOverlay } from '../read-only-overlay'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ReadOnlyBanner, DegradedModeBanner } from '../read-only-overlay'
 
 // Mock the auth store
 let mockSubscriptionStatus: string | null = 'cancelled'
+let mockRetryBillingConnection = vi.fn().mockResolvedValue(true)
 
 vi.mock('@/app/stores/use-auth-store', () => ({
-  useAuthStore: (selector: (s: { subscriptionStatus: string | null }) => unknown) =>
-    selector({ subscriptionStatus: mockSubscriptionStatus }),
+  useAuthStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      subscriptionStatus: mockSubscriptionStatus,
+      retryBillingConnection: mockRetryBillingConnection,
+    }),
 }))
 
 // Mock next/link
@@ -20,47 +24,74 @@ vi.mock('next/link', () => ({
 // Mock lucide-react
 vi.mock('lucide-react', () => ({
   Lock: () => <svg data-testid="lock-icon" />,
+  WifiOff: () => <svg data-testid="wifi-off-icon" />,
+  RefreshCw: ({ className }: { className?: string }) => <svg data-testid="refresh-icon" className={className} />,
+  ExternalLink: () => <svg data-testid="external-link-icon" />,
 }))
 
-// Mock @silentsuite/ui
-vi.mock('@silentsuite/ui', () => ({
-  Button: ({ children, ...props }: { children: React.ReactNode; size?: string; className?: string }) => (
-    <button {...props}>{children}</button>
-  ),
-}))
-
-describe('ReadOnlyOverlay', () => {
+describe('ReadOnlyBanner', () => {
   beforeEach(() => {
     mockSubscriptionStatus = 'cancelled'
   })
 
-  it('renders overlay with subscription ended message', () => {
-    render(<ReadOnlyOverlay />)
-    expect(screen.getByText('Your subscription has ended')).toBeInTheDocument()
-    expect(screen.getByText('Your data is safe and encrypted.')).toBeInTheDocument()
-  })
-
-  it('renders trial ended message for trialing status', () => {
-    mockSubscriptionStatus = 'trialing'
-    render(<ReadOnlyOverlay />)
-    expect(screen.getByText('Your trial has ended')).toBeInTheDocument()
+  it('renders non-blocking banner with subscription ended message', () => {
+    render(<ReadOnlyBanner />)
+    expect(screen.getByText(/Your subscription has ended\./)).toBeInTheDocument()
+    expect(screen.getByText(/Your data is safe and read-only\./)).toBeInTheDocument()
   })
 
   it('renders trial ended message for none status', () => {
     mockSubscriptionStatus = 'none'
-    render(<ReadOnlyOverlay />)
-    expect(screen.getByText('Your trial has ended')).toBeInTheDocument()
+    render(<ReadOnlyBanner />)
+    expect(screen.getByText(/Your trial has ended\./)).toBeInTheDocument()
   })
 
-  it('renders export data link', () => {
-    render(<ReadOnlyOverlay />)
-    const exportLink = screen.getByText('Export my data')
-    expect(exportLink).toBeInTheDocument()
-    expect(exportLink).toHaveAttribute('href', '/settings/account')
+  it('renders choose a plan and export data links', () => {
+    render(<ReadOnlyBanner />)
+    const planLink = screen.getByText('Choose a plan')
+    expect(planLink.closest('a')).toHaveAttribute('href', '/settings/subscription')
+
+    const exportLink = screen.getByText('Export data')
+    expect(exportLink.closest('a')).toHaveAttribute('href', '/settings/export')
   })
 
-  it('renders choose a plan button with link', () => {
-    render(<ReadOnlyOverlay />)
-    expect(screen.getByText('Choose a plan')).toBeInTheDocument()
+  it('is a banner (not a full-screen overlay)', () => {
+    const { container } = render(<ReadOnlyBanner />)
+    // Should NOT have fixed inset-0 (full-screen overlay classes)
+    const root = container.firstElementChild!
+    expect(root.className).not.toContain('fixed')
+    expect(root.className).not.toContain('inset-0')
+    // Should be a banner-style element
+    expect(root.className).toContain('rounded-lg')
+  })
+})
+
+describe('DegradedModeBanner', () => {
+  beforeEach(() => {
+    mockRetryBillingConnection = vi.fn().mockResolvedValue(true)
+  })
+
+  it('renders degraded mode banner with correct message', () => {
+    render(<DegradedModeBanner />)
+    expect(screen.getByText('Billing service temporarily unavailable. Your data is safe.')).toBeInTheDocument()
+  })
+
+  it('renders retry button', () => {
+    render(<DegradedModeBanner />)
+    expect(screen.getByText('Retry')).toBeInTheDocument()
+  })
+
+  it('calls retryBillingConnection when retry is clicked', async () => {
+    render(<DegradedModeBanner />)
+    fireEvent.click(screen.getByText('Retry'))
+    expect(mockRetryBillingConnection).toHaveBeenCalledOnce()
+  })
+
+  it('is a non-blocking banner (not overlay)', () => {
+    const { container } = render(<DegradedModeBanner />)
+    const root = container.firstElementChild!
+    expect(root.className).not.toContain('fixed')
+    expect(root.className).not.toContain('inset-0')
+    expect(root.className).toContain('rounded-lg')
   })
 })

--- a/apps/web/app/components/read-only-overlay.tsx
+++ b/apps/web/app/components/read-only-overlay.tsx
@@ -1,40 +1,78 @@
 'use client'
 
-import { Lock } from 'lucide-react'
-import { Button } from '@silentsuite/ui'
+import { Lock, WifiOff, RefreshCw, ExternalLink } from 'lucide-react'
 import Link from 'next/link'
+import { useState } from 'react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 
-export function ReadOnlyOverlay() {
+/**
+ * Non-blocking banner shown when subscription has ended.
+ * User retains read access but cannot create/update/delete.
+ */
+export function ReadOnlyBanner() {
   const subscriptionStatus = useAuthStore((s) => s.subscriptionStatus)
 
   const title =
-    subscriptionStatus === 'trialing' || subscriptionStatus === 'none'
-      ? 'Your trial has ended'
-      : 'Your subscription has ended'
+    subscriptionStatus === 'none'
+      ? 'Your trial has ended.'
+      : 'Your subscription has ended.'
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgb(var(--background))]/80 backdrop-blur-sm">
-      <div className="mx-4 w-full max-w-sm rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-6 text-center space-y-4">
-        <div className="flex justify-center">
-          <Lock className="h-10 w-10 text-[rgb(var(--foreground))]" />
-        </div>
-        <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">{title}</h2>
-        <p className="text-sm text-[rgb(var(--muted))]">Your data is safe and encrypted.</p>
-        <div className="flex flex-col gap-3 pt-2">
-          <Link href="/settings/subscription">
-            <Button size="sm" className="w-full">
-              Choose a plan
-            </Button>
-          </Link>
-          <Link
-            href="/settings/export"
-            className="text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--primary))] transition-colors"
-          >
-            Export my data
-          </Link>
-        </div>
+    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200 md:mx-4">
+      <Lock className="h-4 w-4 shrink-0 text-amber-400" />
+      <span className="flex-1">
+        {title} Your data is safe and read-only.
+      </span>
+      <div className="flex items-center gap-2">
+        <Link
+          href="/settings/subscription"
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-amber-300 transition-colors hover:bg-amber-500/20"
+        >
+          Choose a plan
+          <ExternalLink className="h-3 w-3" />
+        </Link>
+        <Link
+          href="/settings/export"
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-[rgb(var(--muted))] transition-colors hover:bg-amber-500/20"
+        >
+          Export data
+        </Link>
       </div>
+    </div>
+  )
+}
+
+/**
+ * Non-blocking banner shown when billing API is unreachable.
+ * User retains full read + write access (degraded mode).
+ */
+export function DegradedModeBanner() {
+  const retryBillingConnection = useAuthStore((s) => s.retryBillingConnection)
+  const [isRetrying, setIsRetrying] = useState(false)
+
+  const handleRetry = async () => {
+    setIsRetrying(true)
+    try {
+      await retryBillingConnection()
+    } finally {
+      setIsRetrying(false)
+    }
+  }
+
+  return (
+    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-sm text-blue-200 md:mx-4">
+      <WifiOff className="h-4 w-4 shrink-0 text-blue-400" />
+      <span className="flex-1">
+        Billing service temporarily unavailable. Your data is safe.
+      </span>
+      <button
+        onClick={handleRetry}
+        disabled={isRetrying}
+        className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-blue-300 transition-colors hover:bg-blue-500/20 disabled:opacity-50"
+      >
+        <RefreshCw className={`h-3 w-3 ${isRetrying ? 'animate-spin' : ''}`} />
+        {isRetrying ? 'Retrying…' : 'Retry'}
+      </button>
     </div>
   )
 }

--- a/apps/web/app/providers/auth-provider.tsx
+++ b/apps/web/app/providers/auth-provider.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Shield } from 'lucide-react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+
+const DEGRADED_RETRY_INTERVAL_MS = 60_000 // retry billing every 60s in degraded mode
 
 function LoadingSpinner() {
   return (
@@ -24,13 +26,31 @@ function LoadingSpinner() {
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const restoreSession = useAuthStore((s) => s.restoreSession)
   const fetchSubscription = useAuthStore((s) => s.fetchSubscription)
+  const retryBillingConnection = useAuthStore((s) => s.retryBillingConnection)
+  const isDegraded = useAuthStore((s) => s.isDegraded())
   const [isInitialized, setIsInitialized] = useState(false)
+  const retryTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
     restoreSession()
       .then(() => fetchSubscription())
       .finally(() => setIsInitialized(true))
   }, [restoreSession, fetchSubscription])
+
+  // Auto-retry billing connection when in degraded mode
+  useEffect(() => {
+    if (isDegraded && isInitialized) {
+      retryTimerRef.current = setInterval(() => {
+        retryBillingConnection()
+      }, DEGRADED_RETRY_INTERVAL_MS)
+    }
+    return () => {
+      if (retryTimerRef.current) {
+        clearInterval(retryTimerRef.current)
+        retryTimerRef.current = null
+      }
+    }
+  }, [isDegraded, isInitialized, retryBillingConnection])
 
   if (!isInitialized) {
     return <LoadingSpinner />

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -19,6 +19,7 @@ describe('useAuthStore', () => {
   beforeEach(() => {
     resetStore()
     vi.mocked(fetch).mockReset()
+    localStorage.clear()
   })
 
   it('login sets user and auth state', async () => {
@@ -88,5 +89,99 @@ describe('useAuthStore', () => {
     useAuthStore.getState().setUser(null)
     expect(useAuthStore.getState().isAuthenticated).toBe(false)
     expect(useAuthStore.getState().user).toBeNull()
+  })
+
+  // --- Degraded mode tests ---
+
+  describe('degraded mode (billing_unavailable)', () => {
+    it('isReadOnly returns false when billing_unavailable', () => {
+      useAuthStore.setState({ subscriptionStatus: 'billing_unavailable' })
+      expect(useAuthStore.getState().isReadOnly()).toBe(false)
+    })
+
+    it('canWrite returns true when billing_unavailable', () => {
+      useAuthStore.setState({ subscriptionStatus: 'billing_unavailable' })
+      expect(useAuthStore.getState().canWrite()).toBe(true)
+    })
+
+    it('isDegraded returns true when billing_unavailable', () => {
+      useAuthStore.setState({ subscriptionStatus: 'billing_unavailable' })
+      expect(useAuthStore.getState().isDegraded()).toBe(true)
+    })
+
+    it('isDegraded returns false when active', () => {
+      useAuthStore.setState({ subscriptionStatus: 'active' })
+      expect(useAuthStore.getState().isDegraded()).toBe(false)
+    })
+
+    it('restoreSession enters degraded mode on network error with etebase session', async () => {
+      localStorage.setItem('etebase_session', 'fake-session-data')
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(true)
+      expect(state.subscriptionStatus).toBe('billing_unavailable')
+      expect(state.user).toEqual({ id: 'degraded', email: '', planId: 'unknown', isAdmin: false })
+    })
+
+    it('restoreSession does not enter degraded mode on network error without etebase session', async () => {
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(false)
+      expect(state.user).toBeNull()
+    })
+
+    it('restoreSession does NOT enter degraded mode on 401 response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 401 } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(false)
+      expect(state.subscriptionStatus).not.toBe('billing_unavailable')
+    })
+
+    it('fetchSubscription sets billing_unavailable on network error', async () => {
+      useAuthStore.setState({ subscriptionStatus: 'active' })
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      await useAuthStore.getState().fetchSubscription()
+
+      expect(useAuthStore.getState().subscriptionStatus).toBe('billing_unavailable')
+    })
+
+    it('retryBillingConnection restores normal status on success', async () => {
+      useAuthStore.setState({ subscriptionStatus: 'billing_unavailable', isAuthenticated: true })
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ id: 'u1', email: 'test@x.com', planId: 'pro', isAdmin: false }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ status: 'active' }),
+        } as Response)
+
+      const result = await useAuthStore.getState().retryBillingConnection()
+
+      expect(result).toBe(true)
+      expect(useAuthStore.getState().subscriptionStatus).toBe('active')
+      expect(useAuthStore.getState().isDegraded()).toBe(false)
+    })
+
+    it('retryBillingConnection returns false on continued network failure', async () => {
+      useAuthStore.setState({ subscriptionStatus: 'billing_unavailable' })
+      vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'))
+
+      const result = await useAuthStore.getState().retryBillingConnection()
+
+      expect(result).toBe(false)
+    })
   })
 })

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -31,6 +31,7 @@ interface AuthState {
   error: string | null
   pendingSignup: PendingSignup | null
   subscriptionStatus: string | null
+  isDegraded: () => boolean
   isReadOnly: () => boolean
   canWrite: () => boolean
   createEtebaseAccount: (email: string, password: string, serverUrl?: string) => Promise<void>
@@ -42,6 +43,7 @@ interface AuthState {
   refreshSession: () => Promise<boolean>
   restoreSession: () => Promise<void>
   fetchSubscription: () => Promise<void>
+  retryBillingConnection: () => Promise<boolean>
   setUser: (user: User | null) => void
   clearError: () => void
 }
@@ -68,10 +70,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   pendingSignup: null,
   subscriptionStatus: null,
 
+  isDegraded: () => get().subscriptionStatus === 'billing_unavailable',
+
   isReadOnly: () => {
     if (isSelfHosted) return false
     if (get().user?.isAdmin) return false
     const status = get().subscriptionStatus
+    // billing_unavailable = degraded mode → full access (our infra problem, not theirs)
+    if (status === 'billing_unavailable') return false
     return status === 'cancelled' || status === 'expired' || status === 'none'
   },
   canWrite: () => !get().isReadOnly(),
@@ -352,10 +358,26 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         syncAdminCookie(isAdmin)
         set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin }, isAuthenticated: true, isLoading: false })
       } else {
+        // HTTP error (401/403 etc.) — billing responded, auth is invalid
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, isLoading: false })
       }
-    } catch { syncAdminCookie(false); set({ user: null, isAuthenticated: false, isLoading: false }) }
+    } catch {
+      // Network error — billing API is unreachable.
+      // If a valid Etebase session exists, enter degraded mode instead of kicking the user out.
+      const hasEtebaseSession = !!localStorage.getItem('etebase_session')
+      if (hasEtebaseSession) {
+        set({
+          user: { id: 'degraded', email: '', planId: 'unknown', isAdmin: false },
+          isAuthenticated: true,
+          isLoading: false,
+          subscriptionStatus: 'billing_unavailable',
+        })
+      } else {
+        syncAdminCookie(false)
+        set({ user: null, isAuthenticated: false, isLoading: false })
+      }
+    }
   },
 
   fetchSubscription: async () => {
@@ -365,7 +387,36 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     try {
       const res = await fetch(`${BILLING_API_URL}/subscription`, { credentials: 'include' })
       if (res.ok) { const data = await res.json(); set({ subscriptionStatus: data.status }) }
-    } catch {}
+    } catch {
+      // Network error — don't clear existing status, enter degraded mode
+      set({ subscriptionStatus: 'billing_unavailable' })
+    }
+  },
+
+  retryBillingConnection: async () => {
+    const storedServerUrl = typeof window !== 'undefined' ? localStorage.getItem('silentsuite-server-url') : null
+    if (isSelfHosted || isCustomServer(storedServerUrl ?? undefined)) return true
+
+    try {
+      // Try to refresh session first
+      const refreshRes = await fetch(`${BILLING_API_URL}/auth/refresh`, { method: 'POST', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      if (refreshRes.ok) {
+        const data = await refreshRes.json()
+        const isAdmin = data.isAdmin === true
+        syncAdminCookie(isAdmin)
+        set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin }, isAuthenticated: true })
+      }
+      // Then fetch subscription
+      const subRes = await fetch(`${BILLING_API_URL}/subscription`, { credentials: 'include' })
+      if (subRes.ok) {
+        const data = await subRes.json()
+        set({ subscriptionStatus: data.status })
+        return true
+      }
+      return false
+    } catch {
+      return false
+    }
   },
 
   setUser: (user: User | null) => set({ user, isAuthenticated: user !== null }),

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -398,22 +398,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (isSelfHosted || isCustomServer(storedServerUrl ?? undefined)) return true
 
     try {
-      // Try to refresh session first
-      const refreshRes = await fetch(`${BILLING_API_URL}/auth/refresh`, { method: 'POST', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-      if (refreshRes.ok) {
-        const data = await refreshRes.json()
-        const isAdmin = data.isAdmin === true
-        syncAdminCookie(isAdmin)
-        set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin }, isAuthenticated: true })
-      }
-      // Then fetch subscription
-      const subRes = await fetch(`${BILLING_API_URL}/subscription`, { credentials: 'include' })
-      if (subRes.ok) {
-        const data = await subRes.json()
-        set({ subscriptionStatus: data.status })
-        return true
-      }
-      return false
+      // Fetch both endpoints — only apply state if BOTH succeed
+      const [refreshRes, subRes] = await Promise.all([
+        fetch(`${BILLING_API_URL}/auth/refresh`, { method: 'POST', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } }),
+        fetch(`${BILLING_API_URL}/subscription`, { credentials: 'include' }),
+      ])
+      if (!refreshRes.ok || !subRes.ok) return false
+      const refreshData = await refreshRes.json()
+      const subData = await subRes.json()
+      const isAdmin = refreshData.isAdmin === true
+      syncAdminCookie(isAdmin)
+      set({
+        user: { id: refreshData.id, email: refreshData.email ?? '', planId: refreshData.planId ?? 'free', isAdmin },
+        isAuthenticated: true,
+        subscriptionStatus: subData.status,
+      })
+      return true
     } catch {
       return false
     }

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -388,8 +388,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const res = await fetch(`${BILLING_API_URL}/subscription`, { credentials: 'include' })
       if (res.ok) { const data = await res.json(); set({ subscriptionStatus: data.status }) }
     } catch {
-      // Network error — don't clear existing status, enter degraded mode
-      set({ subscriptionStatus: 'billing_unavailable' })
+      // Network error — only enter degraded mode if there's no existing good status
+      const current = get().subscriptionStatus
+      if (!current) {
+        set({ subscriptionStatus: 'billing_unavailable' })
+      }
     }
   },
 

--- a/apps/web/app/stores/use-calendar-list-store.ts
+++ b/apps/web/app/stores/use-calendar-list-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { useAuthStore } from './use-auth-store'
 
 export interface CalendarList {
   id: string
@@ -38,6 +39,8 @@ export const useCalendarListStore = create<CalendarListState>()(
       ],
       defaultCalendarId: 'default',
       addCalendar: (name, color) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         const nextColor = color || get().getNextColor()
         set((state) => ({
           calendars: [
@@ -52,6 +55,8 @@ export const useCalendarListStore = create<CalendarListState>()(
         }))
       },
       removeCalendar: (id) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         if (id === 'default') return // Can't remove default
         set((state) => ({
           calendars: state.calendars.filter((c) => c.id !== id),
@@ -60,6 +65,8 @@ export const useCalendarListStore = create<CalendarListState>()(
         }))
       },
       updateCalendar: (id, updates) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         set((state) => ({
           calendars: state.calendars.map((c) =>
             c.id === id ? { ...c, ...updates } : c,

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -6,6 +6,7 @@ import { persist } from 'zustand/middleware'
 import type { CalendarEvent, SyncStatus, VAlarm } from '@silentsuite/core'
 import type { RecurrenceScope } from '@/app/(app)/calendar/components/RecurrenceScopeDialog'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+import { useAuthStore } from '@/app/stores/use-auth-store'
 
 type CalendarView = 'week' | 'month'
 
@@ -120,6 +121,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()(persis
   selectedEventId: null,
 
   createEvent: async (newEvent: NewCalendarEvent) => {
+    if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
     const tempId = crypto.randomUUID()
     const now = new Date()
     const event: CalendarEvent = {
@@ -157,6 +159,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()(persis
   },
 
   updateEvent: async (id: string, patch: Partial<CalendarEvent>) => {
+    if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
     const { events } = get()
     const index = events.findIndex((e) => e.id === id)
     if (index === -1) return
@@ -172,6 +175,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()(persis
   },
 
   deleteEvent: async (id: string) => {
+    if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
     // Optimistic update
     set((state) => ({ events: state.events.filter((e) => e.id !== id) }))
 
@@ -199,6 +203,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()(persis
     scope: RecurrenceScope,
     instanceDate: Date,
   ) => {
+    if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
     const { events } = get()
     const master = events.find((e) => e.id === id)
     if (!master) return
@@ -309,6 +314,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()(persis
     scope: RecurrenceScope,
     instanceDate: Date,
   ) => {
+    if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
     const { events } = get()
     const master = events.find((e) => e.id === id)
     if (!master) return

--- a/apps/web/app/stores/use-contact-list-store.ts
+++ b/apps/web/app/stores/use-contact-list-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { useAuthStore } from './use-auth-store'
 
 export interface ContactList {
   id: string
@@ -39,6 +40,8 @@ export const useContactListStore = create<ContactListState>()(
       activeListId: 'default',
 
       addList: (name, color) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         const nextColor = color || get().getNextColor()
         set((state) => ({
           lists: [
@@ -54,6 +57,8 @@ export const useContactListStore = create<ContactListState>()(
       },
 
       removeList: (id) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         if (id === 'default') return
         set((state) => ({
           lists: state.lists.filter((l) => l.id !== id),
@@ -62,6 +67,8 @@ export const useContactListStore = create<ContactListState>()(
       },
 
       updateList: (id, updates) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         set((state) => ({
           lists: state.lists.map((l) =>
             l.id === id ? { ...l, ...updates } : l,

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { Contact, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
 
 interface NewContact {
@@ -43,6 +44,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
       searchQuery: '',
 
       createContact: async (newContact: NewContact) => {
+        if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
         const tempId = crypto.randomUUID()
         const now = new Date()
         const contact: Contact = {
@@ -94,6 +96,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
       },
 
       updateContact: async (id: string, patch: Partial<Contact>) => {
+        if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
         const { contacts } = get()
         const index = contacts.findIndex((c) => c.id === id)
         if (index === -1) return
@@ -124,6 +127,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
       },
 
       deleteContact: async (id: string) => {
+        if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
         set((state) => ({ contacts: state.contacts.filter((c) => c.id !== id) }))
 
         // Sync to Etebase

--- a/apps/web/app/stores/use-task-list-store.ts
+++ b/apps/web/app/stores/use-task-list-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { useAuthStore } from './use-auth-store'
 
 export interface TaskList {
   id: string
@@ -39,6 +40,8 @@ export const useTaskListStore = create<TaskListState>()(
       activeListId: 'default',
 
       addList: (name, color) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         const nextColor = color || get().getNextColor()
         set((state) => ({
           lists: [
@@ -54,6 +57,8 @@ export const useTaskListStore = create<TaskListState>()(
       },
 
       removeList: (id) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         if (id === 'default') return
         set((state) => ({
           lists: state.lists.filter((l) => l.id !== id),
@@ -62,6 +67,8 @@ export const useTaskListStore = create<TaskListState>()(
       },
 
       updateList: (id, updates) => {
+        const { canWrite } = useAuthStore.getState()
+        if (!canWrite()) throw new Error('Your subscription has ended. Renew to make changes.')
         set((state) => ({
           lists: state.lists.map((l) =>
             l.id === id ? { ...l, ...updates } : l,

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { Task, Priority, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
 
 interface NewTask {
@@ -35,6 +36,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
       syncStatus: 'synced' as SyncStatus,
 
       createTask: async (newTask: NewTask) => {
+        if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
         const tempId = crypto.randomUUID()
         const now = new Date()
         const task: Task = {
@@ -77,6 +79,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
       },
 
       updateTask: async (id: string, patch: Partial<Task>) => {
+        if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
         const { tasks } = get()
         const index = tasks.findIndex((t) => t.id === id)
         if (index === -1) return
@@ -108,6 +111,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
       },
 
       deleteTask: async (id: string) => {
+        if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
         set((state) => ({ tasks: state.tasks.filter((t) => t.id !== id) }))
 
         // Sync to Etebase
@@ -129,6 +133,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
       },
 
       toggleComplete: async (id: string) => {
+        if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
         const { tasks } = get()
         const index = tasks.findIndex((t) => t.id === id)
         if (index === -1) return


### PR DESCRIPTION
## What this does

**A4-A5: Billing API fallback**
- When billing API is unreachable but a valid Etebase session exists, users stay logged in (degraded mode)
- New `billing_unavailable` subscription status + `isDegraded()` helper
- Non-blocking blue banner: "Billing service temporarily unavailable. Your data is safe." with Retry button
- Auto-retries billing connection every 60s
- Full read+write access preserved in degraded mode

**B3: Read-only mode for expired subscriptions**
- Replaced full-screen blocking `ReadOnlyOverlay` with non-blocking amber `ReadOnlyBanner`
- Users can still view all data (calendar, tasks, contacts) when subscription expired
- All mutation methods (create, update, delete, toggleComplete, updateRecurring, deleteRecurring) guarded with `canWrite()`
- "Choose a plan" and "Export data" links in banner

**Tests:** 10 new tests covering degraded mode, read-only guards, banner rendering

**Files changed:** 9 files, +316/-69