### PR TITLE
Bridge: live sync progress on the dashboard

### DIFF
--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -56,6 +56,11 @@ class SyncThread(threading.Thread):
         self.last_sync = None
         self._exception = None
         self.interval = config.SYNC_INTERVAL
+        # Progress tracking — etebase-py doesn't expose per-item hooks, so we
+        # can only report "a sync is in flight" plus the last sync's duration.
+        self.is_syncing = False
+        self.sync_started_at = None
+        self.last_sync_duration = None
 
     def force_sync(self):
         self._force_sync.set()
@@ -89,7 +94,11 @@ class SyncThread(threading.Thread):
                 with etesync_for_user(self.user) as (etesync, _):
                     self.last_sync = time.time()
                     self._done_syncing.clear()
+                    self.is_syncing = True
+                    self.sync_started_at = self.last_sync
                     etesync.sync()
+                    self.last_sync_duration = time.time() - self.sync_started_at
+                    self.is_syncing = False
                     logger.debug("Sync completed for user %s", self.user)
 
                     # Update dashboard status with collection counts
@@ -112,6 +121,7 @@ class SyncThread(threading.Thread):
                 update_status("error", error=str(e))
                 log_sync_event("error", f"Sync failed: {e}")
             finally:
+                self.is_syncing = False
                 was_re_requested = self._force_sync.is_set()
                 self._force_sync.clear()
                 self._done_syncing.set()

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -243,6 +243,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
                 <option value="3600">1 hr</option>
             </select>
             <span id="syncIntervalStatus" style="font-size:12px;color:#555;"></span>
+            <span id="syncProgress" style="font-size:12px;color:#888;margin-left:auto;"></span>
         </div>
         <script>
             (function() {
@@ -269,6 +270,26 @@ DASHBOARD_HTML = """<!DOCTYPE html>
                     .then(function() { st.textContent = 'Saved'; setTimeout(function() { st.textContent = ''; }, 2000); })
                     .catch(function() { st.textContent = 'Error'; });
             }
+            // Live sync-status pill. Polls /api/progress every 2s so users see
+            // a running sync without waiting for the 30s full-page refresh.
+            function pollProgress() {
+                fetch('/.web/api/progress').then(function(r) { return r.json(); }).then(function(p) {
+                    var el = document.getElementById('syncProgress');
+                    if (!el) return;
+                    if (p.is_syncing) {
+                        var elapsed = p.sync_started_at ? Math.max(0, Math.round(Date.now() / 1000 - p.sync_started_at)) : null;
+                        el.textContent = 'Syncing\u2026' + (elapsed != null ? ' (' + elapsed + 's)' : '');
+                        el.style.color = '#4ade80';
+                    } else if (p.last_sync_duration != null) {
+                        el.textContent = 'Last sync: ' + p.last_sync_duration.toFixed(1) + 's';
+                        el.style.color = '#888';
+                    } else {
+                        el.textContent = '';
+                    }
+                }).catch(function() { /* ignore — next poll retries */ });
+            }
+            pollProgress();
+            setInterval(pollProgress, 2000);
         </script>
 
         <div class="status-card log-section">
@@ -420,6 +441,30 @@ class Web(BaseWeb):
             data = {
                 "status": _bridge_status,
                 "log": list(_sync_log)[:20],
+            }
+            return (
+                200,
+                {"Content-Type": "application/json"},
+                json.dumps(data).encode(),
+            )
+
+        # Live sync progress — polled by the dashboard while a sync is running.
+        if path == "/.web/api/progress":
+            from ..radicale.storage import _sync_threads
+            is_syncing = False
+            sync_started_at = None
+            last_sync_duration = None
+            for thread in _sync_threads.values():
+                if getattr(thread, "is_syncing", False):
+                    is_syncing = True
+                    sync_started_at = getattr(thread, "sync_started_at", None)
+                if getattr(thread, "last_sync_duration", None) is not None:
+                    last_sync_duration = thread.last_sync_duration
+            data = {
+                "is_syncing": is_syncing,
+                "sync_started_at": sync_started_at,
+                "last_sync_duration": last_sync_duration,
+                "collections": _bridge_status.get("collections", {}),
             }
             return (
                 200,


### PR DESCRIPTION
## Summary

Addresses issue #16 from the 2026-04-12 triage — sync progress wasn't visible.

- `SyncThread` now tracks `is_syncing`, `sync_started_at`, and `last_sync_duration` across the etebase sync call and the exception path.
- New `/.web/api/progress` endpoint aggregates all running threads into a small JSON payload.
- Dashboard polls `/progress` every 2 seconds and shows a green \"Syncing\u2026 (Ns)\" pill while a sync is in flight, or \"Last sync: N.Ns\" when idle. The existing 30s meta-refresh handles everything else.

## Why not per-item counters?

etebase-py's `etesync.sync()` is atomic and doesn't expose per-item hooks, so \"X / Y synced\" would require patching the library or re-running the list after sync (expensive). The in-flight pill + last-sync duration is the honest version we can ship today.

## Test plan

- [ ] Open the dashboard, click \"Sync Now\": pill turns green and counts up.
- [ ] After sync: pill shows \"Last sync: N.Ns\".
- [ ] If the bridge throws during sync: pill clears (no stuck \"Syncing\u2026\").
- [ ] `/.web/api/progress` returns `{is_syncing, sync_started_at, last_sync_duration, collections}`.