### PR TITLE
feat: email overhaul — signup updates checkbox, non-dismissible verify banner, admin dashboard

### DIFF
--- a/apps/web/app/(app)/admin/admin-dashboard.tsx
+++ b/apps/web/app/(app)/admin/admin-dashboard.tsx
@@ -930,11 +930,11 @@ function UserLookupTab() {
             </div>
             <div>
               <p className="text-xs text-[rgb(var(--muted))]">Email Verified</p>
-              <p className="text-sm">{lookupUser.emailVerified ? '✅' : '❌'}</p>
+              <p className="text-sm">{lookupUser.emailVerified === true ? '✅' : lookupUser.emailVerified === false ? '❌' : '—'}</p>
             </div>
             <div>
               <p className="text-xs text-[rgb(var(--muted))]">Product Updates</p>
-              <p className="text-sm">{lookupUser.wantsProductUpdates ? '✅' : '❌'}</p>
+              <p className="text-sm">{lookupUser.wantsProductUpdates === true ? '✅' : lookupUser.wantsProductUpdates === false ? '❌' : '—'}</p>
             </div>
             {lookupUser.trialPath && (
               <div>
@@ -944,7 +944,7 @@ function UserLookupTab() {
             )}
             <div>
               <p className="text-xs text-[rgb(var(--muted))]">Early Adopter</p>
-              <p className="text-sm">{lookupUser.earlyAdopter ? '✅' : '❌'}</p>
+              <p className="text-sm">{lookupUser.earlyAdopter === true ? '✅' : lookupUser.earlyAdopter === false ? '❌' : '—'}</p>
             </div>
             {lookupUser.trialEndsAt && (
               <div>
@@ -1047,16 +1047,16 @@ function UserLookupTab() {
                       {u.planId?.replace(/_/g, ' ') ?? '—'}
                     </td>
                     <td className="hidden px-4 py-2.5 text-center sm:table-cell">
-                      <span className="text-xs">{u.emailVerified ? '✅' : '❌'}</span>
+                      <span className="text-xs">{u.emailVerified === true ? '✅' : u.emailVerified === false ? '❌' : '—'}</span>
                     </td>
                     <td className="hidden px-4 py-2.5 text-center sm:table-cell">
-                      <span className="text-xs">{u.wantsProductUpdates ? '✅' : '❌'}</span>
+                      <span className="text-xs">{u.wantsProductUpdates === true ? '✅' : u.wantsProductUpdates === false ? '❌' : '—'}</span>
                     </td>
                     <td className="hidden px-4 py-2.5 text-xs text-[rgb(var(--foreground))] lg:table-cell">
                       {u.trialPath ?? '—'}
                     </td>
                     <td className="hidden px-4 py-2.5 text-center lg:table-cell">
-                      <span className="text-xs">{u.earlyAdopter ? '✅' : '❌'}</span>
+                      <span className="text-xs">{u.earlyAdopter === true ? '✅' : u.earlyAdopter === false ? '❌' : '—'}</span>
                     </td>
                     <td className="hidden px-4 py-2.5 sm:table-cell">
                       {u.foundingMember ? (
@@ -1118,9 +1118,11 @@ function EmailsSentSection({ userId }: { userId: string }) {
   const [emails, setEmails] = useState<EmailRecord[]>([])
   const [loading, setLoading] = useState(false)
   const [loaded, setLoaded] = useState(false)
+  const [emailsError, setEmailsError] = useState<string | null>(null)
 
   const fetchEmails = useCallback(async () => {
     setLoading(true)
+    setEmailsError(null)
     try {
       const res = await fetch(
         `${BILLING_API_URL}/admin/users/${encodeURIComponent(userId)}/emails`,
@@ -1129,8 +1131,12 @@ function EmailsSentSection({ userId }: { userId: string }) {
       if (res.ok) {
         const data = await res.json()
         setEmails(data.emails ?? data)
+      } else {
+        setEmailsError('Failed to load emails')
       }
-    } catch { /* ignore */ }
+    } catch {
+      setEmailsError('Failed to load emails')
+    }
     setLoading(false)
     setLoaded(true)
   }, [userId])
@@ -1159,6 +1165,8 @@ function EmailsSentSection({ userId }: { userId: string }) {
               <Loader2 className="h-4 w-4 animate-spin text-[rgb(var(--muted))]" />
               <span className="text-xs text-[rgb(var(--muted))]">Loading emails...</span>
             </div>
+          ) : emailsError ? (
+            <p className="text-xs text-red-400 py-2">{emailsError}</p>
           ) : emails.length === 0 ? (
             <p className="text-xs text-[rgb(var(--muted))] py-2">No emails sent to this user</p>
           ) : (
@@ -1176,7 +1184,7 @@ function EmailsSentSection({ userId }: { userId: string }) {
                   {emails.map((em) => (
                     <tr key={em.id} className="border-b border-[rgb(var(--border))] last:border-b-0">
                       <td className="px-3 py-1.5 text-xs font-mono text-[rgb(var(--foreground))]">{em.type}</td>
-                      <td className="px-3 py-1.5 text-xs text-[rgb(var(--foreground))] truncate max-w-[200px]">{em.subject}</td>
+                      <td className="px-3 py-1.5 text-xs text-[rgb(var(--foreground))]"><div className="truncate max-w-[200px]">{em.subject}</div></td>
                       <td className="px-3 py-1.5">
                         <span className={`text-xs font-medium ${em.status === 'delivered' ? 'text-emerald-500' : em.status === 'bounced' ? 'text-red-400' : 'text-[rgb(var(--muted))]'}`}>
                           {em.status}
@@ -1200,17 +1208,23 @@ function SubscribersTab() {
   const [subscribers, setSubscribers] = useState<Subscriber[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [subscribersOffset, setSubscribersOffset] = useState(0)
+  const [subscribersTotal, setSubscribersTotal] = useState(0)
+  const SUBSCRIBERS_LIMIT = 20
 
-  const fetchSubscribers = useCallback(async () => {
+  const fetchSubscribers = useCallback(async (offset: number) => {
     setLoading(true)
     setError(null)
     try {
-      const res = await fetch(`${BILLING_API_URL}/admin/contacts`, {
-        credentials: 'include',
-      })
+      const res = await fetch(
+        `${BILLING_API_URL}/admin/contacts?limit=${SUBSCRIBERS_LIMIT}&offset=${offset}`,
+        { credentials: 'include' },
+      )
       if (res.ok) {
         const data = await res.json()
         setSubscribers(data.contacts ?? data)
+        if (typeof data.total === 'number') setSubscribersTotal(data.total)
+        else setSubscribersTotal((data.contacts ?? data).length)
       } else {
         setError('Failed to load subscribers')
       }
@@ -1220,7 +1234,10 @@ function SubscribersTab() {
     setLoading(false)
   }, [])
 
-  useEffect(() => { fetchSubscribers() }, [fetchSubscribers])
+  useEffect(() => { fetchSubscribers(subscribersOffset) }, [fetchSubscribers, subscribersOffset])
+
+  const subscribersTotalPages = Math.ceil(subscribersTotal / SUBSCRIBERS_LIMIT)
+  const subscribersCurrentPage = Math.floor(subscribersOffset / SUBSCRIBERS_LIMIT) + 1
 
   return (
     <div className="space-y-6">
@@ -1229,11 +1246,11 @@ function SubscribersTab() {
           <Mail className="h-4 w-4 text-[rgb(var(--muted))]" />
           <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">Newsletter Subscribers</h2>
           {!loading && (
-            <span className="text-xs text-[rgb(var(--muted))]">({subscribers.length} total)</span>
+            <span className="text-xs text-[rgb(var(--muted))]">({subscribersTotal} total)</span>
           )}
         </div>
         <button
-          onClick={fetchSubscribers}
+          onClick={() => fetchSubscribers(subscribersOffset)}
           disabled={loading}
           className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface))] hover:text-[rgb(var(--foreground))] transition-colors disabled:opacity-50"
         >
@@ -1269,7 +1286,7 @@ function SubscribersTab() {
             <tbody>
               {subscribers.map((s) => (
                 <tr
-                  key={s.email}
+                  key={`${s.email}-${s.subscribedAt}`}
                   className={`border-b border-[rgb(var(--border))] last:border-b-0 hover:bg-[rgb(var(--background))]/50 transition-colors ${s.unsubscribedAt ? 'opacity-60' : ''}`}
                 >
                   <td className="px-4 py-2.5 text-sm font-mono text-[rgb(var(--foreground))]">{s.email}</td>
@@ -1283,6 +1300,32 @@ function SubscribersTab() {
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {subscribersTotalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-[rgb(var(--muted))]">
+            Showing {subscribersOffset + 1}–{Math.min(subscribersOffset + SUBSCRIBERS_LIMIT, subscribersTotal)} of {subscribersTotal}
+          </p>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setSubscribersOffset(Math.max(0, subscribersOffset - SUBSCRIBERS_LIMIT))}
+              disabled={subscribersOffset === 0}
+              className="rounded p-1 text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] disabled:opacity-30 transition-colors"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+            <span className="px-2 text-xs text-[rgb(var(--muted))]">{subscribersCurrentPage} / {subscribersTotalPages}</span>
+            <button
+              onClick={() => setSubscribersOffset(subscribersOffset + SUBSCRIBERS_LIMIT)}
+              disabled={subscribersOffset + SUBSCRIBERS_LIMIT >= subscribersTotal}
+              className="rounded p-1 text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] disabled:opacity-30 transition-colors"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/app/(app)/admin/admin-dashboard.tsx
+++ b/apps/web/app/(app)/admin/admin-dashboard.tsx
@@ -12,6 +12,7 @@ import {
   Server,
   ChevronLeft,
   ChevronRight,
+  ChevronDown,
   RefreshCw,
   ExternalLink,
   Shield,
@@ -20,6 +21,8 @@ import {
   Clock,
   CreditCard,
   TrendingUp,
+  Mail,
+  Loader2,
 } from 'lucide-react'
 
 const BILLING_API_URL =
@@ -51,6 +54,7 @@ interface EventsPage {
 }
 
 interface LookedUpUser {
+  id: string
   email: string
   createdAt: string
   subscriptionStatus: string
@@ -59,6 +63,10 @@ interface LookedUpUser {
   currentPeriodEnd: string | null
   stripeCustomerId: string | null
   foundingMember: boolean
+  emailVerified?: boolean
+  wantsProductUpdates?: boolean
+  trialPath?: string | null
+  earlyAdopter?: boolean
 }
 
 interface UserListItem {
@@ -69,6 +77,26 @@ interface UserListItem {
   planId: string | null
   foundingMember: boolean
   isAdmin: boolean
+  emailVerified?: boolean
+  wantsProductUpdates?: boolean
+  trialPath?: string | null
+  earlyAdopter?: boolean
+}
+
+interface EmailRecord {
+  id: string
+  type: string
+  subject: string
+  sentAt: string
+  status: string
+}
+
+interface Subscriber {
+  email: string
+  source: string
+  doiConfirmed: boolean
+  subscribedAt: string
+  unsubscribedAt: string | null
 }
 
 interface UsersPage {
@@ -190,6 +218,7 @@ export default function AdminDashboard() {
         { key: 'overview', label: 'Overview' },
         { key: 'payments', label: 'Failed Payments' },
         { key: 'users', label: 'User Lookup' },
+        { key: 'subscribers', label: 'Subscribers' },
         { key: 'health', label: 'System Health' },
       ]
 
@@ -217,6 +246,7 @@ export default function AdminDashboard() {
       {activeTab === 'overview' && (isSelfHosted ? <SelfHostedOverviewTab /> : <OverviewTab />)}
       {activeTab === 'payments' && !isSelfHosted && <FailedPaymentsTab />}
       {activeTab === 'users' && (isSelfHosted ? <SelfHostedUsersTab /> : <UserLookupTab />)}
+      {activeTab === 'subscribers' && !isSelfHosted && <SubscribersTab />}
       {activeTab === 'health' && (isSelfHosted ? <SelfHostedHealthTab /> : <HealthTab />)}
     </div>
   )
@@ -898,6 +928,24 @@ function UserLookupTab() {
                 {lookupUser.foundingMember ? 'Yes' : 'No'}
               </p>
             </div>
+            <div>
+              <p className="text-xs text-[rgb(var(--muted))]">Email Verified</p>
+              <p className="text-sm">{lookupUser.emailVerified ? '✅' : '❌'}</p>
+            </div>
+            <div>
+              <p className="text-xs text-[rgb(var(--muted))]">Product Updates</p>
+              <p className="text-sm">{lookupUser.wantsProductUpdates ? '✅' : '❌'}</p>
+            </div>
+            {lookupUser.trialPath && (
+              <div>
+                <p className="text-xs text-[rgb(var(--muted))]">Trial Path</p>
+                <p className="text-sm text-[rgb(var(--foreground))]">{lookupUser.trialPath}</p>
+              </div>
+            )}
+            <div>
+              <p className="text-xs text-[rgb(var(--muted))]">Early Adopter</p>
+              <p className="text-sm">{lookupUser.earlyAdopter ? '✅' : '❌'}</p>
+            </div>
             {lookupUser.trialEndsAt && (
               <div>
                 <p className="text-xs text-[rgb(var(--muted))]">Trial Ends</p>
@@ -917,6 +965,9 @@ function UserLookupTab() {
               </div>
             )}
           </div>
+
+          {/* Emails Sent */}
+          {lookupUser.id && <EmailsSentSection userId={lookupUser.id} />}
         </div>
       )}
 
@@ -959,6 +1010,10 @@ function UserLookupTab() {
                 <th className="px-4 py-2 text-xs font-medium text-[rgb(var(--muted))]">Email</th>
                 <th className="px-4 py-2 text-xs font-medium text-[rgb(var(--muted))]">Status</th>
                 <th className="px-4 py-2 text-xs font-medium text-[rgb(var(--muted))]">Plan</th>
+                <th className="hidden px-4 py-2 text-xs font-medium text-[rgb(var(--muted))] sm:table-cell">Verified</th>
+                <th className="hidden px-4 py-2 text-xs font-medium text-[rgb(var(--muted))] sm:table-cell">Updates</th>
+                <th className="hidden px-4 py-2 text-xs font-medium text-[rgb(var(--muted))] lg:table-cell">Trial</th>
+                <th className="hidden px-4 py-2 text-xs font-medium text-[rgb(var(--muted))] lg:table-cell">Early</th>
                 <th className="hidden px-4 py-2 text-xs font-medium text-[rgb(var(--muted))] sm:table-cell">Founding</th>
                 <th className="hidden px-4 py-2 text-xs font-medium text-[rgb(var(--muted))] sm:table-cell">Admin</th>
                 <th className="px-4 py-2 text-xs font-medium text-[rgb(var(--muted))]">Joined</th>
@@ -967,13 +1022,13 @@ function UserLookupTab() {
             <tbody>
               {usersLoading && !usersPage ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-xs text-[rgb(var(--muted))]">
+                  <td colSpan={10} className="px-4 py-8 text-center text-xs text-[rgb(var(--muted))]">
                     Loading users...
                   </td>
                 </tr>
               ) : filteredUsers?.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-xs text-[rgb(var(--muted))]">
+                  <td colSpan={10} className="px-4 py-8 text-center text-xs text-[rgb(var(--muted))]">
                     {tableFilter ? 'No users match filter' : 'No users found'}
                   </td>
                 </tr>
@@ -990,6 +1045,18 @@ function UserLookupTab() {
                     </td>
                     <td className="px-4 py-2.5 text-xs text-[rgb(var(--foreground))] capitalize">
                       {u.planId?.replace(/_/g, ' ') ?? '—'}
+                    </td>
+                    <td className="hidden px-4 py-2.5 text-center sm:table-cell">
+                      <span className="text-xs">{u.emailVerified ? '✅' : '❌'}</span>
+                    </td>
+                    <td className="hidden px-4 py-2.5 text-center sm:table-cell">
+                      <span className="text-xs">{u.wantsProductUpdates ? '✅' : '❌'}</span>
+                    </td>
+                    <td className="hidden px-4 py-2.5 text-xs text-[rgb(var(--foreground))] lg:table-cell">
+                      {u.trialPath ?? '—'}
+                    </td>
+                    <td className="hidden px-4 py-2.5 text-center lg:table-cell">
+                      <span className="text-xs">{u.earlyAdopter ? '✅' : '❌'}</span>
                     </td>
                     <td className="hidden px-4 py-2.5 sm:table-cell">
                       {u.foundingMember ? (
@@ -1041,6 +1108,183 @@ function UserLookupTab() {
           </div>
         )}
       </div>
+    </div>
+  )
+}
+
+// ─── Emails Sent Section (per-user expandable) ──────────────────────
+function EmailsSentSection({ userId }: { userId: string }) {
+  const [expanded, setExpanded] = useState(false)
+  const [emails, setEmails] = useState<EmailRecord[]>([])
+  const [loading, setLoading] = useState(false)
+  const [loaded, setLoaded] = useState(false)
+
+  const fetchEmails = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(
+        `${BILLING_API_URL}/admin/users/${encodeURIComponent(userId)}/emails`,
+        { credentials: 'include' },
+      )
+      if (res.ok) {
+        const data = await res.json()
+        setEmails(data.emails ?? data)
+      }
+    } catch { /* ignore */ }
+    setLoading(false)
+    setLoaded(true)
+  }, [userId])
+
+  const handleToggle = () => {
+    if (!expanded && !loaded) {
+      fetchEmails()
+    }
+    setExpanded(!expanded)
+  }
+
+  return (
+    <div className="mt-4 border-t border-[rgb(var(--border))] pt-4">
+      <button
+        onClick={handleToggle}
+        className="flex items-center gap-2 text-sm font-medium text-[rgb(var(--foreground))] hover:text-[rgb(var(--primary))] transition-colors"
+      >
+        <ChevronDown className={`h-4 w-4 transition-transform ${expanded ? 'rotate-0' : '-rotate-90'}`} />
+        <Mail className="h-4 w-4 text-[rgb(var(--muted))]" />
+        Emails Sent
+      </button>
+      {expanded && (
+        <div className="mt-3">
+          {loading ? (
+            <div className="flex items-center gap-2 py-4">
+              <Loader2 className="h-4 w-4 animate-spin text-[rgb(var(--muted))]" />
+              <span className="text-xs text-[rgb(var(--muted))]">Loading emails...</span>
+            </div>
+          ) : emails.length === 0 ? (
+            <p className="text-xs text-[rgb(var(--muted))] py-2">No emails sent to this user</p>
+          ) : (
+            <div className="overflow-x-auto rounded-lg border border-[rgb(var(--border))]">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[rgb(var(--border))] bg-[rgb(var(--surface))]">
+                    <th className="px-3 py-1.5 text-left text-xs font-medium text-[rgb(var(--muted))]">Type</th>
+                    <th className="px-3 py-1.5 text-left text-xs font-medium text-[rgb(var(--muted))]">Subject</th>
+                    <th className="px-3 py-1.5 text-left text-xs font-medium text-[rgb(var(--muted))]">Status</th>
+                    <th className="px-3 py-1.5 text-left text-xs font-medium text-[rgb(var(--muted))]">Sent</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {emails.map((em) => (
+                    <tr key={em.id} className="border-b border-[rgb(var(--border))] last:border-b-0">
+                      <td className="px-3 py-1.5 text-xs font-mono text-[rgb(var(--foreground))]">{em.type}</td>
+                      <td className="px-3 py-1.5 text-xs text-[rgb(var(--foreground))] truncate max-w-[200px]">{em.subject}</td>
+                      <td className="px-3 py-1.5">
+                        <span className={`text-xs font-medium ${em.status === 'delivered' ? 'text-emerald-500' : em.status === 'bounced' ? 'text-red-400' : 'text-[rgb(var(--muted))]'}`}>
+                          {em.status}
+                        </span>
+                      </td>
+                      <td className="px-3 py-1.5 text-xs text-[rgb(var(--muted))]">{formatDate(em.sentAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Subscribers Tab ─────────────────────────────────────────────────
+function SubscribersTab() {
+  const [subscribers, setSubscribers] = useState<Subscriber[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchSubscribers = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`${BILLING_API_URL}/admin/contacts`, {
+        credentials: 'include',
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setSubscribers(data.contacts ?? data)
+      } else {
+        setError('Failed to load subscribers')
+      }
+    } catch {
+      setError('API unavailable')
+    }
+    setLoading(false)
+  }, [])
+
+  useEffect(() => { fetchSubscribers() }, [fetchSubscribers])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Mail className="h-4 w-4 text-[rgb(var(--muted))]" />
+          <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">Newsletter Subscribers</h2>
+          {!loading && (
+            <span className="text-xs text-[rgb(var(--muted))]">({subscribers.length} total)</span>
+          )}
+        </div>
+        <button
+          onClick={fetchSubscribers}
+          disabled={loading}
+          className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface))] hover:text-[rgb(var(--foreground))] transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3 w-3 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+
+      {loading && subscribers.length === 0 ? (
+        <p className="text-sm text-[rgb(var(--muted))]">Loading subscribers...</p>
+      ) : subscribers.length === 0 ? (
+        <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-8 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-[rgb(var(--primary))]/10">
+            <Mail className="h-6 w-6 text-[rgb(var(--primary))]" />
+          </div>
+          <p className="mt-3 text-sm font-medium text-[rgb(var(--foreground))]">No subscribers yet</p>
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">Subscribers will appear here once users opt in</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-[rgb(var(--border))]">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[rgb(var(--border))] bg-[rgb(var(--surface))]">
+                <th className="px-4 py-2 text-left text-xs font-medium text-[rgb(var(--muted))]">Email</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-[rgb(var(--muted))]">Source</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-[rgb(var(--muted))]">DOI Confirmed</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-[rgb(var(--muted))]">Subscribed</th>
+                <th className="px-4 py-2 text-left text-xs font-medium text-[rgb(var(--muted))]">Unsubscribed</th>
+              </tr>
+            </thead>
+            <tbody>
+              {subscribers.map((s) => (
+                <tr
+                  key={s.email}
+                  className={`border-b border-[rgb(var(--border))] last:border-b-0 hover:bg-[rgb(var(--background))]/50 transition-colors ${s.unsubscribedAt ? 'opacity-60' : ''}`}
+                >
+                  <td className="px-4 py-2.5 text-sm font-mono text-[rgb(var(--foreground))]">{s.email}</td>
+                  <td className="px-4 py-2.5 text-xs text-[rgb(var(--foreground))] capitalize">{s.source}</td>
+                  <td className="px-4 py-2.5 text-center">
+                    <span className="text-xs">{s.doiConfirmed ? '✅' : '❌'}</span>
+                  </td>
+                  <td className="px-4 py-2.5 text-xs text-[rgb(var(--muted))]">{formatShortDate(s.subscribedAt)}</td>
+                  <td className="px-4 py-2.5 text-xs text-[rgb(var(--muted))]">{s.unsubscribedAt ? formatShortDate(s.unsubscribedAt) : '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -1086,7 +1086,7 @@ export default function SignupPage() {
   const [provisioning, setProvisioning] = useState(false)
   const [usingSelfHostedServer, setUsingSelfHostedServer] = useState(false)
   const [planView, setPlanView] = useState<PlanView>('cards')
-  const [wantsProductUpdates, setWantsProductUpdates] = useState(true)
+  const [wantsProductUpdates, setWantsProductUpdates] = useState(false)
   const formDataRef = useRef<SignupFormData | null>(null)
 
   const handleAccountComplete = useCallback(async (data: SignupFormData) => {
@@ -1104,6 +1104,7 @@ export default function SignupPage() {
 
     // Store product updates preference in pendingSignup for later use
     const pending = useAuthStore.getState().pendingSignup
+    if (!pending) console.error('pendingSignup not set after createEtebaseAccount')
     if (pending) {
       useAuthStore.setState({
         pendingSignup: { ...pending, wantsProductUpdates },

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -179,11 +179,15 @@ function StepCreateAccount({
   serverUrl,
   setServerUrl,
   initialData,
+  wantsProductUpdates,
+  onWantsProductUpdatesChange,
 }: {
   onNext: (data: SignupFormData) => Promise<void>
   serverUrl: string
   setServerUrl: (url: string) => void
   initialData?: SignupFormData | null
+  wantsProductUpdates: boolean
+  onWantsProductUpdatesChange: (value: boolean) => void
 }) {
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -280,6 +284,21 @@ function StepCreateAccount({
             </p>
           )}
         </div>
+
+        {/* Product updates opt-in */}
+        <label className="flex items-start gap-2.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={wantsProductUpdates}
+            onChange={(e) => onWantsProductUpdatesChange(e.target.checked)}
+            className="mt-0.5 h-4 w-4 rounded border-[rgb(var(--border))] bg-[rgb(var(--surface))] text-[rgb(var(--primary))] focus:ring-[rgb(var(--primary))] focus:ring-offset-0"
+          />
+          <span className="text-xs text-[rgb(var(--muted))] leading-relaxed">
+            Send me product updates and feature announcements (~8/year)
+            <br />
+            <span className="text-[rgb(var(--muted))]/70">We will never share your email. Unsubscribe anytime.</span>
+          </span>
+        </label>
 
         {/* Advanced Settings */}
         <details className="group">
@@ -1067,6 +1086,7 @@ export default function SignupPage() {
   const [provisioning, setProvisioning] = useState(false)
   const [usingSelfHostedServer, setUsingSelfHostedServer] = useState(false)
   const [planView, setPlanView] = useState<PlanView>('cards')
+  const [wantsProductUpdates, setWantsProductUpdates] = useState(true)
   const formDataRef = useRef<SignupFormData | null>(null)
 
   const handleAccountComplete = useCallback(async (data: SignupFormData) => {
@@ -1178,6 +1198,8 @@ export default function SignupPage() {
             serverUrl={serverUrl}
             setServerUrl={setServerUrl}
             initialData={formDataRef.current}
+            wantsProductUpdates={wantsProductUpdates}
+            onWantsProductUpdatesChange={setWantsProductUpdates}
           />
         )}
         {step === 'selfhost' && (

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -1102,6 +1102,14 @@ export default function SignupPage() {
     const identifier = data.email || ''
     await createEtebaseAccount(identifier, data.password, trimmedUrl)
 
+    // Store product updates preference in pendingSignup for later use
+    const pending = useAuthStore.getState().pendingSignup
+    if (pending) {
+      useAuthStore.setState({
+        pendingSignup: { ...pending, wantsProductUpdates },
+      })
+    }
+
     const selfHosted = isSelfHosted || isCustomServer(trimmedUrl)
     setUsingSelfHostedServer(selfHosted)
 
@@ -1110,7 +1118,7 @@ export default function SignupPage() {
     } else {
       setStep('plan')
     }
-  }, [createEtebaseAccount, serverUrl])
+  }, [createEtebaseAccount, serverUrl, wantsProductUpdates])
 
   const handleSelfHostChoice = useCallback(async (choice: 'free' | 'support') => {
     if (choice === 'support') {

--- a/apps/web/app/components/EmailVerificationBanner.tsx
+++ b/apps/web/app/components/EmailVerificationBanner.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { MailWarning, X, Loader2 } from 'lucide-react'
+import { MailWarning, Loader2 } from 'lucide-react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { isSelfHosted } from '@/app/lib/self-hosted'
 
@@ -10,15 +10,12 @@ const BILLING_API_URL =
 
 export function EmailVerificationBanner() {
   const user = useAuthStore((s) => s.user)
-  const [dismissed, setDismissed] = useState(() => {
-    try { return sessionStorage.getItem('email-verify-dismissed') === 'true' } catch { return false }
-  })
   const [resending, setResending] = useState(false)
   const [resent, setResent] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // Don't show for self-hosted, unauthenticated, or already verified
-  if (isSelfHosted || !user || user.emailVerified !== false || dismissed) {
+  if (isSelfHosted || !user || user.emailVerified !== false) {
     return null
   }
 
@@ -46,9 +43,9 @@ export function EmailVerificationBanner() {
   }
 
   return (
-    <div className="relative flex items-center gap-3 px-4 py-2.5 bg-amber-500/10 border-b border-amber-500/20 text-amber-200 text-sm">
+    <div className="flex items-center gap-3 px-4 py-2 bg-amber-500/10 border-b border-amber-500/20 text-amber-200 text-sm">
       <MailWarning className="w-4 h-4 text-amber-400 shrink-0" />
-      <span className="flex-1">
+      <span className="flex-1 text-xs">
         {resent
           ? 'Verification email sent. Check your inbox.'
           : 'Please verify your email address to ensure you receive important account notifications.'}
@@ -67,13 +64,6 @@ export function EmailVerificationBanner() {
         </button>
       )}
       {error && <span className="text-xs text-red-400">{error}</span>}
-      <button
-        onClick={() => { sessionStorage.setItem('email-verify-dismissed', 'true'); setDismissed(true) }}
-        className="shrink-0 text-amber-400/60 hover:text-amber-300"
-        aria-label="Dismiss"
-      >
-        <X className="w-4 h-4" />
-      </button>
     </div>
   )
 }

--- a/apps/web/app/components/EmailVerificationBanner.tsx
+++ b/apps/web/app/components/EmailVerificationBanner.tsx
@@ -43,7 +43,7 @@ export function EmailVerificationBanner() {
   }
 
   return (
-    <div className="flex items-center gap-3 px-4 py-2 bg-amber-500/10 border-b border-amber-500/20 text-amber-200 text-sm">
+    <div role="alert" className="flex items-center gap-3 px-4 py-2 bg-amber-500/10 border-b border-amber-500/20 text-amber-200 text-sm">
       <MailWarning className="w-4 h-4 text-amber-400 shrink-0" />
       <span className="flex-1 text-xs">
         {resent

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -37,7 +37,7 @@ interface AuthState {
   isReadOnly: () => boolean
   canWrite: () => boolean
   createEtebaseAccount: (email: string, password: string, serverUrl?: string) => Promise<void>
-  signup: (planId: string, trialPath: string, wantsProductUpdates?: boolean) => Promise<string | null>
+  signup: (planId: string, trialPath: string) => Promise<string | null>
   /** Call after the entire signup flow (including payment + vault) to finalize authentication. */
   completeSignup: () => void
   login: (email: string, password: string, serverUrl?: string) => Promise<void>
@@ -131,21 +131,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
-  signup: async (planId: string, trialPath: string, wantsProductUpdates?: boolean) => {
+  signup: async (planId: string, trialPath: string) => {
     if (isSelfHosted || planId === 'self-hosted') {
       const pending = get().pendingSignup
       if (!pending) throw new Error('No pending signup')
 
       // Self-hosted: if user opted in, subscribe to newsletter on the SilentSuite API
-      if (pending.wantsProductUpdates ?? wantsProductUpdates) {
+      if (pending.wantsProductUpdates) {
         try {
-          await fetch('https://api.silentsuite.io/newsletter/subscribe', {
+          const res = await fetch('https://api.silentsuite.io/newsletter/subscribe', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ email: pending.email, source: 'self_hosted' }),
           })
-        } catch {
-          // Newsletter subscription is best-effort — don't block signup
+          if (!res.ok) console.warn('Newsletter subscribe failed:', res.status)
+        } catch (err) {
+          console.warn('Newsletter subscribe failed:', err)
         }
       }
 
@@ -176,7 +177,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           etebaseSessionToken: pending.etebaseAuthToken,
           planId,
           trialPath,
-          wantsProductUpdates: pending.wantsProductUpdates ?? wantsProductUpdates,
+          wantsProductUpdates: pending.wantsProductUpdates,
         }),
         credentials: 'include',
       })

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -15,6 +15,7 @@ interface PendingSignup {
   email: string
   etebaseAuthToken: string
   earlyAdopter?: boolean
+  wantsProductUpdates?: boolean
   /** Provisioned user data — stored here until the entire signup flow completes. */
   provisionedUser?: {
     id: string
@@ -36,7 +37,7 @@ interface AuthState {
   isReadOnly: () => boolean
   canWrite: () => boolean
   createEtebaseAccount: (email: string, password: string, serverUrl?: string) => Promise<void>
-  signup: (planId: string, trialPath: string) => Promise<string | null>
+  signup: (planId: string, trialPath: string, wantsProductUpdates?: boolean) => Promise<string | null>
   /** Call after the entire signup flow (including payment + vault) to finalize authentication. */
   completeSignup: () => void
   login: (email: string, password: string, serverUrl?: string) => Promise<void>
@@ -130,10 +131,24 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
-  signup: async (planId: string, trialPath: string) => {
+  signup: async (planId: string, trialPath: string, wantsProductUpdates?: boolean) => {
     if (isSelfHosted || planId === 'self-hosted') {
       const pending = get().pendingSignup
       if (!pending) throw new Error('No pending signup')
+
+      // Self-hosted: if user opted in, subscribe to newsletter on the SilentSuite API
+      if (pending.wantsProductUpdates ?? wantsProductUpdates) {
+        try {
+          await fetch('https://api.silentsuite.io/newsletter/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email: pending.email, source: 'self_hosted' }),
+          })
+        } catch {
+          // Newsletter subscription is best-effort — don't block signup
+        }
+      }
+
       // Self-hosted: store provisioned data but do NOT authenticate yet.
       // completeSignup() will finalize after vault creation.
       set({
@@ -157,7 +172,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const res = await fetch(`${BILLING_API_URL}/auth/provision`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-        body: JSON.stringify({ etebaseSessionToken: pending.etebaseAuthToken, planId, trialPath }),
+        body: JSON.stringify({
+          etebaseSessionToken: pending.etebaseAuthToken,
+          planId,
+          trialPath,
+          wantsProductUpdates: pending.wantsProductUpdates ?? wantsProductUpdates,
+        }),
         credentials: 'include',
       })
       if (!res.ok) {


### PR DESCRIPTION
## Email Overhaul (Frontend)

### What changed
- **Signup flow**: Product updates checkbox in Step 1 (default OFF per GDPR). Passed through to billing API provision call. Self-hosters call `/newsletter/subscribe` if opted in.
- **Verification banner**: Non-dismissible — removed X button and sessionStorage dismiss. Persistent until email verified. Added `role=alert` for a11y.
- **Admin dashboard**: New columns (emailVerified, wantsProductUpdates, trialPath, earlyAdopter). Expandable email history per user. New Subscribers tab with pagination.

### Review fixes applied
- GDPR: checkbox defaults to unchecked (useState false)
- Newsletter subscribe logs warning on failure
- Removed dead `wantsProductUpdates` parameter from `signup()`
- Admin emails section shows error state instead of silent empty
- Subscriber list has pagination + compound React keys
- Boolean fields handle undefined gracefully (shows — instead of ❌)
- Truncate fix for table cells

### Depends on
- silentsuite-billing PR #4 (API endpoints)