### PR TITLE
fix(docker): drop stale apps/landing COPY in Dockerfile.web

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -9,7 +9,6 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 
 # Copy all package.json files so pnpm workspace resolution works
 COPY apps/web/package.json apps/web/
-COPY apps/landing/package.json apps/landing/
 COPY apps/docs/package.json apps/docs/
 COPY packages/core/package.json packages/core/
 COPY packages/ui/package.json packages/ui/


### PR DESCRIPTION
## Summary

Drop the now-stale \`COPY apps/landing/package.json apps/landing/\` from \`Dockerfile.web\`. The landing app moved to \`silent-suite/silentsuite-internal\` in #41 but the Dockerfile wasn't updated, so every subsequent \`preview-web.yml\` build has been failing at line 12 with \`failed to calculate checksum: /apps/landing/package.json: not found\`.

\`pnpm-workspace.yaml\` uses \`apps/*\` glob, so no workspace config update needed.

## Surfaced by

Smoke deploy from \`ss@xl\` during the laptop → ss cutover (originally PR #53, closed).

## Test plan

- [ ] \`preview-web.yml\` build on this PR completes successfully
- [ ] Preview URL renders the homepage