### PR TITLE
docs(readme): add landing OG card below the hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ End-to-end encrypted calendar, contacts, and tasks. Your schedule and relationsh
 
 [Website](https://silentsuite.io) · [Blog](https://silentsuite.io/blog) · [Docs](https://docs.silentsuite.io) · [Waitlist](https://silentsuite.io/#waitlist)
 
+<br />
+
+<a href="https://silentsuite.io">
+  <img src="https://silentsuite.io/social/og-image-1200x630.png" alt="SilentSuite — Private Sync, By Design. Calendar, Contacts, Tasks, E2EE." width="800" />
+</a>
+
 </div>
 
 ---


### PR DESCRIPTION
## Summary
- Refs #63
- Drops the project's branded social card under the centred hero so the README gets a real visual identity above the fold.
- Hotlinked from \`silentsuite.io/social/og-image-1200x630.png\` rather than copying the binary into the public repo:
  - **Pro:** no asset duplication, README tracks whatever the landing site is serving.
  - **Con:** if the landing site is down or that path moves, the README image is broken until fixed. Acceptable trade-off — the OG path is also referenced by every social platform that has crawled the site, so changing it is unlikely.
- Wraps the image in an \`<a href="https://silentsuite.io">\` so it doubles as a click-through to the marketing site.

## Test plan
- [x] \`curl -sI https://silentsuite.io/social/og-image-1200x630.png\` returns 200
- [ ] Render once on GitHub and confirm the image lands centred under the hero / above the TOC