### PR TITLE
docs(readme): polish for first-impression on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,60 @@
+<div align="center">
+
 # SilentSuite
 
 **Private Sync, By Design.**
 
-End-to-end encrypted synchronization for calendar, contacts, and tasks. Your schedule and relationships, visible only to you.
+End-to-end encrypted calendar, contacts, and tasks. Your schedule and relationships, visible only to you.
 
-Built on the [Etebase protocol](https://www.etebase.com/). Open source. EU-hosted.
+[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](./LICENSE)
+[![Stars](https://img.shields.io/github/stars/silent-suite/silentsuite?style=flat&logo=github)](https://github.com/silent-suite/silentsuite/stargazers)
+[![Last commit](https://img.shields.io/github/last-commit/silent-suite/silentsuite/dev?logo=git&logoColor=white)](https://github.com/silent-suite/silentsuite/commits/dev)
+[![Mastodon](https://img.shields.io/badge/Mastodon-@silentsuiteio-6364FF?logo=mastodon&logoColor=white)](https://infosec.exchange/@silentsuiteio)
 
-[Website](https://silentsuite.io) | [Blog](https://silentsuite.io/blog) | [Waitlist](https://silentsuite.io/#waitlist)
+[Website](https://silentsuite.io) · [Blog](https://silentsuite.io/blog) · [Docs](https://docs.silentsuite.io) · [Waitlist](https://silentsuite.io/#waitlist)
+
+</div>
+
+---
+
+## Contents
+
+- [What is SilentSuite?](#what-is-silentsuite)
+- [Why SilentSuite?](#why-silentsuite)
+- [How it works](#how-it-works)
+- [Quick start](#quick-start)
+- [Status](#status)
+- [Tech stack](#tech-stack)
+- [Repository structure](#repository-structure)
+- [Documentation](#documentation)
+- [Self-hosting](#self-hosting)
+- [Principles](#principles)
+- [Contributing](#contributing)
+- [Contributors](#contributors)
+- [Links](#links)
+- [License](#license)
 
 ## What is SilentSuite?
 
-SilentSuite is an encrypted alternative to Google Calendar, Apple iCloud, and other cloud sync services. Every piece of data is encrypted on your device before it reaches our server. The server only ever sees ciphertext.
+SilentSuite is an end-to-end encrypted alternative to Google Calendar, iCloud, and other cloud sync services. Every event, contact, and task is encrypted on your device before it touches our server. The server only ever stores ciphertext — we cannot read your data, and neither can anyone we are compelled to hand it to.
 
-- **Calendar** -- events encrypted before they leave your device
-- **Contacts** -- your relationships, visible only to you
-- **Tasks** -- your to-dos, nobody else's business
+- **Calendar** — events encrypted before they leave your device
+- **Contacts** — your relationships, visible only to you
+- **Tasks** — your to-dos, nobody else's business
+
+Built on the open [Etebase protocol](https://www.etebase.com/). Open source, EU-hosted, GDPR-baseline.
+
+## Why SilentSuite?
+
+|  | Google / Apple / Microsoft | Other "encrypted" calendars | **SilentSuite** |
+|---|:-:|:-:|:-:|
+| End-to-end encrypted by default | ✗ | partial | ✓ |
+| Open-source server + client | ✗ | mixed | ✓ |
+| Works with native CalDAV / CardDAV apps | ✓ | mostly ✗ | ✓ (via bridge) |
+| Self-hostable | ✗ | mixed | ✓ |
+| EU-hosted / GDPR-baseline | varies | varies | ✓ |
+| No data monetisation | ✗ | varies | ✓ (impossible — it's encrypted) |
+| Standard, exportable data format | ✓ | mixed | ✓ |
 
 ## How it works
 
@@ -28,7 +68,41 @@ Your Device          SilentSuite Server          Your Other Device
     |   Server never has the keys. Never sees plaintext.
 ```
 
-All encryption and decryption happens on your devices. The server stores and syncs encrypted blobs. We can't read your data, even if compelled to.
+All encryption and decryption happens on your devices. The server stores and syncs encrypted blobs. Even with full server access, an attacker — or a court order — gets ciphertext and nothing else.
+
+## Quick start
+
+### Try the hosted service
+
+The easiest path is the hosted webapp:
+
+1. Join the waitlist at [silentsuite.io](https://silentsuite.io/#waitlist).
+2. Sign in at [app.silentsuite.io](https://app.silentsuite.io) once your invite arrives.
+3. Optional: pair an existing calendar app (Apple Calendar, Thunderbird, DAVx⁵) via the [CalDAV bridge](./docs/user-guide/).
+
+### Self-host
+
+Spin up the encrypted sync server on your own infrastructure with Docker:
+
+```bash
+git clone https://github.com/silent-suite/silentsuite.git
+cd silentsuite/self-host
+cp .env.example .env   # then edit
+docker compose up -d
+```
+
+Full instructions, TLS setup, and operational guidance are in the [Self-Hosting guide](./docs/self-hosting/).
+
+### Run locally for development
+
+```bash
+git clone https://github.com/silent-suite/silentsuite.git
+cd silentsuite
+pnpm install
+pnpm dev   # webapp + docs site
+```
+
+The Etebase sync server, CalDAV/CardDAV bridge, and Android adapter each have their own setup — see the [Contributing guide](./docs/contributing/) for the full dev environment.
 
 ## Status
 
@@ -36,76 +110,96 @@ SilentSuite is in active development.
 
 - [x] Etebase server deployed and running
 - [x] Real E2E encrypted sync verified between devices
+- [x] Web app live at [app.silentsuite.io](https://app.silentsuite.io)
+- [x] CalDAV / CardDAV bridge (read-write)
 - [x] Landing page live at [silentsuite.io](https://silentsuite.io)
 - [x] Waitlist open (GDPR-compliant double opt-in)
 - [x] Blog with RSS feed
-- [ ] Client apps (Android, web, iOS)
-- [ ] CalDAV bridge for existing calendar apps
+- [ ] Android client
+- [ ] iOS client
 - [ ] Family plans
 
 ## Tech stack
 
 | Component | Technology |
 |-----------|-----------|
-| Server | Python, Etebase protocol, Docker |
-| Landing page | Next.js 15, Tailwind CSS, Cloudflare Workers |
+| Sync server | Python, Etebase protocol, Docker |
+| Web app | Next.js 15, React, Tailwind CSS, libsodium |
+| Docs site | Next.js, Cloudflare Workers |
+| CalDAV / CardDAV bridge | Python, radicale-style adapters |
+| Android adapter | Kotlin |
+| Encryption | Etebase protocol (XChaCha20-Poly1305, Argon2id) |
 | Hosting | EU cloud infrastructure |
-| Encryption | Etebase protocol (XChaCha20-Poly1305, Argon2) |
 | License | AGPL-3.0 (server + apps) |
+
+## Repository structure
+
+| Path | What it is |
+|------|-----------|
+| [`apps/web/`](./apps/web/) | Web app (app.silentsuite.io) — encrypted calendar, contacts, tasks UI |
+| [`apps/docs/`](./apps/docs/) | Documentation site (docs.silentsuite.io) |
+| [`packages/core/`](./packages/core/) | Shared core library (crypto, sync primitives) |
+| [`packages/ui/`](./packages/ui/) | Shared UI components |
+| [`packages/config/`](./packages/config/) | Shared TypeScript / ESLint / Tailwind config |
+| [`server/`](./server/) | Etebase sync server (Python / Django) |
+| [`bridge/`](./bridge/) | CalDAV / CardDAV bridge for native calendar apps |
+| [`android/`](./android/) | Android sync adapter (Kotlin) |
+| [`self-host/`](./self-host/) | Self-hosting Docker configs and scripts |
+| [`docs/`](./docs/) | Markdown documentation (user, self-host, contributing) |
+
+The marketing site (silentsuite.io) and the billing / accounts API live in a separate, private repo. They have no cryptographic responsibilities, and keeping marketing copy out of an AGPL repo is intentional.
+
+## Documentation
+
+- **[User Guide](./docs/user-guide/)** — calendar, contacts, tasks, encryption, CalDAV pairing
+- **[Self-Hosting](./docs/self-hosting/)** — deploy and operate SilentSuite on your own infrastructure
+- **[Contributing](./docs/contributing/)** — set up a dev environment and ship changes
+
+Hosted at [docs.silentsuite.io](https://docs.silentsuite.io).
+
+## Self-hosting
+
+The sync server is self-hostable. See the [Self-Hosting guide](./docs/self-hosting/) for the full walkthrough.
 
 ## Principles
 
 1. **Encryption is the architecture, not a feature.** No toggles, no opt-in. Everything is encrypted by default.
 2. **Open source by default.** Apps and server code are open. Audit the encryption, verify the claims.
 3. **No lock-in.** Export your data anytime. Self-host if you want. Standard Etebase protocol, not proprietary formats.
-4. **EU-hosted, GDPR-compliant.** Your encrypted data stays in the EU. GDPR as a baseline, not a checkbox.
-5. **Sustainable business.** Paid hosted service funds development. No data monetisation. We can't -- it's encrypted.
+4. **EU-hosted, GDPR-baseline.** Your encrypted data stays in the EU. GDPR as a baseline, not a checkbox.
+5. **Sustainable business.** Paid hosted service funds development. No data monetisation. We can't — it's encrypted.
 
-## Repository Structure
+## Contributing
 
-| Directory | Description |
-|-----------|-------------|
-| `apps/web/` | Next.js web app (app.silentsuite.io) |
-| `apps/docs/` | Documentation site (docs.silentsuite.io) |
-| `packages/core/` | Shared core library |
-| `packages/ui/` | Shared UI components |
-| `packages/config/` | Shared configuration |
-| `android/` | Android sync adapter (Kotlin) |
-| `bridge/` | CalDAV/CardDAV bridge (Python) |
-| `server/` | Etebase sync server (Python/Django) |
-| `self-host/` | Self-hosting Docker configs and scripts |
+Bug reports, feature requests, and PRs are welcome. Start with the [Contributing guide](./docs/contributing/) for the dev environment, then check [open issues](https://github.com/silent-suite/silentsuite/issues) for something to pick up.
 
-## Documentation
+Security issues: please email <info@silentsuite.io> rather than opening a public issue.
 
-Full documentation is available in the [`docs/`](./docs/) directory:
+## Contributors
 
-- **[User Guide](./docs/user-guide/)** -- how-to guides for calendar, contacts, tasks, and encryption
-- **[Self-Hosting](./docs/self-hosting/)** -- deploy and manage SilentSuite on your own infrastructure
-- **[Contributing](./docs/contributing/)** -- set up a dev environment and contribute to SilentSuite
-
-## Self-hosting
-
-The server can be self-hosted. See the [Self-Hosting guide](./docs/self-hosting/) for complete instructions.
-
-See `deploy/RUNBOOK.md` in this repo for additional server administration details.
-
-## Development
-
-This repository contains the open-source pieces of SilentSuite: the encrypted sync server, the web client (with end-to-end crypto), the Android sync adapter, and the CalDAV/CardDAV bridge. See the [Contributing guide](./docs/contributing/) for setup instructions.
-
-The marketing site (silentsuite.io) and the billing/accounts API live in a separate, private repository — they don't bear any cryptographic responsibilities, and keeping marketing copy out of an AGPL repo is intentional.
+[![Contributors](https://contrib.rocks/image?repo=silent-suite/silentsuite)](https://github.com/silent-suite/silentsuite/graphs/contributors)
 
 ## Links
 
 - **Website:** [silentsuite.io](https://silentsuite.io)
-- **Blog:** [silentsuite.io/blog](https://silentsuite.io/blog)
-- **RSS:** [silentsuite.io/blog/feed.xml](https://silentsuite.io/blog/feed.xml)
+- **Blog:** [silentsuite.io/blog](https://silentsuite.io/blog) ([RSS](https://silentsuite.io/blog/feed.xml))
+- **Docs:** [docs.silentsuite.io](https://docs.silentsuite.io)
+- **Status:** [status.silentsuite.io](https://status.silentsuite.io)
+- **Mastodon:** [@silentsuiteio@infosec.exchange](https://infosec.exchange/@silentsuiteio)
 - **X:** [@silentsuiteio](https://x.com/silentsuiteio)
 - **Reddit:** [u/silentsuiteio](https://reddit.com/user/silentsuiteio)
-- **Mastodon:** [@silentsuiteio@infosec.exchange](https://infosec.exchange/@silentsuiteio)
 - **Email:** info@silentsuite.io
-- **Status:** [status.silentsuite.io](https://status.silentsuite.io)
+
+## Star history
+
+<a href="https://star-history.com/#silent-suite/silentsuite&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=silent-suite/silentsuite&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=silent-suite/silentsuite&type=Date" />
+    <img alt="Star history chart" src="https://api.star-history.com/svg?repos=silent-suite/silentsuite&type=Date" />
+  </picture>
+</a>
 
 ## License
 
-AGPL-3.0
+[AGPL-3.0](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ SilentSuite is in active development.
 - [x] Etebase server deployed and running
 - [x] Real E2E encrypted sync verified between devices
 - [x] Web app live at [app.silentsuite.io](https://app.silentsuite.io)
-- [x] CalDAV / CardDAV bridge (read-write)
+- [x] CalDAV / CardDAV bridge
 - [x] Landing page live at [silentsuite.io](https://silentsuite.io)
 - [x] Waitlist open (GDPR-compliant double opt-in)
 - [x] Blog with RSS feed
@@ -124,11 +124,11 @@ SilentSuite is in active development.
 | Component | Technology |
 |-----------|-----------|
 | Sync server | Python, Etebase protocol, Docker |
-| Web app | Next.js 15, React, Tailwind CSS, libsodium |
-| Docs site | Next.js, Cloudflare Workers |
-| CalDAV / CardDAV bridge | Python, radicale-style adapters |
+| Web app | Next.js 15, React, Tailwind CSS |
+| Docs site | VitePress, Vue, Cloudflare Workers |
+| CalDAV / CardDAV bridge | Python, Radicale |
 | Android adapter | Kotlin |
-| Encryption | Etebase protocol (XChaCha20-Poly1305, Argon2id) |
+| Encryption | Etebase protocol (XChaCha20-Poly1305, Argon2 via libsodium) |
 | Hosting | EU cloud infrastructure |
 | License | AGPL-3.0 (server + apps) |
 


### PR DESCRIPTION
## Summary
- Refs #63
- Restructured the README so a first-time visitor (HN, Reddit, GitHub search) gets the value prop, the differentiation, and a try-it path within 30 seconds.

## What changed
- **Centred hero** with badges (License AGPL, Stars, Last commit, Mastodon).
- **Table of contents** for the long sections.
- **Tightened "What is SilentSuite?"** — keep the encryption-first framing, tighter copy.
- **New "Why SilentSuite?"** comparison table — SilentSuite vs Google/Apple/Microsoft vs other "encrypted" calendars.
- **"Quick start"** with three paths: hosted, self-host (\`docker compose up -d\`), local dev (\`pnpm dev\`).
- **Refreshed Status** — web app and CalDAV/CardDAV bridge are now ✓.
- **Repo structure** rewritten as path → description, with each path linked.
- **Contributors** block via contrib.rocks.
- **Star history** chart (light/dark variants) at the bottom.
- **Fixed two stale link targets**: the previous README pointed at \`deploy/RUNBOOK.md\` (does not exist) and I had momentarily added \`.github/SECURITY.md\` (also does not exist) — both replaced with what actually exists. Security disclosure points at the \`info@silentsuite.io\` mailbox per \`.github/ISSUE_TEMPLATE/config.yml\`.

## Deferred (still on #63's checklist)
- **Logo swap** — blocked on #60 (new logo design). Text logo for now.
- **Screenshot / demo GIF above the fold** — needs an actual asset; best landed together with the logo.

Issue #63 stays open for those two items.

## Test plan
- [x] Diff renders cleanly on the GitHub PR preview
- [x] All in-repo links point to paths that exist (\`./LICENSE\`, \`./docs/...\`, \`./apps/...\`, \`./packages/...\`, \`./server/\`, \`./bridge/\`, \`./android/\`, \`./self-host/\`)
- [x] All external links resolve to valid SilentSuite properties (silentsuite.io, app.silentsuite.io, docs.silentsuite.io, status.silentsuite.io, blog feed, social handles)
- [ ] Render once on GitHub (mobile + desktop) and visually confirm the hero, badges, and star-history chart