### PR TITLE
fix(web/test): extend jest-dom matchers explicitly in vitest setup

### DIFF
--- a/apps/web/src/__tests__/setup.ts
+++ b/apps/web/src/__tests__/setup.ts
@@ -1,6 +1,8 @@
-import '@testing-library/jest-dom/vitest'
+import * as matchers from '@testing-library/jest-dom/matchers'
 import { cleanup } from '@testing-library/react'
-import { afterEach } from 'vitest'
+import { afterEach, expect } from 'vitest'
+
+expect.extend(matchers)
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## Summary
- CI on dev flaked on 2026-05-02 with 12 tests failing on `Invalid Chai property: toBeInTheDocument` / `toHaveAttribute` ([run 25247583686](https://github.com/silent-suite/silentsuite/actions/runs/25247583686)). Same code passed on the next run with no test-config changes — classic load-order race.
- Replace the side-effect import `@testing-library/jest-dom/vitest` (which internally does `import { expect } from 'vitest'; expect.extend(matchers)`) with an explicit `import * as matchers from '@testing-library/jest-dom/matchers'` and our own `expect.extend(matchers)` call.
- Functionally identical on the happy path, but removes the ordering hazard and makes registration grep-able. This is the pattern recommended by [jest-dom's own docs](https://github.com/testing-library/jest-dom#usage) for monorepos.

## Why this is the right fix (vs. landing-removal hypothesis)
- `@testing-library/jest-dom@^6.6.3`, `vitest@^3.2.1`, `@testing-library/react@^16.3.0` are unchanged across the failing/passing commits and current main.
- `apps/web` does not import or depend on `apps/landing` (grep returns nothing).
- Tests started passing at 14:41Z while `apps/landing` was still in the monorepo (it was removed at 15:54Z in `28b35d9`).

## Test plan
- [x] `pnpm --filter @silentsuite/web run test` locally → 11 files / 109 tests green, including the previously-failing `SyncIndicator`, `read-only-overlay`, and `ExportPage` suites.
- [ ] CI green