### PR TITLE
test(web/import): mapper-layer coverage + DTEND TZID note (#68)

### DIFF
--- a/apps/web/app/components/import/CalendarImport.tsx
+++ b/apps/web/app/components/import/CalendarImport.tsx
@@ -8,6 +8,7 @@ import type { VEvent } from '@silentsuite/core/utils/ical-parser'
 import FileDropZone from './FileDropZone'
 import ImportPreview from './ImportPreview'
 import ImportListSelector from './ImportListSelector'
+import { vEventToImportEvent } from './import-mappers'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 
@@ -115,27 +116,7 @@ export default function CalendarImport({ onImportComplete }: CalendarImportProps
   const handleImport = useCallback(async () => {
     setIsImporting(true)
     try {
-      const newEvents = events.map((event) => {
-        const startTzid = event.dtstartParams?.['TZID']
-        const endTzid = event.dtendParams?.['TZID'] ?? startTzid
-        const { date: start, allDay: isAllDay } = parseICalDateValue(event.dtstart, startTzid)
-        const end = event.dtend
-          ? parseICalDateValue(event.dtend, endTzid).date
-          : new Date(start.getTime() + 60 * 60 * 1000)
-
-        return {
-          title: event.summary || 'Untitled Event',
-          description: event.description ?? '',
-          location: event.location ?? '',
-          startDate: start,
-          endDate: end,
-          allDay: isAllDay,
-          recurrenceRule: event.rrule ?? null,
-          alarms: event.valarms ?? [],
-          calendarId: selectedCalendarId,
-          timezone: isAllDay ? undefined : startTzid,
-        }
-      })
+      const newEvents = events.map((event) => vEventToImportEvent(event, selectedCalendarId))
       const count = await importEvents(newEvents)
       setImportedCount(count)
       onImportComplete(count)

--- a/apps/web/app/components/import/TaskImport.tsx
+++ b/apps/web/app/components/import/TaskImport.tsx
@@ -7,6 +7,7 @@ import type { VTodo } from '@silentsuite/core/utils/ical-parser'
 import FileDropZone from './FileDropZone'
 import ImportPreview from './ImportPreview'
 import ImportListSelector from './ImportListSelector'
+import { parseICalDate } from './import-mappers'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
 import type { Priority } from '@silentsuite/core'
@@ -156,24 +157,6 @@ function mapPriorityToStore(icalPriority?: number): Priority {
   if (icalPriority <= 4) return 'high'
   if (icalPriority <= 6) return 'medium'
   return 'low'
-}
-
-// Date-only on import: the Task model has no timezone field, so a TZID-bearing
-// or UTC datetime would otherwise be parsed in the importer's local zone and
-// land on the wrong instant. Take the wall-clock date from the source value.
-// Full TZID parity for VTODO is tracked in #66.
-function parseICalDate(d: string): Date | null {
-  if (!d) return null
-  const digits = d.replace(/[^0-9]/g, '')
-  if (digits.length < 8) {
-    const parsed = new Date(d)
-    return isNaN(parsed.getTime()) ? null : parsed
-  }
-  return new Date(
-    parseInt(digits.slice(0, 4)),
-    parseInt(digits.slice(4, 6)) - 1,
-    parseInt(digits.slice(6, 8)),
-  )
 }
 
 export default function TaskImport({ onImportComplete }: TaskImportProps) {

--- a/apps/web/app/components/import/__tests__/import-mappers.test.ts
+++ b/apps/web/app/components/import/__tests__/import-mappers.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { vEventToImportEvent, parseICalDate } from '../import-mappers'
+import type { VEvent } from '@silentsuite/core/utils/ical-parser'
+
+describe('vEventToImportEvent', () => {
+  it('propagates source TZID into the import payload', () => {
+    const event: VEvent = {
+      uid: 'a@example',
+      summary: 'NY meeting',
+      dtstart: '20260601T090000',
+      dtend: '20260601T100000',
+      dtstartParams: { TZID: 'America/New_York' },
+      dtendParams: { TZID: 'America/New_York' },
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.timezone).toBe('America/New_York')
+    expect(payload.allDay).toBe(false)
+    expect(payload.calendarId).toBe('cal-1')
+  })
+
+  it('drops timezone for all-day events (DATE-only, no TZID per RFC 5545)', () => {
+    const event: VEvent = {
+      uid: 'b@example',
+      summary: 'All-day',
+      dtstart: '20260601',
+      dtend: '20260602',
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.allDay).toBe(true)
+    expect(payload.timezone).toBeUndefined()
+  })
+
+  it('leaves timezone undefined when DTSTART has no TZID (floating)', () => {
+    const event: VEvent = {
+      uid: 'c@example',
+      summary: 'Floating',
+      dtstart: '20260601T090000',
+      dtend: '20260601T100000',
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.timezone).toBeUndefined()
+    expect(payload.allDay).toBe(false)
+  })
+})
+
+describe('parseICalDate', () => {
+  it('returns null for empty input', () => {
+    expect(parseICalDate('')).toBeNull()
+  })
+
+  // Locale-resilience: assert on date components, not epoch ms — getFullYear /
+  // getMonth / getDate reflect the constructor args regardless of TZ.
+  it('extracts the wall-clock date from a TZID-stripped datetime', () => {
+    const d = parseICalDate('20260601T090000')!
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(5)
+    expect(d.getDate()).toBe(1)
+  })
+
+  it('extracts the wall-clock date from a UTC-suffixed datetime', () => {
+    const d = parseICalDate('20260601T090000Z')!
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(5)
+    expect(d.getDate()).toBe(1)
+  })
+
+  it('extracts the wall-clock date from a date-only value', () => {
+    const d = parseICalDate('20260601')!
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(5)
+    expect(d.getDate()).toBe(1)
+  })
+})

--- a/apps/web/app/components/import/import-mappers.ts
+++ b/apps/web/app/components/import/import-mappers.ts
@@ -1,0 +1,62 @@
+import { parseICalDateValue } from '@silentsuite/core'
+import type { VEvent } from '@silentsuite/core/utils/ical-parser'
+
+export interface ImportEventPayload {
+  title: string
+  description: string
+  location: string
+  startDate: Date
+  endDate: Date
+  allDay: boolean
+  recurrenceRule: string | null
+  alarms: NonNullable<VEvent['valarms']>
+  calendarId: string
+  timezone: string | undefined
+}
+
+// DTEND TZID note: when DTSTART and DTEND carry different TZIDs the per-side
+// instant is parsed correctly here, but only `startTzid` is persisted as
+// `timezone`. On round-trip both sides re-emit with the start-side TZID — the
+// per-side label is lost. Rare in real-world ICS; tracked in #68.
+export function vEventToImportEvent(
+  event: VEvent,
+  calendarId: string,
+): ImportEventPayload {
+  const startTzid = event.dtstartParams?.['TZID']
+  const endTzid = event.dtendParams?.['TZID'] ?? startTzid
+  const { date: start, allDay: isAllDay } = parseICalDateValue(event.dtstart, startTzid)
+  const end = event.dtend
+    ? parseICalDateValue(event.dtend, endTzid).date
+    : new Date(start.getTime() + 60 * 60 * 1000)
+
+  return {
+    title: event.summary || 'Untitled Event',
+    description: event.description ?? '',
+    location: event.location ?? '',
+    startDate: start,
+    endDate: end,
+    allDay: isAllDay,
+    recurrenceRule: event.rrule ?? null,
+    alarms: event.valarms ?? [],
+    calendarId,
+    timezone: isAllDay ? undefined : startTzid,
+  }
+}
+
+// Date-only on import: the Task model has no timezone field, so a TZID-bearing
+// or UTC datetime would otherwise be parsed in the importer's local zone and
+// land on the wrong instant. Take the wall-clock date from the source value.
+// Full TZID parity for VTODO is tracked in #66.
+export function parseICalDate(d: string): Date | null {
+  if (!d) return null
+  const digits = d.replace(/[^0-9]/g, '')
+  if (digits.length < 8) {
+    const parsed = new Date(d)
+    return isNaN(parsed.getTime()) ? null : parsed
+  }
+  return new Date(
+    parseInt(digits.slice(0, 4)),
+    parseInt(digits.slice(4, 6)) - 1,
+    parseInt(digits.slice(6, 8)),
+  )
+}


### PR DESCRIPTION
## Summary

Closes #68 (adversarial-review follow-ups from #65 / PR #67).

- Extract \`vEventToImportEvent\` and \`parseICalDate\` from \`CalendarImport.tsx\` / \`TaskImport.tsx\` into a pure \`import-mappers.ts\` module (no React, no client boundary), so the mapping logic is unit-testable in isolation.
- Add 7 tests covering the gaps the review called out:
  - **CalendarImport propagation**: TZID survives into the store payload; all-day drops timezone (RFC 5545); floating events leave timezone undefined.
  - **TaskImport \`parseICalDate\`**: TZID-stripped, UTC-suffixed, and date-only inputs all yield the correct wall-clock year/month/day. Asserted on date components rather than \`getTime()\` so the test is locale-resilient.
- Document the DTEND TZID limitation in the mapper rather than plumb \`endTimezone\` through the model — DTEND-with-different-TZID-than-DTSTART is rare in real ICS, and a model-layer fix isn't worth the churn yet. Locked into the comment so future readers understand the trade-off.

## Why not the model fix?

Issue #68 lists two options for the DTEND nit:

- (cheap) document the limitation
- (invasive) add \`endTimezone?: string\` to \`CalendarEvent\`, plumb through serialize/deserialize + the import path

Most exporters emit identical TZIDs on both sides; the wall-clock instant is parsed correctly in either case (\`endTzid\` is already used for parsing). Only the per-side TZ label is lost on re-emit. Going with the cheap path; if a real-world bug ever lands on this we can re-open.

## Test plan

- [x] \`pnpm --filter @silentsuite/web test\` — all 109 tests pass, including 7 new ones in \`import-mappers.test.ts\`.
- [x] \`pnpm --filter @silentsuite/web build\` — succeeds (TS typecheck included).
- [x] \`pnpm --filter @silentsuite/web lint\` — no new warnings on the changed files.

## Out of scope

- Full TZID parity for VTODO is tracked in #66 — \`parseICalDate\` here remains the date-only fallback the Task model needs until then.