### PR TITLE
fix(web): import resilience — pause sync, retry batches, partial recovery

### DIFF
--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useEtebaseStore } from '../use-etebase-store'
+
+// Stub the offline queue so isOfflineError + enqueue don't try to open IndexedDB.
+vi.mock('@/app/lib/offline-queue', () => ({
+  enqueue: vi.fn(async () => {}),
+  isOfflineError: () => false,
+}))
+
+vi.mock('@/app/lib/secure-storage', () => ({
+  secureGet: vi.fn(async () => null),
+  secureSet: vi.fn(async () => {}),
+  secureRemove: vi.fn(async () => {}),
+  secureClear: vi.fn(async () => {}),
+  migrateFromLocalStorage: vi.fn(async () => {}),
+}))
+
+vi.mock('@/app/stores/use-toast-store', () => ({
+  showErrorToast: vi.fn(),
+}))
+
+interface MockItemManager {
+  create: ReturnType<typeof vi.fn>
+  batch: ReturnType<typeof vi.fn>
+}
+
+interface MockSyncEngine {
+  pause: ReturnType<typeof vi.fn>
+  resume: ReturnType<typeof vi.fn>
+}
+
+function setupStoreWithMocks(itemManager: MockItemManager, syncEngine: MockSyncEngine) {
+  const collection = { uid: 'col-1' }
+  const account = {
+    getCollectionManager: () => ({
+      getItemManager: () => itemManager,
+    }),
+  }
+  useEtebaseStore.setState({
+    account: account as any,
+    collections: { calendar: collection as any, tasks: null, contacts: null },
+    itemCache: new Map(),
+    itemTypeMap: new Map(),
+    isInitialized: true,
+    syncEngine: syncEngine as any,
+  })
+}
+
+describe('useEtebaseStore.createItemsBatch', () => {
+  beforeEach(() => {
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: null, tasks: null, contacts: null },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('uploads items in batches of 20 (not 50)', async () => {
+    let nextUid = 0
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: `item-${nextUid++}` })),
+      batch: vi.fn(async () => {}),
+    }
+    const syncEngine: MockSyncEngine = { pause: vi.fn(), resume: vi.fn() }
+    setupStoreWithMocks(itemManager, syncEngine)
+
+    const contents = Array.from({ length: 50 }, (_, i) => ({
+      content: `c${i}`,
+      tempId: `t${i}`,
+    }))
+    const uids = await useEtebaseStore.getState().createItemsBatch('calendar', contents)
+
+    // 50 items / 20-per-batch = 3 batches (20, 20, 10)
+    expect(itemManager.batch).toHaveBeenCalledTimes(3)
+    expect(itemManager.batch.mock.calls[0]![0]).toHaveLength(20)
+    expect(itemManager.batch.mock.calls[1]![0]).toHaveLength(20)
+    expect(itemManager.batch.mock.calls[2]![0]).toHaveLength(10)
+    expect(uids.filter((u) => u !== null)).toHaveLength(50)
+  })
+
+  it('pauses the sync engine for the duration of the import', async () => {
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: 'x' })),
+      batch: vi.fn(async () => {}),
+    }
+    const syncEngine: MockSyncEngine = { pause: vi.fn(), resume: vi.fn() }
+    setupStoreWithMocks(itemManager, syncEngine)
+
+    await useEtebaseStore.getState().createItemsBatch('calendar', [
+      { content: 'a', tempId: 't1' },
+    ])
+
+    expect(syncEngine.pause).toHaveBeenCalledTimes(1)
+    expect(syncEngine.resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('resumes the sync engine even when the import throws', async () => {
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => {
+        throw new Error('crypto blew up')
+      }),
+      batch: vi.fn(),
+    }
+    const syncEngine: MockSyncEngine = { pause: vi.fn(), resume: vi.fn() }
+    setupStoreWithMocks(itemManager, syncEngine)
+
+    await useEtebaseStore.getState().createItemsBatch('calendar', [
+      { content: 'a', tempId: 't1' },
+    ])
+
+    expect(syncEngine.pause).toHaveBeenCalledTimes(1)
+    expect(syncEngine.resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a transient batch failure with backoff and recovers', async () => {
+    let nextUid = 0
+    let batchCallCount = 0
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: `item-${nextUid++}` })),
+      batch: vi.fn(async () => {
+        batchCallCount++
+        if (batchCallCount === 1) throw new Error('500 server error')
+      }),
+    }
+    const syncEngine: MockSyncEngine = { pause: vi.fn(), resume: vi.fn() }
+    setupStoreWithMocks(itemManager, syncEngine)
+
+    vi.useFakeTimers()
+    const promise = useEtebaseStore
+      .getState()
+      .createItemsBatch(
+        'calendar',
+        Array.from({ length: 5 }, (_, i) => ({ content: `c${i}`, tempId: `t${i}` })),
+      )
+    // Drain the retry backoff timers (1s) plus the local-crypto + post awaits.
+    await vi.runAllTimersAsync()
+    const uids = await promise
+    vi.useRealTimers()
+
+    expect(itemManager.batch).toHaveBeenCalledTimes(2)
+    expect(uids.filter((u) => u !== null)).toHaveLength(5)
+  })
+
+  it('returns partial uids and stops when retries are exhausted', async () => {
+    let nextUid = 0
+    let batchCallCount = 0
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: `item-${nextUid++}` })),
+      batch: vi.fn(async () => {
+        batchCallCount++
+        // First batch (items 0-19) succeeds; second batch fails permanently.
+        if (batchCallCount === 1) return
+        throw new Error('500 server error')
+      }),
+    }
+    const syncEngine: MockSyncEngine = { pause: vi.fn(), resume: vi.fn() }
+    setupStoreWithMocks(itemManager, syncEngine)
+
+    vi.useFakeTimers()
+    const promise = useEtebaseStore.getState().createItemsBatch(
+      'calendar',
+      Array.from({ length: 30 }, (_, i) => ({ content: `c${i}`, tempId: `t${i}` })),
+    )
+    await vi.runAllTimersAsync()
+    const uids = await promise
+    vi.useRealTimers()
+
+    // First batch (20) succeeded; second batch retried 3 times then gave up.
+    expect(itemManager.batch).toHaveBeenCalledTimes(1 + 3)
+    expect(uids.slice(0, 20).every((u) => typeof u === 'string')).toBe(true)
+    expect(uids.slice(20).every((u) => u === null)).toBe(true)
+  })
+})

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -288,35 +288,100 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       return contents.map(() => null)
     }
 
+    // Pause the sync engine for the duration of the import. The local-crypto
+    // phase below blocks the main thread; without this, a 30s poll firing
+    // mid-import would also decrypt freshly-imported items on the same thread,
+    // freezing the UI long enough for the user to refresh and abort the import.
+    const { syncEngine } = get()
+    syncEngine?.pause()
+
     try {
       const core = await import('@silentsuite/core')
       const collectionManager = account.getCollectionManager()
       const itemManager = collectionManager.getItemManager(collection)
 
-      // Create all item objects locally
+      // Create all item objects locally. Yield to the event loop every
+      // YIELD_EVERY items so the UI stays responsive during 1000+ item imports.
+      const YIELD_EVERY = 25
       const items: any[] = []
-      for (const { content } of contents) {
-        const item = await itemManager.create({}, content)
+      for (let i = 0; i < contents.length; i++) {
+        const item = await itemManager.create({}, contents[i]!.content)
         items.push(item)
+        if (i > 0 && i % YIELD_EVERY === 0) {
+          await new Promise((r) => setTimeout(r, 0))
+        }
       }
 
-      // Upload in batches of 50 to avoid oversized requests
-      const BATCH_SIZE = 50
+      // Smaller batches finish each request faster, so a single slow batch is
+      // less likely to cross a Cloudflare/proxy gateway timeout. Combined with
+      // retry-with-backoff, this turns a transient batch failure from
+      // "import aborted, ~100 items stuck" into "1-3s pause, then resume".
+      const BATCH_SIZE = 20
+      const MAX_BATCH_RETRIES = 3
+      let lastSuccessfulItemIndex = -1
+      let permanentFailure: unknown = null
+
       for (let i = 0; i < items.length; i += BATCH_SIZE) {
         const batch = items.slice(i, i + BATCH_SIZE)
-        await itemManager.batch(batch)
+        let attempt = 0
+        let succeeded = false
+
+        while (attempt < MAX_BATCH_RETRIES) {
+          try {
+            await itemManager.batch(batch)
+            succeeded = true
+            lastSuccessfulItemIndex = i + batch.length - 1
+            break
+          } catch (err) {
+            // Offline errors are handled by the outer catch + offline queue —
+            // bubble out instead of retrying on a known-down network.
+            if (isOfflineError(err)) throw err
+            attempt++
+            if (attempt >= MAX_BATCH_RETRIES) {
+              permanentFailure = err
+              break
+            }
+            const backoffMs = 1000 * 2 ** (attempt - 1) // 1s, 2s, 4s
+            logger.warn(
+              `[etebase-store] Batch ${i / BATCH_SIZE + 1} failed (attempt ${attempt}/${MAX_BATCH_RETRIES}), retrying in ${backoffMs}ms:`,
+              err,
+            )
+            await new Promise((r) => setTimeout(r, backoffMs))
+          }
+        }
+
+        if (!succeeded) break
       }
 
-      // Update cache with all items at once
+      // Update cache with whatever made it to the server. Items past
+      // lastSuccessfulItemIndex never got an ack, so we can't claim them.
       const itemCache = new Map(get().itemCache)
       const itemTypeMap = new Map(get().itemTypeMap)
       const uids: (string | null)[] = []
-      for (const item of items) {
-        itemCache.set(item.uid, item)
-        itemTypeMap.set(item.uid, type)
-        uids.push(item.uid)
+      for (let i = 0; i < items.length; i++) {
+        if (i <= lastSuccessfulItemIndex) {
+          const item = items[i]
+          itemCache.set(item.uid, item)
+          itemTypeMap.set(item.uid, type)
+          uids.push(item.uid)
+        } else {
+          uids.push(null)
+        }
       }
       set({ itemCache, itemTypeMap })
+
+      if (permanentFailure) {
+        const succeeded = lastSuccessfulItemIndex + 1
+        const total = items.length
+        const noun = type === 'calendar' ? 'events' : type === 'tasks' ? 'tasks' : 'contacts'
+        console.error(`[etebase-store] Batch import failed after retries (${succeeded}/${total} ${noun} imported):`, permanentFailure)
+        if (succeeded > 0) {
+          showErrorToast(`Imported ${succeeded} of ${total} ${noun}. Please try again to import the rest.`)
+        } else {
+          showErrorToast(`Failed to import ${noun}. Please try again.`)
+        }
+      }
+
       return uids
     } catch (err) {
       if (isOfflineError(err)) {
@@ -333,6 +398,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         showErrorToast(`Failed to import ${type === 'calendar' ? 'events' : type === 'tasks' ? 'tasks' : 'contacts'}. Please try again.`)
       }
       return contents.map(() => null)
+    } finally {
+      syncEngine?.resume()
     }
   },
 

--- a/packages/core/src/etebase/sync.test.ts
+++ b/packages/core/src/etebase/sync.test.ts
@@ -565,4 +565,95 @@ describe('SyncEngine', () => {
       engine.stop();
     });
   });
+
+  // ── Pause / resume ──
+
+  describe('pause and resume', () => {
+    it('does not poll while paused', async () => {
+      const { account, mockItemManager } = createMockAccount();
+      const engine = new SyncEngine(defaultOptions({ pollIntervalMs: 1_000 }));
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+      expect(mockItemManager.list).toHaveBeenCalledTimes(1);
+
+      engine.pause();
+      expect(engine.isPaused()).toBe(true);
+
+      // Advance well past several poll intervals — no new list calls
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(mockItemManager.list).toHaveBeenCalledTimes(1);
+    });
+
+    it('syncNow is a no-op while paused', async () => {
+      const { account, mockItemManager } = createMockAccount();
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+      mockItemManager.list.mockClear();
+
+      engine.pause();
+      await engine.syncNow();
+
+      expect(mockItemManager.list).not.toHaveBeenCalled();
+    });
+
+    it('resumes polling on resume()', async () => {
+      const { account, mockItemManager } = createMockAccount();
+      const engine = new SyncEngine(defaultOptions({ pollIntervalMs: 1_000 }));
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+      engine.pause();
+      mockItemManager.list.mockClear();
+
+      engine.resume();
+      expect(engine.isPaused()).toBe(false);
+
+      // Next poll interval should fire
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(mockItemManager.list).toHaveBeenCalledTimes(1);
+
+      engine.stop();
+    });
+
+    it('pause is idempotent and resume is a no-op when not paused', async () => {
+      const { account } = createMockAccount();
+      const engine = new SyncEngine(defaultOptions());
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+
+      engine.pause();
+      engine.pause(); // no-op
+      expect(engine.isPaused()).toBe(true);
+
+      engine.resume();
+      engine.resume(); // no-op
+      expect(engine.isPaused()).toBe(false);
+
+      engine.stop();
+    });
+
+    it('pause does not change reported status', async () => {
+      const { account } = createMockAccount();
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+      expect(engine.getStatus()).toBe('synced');
+
+      engine.pause();
+      // We deliberately do NOT flip status to 'offline' on pause — the user
+      // is still online, we're just deferring polls.
+      expect(engine.getStatus()).toBe('synced');
+
+      engine.stop();
+    });
+  });
 });

--- a/packages/core/src/etebase/sync.ts
+++ b/packages/core/src/etebase/sync.ts
@@ -34,6 +34,7 @@ export class SyncEngine {
   private statusHandlers: Set<StatusChangeHandler> = new Set();
   private reconnectAttempt = 0;
   private isDestroyed = false;
+  private paused = false;
 
   readonly options: Required<SyncEngineOptions>;
 
@@ -125,7 +126,7 @@ export class SyncEngine {
    * Manually trigger a sync cycle.
    */
   async syncNow(): Promise<void> {
-    if (!this.account || this.isDestroyed) return;
+    if (!this.account || this.isDestroyed || this.paused) return;
     this.setStatus('syncing');
     try {
       await this.syncAll();
@@ -134,6 +135,40 @@ export class SyncEngine {
     } catch (err) {
       this.handleSyncError(err);
     }
+  }
+
+  /**
+   * Pause the polling loop. Use during local-heavy work like a large import
+   * so the 30s poll doesn't fire `itemManager.list` (which decrypts results
+   * on the main thread) while the import is encrypting items on the same
+   * thread. Reversible via `resume()`. No-op if already paused or destroyed.
+   */
+  pause(): void {
+    if (this.isDestroyed || this.paused) return;
+    this.paused = true;
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+
+  /**
+   * Resume polling after `pause()`. Re-arms the poll timer so the next
+   * sync cycle fires after `pollIntervalMs`. No-op if not paused or destroyed.
+   */
+  resume(): void {
+    if (this.isDestroyed || !this.paused) return;
+    this.paused = false;
+    if (this.account) {
+      this.schedulePoll();
+    }
+  }
+
+  /**
+   * Whether polling is currently paused.
+   */
+  isPaused(): boolean {
+    return this.paused;
   }
 
   // ── Internal ──
@@ -241,7 +276,7 @@ export class SyncEngine {
   }
 
   private schedulePoll(): void {
-    if (this.isDestroyed) return;
+    if (this.isDestroyed || this.paused) return;
 
     this.pollTimer = setTimeout(() => {
       this.syncNow()


### PR DESCRIPTION
## Summary

PR-D2 from the 2026-04-12 brainstorm. Fixes the user-reported throttle: 1200-item imports were only persisting ~100 items per run.

Independent of PR #33 (server prefetch). Both can land in either order.

## Why ~100/1200 was happening

Two reinforcing causes, neither obvious in isolation:

1. **30s SyncEngine poll racing the import.** During `createItemsBatch`, the local-crypto phase encrypts every item on the main thread before any HTTP fires. If the 30s sync poll fires mid-import, it does `itemManager.list` → decrypt-just-imported-items, also on the main thread. UI freezes long enough that users hit refresh, killing the import.
2. **Batch failures abort the whole loop.** Old code: BATCH_SIZE=50, sequential `await itemManager.batch(batch)`, no retry, single `try/catch` around the entire loop. One slow batch crossing a proxy gateway timeout meant the whole import was done — items already-acked stayed, the rest were lost silently.

## What's in this PR

**`packages/core/src/etebase/sync.ts`** — `SyncEngine` gains `pause()` / `resume()` / `isPaused()`:
- `pause()` clears the pending poll timer; `syncNow()` and `schedulePoll()` short-circuit while paused.
- `resume()` re-arms the next poll.
- Status stays `'synced'` while paused (the user is still online; we're just deferring).

**`apps/web/app/stores/use-etebase-store.ts`** — `createItemsBatch`:
- Wrapped in `syncEngine.pause()` / `resume()` via try/finally.
- Yields to the event loop every 25 items during local-crypto so the UI doesn't lock up on 1000+ item imports.
- BATCH_SIZE: 50 → 20 (each request finishes faster, less likely to trip proxy timeouts).
- Per-batch retry loop: 3 attempts with 1s / 2s / 4s backoff. Offline errors bypass retry and bubble to the existing offline-queue path.
- On permanent failure, returns partial uids (real uids for items that acked, nulls for the rest) and surfaces a partial-success toast: *"Imported 800 of 1200 events. Please try again to import the rest."*

## Test plan

- [x] `pnpm test` in `packages/core` — 28 sync.test.ts pass (5 new pause/resume cases)
- [x] `pnpm test` in `apps/web` — 95 / 95 pass (5 new `use-etebase-store.test.ts` cases covering batch sizing, pause/resume, retry recovery, retry-exhaustion partial result)
- [x] `pnpm tsc --noEmit` clean
- [ ] Manual verification: import a 500+ event .ics on staging
- [ ] Watch for any regression in normal single-item creates (path is unchanged but worth a smoke test)

## Out of scope

- The "decrypting your workspace" boot hang from the brainstorm was misdiagnosed — it's gated on billing-API calls in `auth-provider.tsx`, not Etebase. Belongs in a separate ticket.
- Server-side prefetch (PR #33) helps every read path under load but is independent of this PR.