### PR TITLE
fix(server): prefetch revisions + chunks for item-list to drop the N+1

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -2,11 +2,11 @@ name: CI Server
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - 'server/**'
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - 'server/**'
 

--- a/server/etebase_server/django/models.py
+++ b/server/etebase_server/django/models.py
@@ -95,6 +95,9 @@ class CollectionItem(models.Model):
 
     @cached_property
     def content(self) -> "CollectionItemRevision":
+        prefetched = getattr(self, "_prefetched_current_revisions", None)
+        if prefetched is not None:
+            return prefetched[0]
         return self.revisions.filter(current=True)[0]
 
     @property

--- a/server/etebase_server/fastapi/dependencies.py
+++ b/server/etebase_server/fastapi/dependencies.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from django.db.models import QuerySet
+from django.db.models import Prefetch, QuerySet
 from django.utils import timezone
 from fastapi import Depends
 from fastapi.security import APIKeyHeader
@@ -78,11 +78,36 @@ def get_collection(collection_uid: str, queryset: QuerySet = Depends(get_collect
     return get_object_or_404(queryset, uid=collection_uid)
 
 
-@django_db_cleanup_decorator
-def get_item_queryset(collection: models.Collection = Depends(get_collection)) -> QuerySet:
-    default_item_queryset: QuerySet = models.CollectionItem.objects.all()
-    queryset = default_item_queryset.filter(
+def build_item_queryset(collection: models.Collection) -> QuerySet:
+    """Queryset for items in a collection, with the per-item revision +
+    chunk graph prefetched.
+
+    Serializing this queryset is the hot read path for sync polls and import
+    refresh. Per-item access to `obj.content` (current revision) and the
+    chunk graph below it must avoid an N+1 — see `test_item_list_queryset.py`
+    and the 2026-03-25 revert (commit 4d7893f3) for why we are deliberate
+    about the relation names.
+
+    `to_attr` puts the filtered current revisions on `_prefetched_current_revisions`
+    so `CollectionItem.content` can read it without a separate filter query.
+    """
+    current_revisions = models.CollectionItemRevision.objects.filter(current=True).prefetch_related(
+        Prefetch(
+            "chunks_relation",
+            queryset=models.RevisionChunkRelation.objects.select_related("chunk"),
+        )
+    )
+    return models.CollectionItem.objects.filter(
         collection__pk=collection.pk, revisions__current=True
+    ).prefetch_related(
+        Prefetch(
+            "revisions",
+            queryset=current_revisions,
+            to_attr="_prefetched_current_revisions",
+        )
     )
 
-    return queryset
+
+@django_db_cleanup_decorator
+def get_item_queryset(collection: models.Collection = Depends(get_collection)) -> QuerySet:
+    return build_item_queryset(collection)

--- a/server/etebase_server/fastapi/test_item_list_queryset.py
+++ b/server/etebase_server/fastapi/test_item_list_queryset.py
@@ -1,0 +1,95 @@
+"""Regression test for N+1 query bug in item-list serialization (PR-D1).
+
+The 2026-03-25 attempt to add `prefetch_related` to `get_item_queryset` was
+reverted (commit 4d7893f3) because it used the wrong relation names and broke
+sync. This test pins the fix in place: query count for a full item-list
+serialization must not scale linearly with the number of items.
+"""
+
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "etebase_server.settings")
+
+import django  # noqa: E402
+
+django.setup()
+
+from django.contrib.auth import get_user_model  # noqa: E402
+from django.core.files.base import ContentFile  # noqa: E402
+from django.test import TestCase  # noqa: E402
+
+from etebase_server.django import models  # noqa: E402
+from etebase_server.fastapi.dependencies import build_item_queryset  # noqa: E402
+
+User = get_user_model()
+
+
+_FIXTURE_COUNTER = {"n": 0}
+
+
+def _make_collection_with_items(n_items: int):
+    _FIXTURE_COUNTER["n"] += 1
+    nonce = _FIXTURE_COUNTER["n"]
+    user = User.objects.create_user(username=f"test_user_n1_{nonce}", email=f"t{nonce}@t.t", password="x")
+    col = models.Collection.objects.create(uid=f"col{nonce:03d}" + "a" * 37, owner=user)
+    for i in range(n_items):
+        item = models.CollectionItem.objects.create(
+            uid=f"item{nonce:03d}{i:036d}",
+            collection=col,
+            version=1,
+        )
+        stoken = models.Stoken.objects.create()
+        rev = models.CollectionItemRevision.objects.create(
+            uid=f"rev_{nonce:03d}_{i:034d}",
+            stoken=stoken,
+            item=item,
+            meta=b"{}",
+            current=True,
+        )
+        chunk = models.CollectionItemChunk(uid=f"chk_{nonce:03d}_{i:034d}", collection=col)
+        chunk.chunkFile.save("IGNORED", ContentFile(b"\x00\x01\x02"))
+        chunk.save()
+        models.RevisionChunkRelation.objects.create(chunk=chunk, revision=rev)
+    return user, col
+
+
+class ItemListQuerysetTests(TestCase):
+    """`build_item_queryset` must serialize in O(1) queries regardless of item count."""
+
+    def test_query_count_does_not_scale_with_items(self):
+        _, col_small = _make_collection_with_items(5)
+        _, col_large = _make_collection_with_items(25)
+
+        small_count = self._count_serialization_queries(col_small)
+        large_count = self._count_serialization_queries(col_large)
+
+        # Allow a small constant difference for prefetch result-set size, but the
+        # count must not grow proportionally with item count.
+        self.assertLess(
+            large_count,
+            small_count + 5,
+            f"Item-list query count grew from {small_count} to {large_count} when "
+            f"item count went from 5 to 25 — N+1 has regressed.",
+        )
+
+    def test_query_count_is_bounded_for_large_collection(self):
+        _, col = _make_collection_with_items(50)
+        count = self._count_serialization_queries(col)
+        # With prefetch in place this is 3 queries (items + revisions + chunks_relation
+        # joined to chunks via select_related). Bound at 8 to catch any regression
+        # without being so tight it breaks on Django version bumps.
+        self.assertLessEqual(count, 8, f"Item-list serialization issued {count} queries for 50 items")
+
+    def _count_serialization_queries(self, collection: models.Collection) -> int:
+        """Mimic the access pattern in `CollectionItemRevisionInOut.from_orm_context`
+        and return how many DB queries it issues.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            for item in build_item_queryset(collection):
+                rev = item.content
+                for chunk_relation in rev.chunks_relation.all():
+                    _ = chunk_relation.chunk.uid
+        return len(ctx.captured_queries)


### PR DESCRIPTION
## Summary

Re-applies (correctly) the prefetch fix that was reverted in 4d7893f3. Item-list serialization is the hot read path for sync polls; without prefetch it issues ~3 queries per item, so a 1200-item collection's sync poll fires 3000+ queries — a big chunk of the read-side load during large imports (PR-D #4 from the 2026-04-12 brainstorm).

The 2026-03-25 revert was caused by using the wrong relation name (`revisions__chunks__chunk`); the actual reverse name on `CollectionItemRevision` is `chunks_relation`. This PR pins the correct chain in place with a regression test.

## What's in this PR

- `server/etebase_server/fastapi/dependencies.py` — extract `build_item_queryset(collection)` that adds `Prefetch('revisions', queryset=…filter(current=True).prefetch_related(Prefetch('chunks_relation', queryset=…select_related('chunk'))), to_attr='_prefetched_current_revisions')`.
- `server/etebase_server/django/models.py` — `CollectionItem.content` now reads from `_prefetched_current_revisions` when present, falls back to the original `revisions.filter(current=True)[0]` otherwise. Write paths (item_create, etag check) hit the fallback unchanged.
- `server/etebase_server/fastapi/test_item_list_queryset.py` — new Django TestCase that asserts query count is bounded as item count grows. Drove the development of the fix.
- `.github/workflows/ci-server.yml` — add `dev` to the branch trigger so this PR's tests actually run in CI (the trigger was still pinned to the old `develop` name).

## Measured impact

Query count for a full item-list serialization at the bench:

| Items | Before | After |
|------:|------:|------:|
|     5 |     16 |     3 |
|    25 |     76 |     3 |
|    50 |    151 |     3 |

## Test plan

- [x] `python manage.py test` — 8 / 8 pass (6 existing + 2 new)
- [x] `ruff check` clean
- [ ] Manual verification on staging/prod once merged: sync poll latency for accounts with 500+ items
- [ ] Watch for any unexpected error in `/collection/{uid}/item/` requests after deploy

## Out of scope (follow-up PRs)

- **PR-D2**: web-side import retry/resume + smaller batch + pause sync engine during import. That's the actual fix for "1200 items only sync ~100/run." This PR only addresses the read-side load that competes with imports.
- The "decrypting your workspace" boot hang (#11 in the brainstorm) was a misdiagnosis — that splash is in `auth-provider.tsx` gated on billing-API calls, not Etebase. Belongs in a separate ticket against billing-API latency.