### PR TITLE
fix(web/import): preserve source TZID on imported events; date-only DUE for tasks

### DIFF
--- a/apps/web/app/components/import/CalendarImport.tsx
+++ b/apps/web/app/components/import/CalendarImport.tsx
@@ -133,6 +133,7 @@ export default function CalendarImport({ onImportComplete }: CalendarImportProps
           recurrenceRule: event.rrule ?? null,
           alarms: event.valarms ?? [],
           calendarId: selectedCalendarId,
+          timezone: isAllDay ? undefined : startTzid,
         }
       })
       const count = await importEvents(newEvents)

--- a/apps/web/app/components/import/TaskImport.tsx
+++ b/apps/web/app/components/import/TaskImport.tsx
@@ -158,28 +158,22 @@ function mapPriorityToStore(icalPriority?: number): Priority {
   return 'low'
 }
 
+// Date-only on import: the Task model has no timezone field, so a TZID-bearing
+// or UTC datetime would otherwise be parsed in the importer's local zone and
+// land on the wrong instant. Take the wall-clock date from the source value.
+// Full TZID parity for VTODO is tracked in #66.
 function parseICalDate(d: string): Date | null {
   if (!d) return null
-  if (/^\d{8}$/.test(d)) {
-    return new Date(
-      parseInt(d.slice(0, 4)),
-      parseInt(d.slice(4, 6)) - 1,
-      parseInt(d.slice(6, 8)),
-    )
+  const digits = d.replace(/[^0-9]/g, '')
+  if (digits.length < 8) {
+    const parsed = new Date(d)
+    return isNaN(parsed.getTime()) ? null : parsed
   }
-  if (/^\d{8}T\d{6}/.test(d)) {
-    const isUtc = d.endsWith('Z')
-    const y = parseInt(d.slice(0, 4))
-    const mo = parseInt(d.slice(4, 6)) - 1
-    const day = parseInt(d.slice(6, 8))
-    const h = parseInt(d.slice(9, 11))
-    const mi = parseInt(d.slice(11, 13))
-    const s = parseInt(d.slice(13, 15))
-    if (isUtc) return new Date(Date.UTC(y, mo, day, h, mi, s))
-    return new Date(y, mo, day, h, mi, s)
-  }
-  const parsed = new Date(d)
-  return isNaN(parsed.getTime()) ? null : parsed
+  return new Date(
+    parseInt(digits.slice(0, 4)),
+    parseInt(digits.slice(4, 6)) - 1,
+    parseInt(digits.slice(6, 8)),
+  )
 }
 
 export default function TaskImport({ onImportComplete }: TaskImportProps) {

--- a/apps/web/app/stores/__tests__/use-calendar-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-calendar-store.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useCalendarStore } from '../use-calendar-store'
+import { serializeCalendarEvent, deserializeCalendarEvent } from '@silentsuite/core'
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: {
+    getState: () => ({ canWrite: () => true }),
+  },
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: {
+    getState: () => ({ account: null }),
+  },
+}))
+
+vi.mock('@/app/stores/use-toast-store', () => ({
+  showErrorToast: vi.fn(),
+}))
+
+function resetStore() {
+  useCalendarStore.setState({
+    events: [],
+    isLoading: false,
+    syncStatus: 'synced',
+    currentView: 'week',
+    currentDate: new Date('2026-06-01T12:00:00Z'),
+    selectedEventId: null,
+  })
+}
+
+describe('useCalendarStore.importEvents', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it('preserves source TZID on imported events', async () => {
+    const { importEvents } = useCalendarStore.getState()
+    await importEvents([
+      {
+        title: 'NY meeting',
+        startDate: new Date('2026-06-01T13:00:00Z'),
+        endDate: new Date('2026-06-01T14:00:00Z'),
+        timezone: 'America/New_York',
+      },
+    ])
+
+    const { events } = useCalendarStore.getState()
+    expect(events).toHaveLength(1)
+    expect(events[0]!.timezone).toBe('America/New_York')
+  })
+
+  it('leaves timezone undefined when none was supplied', async () => {
+    const { importEvents } = useCalendarStore.getState()
+    await importEvents([
+      {
+        title: 'Floating',
+        startDate: new Date('2026-06-01T09:00:00Z'),
+        endDate: new Date('2026-06-01T10:00:00Z'),
+      },
+    ])
+
+    const { events } = useCalendarStore.getState()
+    expect(events[0]!.timezone).toBeUndefined()
+  })
+
+  it('serializes a TZID-bearing imported event back out with TZID intact (round-trip)', async () => {
+    const { importEvents } = useCalendarStore.getState()
+    await importEvents([
+      {
+        title: 'Tokyo standup',
+        startDate: new Date('2026-06-01T00:00:00Z'),
+        endDate: new Date('2026-06-01T01:00:00Z'),
+        timezone: 'Asia/Tokyo',
+      },
+    ])
+
+    const { events } = useCalendarStore.getState()
+    const ical = serializeCalendarEvent(events[0]!)
+    expect(ical).toContain('DTSTART;TZID=Asia/Tokyo:')
+    expect(ical).toContain('DTEND;TZID=Asia/Tokyo:')
+
+    // And deserializing produces the same TZID
+    const roundTripped = deserializeCalendarEvent(ical)
+    expect(roundTripped.timezone).toBe('Asia/Tokyo')
+  })
+
+  it('drops timezone for all-day events (DATE-only, no TZID per RFC 5545)', async () => {
+    const { importEvents } = useCalendarStore.getState()
+    await importEvents([
+      {
+        title: 'All-day',
+        startDate: new Date(2026, 5, 1),
+        endDate: new Date(2026, 5, 2),
+        allDay: true,
+        // CalendarImport passes undefined for all-day to honour RFC 5545
+        timezone: undefined,
+      },
+    ])
+
+    const { events } = useCalendarStore.getState()
+    const ical = serializeCalendarEvent(events[0]!)
+    expect(ical).not.toMatch(/DTSTART;TZID=/)
+    expect(ical).toContain('DTSTART;VALUE=DATE:')
+  })
+})

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -452,6 +452,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
         exceptions: [],
         alarms: ne.alarms ?? [],
         calendarId: ne.calendarId ?? 'default',
+        timezone: ne.timezone,
         created: now,
         updated: now,
       }


### PR DESCRIPTION
Closes #65. Follow-up #66 tracks full TZID parity for tasks.

## Problem
After importing an `.ics` file, events that had a source timezone (e.g. `DTSTART;TZID=America/New_York:…`) showed up displaying their wall-clock in **MEZ/CET** (the user's default zone). The wall-clock instant was actually correct — but the **source TZID was being silently discarded** during import, so:

- The EventDialog showed the user's default timezone, not the source TZ
- Round-trip export emitted bare UTC (`Z` suffix) instead of `DTSTART;TZID=America/New_York:…`
- Every imported event "looked" like a Berlin event regardless of origin

## Root cause — calendar (`#65`)
The TZID is parsed once to compute the right UTC instant, then thrown away. Two missed propagations:

1. `apps/web/app/components/import/CalendarImport.tsx` — `handleImport` reads `startTzid` but doesn't put it on the payload passed to `importEvents`.
2. `apps/web/app/stores/use-calendar-store.ts` — `importEvents` mapper doesn't copy `ne.timezone` onto the resulting `CalendarEvent`, even though the input type already has the field.

The downstream serialize/deserialize path was already correct: `toVEvent` writes `DTSTART;TZID=…` when `event.timezone` is set, and `fromVEvent` extracts it back. The bug was purely import-side data loss.

## Fix — calendar
Two-line propagation (`isAllDay ? undefined : startTzid` to honour RFC 5545: all-day events shouldn't carry TZID).

## Fix — tasks (`Option A`, minimal)
Tasks have a worse problem: the `Task` model has no `timezone` field at all, and `TaskImport.tsx`'s local `parseICalDate` ignores TZID entirely (no `tzid` parameter, no Intl conversion). A TZID'd DUE got parsed in the importer's local zone — **wrong instant**, not just wrong label.

Minimal fix here: treat all imported DUE as date-only (Apple Reminders convention — which is how Google Tasks and most VTODO sources behave anyway). Avoids the wrong-instant bug; loses time-of-day fidelity for the niche case of TZID'd timed tasks. Full RFC 5545 TZID parity for VTODO tracked in **#66**.

## Tests
New regression suite at `apps/web/app/stores/__tests__/use-calendar-store.test.ts`:

- `importEvents` preserves source TZID
- `importEvents` leaves timezone undefined when none supplied (floating)
- TZID-bearing imported event round-trips through `serializeCalendarEvent` → `deserializeCalendarEvent` with TZID intact
- All-day events do **not** get a `TZID` parameter on serialize (they get `VALUE=DATE`)

## Verification
- `pnpm test` — 102/102 pass (4 new)
- `pnpm type-check` — clean

## Test plan
- [ ] Re-import the original ICS file that triggered this bug
- [ ] Open a previously-NY event in the EventDialog → timezone selector shows `America/New_York`, not `Europe/Berlin`
- [ ] Export the calendar back out → `DTSTART;TZID=America/New_York:…` present in the output
- [ ] All-day events still display as all-day (no TZID, no time shift)
- [ ] Floating-time events (no TZID, no Z) still parse to importer-local — unchanged behaviour