### PR TITLE
fix(web): signup redirect state → sessionStorage (closes #20)

### DIFF
--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -231,4 +231,44 @@ describe('useAuthStore', () => {
       expect(result).toBe(false)
     })
   })
+
+  // --- Stripe redirect signup state (issue #20) ---
+
+  describe('signup redirect state storage', () => {
+    const pending = {
+      email: 'user@example.com',
+      etebaseAuthToken: 'auth-token-abc',
+    }
+
+    it('saves redirect state to sessionStorage, not localStorage', () => {
+      useAuthStore.setState({ pendingSignup: pending })
+      useAuthStore.getState().saveSignupStateForRedirect('monthly')
+
+      expect(sessionStorage.getItem('silentsuite-signup-redirect-state')).not.toBeNull()
+      expect(localStorage.getItem('silentsuite-signup-redirect-state')).toBeNull()
+    })
+
+    it('restores from sessionStorage and clears the key', () => {
+      useAuthStore.setState({ pendingSignup: pending })
+      useAuthStore.getState().saveSignupStateForRedirect('annual')
+
+      const restored = useAuthStore.getState().restoreSignupStateFromRedirect()
+
+      expect(restored?.selectedInterval).toBe('annual')
+      expect(restored?.pendingSignup.email).toBe('user@example.com')
+      expect(sessionStorage.getItem('silentsuite-signup-redirect-state')).toBeNull()
+    })
+
+    it('ignores legacy localStorage entries left behind by older builds', () => {
+      // Simulate a tab that saved redirect state under the old localStorage key.
+      localStorage.setItem(
+        'silentsuite-signup-redirect-state',
+        JSON.stringify({ pendingSignup: pending, selectedInterval: 'monthly', savedAt: Date.now() }),
+      )
+
+      const restored = useAuthStore.getState().restoreSignupStateFromRedirect()
+
+      expect(restored).toBeNull()
+    })
+  })
 })

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -30,7 +30,7 @@ interface PendingSignup {
   provisionedSubscriptionStatus?: string
 }
 
-/** Shape of the data persisted to localStorage for surviving Stripe 3DS redirects. */
+/** Shape of the data persisted to sessionStorage for surviving Stripe 3DS redirects. */
 export interface RedirectSignupState {
   pendingSignup: PendingSignup
   selectedInterval: 'monthly' | 'annual'
@@ -60,17 +60,16 @@ interface AuthState {
   setUser: (user: User | null) => void
   clearError: () => void
   /**
-   * Persist pendingSignup + billing interval to localStorage so the signup flow
-   * survives a full-page Stripe 3DS redirect.
-   *
-   * SECURITY: The etebaseAuthToken is stored in localStorage. This is the same
-   * XSS risk surface as the existing `etebase_session` key — acceptable given
-   * the current security posture. The data is cleared on first read.
+   * Persist pendingSignup + billing interval to sessionStorage so the signup
+   * flow survives a full-page Stripe 3DS redirect. sessionStorage is scoped to
+   * the tab and cleared on close, which is a tighter blast radius than
+   * localStorage for the etebaseAuthToken this blob carries. The data is also
+   * cleared on first read and rejected if older than 10 minutes.
    */
   saveSignupStateForRedirect: (selectedInterval: 'monthly' | 'annual') => void
   /**
    * Restore signup state saved before a Stripe 3DS redirect.
-   * Returns the saved data and removes it from localStorage (one-time use).
+   * Returns the saved data and removes it from sessionStorage (one-time use).
    * Returns null if no data exists or if it is older than 10 minutes.
    */
   restoreSignupStateFromRedirect: () => RedirectSignupState | null
@@ -508,7 +507,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       savedAt: Date.now(),
     }
     try {
-      localStorage.setItem('silentsuite-signup-redirect-state', JSON.stringify(data))
+      sessionStorage.setItem('silentsuite-signup-redirect-state', JSON.stringify(data))
     } catch (err) {
       logger.warn('[auth-store] Failed to save signup redirect state:', err)
     }
@@ -516,12 +515,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   restoreSignupStateFromRedirect: () => {
     try {
-      const raw = localStorage.getItem('silentsuite-signup-redirect-state')
+      const raw = sessionStorage.getItem('silentsuite-signup-redirect-state')
       if (!raw) return null
       // Always remove immediately — one-time use
-      localStorage.removeItem('silentsuite-signup-redirect-state')
+      sessionStorage.removeItem('silentsuite-signup-redirect-state')
       const data = JSON.parse(raw) as RedirectSignupState
-      // Basic shape validation — guard against corrupted or tampered localStorage data
+      // Basic shape validation — guard against corrupted or tampered storage data
       if (!data.pendingSignup?.email || !data.pendingSignup?.etebaseAuthToken) {
         logger.warn('[auth-store] Redirect signup state is malformed, discarding')
         return null
@@ -541,7 +540,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       return data
     } catch (err) {
       logger.warn('[auth-store] Failed to restore signup redirect state:', err)
-      localStorage.removeItem('silentsuite-signup-redirect-state')
+      sessionStorage.removeItem('silentsuite-signup-redirect-state')
       return null
     }
   },


### PR DESCRIPTION
## Summary

Issue #20's biggest items (\`etebase_session\`, calendar/contacts/tasks payloads) were already moved to IndexedDB by \`apps/web/app/lib/secure-storage.ts\`. The remaining residual leak was \`silentsuite-signup-redirect-state\` — a one-time-use, 10-minute-expiring Stripe 3DS redirect blob that still carried an \`etebaseAuthToken\` in \`localStorage\`.

- Switches \`saveSignupStateForRedirect\` / \`restoreSignupStateFromRedirect\` to \`sessionStorage\`. Same UX (sessionStorage survives a full-page redirect), tighter blast radius (tab-scoped, cleared on close).
- Updates the docstrings to match.
- Adds three regression tests:
  - save writes to sessionStorage, not localStorage
  - restore reads from sessionStorage and clears the key
  - legacy localStorage entries from older builds are ignored on restore

## Test plan

- [x] \`pnpm --filter @silentsuite/web test -- use-auth-store\` — 22 passed
- [ ] CI passes
- [ ] After deploy, signup → 3DS redirect flow still completes (manual smoke)

Closes #20.