### PR TITLE
test(server): cover FastAPI auth challenge / signature / session flows

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest ruff
+          pip install pytest pytest-django ruff
 
       - name: Compile check (smoke test)
         working-directory: server

--- a/server/etebase_server/fastapi/conftest.py
+++ b/server/etebase_server/fastapi/conftest.py
@@ -1,0 +1,207 @@
+"""Shared fixtures for FastAPI auth tests.
+
+Provides:
+  - A minimal FastAPI app + TestClient that exposes only the routers under
+    test (no static files, no Redis, no CORS — just what we need to drive
+    the request lifecycle through the real exception handler).
+  - Crypto helpers that mimic an Etebase client: signing key, login pubkey,
+    salt, and a `login_flow` helper that performs the full
+    challenge → sign → submit handshake the way a real client does.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import nacl.public
+import nacl.signing
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from etebase_server.fastapi.exceptions import CustomHttpException
+from etebase_server.fastapi.msgpack import MsgpackResponse
+from etebase_server.fastapi.utils import msgpack_decode, msgpack_encode
+
+AUTH_PREFIX = "/api/v1/authentication"
+
+
+# ---------------------------------------------------------------------------
+# App / client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auth_app() -> FastAPI:
+    """A minimal FastAPI app that mounts the authentication router and the
+    same `CustomHttpException` handler that production registers — so error
+    bodies are msgpack-encoded `{code, detail}` exactly like the real server."""
+    from etebase_server.fastapi.routers.authentication import authentication_router
+
+    app = FastAPI()
+    app.include_router(authentication_router, prefix=AUTH_PREFIX)
+
+    @app.exception_handler(CustomHttpException)
+    async def _custom_exception_handler(_request, exc: CustomHttpException):  # noqa: RUF029
+        return MsgpackResponse(status_code=exc.status_code, content=exc.as_dict)
+
+    return app
+
+
+@pytest.fixture
+def auth_client(auth_app: FastAPI) -> TestClient:
+    return TestClient(auth_app)
+
+
+# ---------------------------------------------------------------------------
+# Msgpack request/response helpers
+# ---------------------------------------------------------------------------
+
+
+def msgpack_post(client: TestClient, url: str, body: Any, **kwargs: Any):
+    """POST a msgpack-encoded body and ask for a msgpack response."""
+    headers = {
+        "Content-Type": "application/msgpack",
+        "Accept": "application/msgpack",
+    }
+    headers.update(kwargs.pop("headers", {}))
+    return client.post(url, content=msgpack_encode(body), headers=headers, **kwargs)
+
+
+def decode_response(response) -> Any:
+    """Decode a msgpack response body."""
+    return msgpack_decode(response.content)
+
+
+# ---------------------------------------------------------------------------
+# Crypto/identity fixtures — mimic what an Etebase client derives from the
+# user's password.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def signing_key() -> nacl.signing.SigningKey:
+    """The "password-derived" signing key. In real clients this is derived
+    from the user's password via a KDF; in tests we just generate one."""
+    return nacl.signing.SigningKey.generate()
+
+
+@pytest.fixture
+def login_pubkey(signing_key: nacl.signing.SigningKey) -> bytes:
+    """The verify-key bytes that get stored in `UserInfo.loginPubkey`."""
+    return bytes(signing_key.verify_key)
+
+
+@pytest.fixture
+def encryption_pubkey() -> bytes:
+    """A separate per-account encryption pubkey stored in `UserInfo.pubkey`.
+    The auth flow doesn't use it — it's only needed to satisfy the NOT NULL
+    constraint when we create UserInfo rows."""
+    return bytes(nacl.public.PrivateKey.generate().public_key)
+
+
+@pytest.fixture
+def user_salt() -> bytes:
+    """A fresh random salt for the test user."""
+    return os.urandom(32)
+
+
+# ---------------------------------------------------------------------------
+# User factory
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def user_factory(transactional_db, user_salt, login_pubkey, encryption_pubkey):
+    """Factory for creating Django User + UserInfo rows.
+
+    Uses `transactional_db` rather than `db` because the route handlers go
+    through `django_db_cleanup_decorator`, which calls `close_old_connections()`
+    and breaks the per-test transaction wrapper that `db` relies on.
+    """
+    from etebase_server.django.models import UserInfo
+    from etebase_server.myauth.models import get_typed_user_model
+
+    User = get_typed_user_model()
+
+    def _make(
+        username: str = "test_user_alice",
+        email: str = "alice@example.com",
+        salt: bytes | None = None,
+        login_pubkey_override: bytes | None = None,
+        with_userinfo: bool = True,
+    ):
+        user = User.objects.create_user(username=username, email=email, password=None)
+        if with_userinfo:
+            UserInfo.objects.create(
+                owner=user,
+                salt=salt if salt is not None else user_salt,
+                loginPubkey=login_pubkey_override if login_pubkey_override is not None else login_pubkey,
+                pubkey=encryption_pubkey,
+                encryptedContent=b"\x00" * 64,
+            )
+        return user
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Login handshake helper — performs the same dance an Etebase client does
+# ---------------------------------------------------------------------------
+
+
+def login_challenge(client: TestClient, username: str):
+    """Hit /login_challenge/ and return the decoded `{salt, challenge, version}`."""
+    response = msgpack_post(client, f"{AUTH_PREFIX}/login_challenge/", {"username": username})
+    return response, decode_response(response) if response.status_code == 200 else None
+
+
+def build_signed_response(
+    *,
+    username: str,
+    challenge_bytes: bytes,
+    signing_key: nacl.signing.SigningKey,
+    action: str = "login",
+    host: str = "testserver",
+    extra: dict | None = None,
+) -> dict:
+    """Build the `{response, signature}` body for /login/ or /change_password/.
+
+    The server doesn't require the client to decrypt the challenge — it only
+    needs the same encrypted bytes echoed back so it can decrypt them with
+    its own key and verify the timestamp/userId. The cryptographic proof of
+    password possession is in the *signature* over the msgpack-encoded
+    response, verified against the user's stored loginPubkey.
+    """
+    payload: dict = {
+        "username": username,
+        "challenge": challenge_bytes,
+        "host": host,
+        "action": action,
+    }
+    if extra:
+        payload.update(extra)
+    encoded = msgpack_encode(payload)
+    signature = signing_key.sign(encoded).signature
+    return {"response": encoded, "signature": bytes(signature)}
+
+
+def perform_login(
+    client: TestClient,
+    *,
+    username: str,
+    signing_key: nacl.signing.SigningKey,
+    host: str = "testserver",
+):
+    """Full login round-trip: challenge → signed response → token."""
+    challenge_resp, challenge_data = login_challenge(client, username)
+    assert challenge_resp.status_code == 200, decode_response(challenge_resp)
+    body = build_signed_response(
+        username=username,
+        challenge_bytes=challenge_data["challenge"],
+        signing_key=signing_key,
+        action="login",
+        host=host,
+    )
+    return msgpack_post(client, f"{AUTH_PREFIX}/login/", body)

--- a/server/etebase_server/fastapi/test_authentication.py
+++ b/server/etebase_server/fastapi/test_authentication.py
@@ -1,0 +1,324 @@
+"""Tests for the FastAPI authentication router.
+
+Covers the login challenge / signed-response handshake, signup, logout,
+and — critically — `change_password`'s cryptographic proof of current
+credentials. The bridge/server does NOT take an old password as a
+plaintext argument; instead it requires the change-password request to
+be signed by the current `loginPubkey`'s signing key. That signature
+verification IS the old-password check, and one of the tests below
+asserts it explicitly (PR #21 — the security guarantee that
+silentsuite-billing's `PATCH /account/password` notification endpoint
+delegates to).
+"""
+
+from __future__ import annotations
+
+import nacl.signing
+import pytest
+from django.test.utils import override_settings
+
+from etebase_server.fastapi.conftest import (
+    AUTH_PREFIX,
+    build_signed_response,
+    decode_response,
+    login_challenge,
+    msgpack_post,
+    perform_login,
+)
+
+
+@pytest.mark.django_db(transaction=True)
+class TestLoginChallenge:
+    def test_returns_salt_and_challenge_for_existing_user(
+        self, auth_client, user_factory, user_salt
+    ):
+        user_factory(username="test_user_alice")
+
+        response, body = login_challenge(auth_client, "test_user_alice")
+
+        assert response.status_code == 200
+        assert body["salt"] == user_salt
+        assert isinstance(body["challenge"], bytes) and len(body["challenge"]) > 0
+        assert body["version"] == 1
+
+    def test_returns_401_for_missing_user(self, auth_client):
+        response, _ = login_challenge(auth_client, "test_user_does_not_exist")
+
+        assert response.status_code == 401
+        assert decode_response(response)["code"] == "user_not_found"
+
+    def test_returns_401_when_user_has_no_userinfo(self, auth_client, user_factory):
+        # An account that exists in Django but never completed signup ends up
+        # without a UserInfo row — login should refuse to issue a challenge.
+        user_factory(username="test_user_uninit", with_userinfo=False)
+
+        response, _ = login_challenge(auth_client, "test_user_uninit")
+
+        assert response.status_code == 401
+        assert decode_response(response)["code"] == "user_not_init"
+
+    def test_username_lookup_is_case_insensitive(self, auth_client, user_factory):
+        # myauth.User normalises usernames to lowercase, so the challenge
+        # endpoint must succeed regardless of how the client capitalises.
+        user_factory(username="test_user_casey")
+
+        response, body = login_challenge(auth_client, "TEST_USER_CASEY")
+
+        assert response.status_code == 200
+        assert isinstance(body["challenge"], bytes)
+
+
+@pytest.mark.django_db(transaction=True)
+class TestLogin:
+    def test_login_with_valid_signature_returns_token(
+        self, auth_client, user_factory, signing_key
+    ):
+        user_factory(username="test_user_alice")
+
+        response = perform_login(
+            auth_client, username="test_user_alice", signing_key=signing_key
+        )
+
+        assert response.status_code == 200
+        body = decode_response(response)
+        assert isinstance(body["token"], str) and len(body["token"]) >= 32
+        assert body["user"]["username"] == "test_user_alice"
+
+    def test_login_with_wrong_signature_returns_401(
+        self, auth_client, user_factory
+    ):
+        # User was created with `signing_key`'s pubkey, but we sign the
+        # response with a different key — i.e. the attacker doesn't know the
+        # password. This is the core "wrong password → 401" guarantee.
+        user_factory(username="test_user_alice")
+        attacker_key = nacl.signing.SigningKey.generate()
+
+        challenge_resp, challenge = login_challenge(auth_client, "test_user_alice")
+        body = build_signed_response(
+            username="test_user_alice",
+            challenge_bytes=challenge["challenge"],
+            signing_key=attacker_key,
+        )
+        response = msgpack_post(auth_client, f"{AUTH_PREFIX}/login/", body)
+
+        assert challenge_resp.status_code == 200
+        assert response.status_code == 401
+        assert decode_response(response)["code"] == "login_bad_signature"
+
+    def test_login_with_wrong_action_is_rejected(
+        self, auth_client, user_factory, signing_key
+    ):
+        user_factory(username="test_user_alice")
+
+        _, challenge = login_challenge(auth_client, "test_user_alice")
+        body = build_signed_response(
+            username="test_user_alice",
+            challenge_bytes=challenge["challenge"],
+            signing_key=signing_key,
+            action="changePassword",  # but we're hitting /login/
+        )
+        response = msgpack_post(auth_client, f"{AUTH_PREFIX}/login/", body)
+
+        assert response.status_code == 400
+        assert decode_response(response)["code"] == "wrong_action"
+
+    @override_settings(DEBUG=False)
+    def test_login_with_wrong_host_is_rejected_in_production(
+        self, auth_client, user_factory, signing_key
+    ):
+        # In DEBUG mode the host check is skipped (so dev clients on
+        # localhost can talk to a remote server). With DEBUG off, the
+        # host in the signed response must match the request's Host header.
+        user_factory(username="test_user_alice")
+
+        _, challenge = login_challenge(auth_client, "test_user_alice")
+        body = build_signed_response(
+            username="test_user_alice",
+            challenge_bytes=challenge["challenge"],
+            signing_key=signing_key,
+            host="evil.example.com",
+        )
+        response = msgpack_post(auth_client, f"{AUTH_PREFIX}/login/", body)
+
+        assert response.status_code == 400
+        assert decode_response(response)["code"] == "wrong_host"
+
+    def test_login_with_garbage_challenge_bytes_fails(
+        self, auth_app, user_factory, signing_key
+    ):
+        # Skip the real challenge endpoint and send random bytes — the
+        # server can't decrypt them, so the login must not succeed.
+        # (Note: the route doesn't currently catch NaCl's CryptoError, so
+        # this surfaces as a 500 rather than a clean 4xx. That's a minor
+        # robustness gap worth fixing separately; it isn't exploitable —
+        # no user data leaks — but it should be a 400. Filed mentally.)
+        from fastapi.testclient import TestClient
+
+        client = TestClient(auth_app, raise_server_exceptions=False)
+        user_factory(username="test_user_alice")
+
+        body = build_signed_response(
+            username="test_user_alice",
+            challenge_bytes=b"\x00" * 64,
+            signing_key=signing_key,
+        )
+        response = msgpack_post(client, f"{AUTH_PREFIX}/login/", body)
+
+        assert response.status_code != 200
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSignup:
+    def test_signup_creates_a_new_user(self, auth_client, login_pubkey, encryption_pubkey, user_salt):
+        body = {
+            "user": {"username": "test_user_new", "email": "new@example.com"},
+            "salt": user_salt,
+            "loginPubkey": login_pubkey,
+            "pubkey": encryption_pubkey,
+            "encryptedContent": b"\x00" * 64,
+        }
+
+        response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
+
+        # The route is declared `status_code=201` but MsgpackRoute's custom
+        # response path drops the declared status — actual responses are 200.
+        # Allow either to keep the test honest about current behaviour.
+        assert response.status_code in (200, 201)
+        decoded = decode_response(response)
+        assert decoded["user"]["username"] == "test_user_new"
+        assert isinstance(decoded["token"], str)
+
+    def test_signup_for_existing_user_returns_409(
+        self, auth_client, user_factory, login_pubkey, encryption_pubkey, user_salt
+    ):
+        user_factory(username="test_user_alice")
+        body = {
+            "user": {"username": "test_user_alice", "email": "alice@example.com"},
+            "salt": user_salt,
+            "loginPubkey": login_pubkey,
+            "pubkey": encryption_pubkey,
+            "encryptedContent": b"\x00" * 64,
+        }
+
+        response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
+
+        assert response.status_code == 409
+        assert decode_response(response)["code"] == "user_exists"
+
+
+@pytest.mark.django_db(transaction=True)
+class TestChangePassword:
+    """The architectural assertion called out in PR #21:
+
+    `silentsuite-billing`'s `PATCH /account/password` endpoint is purely a
+    "password was changed elsewhere, rotate refresh tokens" notification —
+    it can't verify the old password because it doesn't have it. The
+    *actual* old-password check lives here, in the bridge/server's
+    `change_password` route, where the request body must be signed by the
+    user's current `loginPubkey`. These tests prove that property.
+    """
+
+    def _auth_token(self, auth_client, signing_key, username="test_user_alice"):
+        login = perform_login(auth_client, username=username, signing_key=signing_key)
+        assert login.status_code == 200, decode_response(login)
+        return decode_response(login)["token"]
+
+    def test_change_password_requires_authentication(
+        self, auth_client, user_factory, signing_key
+    ):
+        user_factory(username="test_user_alice")
+
+        _, challenge = login_challenge(auth_client, "test_user_alice")
+        body = build_signed_response(
+            username="test_user_alice",
+            challenge_bytes=challenge["challenge"],
+            signing_key=signing_key,
+            action="changePassword",
+            extra={"loginPubkey": b"\x01" * 32, "encryptedContent": b"\x02" * 64},
+        )
+
+        # No Authorization header — must be rejected before any crypto check.
+        response = msgpack_post(
+            auth_client, f"{AUTH_PREFIX}/change_password/", body
+        )
+
+        assert response.status_code in (401, 403)
+
+    def test_change_password_rejects_wrong_signature(
+        self, auth_client, user_factory, signing_key
+    ):
+        # The user's current loginPubkey is `signing_key.verify_key`. An
+        # attacker who has stolen the session token but does NOT know the
+        # current password cannot produce a valid signature, and the
+        # change must be refused. This is THE security check.
+        user_factory(username="test_user_alice")
+        token = self._auth_token(auth_client, signing_key)
+
+        attacker_key = nacl.signing.SigningKey.generate()
+        new_login_pubkey = bytes(nacl.signing.SigningKey.generate().verify_key)
+
+        _, challenge = login_challenge(auth_client, "test_user_alice")
+        body = build_signed_response(
+            username="test_user_alice",
+            challenge_bytes=challenge["challenge"],
+            signing_key=attacker_key,
+            action="changePassword",
+            extra={"loginPubkey": new_login_pubkey, "encryptedContent": b"\x03" * 64},
+        )
+        response = msgpack_post(
+            auth_client,
+            f"{AUTH_PREFIX}/change_password/",
+            body,
+            headers={"Authorization": f"Token {token}"},
+        )
+
+        assert response.status_code == 401
+        assert decode_response(response)["code"] == "login_bad_signature"
+
+        # And the user's stored loginPubkey must NOT have been overwritten.
+        from etebase_server.django.models import UserInfo
+
+        info = UserInfo.objects.get(owner__username="test_user_alice")
+        assert bytes(info.loginPubkey) == bytes(signing_key.verify_key)
+
+    def test_change_password_succeeds_with_correct_signature(
+        self, auth_client, user_factory, signing_key
+    ):
+        user_factory(username="test_user_alice")
+        token = self._auth_token(auth_client, signing_key)
+
+        new_signing_key = nacl.signing.SigningKey.generate()
+        new_login_pubkey = bytes(new_signing_key.verify_key)
+        new_encrypted_content = b"\xaa" * 64
+
+        _, challenge = login_challenge(auth_client, "test_user_alice")
+        body = build_signed_response(
+            username="test_user_alice",
+            challenge_bytes=challenge["challenge"],
+            signing_key=signing_key,  # signed with CURRENT key — proves old-password possession
+            action="changePassword",
+            extra={"loginPubkey": new_login_pubkey, "encryptedContent": new_encrypted_content},
+        )
+        response = msgpack_post(
+            auth_client,
+            f"{AUTH_PREFIX}/change_password/",
+            body,
+            headers={"Authorization": f"Token {token}"},
+        )
+
+        assert response.status_code == 204
+
+        # The new credentials must be persisted: future logins succeed with
+        # `new_signing_key` and fail with the old one.
+        from etebase_server.django.models import UserInfo
+
+        info = UserInfo.objects.get(owner__username="test_user_alice")
+        assert bytes(info.loginPubkey) == new_login_pubkey
+        assert bytes(info.encryptedContent) == new_encrypted_content
+
+        good = perform_login(auth_client, username="test_user_alice", signing_key=new_signing_key)
+        assert good.status_code == 200
+
+        bad = perform_login(auth_client, username="test_user_alice", signing_key=signing_key)
+        assert bad.status_code == 401
+        assert decode_response(bad)["code"] == "login_bad_signature"

--- a/server/etebase_server/fastapi/test_session_auth.py
+++ b/server/etebase_server/fastapi/test_session_auth.py
@@ -1,0 +1,221 @@
+"""Tests for session/token authentication on the FastAPI side.
+
+Drives `get_authenticated_user` and `get_auth_data` (the dependencies that
+gate every authenticated endpoint) by attaching a small protected route
+to a test app and asserting how missing / invalid / revoked / expired
+tokens are handled.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from etebase_server.fastapi.conftest import (
+    AUTH_PREFIX,
+    decode_response,
+    msgpack_post,
+    perform_login,
+)
+from etebase_server.fastapi.dependencies import get_auth_data, get_authenticated_user
+from etebase_server.fastapi.exceptions import CustomHttpException
+from etebase_server.fastapi.msgpack import MsgpackResponse
+
+
+@pytest.fixture
+def session_app():
+    """A FastAPI app with both the auth router (so we can log in / log out)
+    and a small protected probe endpoint that exercises `get_authenticated_user`."""
+    from etebase_server.fastapi.routers.authentication import authentication_router
+
+    app = FastAPI()
+    app.include_router(authentication_router, prefix=AUTH_PREFIX)
+
+    @app.get("/whoami")
+    def whoami(user=Depends(get_authenticated_user)):
+        return {"username": user.username}
+
+    @app.get("/whoami_with_token")
+    def whoami_with_token(auth=Depends(get_auth_data)):
+        return {"username": auth.user.username, "token_key": auth.token.key}
+
+    @app.exception_handler(CustomHttpException)
+    async def _custom_exception_handler(_request, exc: CustomHttpException):  # noqa: RUF029
+        return MsgpackResponse(status_code=exc.status_code, content=exc.as_dict)
+
+    return app
+
+
+@pytest.fixture
+def session_client(session_app: FastAPI) -> TestClient:
+    return TestClient(session_app)
+
+
+def _login_and_get_token(client, signing_key, username="test_user_alice"):
+    response = perform_login(client, username=username, signing_key=signing_key)
+    assert response.status_code == 200, decode_response(response)
+    return decode_response(response)["token"]
+
+
+@pytest.mark.django_db(transaction=True)
+class TestTokenAuth:
+    def test_request_with_valid_token_succeeds(
+        self, session_client, user_factory, signing_key
+    ):
+        user_factory(username="test_user_alice")
+        token = _login_and_get_token(session_client, signing_key)
+
+        response = session_client.get(
+            "/whoami", headers={"Authorization": f"Token {token}"}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"username": "test_user_alice"}
+
+    def test_request_without_authorization_header_is_rejected(self, session_client):
+        response = session_client.get("/whoami")
+
+        # FastAPI's APIKeyHeader returns 403 when the header is missing.
+        assert response.status_code in (401, 403)
+
+    def test_request_with_invalid_token_is_rejected(self, session_client):
+        response = session_client.get(
+            "/whoami", headers={"Authorization": "Token not-a-real-token"}
+        )
+
+        assert response.status_code == 401
+        assert decode_response(response)["detail"] == "Invalid token."
+
+    def test_logout_invalidates_the_token(
+        self, session_client, user_factory, signing_key
+    ):
+        user_factory(username="test_user_alice")
+        token = _login_and_get_token(session_client, signing_key)
+        auth_header = {"Authorization": f"Token {token}"}
+
+        # First call works — token is valid.
+        before = session_client.get("/whoami", headers=auth_header)
+        assert before.status_code == 200
+
+        logout = msgpack_post(
+            session_client, f"{AUTH_PREFIX}/logout/", None, headers=auth_header
+        )
+        assert logout.status_code == 204
+
+        # Same token, post-logout — must be rejected.
+        after = session_client.get("/whoami", headers=auth_header)
+        assert after.status_code == 401
+        assert decode_response(after)["detail"] == "Invalid token."
+
+    def test_each_login_issues_a_unique_token(
+        self, session_client, user_factory, signing_key
+    ):
+        user_factory(username="test_user_alice")
+
+        first = _login_and_get_token(session_client, signing_key)
+        second = _login_and_get_token(session_client, signing_key)
+
+        # Distinct logins must mint distinct tokens — a shared key would
+        # mean revoking one session revokes the other.
+        assert first != second
+
+        # And both tokens are independently valid.
+        for tok in (first, second):
+            response = session_client.get(
+                "/whoami", headers={"Authorization": f"Token {tok}"}
+            )
+            assert response.status_code == 200
+
+    def test_expired_token_is_rejected_and_deleted(
+        self, session_client, user_factory, signing_key
+    ):
+        from django.utils import timezone
+
+        from etebase_server.django.token_auth.models import AuthToken
+
+        user_factory(username="test_user_alice")
+        token = _login_and_get_token(session_client, signing_key)
+
+        # Force the token to be expired in the DB.
+        AuthToken.objects.filter(key=token).update(
+            expiry=timezone.now() - timezone.timedelta(seconds=10)
+        )
+
+        response = session_client.get(
+            "/whoami", headers={"Authorization": f"Token {token}"}
+        )
+
+        assert response.status_code == 401
+        assert decode_response(response)["detail"] == "Invalid token."
+        # And the expired record must be cleaned up so it can't linger in the DB.
+        assert not AuthToken.objects.filter(key=token).exists()
+
+    def test_inactive_user_cannot_use_existing_token(
+        self, session_client, user_factory, signing_key
+    ):
+        user_factory(username="test_user_alice")
+        token = _login_and_get_token(session_client, signing_key)
+
+        # Disable the account after the token was issued — outstanding
+        # tokens for inactive users must stop working.
+        from etebase_server.myauth.models import get_typed_user_model
+
+        User = get_typed_user_model()
+        u = User.objects.get(username="test_user_alice")
+        u.is_active = False
+        u.save(update_fields=["is_active"])
+
+        response = session_client.get(
+            "/whoami", headers={"Authorization": f"Token {token}"}
+        )
+
+        assert response.status_code == 401
+        assert decode_response(response)["detail"] == "User inactive or deleted."
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSessionLifecycle:
+    def test_full_signup_login_logout_round_trip(
+        self, session_client, signing_key, login_pubkey, encryption_pubkey, user_salt
+    ):
+        # Signup mints a fresh token in the response — confirm we can use it
+        # immediately, then log out, then log back in with the same key, and
+        # that *that* token also works.
+        signup = msgpack_post(
+            session_client,
+            f"{AUTH_PREFIX}/signup/",
+            {
+                "user": {"username": "test_user_signup", "email": "signup@example.com"},
+                "salt": user_salt,
+                "loginPubkey": login_pubkey,
+                "pubkey": encryption_pubkey,
+                "encryptedContent": b"\x00" * 64,
+            },
+        )
+        # See the matching note in test_authentication.py — declared 201,
+        # actual 200 due to MsgpackRoute's response handling.
+        assert signup.status_code in (200, 201)
+        token1 = decode_response(signup)["token"]
+
+        whoami1 = session_client.get(
+            "/whoami_with_token", headers={"Authorization": f"Token {token1}"}
+        )
+        assert whoami1.status_code == 200
+        assert whoami1.json()["username"] == "test_user_signup"
+
+        logout = msgpack_post(
+            session_client,
+            f"{AUTH_PREFIX}/logout/",
+            None,
+            headers={"Authorization": f"Token {token1}"},
+        )
+        assert logout.status_code == 204
+
+        token2 = _login_and_get_token(session_client, signing_key, username="test_user_signup")
+        assert token2 != token1
+
+        whoami2 = session_client.get(
+            "/whoami_with_token", headers={"Authorization": f"Token {token2}"}
+        )
+        assert whoami2.status_code == 200

--- a/server/pytest.ini
+++ b/server/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = etebase_server.settings
+python_files = tests.py test_*.py *_tests.py
+filterwarnings =
+    ignore::DeprecationWarning:django.*
+    ignore::DeprecationWarning:pkg_resources.*

--- a/server/requirements.in/development.txt
+++ b/server/requirements.in/development.txt
@@ -4,3 +4,5 @@ pywatchman
 ruff
 mypy
 django-stubs
+pytest
+pytest-django


### PR DESCRIPTION
## Summary
First real test infrastructure for the FastAPI side of the server, plus 22 tests across two files:

- **`test_authentication.py`** — login challenge, login (valid / wrong-signature / wrong-action / wrong-host / garbage-challenge), signup (new / duplicate), and **change_password** (auth required, wrong signature rejected, correct signature rotates and old signature stops working).
- **`test_session_auth.py`** — token validity / missing / invalid / logout / uniqueness / expired-cleanup / inactive-user, plus a full signup → use → logout → login round-trip.

Bundled infra:
- `server/pytest.ini` — pytest-django config.
- `server/etebase_server/fastapi/conftest.py` — minimal FastAPI app (auth router + the same `CustomHttpException` handler production registers), msgpack request/response helpers, NaCl signing-key/salt fixtures, a Django `User` + `UserInfo` factory, and a full `perform_login` handshake helper that mimics what an Etebase client does.
- `server/requirements.in/development.txt` — adds `pytest`, `pytest-django`.
- `.github/workflows/ci-server.yml` — installs `pytest-django` so CI can run the new suite.

## Why this matters for #21

\`silentsuite-billing\`'s \`PATCH /account/password\` (covered in https://github.com/silent-suite/silentsuite-billing/pull/17) is purely a notification endpoint — it can't verify an old password because it doesn't have one. The architectural decision was that the **actual** old-password check lives here, in the bridge/server's \`change_password\` flow, where the request body must be NaCl-signed by the user's current \`loginPubkey\`.

\`TestChangePassword.test_change_password_rejects_wrong_signature\` is the explicit assertion: an attacker with a stolen session token but no current password cannot rotate credentials, and the user's stored loginPubkey is verifiably untouched after such an attempt. \`test_change_password_succeeds_with_correct_signature\` proves the positive direction — old signing key stops working, new one starts.

## Findings worth noting (not fixed in this PR)

- The signup route is declared \`status_code=201\` but \`MsgpackRoute\`'s response handling drops the declared status; actual responses are 200. Tests accept either.
- A login request with garbage challenge bytes raises \`nacl.exceptions.CryptoError\` uncaught, surfacing as a 500 instead of a clean 4xx. Not exploitable (no info leak) but worth tightening; flagged inline.

## Test plan
- [x] \`pytest etebase_server/fastapi/test_authentication.py etebase_server/fastapi/test_session_auth.py\` — 22/22 pass locally
- [x] \`pytest etebase_server/\` — 30/30 pass (includes existing myauth smoke tests)
- [x] \`ruff check etebase_server/fastapi/{conftest,test_authentication,test_session_auth}.py --select=E,F,I --ignore=E501\` — clean
- [ ] CI (\`ci-server.yml\`) green on PR