### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Something is broken or behaving unexpectedly.
+labels: [bug]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which surface is affected?
+      options:
+        - webapp (app.silentsuite.io)
+        - server (Etebase sync server)
+        - bridge (CalDAV/CardDAV)
+        - android
+        - docs
+        - other
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      placeholder: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      placeholder: Steps, sample data, or commands.
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      placeholder: Browser/OS, app version, self-hosted vs hosted, anything relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security disclosure
+    url: mailto:info@silentsuite.io
+    about: Report security or privacy issues privately, not via a public issue.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,21 @@
+name: Task
+description: A discrete piece of work to do.
+labels: []
+body:
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: What does "done" look like? Be concrete.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why this matters, links to related work, constraints.
+  - type: textarea
+    id: notes
+    attributes:
+      label: Implementation notes
+      description: Suggested approach, files to touch, gotchas.


### PR DESCRIPTION
Adds bug.yml + task.yml under .github/ISSUE_TEMPLATE plus a config.yml that points security disclosures at info@silentsuite.io rather than a public issue.