### PR TITLE
fix(web): fall back to user email for Stripe billing name

### DIFF
--- a/apps/web/app/components/stripe-payment-form.tsx
+++ b/apps/web/app/components/stripe-payment-form.tsx
@@ -70,7 +70,11 @@ function PaymentFormInner({ onSuccess, onError, submitLabel, mode, selectedInter
     // PaymentElement is rendered with `fields.billingDetails.name = 'never'`,
     // so Stripe requires the billing name be passed explicitly here or it throws
     // an IntegrationError that bubbles out of the await and leaves the button stuck.
-    const billingName = useAuthStore.getState().pendingSignup?.email ?? 'Customer'
+    // The form is reused on /settings/subscription and the add-card banner where
+    // pendingSignup is null — fall back to the logged-in user's email so Stripe
+    // records still get a real identifier instead of the literal 'Customer'.
+    const authState = useAuthStore.getState()
+    const billingName = authState.pendingSignup?.email ?? authState.user?.email ?? 'Customer'
     const confirmParams = {
       return_url: `${window.location.origin}/signup/success`,
       payment_method_data: { billing_details: { name: billingName } },

--- a/apps/web/app/components/stripe-payment-form.tsx
+++ b/apps/web/app/components/stripe-payment-form.tsx
@@ -70,11 +70,11 @@ function PaymentFormInner({ onSuccess, onError, submitLabel, mode, selectedInter
     // PaymentElement is rendered with `fields.billingDetails.name = 'never'`,
     // so Stripe requires the billing name be passed explicitly here or it throws
     // an IntegrationError that bubbles out of the await and leaves the button stuck.
-    // The form is reused on /settings/subscription and the add-card banner where
-    // pendingSignup is null — fall back to the logged-in user's email so Stripe
-    // records still get a real identifier instead of the literal 'Customer'.
+    // Fall back to user.email on /settings/subscription and the add-card banner
+    // where pendingSignup is null. Use `||` not `??` because degraded/self-hosted
+    // states set user.email to '', and we'd rather land on 'Customer' than ''.
     const authState = useAuthStore.getState()
-    const billingName = authState.pendingSignup?.email ?? authState.user?.email ?? 'Customer'
+    const billingName = authState.pendingSignup?.email || authState.user?.email || 'Customer'
     const confirmParams = {
       return_url: `${window.location.origin}/signup/success`,
       payment_method_data: { billing_details: { name: billingName } },


### PR DESCRIPTION
## Summary
- `StripePaymentForm` runs `PaymentElement` with `fields.billingDetails.name='never'` and supplies the name itself in `confirmParams.payment_method_data` (otherwise Stripe throws an `IntegrationError` and the submit button locks on "Processing" — see `feedback_stripe_payment_element_billing_name`).
- The form is reused on `/signup`, `/settings/subscription`, and the add-card banner. On `/signup` we have `pendingSignup.email`; on the other two `pendingSignup` is `null`, so the name was falling through to the literal string `'Customer'` on Stripe records.
- Add `useAuthStore.user?.email` as a secondary fallback before `'Customer'`. Cosmetic only — Stripe still processes the card either way — but our records now show real identifiers.

## Test plan
- [ ] Signup flow still passes the email-based billing name (no regression).
- [ ] `/settings/subscription` "Update card" → confirm → Stripe dashboard's payment method record shows the logged-in user's email rather than `Customer`.
- [ ] Add-card banner (post-signup, no subscription yet) → same check.
- [ ] Smoke: button does not get stuck on "Processing" in any of the three contexts.