### PR TITLE
chore: rename stale develop → dev in workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - develop
+      - dev
     paths:
       - 'apps/landing/**'
       - 'packages/**'
@@ -56,7 +56,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy to preview Worker
-        if: github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/dev'
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/test-bridge-linux.yml
+++ b/.github/workflows/test-bridge-linux.yml
@@ -3,11 +3,11 @@ name: Test Bridge (Linux x86_64)
 on:
   workflow_dispatch:
   push:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - 'bridge/**'
   pull_request:
-    branches: [main, develop]
+    branches: [main, dev]
     paths:
       - 'bridge/**'
 


### PR DESCRIPTION
## Summary

PR #33 fixed \`ci-server.yml\` but three workflows still referenced the old \`develop\` branch name — they would never trigger on pushes/PRs to the active \`dev\` branch.

- \`ci.yml\` — push + pull_request \`branches: [main, develop]\` → \`[main, dev]\`
- \`test-bridge-linux.yml\` — same pattern
- \`deploy-landing.yml\` — \`branches:\` list and the \`if: github.ref == 'refs/heads/develop'\` gate for the preview Worker deploy

## Test plan

- [ ] CI fires on this PR (proves the new branch matchers work)
- [ ] After merge to \`dev\`, deploy-landing's preview-Worker step actually runs (the previous \`develop\` gate would have skipped it)