### PR TITLE
Expose only one collection per type in the bridge

### DIFF
--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -139,14 +139,16 @@ def _initial_status_check():
     try:
         with etesync_for_user(user) as (etesync, _):
             etesync.sync()
+            # Dashboard mirrors what the bridge actually exposes — one collection
+            # per type — even if the server has more (multi-collection was dropped).
             collections = {"calendars": 0, "contacts": 0, "tasks": 0}
             for col in etesync.list():
-                if col.col_type == "etebase.vevent":
-                    collections["calendars"] += 1
-                elif col.col_type == "etebase.vcard":
-                    collections["contacts"] += 1
-                elif col.col_type == "etebase.vtodo":
-                    collections["tasks"] += 1
+                if col.col_type == "etebase.vevent" and collections["calendars"] == 0:
+                    collections["calendars"] = 1
+                elif col.col_type == "etebase.vcard" and collections["contacts"] == 0:
+                    collections["contacts"] = 1
+                elif col.col_type == "etebase.vtodo" and collections["tasks"] == 0:
+                    collections["tasks"] = 1
             update_status("connected", collections=collections)
             log_sync_event("info", f"Initial sync complete for {user}")
             logger.info(

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -528,11 +528,19 @@ class Storage(BaseStorage):
             if self.user:
                 yield Collection(self, posixpath.join(path, self.user))
         elif len(attributes) == 1:
+            # Expose at most one collection per type. Multi-collection support was
+            # dropped 2026-04-12 — CalDAV/CardDAV clients see a single calendar,
+            # address book, and task list each.
+            seen_types: set = set()
             for journal in self.etesync.list():
-                if journal.col_type in config.COL_TYPES:
-                    yield Collection(
-                        self, posixpath.join(path, journal.uid)
-                    )
+                if journal.col_type not in config.COL_TYPES:
+                    continue
+                if journal.col_type in seen_types:
+                    continue
+                seen_types.add(journal.col_type)
+                yield Collection(
+                    self, posixpath.join(path, journal.uid)
+                )
         elif len(attributes) == 2:
             for href in collection._list():
                 yield collection._get(href)


### PR DESCRIPTION
## Summary

- Filter Radicale's collection enumeration to the first journal per `col_type` (calendar / address book / tasks), so CalDAV/CardDAV clients see a single collection of each kind.
- Clamp the dashboard counts in `__main__.py` to match what the bridge actually surfaces (max one per type).
- Nothing is deleted on the Etebase side — the bridge still syncs every collection locally, it just stops advertising the extras to desktop clients.

## Why

Issue #15 from the 2026-04-12 triage — multi-collection support was dropped across webapp, bridge, and Android. This is the bridge half (PR-F).

## Test plan

- [ ] User with 2+ calendars on the server: Thunderbird discovery shows exactly one calendar.
- [ ] Same for address books and task lists.
- [ ] Bridge dashboard status card shows "1 calendar / 1 contacts / 1 tasks" (or 0 if none).
- [ ] Existing single-collection users are unaffected.