### PR TITLE
Surface one collection per type in the Android account screen

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -604,23 +604,23 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             }
 
             synchronized(etebaseLocalCache) {
-                return etebaseLocalCache.collectionList(colMgr).map {
-                    val meta = it.meta
-                    val collectionType = it.collectionType
+                // Surface at most one collection per type — multi-collection support was
+                // dropped in the 2026-04-12 triage. The sync adapter still caches every
+                // collection locally so nothing is lost for users with prior extras.
+                return etebaseLocalCache.collectionList(colMgr)
+                    .filter { it.collectionType == strType }
+                    .take(1)
+                    .map {
+                        val meta = it.meta
+                        val accessLevel = it.col.accessLevel
+                        val isReadOnly = accessLevel == CollectionAccessLevel.ReadOnly
+                        val isAdmin = accessLevel == CollectionAccessLevel.Admin
 
-                    if (strType != collectionType) {
-                        return@map null
+                        val metaColor = meta.color
+                        val color = if (!metaColor.isNullOrBlank()) LocalCalendar.parseColor(metaColor) else null
+                        CollectionListItemInfo(it.col.uid, type, meta.name!!, meta.description
+                                ?: "", color, isReadOnly, isAdmin)
                     }
-
-                    val accessLevel = it.col.accessLevel
-                    val isReadOnly = accessLevel == CollectionAccessLevel.ReadOnly
-                    val isAdmin = accessLevel == CollectionAccessLevel.Admin
-
-                    val metaColor = meta.color
-                    val color = if (!metaColor.isNullOrBlank()) LocalCalendar.parseColor(metaColor) else null
-                    CollectionListItemInfo(it.col.uid, type, meta.name!!, meta.description
-                            ?: "", color, isReadOnly, isAdmin)
-                }.filterNotNull()
             }
         }
 


### PR DESCRIPTION
## Summary

- Cap `AccountActivity.getCollections` at one item per type (calendar / address book / tasks). `WizardFragment` already only creates one of each on new accounts, so this only affects users with pre-existing extras.
- Left the sync adapter untouched: `EtebaseLocalCache.collectionSet` still caches every collection locally, so nothing server-side is deleted or orphaned if we ever restore multi-collection.
- Pairs with PR-F (bridge) and the upcoming webapp drop.

## Why

Issue #15 from the 2026-04-12 triage — drop multi-collection UX across all three clients.

## Test plan

- [ ] Account with one of each collection type: UI identical to today.
- [ ] Account with 2+ calendars on the server: Android shows exactly one calendar card, one contacts card, one tasks card.
- [ ] Full sync still completes — local cache stores every collection (no data loss).