### PR TITLE
fix(android): 16KB page alignment for Android 16 (C1)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,6 +64,9 @@ android {
         resources {
             excludes += ['LICENSE', 'META-INF/LICENSE.txt', 'META-INF/NOTICE.txt']
         }
+        jniLibs {
+            useLegacyPackaging = false
+        }
     }
 
 


### PR DESCRIPTION
## What
- Added `jniLibs { useLegacyPackaging = false }` in packaging block
- Ensures .so files are uncompressed and aligned for 16KB page size

## What this does NOT do (intentionally)
- Does NOT bump targetSdkVersion (stays 34) — SDK 35 introduces edge-to-edge enforcement, foreground service changes, and predictive back that need separate handling
- Does NOT add preciseShrinking flag — unrelated to alignment

## Why
Android 16 enforces 16KB memory page alignment for native .so libraries. Apps that don't comply will crash on Android 16 devices.

## Findings
- No NDK/native code in app or submodules (cert4android, ical4android, vcard4android are pure Java/Kotlin)
- No `extractNativeLibs=true` found
- AGP 8.2.2 supports the packaging block
- Minimal 3-line change, low risk