### PR TITLE
Fix Android first-login crash (null Etebase session)

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/EtebaseLocalCache.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/EtebaseLocalCache.kt
@@ -117,9 +117,19 @@ class EtebaseLocalCache private constructor(context: Context, username: String) 
         }
 
         // FIXME: If we ever cache this we need to cache bust on changePassword
-        fun getEtebase(context: Context, httpClient: OkHttpClient, settings: AccountSettings): Account {
+        fun getEtebase(
+            context: Context,
+            httpClient: OkHttpClient,
+            settings: AccountSettings,
+            sessionOverride: String? = null,
+        ): Account {
             val client = Client.create(httpClient, settings.uri?.toString())
-            val session = requireNotNull(settings.etebaseSession) { "Etebase session is null for account" }
+            // On first login AccountManager.setUserData hasn't always landed by the time
+            // the next activity reads it back, so accept an in-memory override from the
+            // caller and fall back to the persisted value only if one wasn't supplied.
+            val session = sessionOverride
+                ?: settings.etebaseSession
+                ?: throw IllegalStateException("Etebase session is null for account ${settings.account.name}")
             return Account.restore(client, session, null)
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionActivity.kt
@@ -91,13 +91,13 @@ class CollectionActivity() : BaseActivity() {
 class AccountViewModel : ViewModel() {
     private val holder = MutableLiveData<AccountHolder>()
 
-    fun loadAccount(context: Context, account: Account) {
+    fun loadAccount(context: Context, account: Account, sessionOverride: String? = null) {
         viewModelScope.launch {
             val accountHolder = withContext(Dispatchers.IO) {
                 val settings = AccountSettings(context, account)
                 val etebaseLocalCache = EtebaseLocalCache.getInstance(context, account.name)
                 val httpClient = HttpClient.Builder(context).setForeground(true).build().okHttpClient
-                val etebase = EtebaseLocalCache.getEtebase(context, httpClient, settings)
+                val etebase = EtebaseLocalCache.getEtebase(context, httpClient, settings, sessionOverride)
                 val colMgr = etebase.collectionManager
                 AccountHolder(
                         account,

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -38,13 +38,15 @@ class NewAccountWizardActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        account = requireNotNull(requireNotNull(intent.extras) { "NewAccountWizardActivity requires intent extras" }.getParcelable(EXTRA_ACCOUNT)) { "NewAccountWizardActivity requires EXTRA_ACCOUNT" }
+        val extras = requireNotNull(intent.extras) { "NewAccountWizardActivity requires intent extras" }
+        account = requireNotNull(extras.getParcelable(EXTRA_ACCOUNT)) { "NewAccountWizardActivity requires EXTRA_ACCOUNT" }
+        val etebaseSession = extras.getString(EXTRA_ETEBASE_SESSION)
 
         setContentView(R.layout.etebase_fragment_activity)
 
         if (savedInstanceState == null) {
             setTitle(R.string.account_wizard_collections_title)
-            model.loadAccount(this, account)
+            model.loadAccount(this, account, etebaseSession)
             supportFragmentManager.commit {
                 replace(R.id.fragment_container, WizardCheckFragment())
             }
@@ -53,10 +55,12 @@ class NewAccountWizardActivity : BaseActivity() {
 
     companion object {
         private val EXTRA_ACCOUNT = "account"
+        private val EXTRA_ETEBASE_SESSION = "etebaseSession"
 
-        fun newIntent(context: Context, account: Account): Intent {
+        fun newIntent(context: Context, account: Account, etebaseSession: String? = null): Intent {
             val intent = Intent(context, NewAccountWizardActivity::class.java)
             intent.putExtra(EXTRA_ACCOUNT, account)
+            if (etebaseSession != null) intent.putExtra(EXTRA_ETEBASE_SESSION, etebaseSession)
             return intent
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
@@ -44,7 +44,9 @@ class CreateAccountFragment : DialogFragment() {
         val account = createAccount(config.userName, config)
         if (account != null) {
             activity.setResult(Activity.RESULT_OK)
-            startActivity(ModeSelectionActivity.newIntent(requireContext(), account))
+            // Pass the freshly-minted session through the intent as well — AccountManager.setUserData
+            // isn't always visible to the next activity's read on the first login.
+            startActivity(ModeSelectionActivity.newIntent(requireContext(), account, config.etebaseSession))
             activity.finish()
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/ModeSelectionActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/ModeSelectionActivity.kt
@@ -15,13 +15,15 @@ class ModeSelectionActivity : BaseActivity() {
 
     companion object {
         private const val EXTRA_ACCOUNT = "account"
+        private const val EXTRA_ETEBASE_SESSION = "etebaseSession"
         const val PREF_NAME = "app_mode"
         const val KEY_MODE = "sync_mode"
         const val MODE_BRIDGE = "bridge"
 
-        fun newIntent(context: Context, account: Account): Intent {
+        fun newIntent(context: Context, account: Account, etebaseSession: String? = null): Intent {
             val intent = Intent(context, ModeSelectionActivity::class.java)
             intent.putExtra(EXTRA_ACCOUNT, account)
+            if (etebaseSession != null) intent.putExtra(EXTRA_ETEBASE_SESSION, etebaseSession)
             return intent
         }
     }
@@ -30,6 +32,7 @@ class ModeSelectionActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         val account = requireNotNull(intent.getParcelableExtra<Account>(EXTRA_ACCOUNT)) { "ModeSelectionActivity requires EXTRA_ACCOUNT" }
+        val etebaseSession = intent.getStringExtra(EXTRA_ETEBASE_SESSION)
 
         // Always use bridge mode (walled garden removed)
         getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
@@ -37,7 +40,7 @@ class ModeSelectionActivity : BaseActivity() {
             .putString(KEY_MODE, MODE_BRIDGE)
             .apply()
 
-        startActivity(NewAccountWizardActivity.newIntent(this, account))
+        startActivity(NewAccountWizardActivity.newIntent(this, account, etebaseSession))
         finish()
     }
 }


### PR DESCRIPTION
## Summary

- First login crashed in `EtebaseLocalCache.getEtebase` at `requireNotNull(settings.etebaseSession)` — the session we'd just written via `AccountManager.setUserData` in `CreateAccountFragment` wasn't always visible from the next activity's read.
- Forward the session string through the intent chain (`CreateAccountFragment` → `ModeSelectionActivity` → `NewAccountWizardActivity`) and pass it to `AccountViewModel.loadAccount` as an in-memory override, which `getEtebase` uses if the persisted value comes back null.
- All other `loadAccount` call sites (`CollectionActivity`, `InvitationsActivity`, `AccountActivity`, etc.) are unchanged — they default the new parameter to `null` and keep reading from AccountManager, which has always worked on subsequent launches.

## Why

Issue #17 from the 2026-04-12 triage — the only crash-on-first-login bug. PR-C in the executable plan.

## Test plan

- [ ] Clean install on a test device (or wipe app data), create a new account → app reaches the wizard without crashing.
- [ ] Log out and log in again with an existing account → still works (uses the persisted session via AccountManager).
- [ ] Kill and relaunch the app after first login → `AccountActivity` and friends still resolve the session from AccountManager.