### PR TITLE
Android: auto-sync on open and drop dead overflow menu

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -211,9 +211,22 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             model.observe(this) {
                 updateUi(it)
             }
+
+            // Kick off a sync automatically on first open so users don't have to
+            // hit the toolbar button — the existing progress bars surface it.
+            io.silentsuite.sync.syncadapter.requestSync(applicationContext, account)
         }
 
         PermissionsActivity.requestAllPermissions(this)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // Refresh on foreground so returning to the app gives a fresh state.
+        // Guarded because onCreate has early-exit paths that skip account init.
+        if (::account.isInitialized) {
+            io.silentsuite.sync.syncadapter.requestSync(applicationContext, account)
+        }
     }
 
     private fun setupNavHeader(navigationView: NavigationView) {
@@ -321,13 +334,6 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             R.id.settings -> {
                 startActivity(Intent(this, AppSettingsActivity::class.java))
             }
-            R.id.delete_account -> AlertDialog.Builder(this@AccountActivity)
-                    .setIcon(R.drawable.ic_error_dark)
-                    .setTitle(R.string.account_delete_confirmation_title)
-                    .setMessage(R.string.account_delete_confirmation_text)
-                    .setNegativeButton(android.R.string.no, null)
-                    .setPositiveButton(android.R.string.yes) { _, _ -> deleteAccount() }
-                    .show()
             R.id.show_fingerprint -> {
                 val view = layoutInflater.inflate(R.layout.fingerprint_alertdialog, null)
                 view.findViewById<View>(R.id.body).visibility = View.GONE
@@ -717,46 +723,6 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
     }
 
     /* USER ACTIONS */
-
-    private fun deleteAccount() {
-        val accountManager = AccountManager.get(this)
-        val settings = AccountSettings(this@AccountActivity, account)
-
-        lifecycleScope.launch {
-            withContext(Dispatchers.IO) {
-                EtebaseLocalCache.clearUserCache(this@AccountActivity, account.name)
-
-                try {
-                    val httpClient = HttpClient.Builder(this@AccountActivity).build()
-                    val etebase = EtebaseLocalCache.getEtebase(this@AccountActivity, httpClient.okHttpClient, settings)
-                    etebase.logout()
-                } catch(e: EtebaseException) {
-                    // Ignore failures for now
-                    Logger.log.warning(e.toString())
-                }
-            }
-        }
-
-        if (Build.VERSION.SDK_INT >= 22)
-            accountManager.removeAccount(account, this, { future ->
-                try {
-                    if (future.result.getBoolean(AccountManager.KEY_BOOLEAN_RESULT))
-                        finish()
-                } catch(e: Exception) {
-                    Logger.log.log(Level.SEVERE, "Couldn't remove account", e)
-                }
-            }, null)
-        else
-            accountManager.removeAccount(account, { future ->
-                try {
-                    if (future.result)
-                        finish()
-                } catch (e: Exception) {
-                    Logger.log.log(Level.SEVERE, "Couldn't remove account", e)
-                }
-            }, null)
-    }
-
 
     private fun requestSync() {
         requestSync(applicationContext, account)

--- a/android/app/src/main/res/menu/activity_account.xml
+++ b/android/app/src/main/res/menu/activity_account.xml
@@ -26,11 +26,8 @@
         app:showAsAction="ifRoom"/>
 
     <item android:id="@+id/invitations"
+        android:icon="@drawable/ic_people_light"
         android:title="@string/invitations_title"
-        app:showAsAction="never"/>
-
-    <item android:id="@+id/delete_account"
-          android:title="@string/account_delete"
-          app:showAsAction="never"/>
+        app:showAsAction="ifRoom"/>
 
 </menu>


### PR DESCRIPTION
## Summary

Addresses issues #18 (auto-start sync) and #19 (blank overflow menu) from the 2026-04-12 triage.

- `AccountActivity.onCreate` now calls `requestSync(applicationContext, account)` on the first entry (when `savedInstanceState == null`), and `onResume` refires it when the app returns to the foreground. The existing per-collection progress bars surface the activity, so no new UI.
- `onResume` is guarded by `::account.isInitialized` because `onCreate` has early-exit paths that skip account init.
- Overflow menu had two entries: \"Invitations\" (`showAsAction=\"never\"`) and \"Delete account\" (also `never`, duplicated by the drawer's logout flow). Promoted Invitations to `ifRoom` with the existing `ic_people_light` icon so it becomes a toolbar action. Removed the delete entry and the now-orphaned `deleteAccount()` helper.

## Why

The app felt stale until the user manually hit sync, and the overflow menu looked like a placeholder — dropping it makes the toolbar feel deliberate.

## Test plan

- [ ] Cold open the app → events/contacts start arriving without hitting sync.
- [ ] Background the app, return → sync fires again.
- [ ] Toolbar shows sync / settings / fingerprint / invitations (overflow absorbs whichever don't fit).
- [ ] Tapping \"Invitations\" still opens `InvitationsActivity`.
- [ ] Drawer logout still works (that path wasn't touched).