### PR TITLE
Bridge: fix stale post-login message and Linux autostart survival

### DIFF
--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -397,8 +397,7 @@ SUCCESS_PAGE_HTML = """<!DOCTYPE html>
                 &#11088; Bookmark <a href="DASHBOARD_URL">DASHBOARD_URL</a> to find these details later
             </div>
             <div class="next-step">
-                <strong>Next step:</strong> You can close this tab. Start the bridge with <code>./silentsuite-bridge</code> to begin syncing.<br>
-                The dashboard will be at <code>DASHBOARD_URL</code>
+                You're signed in. You can close this tab &mdash; the bridge is already running in the background and will keep syncing on its own.
             </div>
         </div>
 

--- a/bridge/src/silentsuite_bridge/autostart.py
+++ b/bridge/src/silentsuite_bridge/autostart.py
@@ -102,6 +102,28 @@ def install_autostart_linux():
     print("Service enabled and started.")
     print("Check status: systemctl --user status silentsuite-bridge")
 
+    # systemd user units don't survive reboot unless the user has lingering enabled.
+    # Try it non-interactively with sudo -n; if that needs a password we just tell
+    # the user how to run it themselves. This is best-effort — the service still
+    # works for the current session either way.
+    linger_check = subprocess.run(
+        ["loginctl", "show-user", os.environ.get("USER", ""), "--property=Linger"],
+        check=False, capture_output=True,
+    )
+    if b"Linger=yes" in linger_check.stdout:
+        return
+    user = os.environ.get("USER", "")
+    r = subprocess.run(
+        ["sudo", "-n", "loginctl", "enable-linger", user],
+        check=False, capture_output=True,
+    )
+    if r.returncode == 0:
+        print(f"Enabled linger for {user} so the bridge survives logout/reboot.")
+    else:
+        print("")
+        print("Note: to keep the bridge running after logout/reboot, run:")
+        print(f"  sudo loginctl enable-linger {user}")
+
 
 def remove_autostart_linux():
     """Remove systemd user service."""


### PR DESCRIPTION
## Summary

Two bridge fixes from issues #13 and #14 of the 2026-04-12 triage.

- **#13** — the OAuth success page told users to \"start the bridge with \`./silentsuite-bridge\`\" even though the installer had already started it. Replaced the outdated block in \`auth_browser.py\` with a plain \"you can close this tab\" message.
- **#14** — systemd user units don't survive logout/reboot unless the user has lingering enabled, which explains why the bridge died after Timo rebooted despite the autostart code being present. \`install_autostart_linux\` now checks \`loginctl show-user --property=Linger\`, attempts \`sudo -n loginctl enable-linger $USER\` non-interactively, and falls back to printing a one-liner the user can run manually. macOS launchd and Windows HKCU Run don't have this problem, so no changes there.

## Why

\`bridge/src/silentsuite_bridge/autostart.py\` already implements all three platforms. The install script already calls \`--install-autostart\`. So the code was correct — the only missing piece on Linux was the linger bit.

## Test plan

- [ ] Fresh install on Ubuntu: bridge survives logout + login.
- [ ] Fresh install as root or with passwordless sudo: linger is enabled automatically.
- [ ] Fresh install without sudo access: installer prints the \`sudo loginctl enable-linger\` line.
- [ ] Post-login success page renders the new message without the \"Next step\" block.
- [ ] macOS + Windows unchanged.