### PR TITLE
test(21): tighten assertions flagged in adversarial review

### DIFF
--- a/bridge/tests/test_auth_roundtrip.py
+++ b/bridge/tests/test_auth_roundtrip.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import hashlib
 import hmac as hmac_mod
 import os
+import secrets as secrets_mod
 from unittest.mock import MagicMock
 
 import pytest
@@ -142,26 +143,39 @@ class TestPbkdf2RoundTrip:
     def test_password_comparison_uses_constant_time_compare(
         self, auth, creds_file, monkeypatch
     ):
-        # The auth path uses hmac.compare_digest specifically to avoid
-        # timing-side-channel password recovery. If a future refactor
-        # accidentally swapped to `==`, this test would fail loudly.
+        # The auth path must use a constant-time compare (hmac.compare_digest
+        # OR the equivalent-and-safe secrets.compare_digest) to avoid timing
+        # side-channel password recovery. If a future refactor accidentally
+        # swaps to plain `==`, neither spy fires and the test fails loudly.
         _seed_pbkdf2_user(creds_file)
 
-        calls: list[tuple[str, str]] = []
-        real_compare = hmac_mod.compare_digest
+        calls: list[tuple[str, tuple]] = []
+        real_hmac_compare = hmac_mod.compare_digest
+        real_secrets_compare = secrets_mod.compare_digest
 
-        def spy(a, b):
-            calls.append((a, b))
-            return real_compare(a, b)
+        def hmac_spy(a, b):
+            calls.append(("hmac", (a, b)))
+            return real_hmac_compare(a, b)
+
+        def secrets_spy(a, b):
+            calls.append(("secrets", (a, b)))
+            return real_secrets_compare(a, b)
 
         monkeypatch.setattr(
-            "silentsuite_bridge.radicale.auth.hmac.compare_digest", spy
+            "silentsuite_bridge.radicale.auth.hmac.compare_digest", hmac_spy
         )
+        # secrets.compare_digest may not be imported by the auth module today,
+        # but patching it defensively means a refactor that switches to it
+        # still satisfies this test instead of silently bypassing the check.
+        monkeypatch.setattr(secrets_mod, "compare_digest", secrets_spy)
 
         result = auth.login(USERNAME, PASSWORD)
 
         assert result == USERNAME
-        assert len(calls) == 1, "expected exactly one constant-time compare per login"
+        assert len(calls) == 1, (
+            "expected exactly one constant-time compare per login "
+            f"(hmac.compare_digest or secrets.compare_digest); got {calls!r}"
+        )
 
 
 class TestLegacySha256Upgrade:

--- a/server/etebase_server/fastapi/test_authentication.py
+++ b/server/etebase_server/fastapi/test_authentication.py
@@ -143,15 +143,25 @@ class TestLogin:
         assert response.status_code == 400
         assert decode_response(response)["code"] == "wrong_host"
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "validate_login_request in routers/authentication.py:156-157 "
+            "doesn't catch nacl.exceptions.CryptoError, so undecryptable "
+            "challenge bytes surface as a 500 instead of a clean 400. "
+            "Not exploitable — no user data leaks — but the route should "
+            "raise HttpError('invalid_challenge', ..., 400). When that fix "
+            "lands, this xfail will flip to XPASS and strict mode will "
+            "force removing the marker."
+        ),
+    )
     def test_login_with_garbage_challenge_bytes_fails(
         self, auth_app, user_factory, signing_key
     ):
         # Skip the real challenge endpoint and send random bytes — the
-        # server can't decrypt them, so the login must not succeed.
-        # (Note: the route doesn't currently catch NaCl's CryptoError, so
-        # this surfaces as a 500 rather than a clean 4xx. That's a minor
-        # robustness gap worth fixing separately; it isn't exploitable —
-        # no user data leaks — but it should be a 400. Filed mentally.)
+        # server can't decrypt them, so the login must not succeed AND the
+        # response must be a clean 4xx (not a 500 from an uncaught crypto
+        # exception).
         from fastapi.testclient import TestClient
 
         client = TestClient(auth_app, raise_server_exceptions=False)
@@ -164,7 +174,7 @@ class TestLogin:
         )
         response = msgpack_post(client, f"{AUTH_PREFIX}/login/", body)
 
-        assert response.status_code != 200
+        assert response.status_code in (400, 422)
 
 
 @pytest.mark.django_db(transaction=True)
@@ -228,11 +238,20 @@ class TestChangePassword:
     ):
         user_factory(username="test_user_alice")
 
+        # Sign with an attacker key, NOT the user's real signing key. The
+        # request must be rejected by the auth layer before crypto runs at
+        # all — if a future regression accidentally bypasses auth but keeps
+        # the crypto check intact, this body would still be rejected (wrong
+        # signature) and the test would falsely pass. Using an attacker key
+        # ensures only a true auth-layer rejection produces the expected
+        # 401/403; a crypto-layer rejection would surface differently.
+        attacker_key = nacl.signing.SigningKey.generate()
+
         _, challenge = login_challenge(auth_client, "test_user_alice")
         body = build_signed_response(
             username="test_user_alice",
             challenge_bytes=challenge["challenge"],
-            signing_key=signing_key,
+            signing_key=attacker_key,
             action="changePassword",
             extra={"loginPubkey": b"\x01" * 32, "encryptedContent": b"\x02" * 64},
         )


### PR DESCRIPTION
## Summary

Three follow-ups from the SHIP-WITH-NOTES reviews on PRs #39 and #40 (issue #21). All non-blocking but real, bundled into one PR.

### server `test_authentication.py`

- **`test_login_with_garbage_challenge_bytes_fails`** previously asserted only `status_code != 200`, so the current 500 (uncaught `nacl.exceptions.CryptoError` in `validate_login_request`, `routers/authentication.py:156-157`) satisfied it as readily as a clean 400. Mark `@pytest.mark.xfail(strict=True)` with the underlying-bug reference and tighten the assertion to `status_code in (400, 422)`. When the route fix lands, strict-xfail flips to XPASS and forces removing the marker.
- **`test_change_password_requires_authentication`** signed with the user's legitimate `signing_key`. Switch to a generated attacker key so a hypothetical regression where auth is bypassed but the crypto check still gates would surface differently from "neither check ran".

### bridge `test_auth_roundtrip.py`

- The `hmac.compare_digest` spy in `test_password_comparison_uses_constant_time_compare` would false-positive a refactor that switched to the equivalent-and-safe `secrets.compare_digest`. Patch both modules defensively and assert exactly one constant-time compare across the pair (with the call list captured in the failure message for debuggability).

## Out of scope

- The actual `validate_login_request` `CryptoError` fix and the `MsgpackResponse` `status_code=201` propagation fix that the xfail points at. Those are real route fixes, not test tightening — separate PRs when someone picks them up.
- The `Credentials.load()` mtime-granularity issue noted on PR #40 (pre-existing, not introduced by #40 or this PR).
- The bridge CI `branches: [main, develop]` filter note from `next-session-prompt.md` was already correct as `[main, dev]` (PR #36 fixed it before #40 landed) — no change needed.
- Triage of the pre-existing red `test_acquire_lock_write_forces_sync_after` — separate task.

## Test plan

- [ ] `test-bridge-linux.yml` runs on this PR; bridge `test_password_comparison_uses_constant_time_compare` passes (spy still fires once via `hmac.compare_digest` since the auth module imports it directly).
- [ ] Server pytest: `test_login_with_garbage_challenge_bytes_fails` reports as XFAIL (not XPASS, not FAILED) — confirms the 500 bug is still latent and the strict-xfail will catch the eventual fix.
- [ ] Server pytest: `test_change_password_requires_authentication` still passes — the auth check rejects the unauthenticated request before crypto runs, so the attacker-key signature is irrelevant to the outcome but eliminates the false-positive shape if auth ever regresses.