### PR TITLE
feat: custom server URL support (A10)

### DIFF
--- a/apps/web/app/(app)/settings/account/page.tsx
+++ b/apps/web/app/(app)/settings/account/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
@@ -52,10 +52,13 @@ export default function AccountPage() {
     fetchAccount()
   }, [])
 
-  const storedServerUrl = typeof window !== 'undefined' ? localStorage.getItem('silentsuite-server-url') : null
-  const connectedServer = isSelfHosted || isCustomServer(storedServerUrl ?? undefined)
-    ? (storedServerUrl ?? process.env.NEXT_PUBLIC_ETEBASE_SERVER_URL ?? 'Self-Hosted')
-    : 'SilentSuite Cloud'
+  const connectedServer = useMemo(() => {
+    const stored = localStorage.getItem('silentsuite-server-url')
+    if (isSelfHosted || isCustomServer(stored ?? undefined)) {
+      return stored ?? process.env.NEXT_PUBLIC_ETEBASE_SERVER_URL ?? 'Self-Hosted'
+    }
+    return 'SilentSuite Cloud'
+  }, [])
 
   const email = account?.email ?? user?.email ?? '—'
   const createdAt = account?.createdAt

--- a/apps/web/app/(app)/settings/account/page.tsx
+++ b/apps/web/app/(app)/settings/account/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
-import { isSelfHosted } from '@/app/lib/self-hosted'
+import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 
 const BILLING_API_URL =
   process.env.NEXT_PUBLIC_BILLING_API_URL ?? 'http://localhost:3736'
@@ -52,6 +52,11 @@ export default function AccountPage() {
     fetchAccount()
   }, [])
 
+  const storedServerUrl = typeof window !== 'undefined' ? localStorage.getItem('silentsuite-server-url') : null
+  const connectedServer = isSelfHosted || isCustomServer(storedServerUrl ?? undefined)
+    ? (storedServerUrl ?? process.env.NEXT_PUBLIC_ETEBASE_SERVER_URL ?? 'Self-Hosted')
+    : 'SilentSuite Cloud'
+
   const email = account?.email ?? user?.email ?? '—'
   const createdAt = account?.createdAt
     ? new Date(account.createdAt).toLocaleDateString('en-US', {
@@ -85,6 +90,11 @@ export default function AccountPage() {
               <div>
                 <p className="text-xs text-[rgb(var(--muted))]">Plan</p>
                 <p className="text-sm text-[rgb(var(--foreground))] capitalize">{status.replace(/_/g, ' ')}</p>
+              </div>
+
+              <div>
+                <p className="text-xs text-[rgb(var(--muted))]">Connected server</p>
+                <p className="text-sm text-[rgb(var(--foreground))]">{connectedServer}</p>
               </div>
             </div>
           </section>

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -20,11 +20,20 @@ import { showErrorToast } from '@/app/stores/use-toast-store'
 const DEFAULT_ETEBASE_SERVER_URL =
   process.env.NEXT_PUBLIC_ETEBASE_SERVER_URL ?? 'http://localhost:3735'
 
+function isValidServerUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
 /** Read the user's custom server URL from localStorage, falling back to the env default. */
 function getServerUrl(): string {
   if (typeof window !== 'undefined') {
     const custom = localStorage.getItem('silentsuite-server-url')
-    if (custom && custom.trim()) return custom.trim()
+    if (custom && custom.trim() && isValidServerUrl(custom.trim())) return custom.trim()
   }
   return DEFAULT_ETEBASE_SERVER_URL
 }
@@ -121,7 +130,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   initialize: async () => {
     const savedSession = localStorage.getItem('etebase_session')
     if (!savedSession) {
-      console.log('[etebase-store] No saved session, skipping initialization')
+      console.debug('[etebase-store] No saved session, skipping initialization')
       return
     }
 
@@ -130,12 +139,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const core = await import('@silentsuite/core')
 
       // 1. Restore the Account
-      console.log('[etebase-store] Restoring Etebase session...')
+      console.debug('[etebase-store] Restoring Etebase session...')
       const serverUrl = getServerUrl()
-      console.log(`[etebase-store] Using server URL: ${serverUrl}`)
       const account = await core.restoreSession(serverUrl, savedSession)
       set({ account })
-      console.log('[etebase-store] Session restored')
+      console.debug('[etebase-store] Session restored')
 
       // 2. Ensure collections exist (create if first login, fetch if returning)
       const collections: Record<CollectionTypeKey, any> = {
@@ -154,10 +162,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const existing = await core.listCollections(account, colType)
         if (existing.length > 0) {
           collections[key] = existing[0]
-          console.log(`[etebase-store] Found existing ${key} collection: ${existing[0].uid}`)
+          console.debug(`[etebase-store] Found existing ${key} collection: ${existing[0].uid}`)
         } else {
           collections[key] = await core.createCollection(account, colType, { name: defaultName })
-          console.log(`[etebase-store] Created ${key} collection: ${collections[key].uid}`)
+          console.debug(`[etebase-store] Created ${key} collection: ${collections[key].uid}`)
         }
       }
 
@@ -188,7 +196,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       }
 
       set({ itemCache, itemTypeMap })
-      console.log(`[etebase-store] Loaded ${itemCache.size} items into cache`)
+      console.debug(`[etebase-store] Loaded ${itemCache.size} items into cache`)
 
       // 4. Start SyncEngine
       const engine = new core.SyncEngine({
@@ -206,7 +214,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
       await engine.start(account)
       set({ syncEngine: engine, isInitialized: true })
-      console.log('[etebase-store] SyncEngine started')
+      console.debug('[etebase-store] SyncEngine started')
     } catch (err) {
       console.error('[etebase-store] Initialization failed:', err)
       // Don't clear the session -- the user might be offline
@@ -388,7 +396,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       newCollections[type] = freshCollection
       set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, collections: newCollections })
 
-      console.log(`[etebase-store] Refreshed ${type}: ${results.length} items`)
+      console.debug(`[etebase-store] Refreshed ${type}: ${results.length} items`)
       return results
     } catch (err) {
       console.error(`[etebase-store] Failed to refresh ${type}:`, err)
@@ -409,7 +417,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       isInitialized: false,
       syncEngine: null,
     })
-    console.log('[etebase-store] Destroyed')
+    console.debug('[etebase-store] Destroyed')
   },
 
   onSyncChange: (handler) => {

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -17,8 +17,17 @@ import { showErrorToast } from '@/app/stores/use-toast-store'
 // We dynamically import Etebase types to avoid SSR issues with the etebase WASM module.
 // The actual Etebase SDK objects are stored as `any` in the store and typed at usage sites.
 
-const ETEBASE_SERVER_URL =
+const DEFAULT_ETEBASE_SERVER_URL =
   process.env.NEXT_PUBLIC_ETEBASE_SERVER_URL ?? 'http://localhost:3735'
+
+/** Read the user's custom server URL from localStorage, falling back to the env default. */
+function getServerUrl(): string {
+  if (typeof window !== 'undefined') {
+    const custom = localStorage.getItem('silentsuite-server-url')
+    if (custom && custom.trim()) return custom.trim()
+  }
+  return DEFAULT_ETEBASE_SERVER_URL
+}
 
 const COLLECTION_TYPE_CALENDAR = 'etebase.vevent'
 const COLLECTION_TYPE_TASKS = 'etebase.vtodo'
@@ -122,7 +131,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
       // 1. Restore the Account
       console.log('[etebase-store] Restoring Etebase session...')
-      const account = await core.restoreSession(ETEBASE_SERVER_URL, savedSession)
+      const serverUrl = getServerUrl()
+      console.log(`[etebase-store] Using server URL: ${serverUrl}`)
+      const account = await core.restoreSession(serverUrl, savedSession)
       set({ account })
       console.log('[etebase-store] Session restored')
 
@@ -181,7 +192,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
       // 4. Start SyncEngine
       const engine = new core.SyncEngine({
-        serverUrl: ETEBASE_SERVER_URL,
+        serverUrl: serverUrl,
         pollIntervalMs: 30_000,
       })
 


### PR DESCRIPTION
## What
- `use-etebase-store.ts`: New `getServerUrl()` reads custom server URL from localStorage, falls back to env var. URL validation (http/https only). Both `restoreSession` and `SyncEngine` use it.
- Settings page: Shows 'Connected server' row (custom URL or 'SilentSuite Cloud')
- All console.log → console.debug, prod URL logging removed

## Why
Self-hosters logging in with a custom server URL had it saved to localStorage, but on page refresh `restoreSession()` used the default env var URL. This broke sync for anyone on a custom server after refresh.

## Testing
- Login with custom server URL → refresh → verify sync continues to custom server
- Check settings page shows correct server
- Logout clears stored URL (existing behavior)