### PR TITLE
fix(bridge): UID extraction from VCALENDAR child components + peewee <4.0 pin

### DIFF
--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -55,6 +55,25 @@ def get_millis():
     return int(round(time.time() * 1000))
 
 
+def _extract_uid(vobject_item):
+    """Extract UID from a vobject item.
+
+    For VCALENDAR/VCARD containers, the UID lives on the child component
+    (VEVENT, VTODO, VJOURNAL, VCARD), not the parent.
+    """
+    try:
+        return vobject_item.uid.value if hasattr(vobject_item.uid, 'value') else vobject_item.uid
+    except AttributeError:
+        pass
+    # Try child components
+    for child in vobject_item.components():
+        try:
+            return child.uid.value if hasattr(child.uid, 'value') else child.uid
+        except AttributeError:
+            continue
+    raise StorageException("No UID found in vobject item")
+
+
 class StorageException(Exception):
     pass
 


### PR DESCRIPTION
## Summary

Two changes from laptop \`stash@{3}\`:

1. **\`bridge/src/silentsuite_bridge/local_cache/__init__.py\`** — new \`_extract_uid()\` helper. VCALENDAR and VCARD vobject items hold their UID on the child component (VEVENT, VTODO, VJOURNAL, VCARD), not the container. Previous direct \`vobject_item.uid\` access raised \`AttributeError\` on real DAV input. \`Collection.create\` updated to use the helper.
2. **\`bridge/pyproject.toml\`** — pin \`peewee\` to \`<4.0.0\`. The previous \`>=3.14.0\` bound would silently accept a peewee 4.x release.

The \`bridge/install.sh\` REPO URL fix that was also in this stash is now redundant — the same change has landed on \`dev\` via another path.

## Provenance

Laptop \`stash@{3}\` ('WIP on fix/selfhost-docs'), captured during the laptop → ss cutover (2026-04-30).

## Test plan

- [ ] Add a unit test for \`_extract_uid()\` covering VCALENDAR-with-VEVENT, VCALENDAR-with-VTODO, VCARD, raw-VEVENT-no-container
- [ ] Run \`bridge/\` tests in CI