### PR TITLE
Webapp polish: onboarding auto-dismiss, calendar padding, light theme, favicon

### DIFF
--- a/apps/web/app/apple-icon.svg
+++ b/apps/web/app/apple-icon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
-  <rect width="180" height="180" rx="32" fill="#1B2838"/>
-  <path d="M90 30C70 44 52 46 40 46v56c0 28 22 48 50 56 28-8 50-28 50-56V46c-12 0-30-2-50-16z" fill="none" stroke="#34d399" stroke-width="8" stroke-linejoin="round"/>
+  <rect width="180" height="180" rx="36" fill="#1B2838"/>
+  <path d="M90 30C70 44 50 47 40 47v55c0 28 22 48 50 56 28-8 50-28 50-56V47c-10 0-30-3-50-17z" fill="none" stroke="#34d399" stroke-width="8"/>
 </svg>

--- a/apps/web/app/components/OnboardingChecklist.tsx
+++ b/apps/web/app/components/OnboardingChecklist.tsx
@@ -13,6 +13,9 @@ import {
   X,
 } from 'lucide-react'
 import { MobileAppDialog } from '@/app/components/MobileAppDialog'
+import { useCalendarStore } from '@/app/stores/use-calendar-store'
+import { useContactStore } from '@/app/stores/use-contact-store'
+import { useTaskStore } from '@/app/stores/use-task-store'
 
 interface ChecklistItem {
   id: string
@@ -28,6 +31,31 @@ export function OnboardingChecklist() {
   const [dismissed, setDismissed] = useState(false)
   const [completedItems, setCompletedItems] = useState<Set<string>>(new Set())
   const [mobileDialogOpen, setMobileDialogOpen] = useState(false)
+
+  const hasEvents = useCalendarStore((s) => s.events.length > 0)
+  const hasContacts = useContactStore((s) => s.contacts.length > 0)
+  const hasTasks = useTaskStore((s) => s.tasks.length > 0)
+
+  // Auto-complete import steps once the corresponding store has data, so the
+  // checklist doesn't linger after a user imports via the normal flow.
+  useEffect(() => {
+    const toAdd: string[] = []
+    if (hasEvents) toAdd.push('import-calendar')
+    if (hasContacts) toAdd.push('import-contacts')
+    if (hasTasks) toAdd.push('import-tasks')
+    if (toAdd.length === 0) return
+    setCompletedItems((prev) => {
+      let changed = false
+      const next = new Set(prev)
+      for (const id of toAdd) {
+        if (!next.has(id)) {
+          next.add(id)
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [hasEvents, hasContacts, hasTasks])
 
   // Load completed items from localStorage
   useEffect(() => {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -8,8 +8,8 @@
   --foreground: 17 27 39;
   --primary: 16 185 129;
   --primary-hover: 5 150 105;
-  --muted: 100 116 139;
-  --border: 226 232 240;
+  --muted: 71 85 105;
+  --border: 200 210 222;
   color-scheme: light;
 }
 
@@ -269,10 +269,10 @@
 }
 
 .sx-silentsuite-calendar .sx__time-grid-event-inner {
-  padding: 4px 8px !important;
+  padding: 2px 8px !important;
   font-size: 0.75rem;
   font-weight: 500;
-  line-height: 1.35;
+  line-height: 1.25;
   border-radius: 6px !important;
   border: none !important;
   border-left: none !important;
@@ -343,11 +343,14 @@
   padding: 1px 6px !important;
   font-size: 0.65rem;
   font-weight: 500;
-  line-height: 1.6;
+  line-height: 1.35;
   margin: 1px 0 !important;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .sx-silentsuite-calendar .sx__month-grid-day.sx__month-grid-day--outside,

--- a/apps/web/app/icon.svg
+++ b/apps/web/app/icon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="6" fill="#1B2838"/>
-  <path d="M16 5C12.5 7.5 9 8 7 8v10c0 5 4 8.5 9 10 5-1.5 9-5 9-10V8c-2 0-5.5-.5-9-3z" fill="none" stroke="#34d399" stroke-width="1.8" stroke-linejoin="round"/>
+  <path d="M16 5C12.5 7.5 9 8 7 8v10c0 5 4 8.5 9 10 5-1.5 9-5 9-10V8c-2 0-5.5-.5-9-3z" fill="none" stroke="#34d399" stroke-width="1.8"/>
 </svg>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,16 +10,9 @@ export const metadata: Metadata = {
   title: 'SilentSuite',
   description: 'End-to-end encrypted productivity suite',
   manifest: '/manifest.json',
-  icons: {
-    icon: [
-      { url: '/favicon.ico', sizes: '32x32' },
-      { url: '/icon-192.png', sizes: '192x192', type: 'image/png' },
-      { url: '/icon-512.png', sizes: '512x512', type: 'image/png' },
-    ],
-    apple: [
-      { url: '/apple-touch-icon.png', sizes: '180x180', type: 'image/png' },
-    ],
-  },
+  // Next picks up app/icon.svg and app/apple-icon.svg automatically, which now
+  // match the landing page shield. The PNGs in public/ are kept for the PWA
+  // manifest but no longer advertised in <head>.
   appleWebApp: {
     capable: true,
     statusBarStyle: 'black-translucent',


### PR DESCRIPTION
## Summary

Four fixes from issues #7, #8, #9, #12 of the 2026-04-12 triage, bundled as PR-H.

- **#7 onboarding**: auto-mark the import steps complete once `useCalendarStore`, `useContactStore`, or `useTaskStore` have anything in them. Users who imported via the normal flow were stuck with the checklist sitting there forever.
- **#8 padding**: drop time-grid event `padding-top` from 4px → 2px and `line-height` from 1.35 → 1.25 so the time no longer clips. Month-grid events switch from ellipsed `white-space: nowrap` to a 2-line clamp.
- **#9 light theme**: darken `--border` (226 → 200) and `--muted` (100 → 71) so gridlines and secondary text are visible on white.
- **#12 favicon**: overwrite `app/icon.svg` and `app/apple-icon.svg` with the landing page versions (the two files were 99% identical — now byte-identical). Remove the hardcoded `icons:` metadata in `layout.tsx` so Next's app-router convention picks up the SVGs automatically.

## Why

Minor UX debt from testing — individually tiny, collectively annoying. None of them warrant a standalone PR.

## Test plan

- [ ] Fresh account: checklist shows. After an import, the matching row auto-ticks; once all four are done, checklist disappears.
- [ ] Week view with short events (~15 min): time text renders without clipping.
- [ ] Month view with long titles: event wraps to 2 lines instead of ellipsing.
- [ ] Light theme: gridlines and "muted" labels are readable.
- [ ] Favicon in browser tab and iOS "add to homescreen" matches the landing page shield.

## Not in scope

- PWA manifest PNGs (`public/icon-192.png`, `icon-512.png`, `apple-touch-icon.png`) still render from the old design. They need a separate regen pass since this machine has no image-generation toolchain installed.