### PR TITLE
fix(android): clear Etebase cache and server session on drawer logout

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -437,14 +437,18 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             .setTitle(R.string.account_delete_confirmation_title)
             .setMessage(R.string.account_delete_confirmation_text)
             .setPositiveButton(R.string.navigation_drawer_logout) { _, _ ->
-                for (acc in accounts) {
-                    accountManager.removeAccountExplicitly(acc)
+                lifecycleScope.launch {
+                    for (acc in accounts) {
+                        teardownAccountState(acc)
+                    }
+                    for (acc in accounts) {
+                        accountManager.removeAccountExplicitly(acc)
+                    }
+                    val intent = Intent(this@AccountActivity, LoginActivity::class.java)
+                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+                    startActivity(intent)
+                    finish()
                 }
-                // Return to login
-                val intent = Intent(this, LoginActivity::class.java)
-                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
-                startActivity(intent)
-                finish()
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
@@ -723,41 +727,50 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
     private fun deleteAccount() {
         val accountManager = AccountManager.get(this)
-        val settings = AccountSettings(this@AccountActivity, account)
 
         lifecycleScope.launch {
-            withContext(Dispatchers.IO) {
-                EtebaseLocalCache.clearUserCache(this@AccountActivity, account.name)
+            teardownAccountState(account)
 
-                try {
-                    val httpClient = HttpClient.Builder(this@AccountActivity).build()
-                    val etebase = EtebaseLocalCache.getEtebase(this@AccountActivity, httpClient.okHttpClient, settings)
-                    etebase.logout()
-                } catch(e: EtebaseException) {
-                    // Ignore failures for now
-                    Logger.log.warning(e.toString())
-                }
-            }
+            if (Build.VERSION.SDK_INT >= 22)
+                accountManager.removeAccount(account, this@AccountActivity, { future ->
+                    try {
+                        if (future.result.getBoolean(AccountManager.KEY_BOOLEAN_RESULT))
+                            finish()
+                    } catch(e: Exception) {
+                        Logger.log.log(Level.SEVERE, "Couldn't remove account", e)
+                    }
+                }, null)
+            else
+                accountManager.removeAccount(account, { future ->
+                    try {
+                        if (future.result)
+                            finish()
+                    } catch (e: Exception) {
+                        Logger.log.log(Level.SEVERE, "Couldn't remove account", e)
+                    }
+                }, null)
         }
+    }
 
-        if (Build.VERSION.SDK_INT >= 22)
-            accountManager.removeAccount(account, this, { future ->
-                try {
-                    if (future.result.getBoolean(AccountManager.KEY_BOOLEAN_RESULT))
-                        finish()
-                } catch(e: Exception) {
-                    Logger.log.log(Level.SEVERE, "Couldn't remove account", e)
-                }
-            }, null)
-        else
-            accountManager.removeAccount(account, { future ->
-                try {
-                    if (future.result)
-                        finish()
-                } catch (e: Exception) {
-                    Logger.log.log(Level.SEVERE, "Couldn't remove account", e)
-                }
-            }, null)
+    // Tear down per-account client state before the Android account is removed.
+    // Must run while AccountManager still has the user data, since AccountSettings
+    // (and the etebase session) are read from it. Both deleteAccount() and
+    // confirmLogout() must call this — leaving the Etebase FS cache behind causes
+    // stale stokens on re-login, which makes incremental sync miss historical items.
+    private suspend fun teardownAccountState(account: Account) = withContext(Dispatchers.IO) {
+        EtebaseLocalCache.clearUserCache(this@AccountActivity, account.name)
+
+        try {
+            val settings = AccountSettings(this@AccountActivity, account)
+            HttpClient.Builder(this@AccountActivity).build().use { httpClient ->
+                val etebase = EtebaseLocalCache.getEtebase(this@AccountActivity, httpClient.okHttpClient, settings)
+                etebase.logout()
+            }
+        } catch (e: EtebaseException) {
+            Logger.log.warning("Server logout failed for ${account.name}: $e")
+        } catch (e: Exception) {
+            Logger.log.warning("Account teardown failed for ${account.name}: $e")
+        }
     }
 
 


### PR DESCRIPTION
## Summary

- Fixes #83: drawer Logout was leaving the per-account Etebase filesystem cache (`context.filesDir/<username>/`) and the in-memory `EtebaseLocalCache` instance behind, so re-logging in with the same username resumed sync from a stale stoken. Incremental fetch then returned only deltas, while the OS calendar/contacts rows had been dropped along with the Android account — many historical events never reappeared in the native calendar.
- Extracts the teardown that `deleteAccount()` already did into a shared `teardownAccountState()` helper, and routes both `confirmLogout()` and `deleteAccount()` through it. The helper clears the FS cache + in-memory map and best-effort invalidates the server session before the Android account is removed (must run while `AccountManager` still has the user data, since `AccountSettings` is read from it).
- Also fixes a pre-existing race in `deleteAccount()`: `removeAccount` was kicked off in parallel with the IO cleanup instead of after it. Now sequenced via the same `lifecycleScope.launch`.

## Test plan

- [ ] CI Android build passes (touched `android/**`, so `build-android.yml` runs).
- [ ] Manual repro on a debug build:
  - [ ] Log in as account A → events sync down → drawer **Log out** → log in as A again → all pre-logout events present in native calendar (regression test for #83).
  - [ ] Log in as A → drawer-logout → log in as B → drawer-logout → log in as A again → A's calendar fully restored.
  - [ ] Server side: confirm the previous session token is invalidated after logout (not just abandoned client-side).
  - [ ] `Delete account` flow still works end-to-end (no behavioural change visible).

## Out of scope

The mockup-account symptom from the issue (fresh login: webapp → mobile calendar didn't sync, while contacts worked, mobile → webapp worked) doesn't fall out of this bug cleanly — see the analysis section of #83. Worth investigating separately once we can capture a sync log from a fresh-account session that exhibits it.