### PR TITLE
fix(web): use real argon2-webworker for signup key derivation

### DIFF
--- a/apps/web/app/lib/argon2-shim.js
+++ b/apps/web/app/lib/argon2-shim.js
@@ -1,4 +1,0 @@
-module.exports.ArgonType = { Argon2id: 2, Argon2d: 0, Argon2i: 1 }
-module.exports.hash = function() {
-  return Promise.reject(new Error('argon2-webworker disabled'))
-}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -30,7 +30,6 @@ const nextConfig = {
     config.resolve.alias = {
       ...config.resolve.alias,
       etebase: resolveEtebase(),
-      'argon2-webworker': path.resolve(__dirname, 'app/lib/argon2-shim.js'),
     }
     return config
   },


### PR DESCRIPTION
## Summary

Removes a shim that always rejected `argon2-webworker.hash`, which forced Etebase's `deriveKey` to fall back to running `sodium.crypto_pwhash` on the main thread during every signup and login. The fallback froze the UI for ~2 seconds and logged a confusing `Failed loading web worker! Error: argon2-webworker disabled` warning.

The real worker now does the same Argon2id work off-thread, so the spinner animates and the page stays interactive while the key is derived.

## Changes

- `apps/web/next.config.js` — drop the webpack alias that pointed `argon2-webworker` at the shim
- `apps/web/app/lib/argon2-shim.js` — delete the shim

## How I verified (dev server, fresh Chromium profile, timed by measuring the gap between submit click and Etebase's first `/authentication/...` request)

| Run | Before fix (shim → main-thread `sodium.crypto_pwhash`) | After fix (real `argon2-webworker`) |
|----:|:-----|:-----|
| 1 | 2113 ms | 2248 ms |
| 2 | 2038 ms | 2298 ms |
| 3 | 2177 ms | 2278 ms |
| **median** | **2113 ms** | **2278 ms** |
| Console warning | `Failed loading web worker! Error: argon2-webworker disabled` | none |

Wall-clock cost is essentially the same — both paths run an Argon2id with `OPSLIMIT_SENSITIVE` + `MEMLIMIT_MODERATE`, which is CPU-bound. The worker adds ~150 ms of spawn/post overhead but moves the work off the main thread, which is the actual UX win: no UI freeze and no confusing warning.

Production build, type check, and the existing 90-test webapp suite all pass.

## CSP `connect-src` warning (`data:application/octet-stream;base64,…`) — investigated, no code change

Could not reproduce on the dev server. Searched the entire repo for `Content-Security-Policy` / `connect-src` / `worker-src`: the webapp does not set a CSP anywhere (no `next.config.js` `headers()`, no middleware, no `<meta http-equiv>`, no nginx config in this repo). A probe load of `/signup` confirmed: `CSP header on /signup response: (none)`, `data: URI responses observed: 0`, `CSP-related console messages: 0`.

Where the user-reported CSP comes from must therefore be the prod nginx in front of `app.silentsuite.io`, which is configured outside this repo. The reported value (`'self' https: http://localhost:*`) looks like a leftover dev-permissive policy.

If/when prod CSP is tightened on the webapp, libsodium-wrappers 0.7.6 needs `connect-src` to allow `data:` (it loads its WASM via a `data:application/octet-stream;base64,...` URI, and silently falls back to a much slower asm.js build via `useBackupModule()` if the fetch is blocked). `argon2-webworker` similarly needs `worker-src 'self' blob: data:` since it spawns its worker from a `data:application/javascript,...` URI. None of that is enforceable from this repo today; flagging it here so it's recorded somewhere when the prod CSP eventually gets touched.

## Test plan

- [x] Dev server: signup form derives key without the worker warning
- [x] Dev server: signup form remains interactive (spinner animates) during derivation
- [x] `pnpm --filter @silentsuite/web build` succeeds
- [x] `pnpm --filter @silentsuite/web type-check` succeeds
- [x] `pnpm --filter @silentsuite/web test` (90 tests) passes
- [ ] Live signup against staging/dev billing API (Paul to verify)
- [ ] Login flow uses the same `deriveKey` path — verify it also no longer warns