### PR TITLE
fix(bridge/install): walk releases list to survive umbrella/component split

### DIFF
--- a/bridge/install.ps1
+++ b/bridge/install.ps1
@@ -50,19 +50,33 @@ if (Test-Path $ExePath) {
 }
 
 # --- Download latest release ---
+# Fetches the releases list (sorted newest-first) and walks until we find one
+# that carries the bridge asset. Umbrella releases (e.g. v0.1.0-beta) won't
+# have bridge binaries, so we skip past them to the most recent release that
+# actually has a bridge asset (bridge-vX.Y.Z prefix going forward, or the
+# legacy vX.Y.Z-bridge suffix).
 Write-Step "Downloading latest release..."
 $AssetName = "$BinaryName-windows-x86_64.exe"
-$ReleaseUrl = "https://api.github.com/repos/$Repo/releases/latest"
+$ReleaseUrl = "https://api.github.com/repos/$Repo/releases?per_page=30"
 
 try {
-    $Release = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
+    $Releases = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
 } catch {
     Write-Err "Failed to fetch release info from GitHub: $_"
 }
 
-$Asset = $Release.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+$Release = $null
+$Asset = $null
+foreach ($r in $Releases) {
+    $candidate = $r.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+    if ($candidate) {
+        $Release = $r
+        $Asset = $candidate
+        break
+    }
+}
 if (-not $Asset) {
-    Write-Err "No asset found matching $AssetName. Check https://github.com/$Repo/releases"
+    Write-Err "No asset found matching $AssetName across recent releases. Check https://github.com/$Repo/releases"
 }
 
 # Create install directory

--- a/bridge/install.ps1
+++ b/bridge/install.ps1
@@ -57,7 +57,7 @@ if (Test-Path $ExePath) {
 # legacy vX.Y.Z-bridge suffix).
 Write-Step "Downloading latest release..."
 $AssetName = "$BinaryName-windows-x86_64.exe"
-$ReleaseUrl = "https://api.github.com/repos/$Repo/releases?per_page=30"
+$ReleaseUrl = "https://api.github.com/repos/$Repo/releases?per_page=100"
 
 try {
     $Releases = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }

--- a/bridge/install.sh
+++ b/bridge/install.sh
@@ -88,7 +88,7 @@ detect_arch() {
 # past them to the most recent release that actually has a bridge asset
 # (bridge-vX.Y.Z prefix going forward, or the legacy vX.Y.Z-bridge suffix).
 get_download_url() {
-    RELEASE_URL="https://api.github.com/repos/${REPO}/releases?per_page=30"
+    RELEASE_URL="https://api.github.com/repos/${REPO}/releases?per_page=100"
     ASSET_NAME="${BINARY_NAME}-${OS}-${ARCH}"
 
     # Trailing `"` anchors the match to the binary itself, not its `.sha256` sidecar.

--- a/bridge/install.sh
+++ b/bridge/install.sh
@@ -82,18 +82,24 @@ detect_arch() {
 }
 
 # --- Get latest release URL ---
+# Fetches the releases list (sorted newest-first) and picks the first matching
+# asset across all releases. This survives the umbrella-vs-component split:
+# umbrella releases (e.g. v0.1.0-beta) won't carry bridge binaries, so we walk
+# past them to the most recent release that actually has a bridge asset
+# (bridge-vX.Y.Z prefix going forward, or the legacy vX.Y.Z-bridge suffix).
 get_download_url() {
-    RELEASE_URL="https://api.github.com/repos/${REPO}/releases/latest"
+    RELEASE_URL="https://api.github.com/repos/${REPO}/releases?per_page=30"
     ASSET_NAME="${BINARY_NAME}-${OS}-${ARCH}"
 
+    # Trailing `"` anchors the match to the binary itself, not its `.sha256` sidecar.
     if command -v curl >/dev/null 2>&1; then
         DOWNLOAD_URL=$(curl -fsSL "$RELEASE_URL" 2>/dev/null | \
-            grep "browser_download_url.*${ASSET_NAME}" | \
+            grep "browser_download_url.*${ASSET_NAME}\"" | \
             head -1 | \
             cut -d '"' -f 4)
     elif command -v wget >/dev/null 2>&1; then
         DOWNLOAD_URL=$(wget -qO- "$RELEASE_URL" 2>/dev/null | \
-            grep "browser_download_url.*${ASSET_NAME}" | \
+            grep "browser_download_url.*${ASSET_NAME}\"" | \
             head -1 | \
             cut -d '"' -f 4)
     else


### PR DESCRIPTION
## Summary

- Switch both `bridge/install.sh` and `bridge/install.ps1` from `/releases/latest` to `/releases?per_page=30` and walk the list looking for the first release that carries a bridge asset for the host platform.
- Tighten the bash grep with a trailing `"` so we match the binary asset, not its `.sha256` sidecar.

## Why

The umbrella release `v0.1.0-beta` (planned in [silent-suite/silentsuite-internal#51](https://github.com/silent-suite/silentsuite-internal/issues/51)) will become `/releases/latest`. It won't carry bridge binaries — those will live in component releases tagged `bridge-vX.Y.Z` going forward. Without this fix, the install one-liner at `silentsuite.io/bridge/install.sh` would 404 the moment the umbrella ships.

The new logic transparently handles both the legacy `vX.Y.Z-bridge` suffix style of the existing `v0.1.1-bridge` release and the `bridge-vX.Y.Z` prefix style we'll use going forward — it doesn't care about the tag, it cares about whether the asset exists.

## Sanity check

Live API call against the new URL still resolves the existing release:

\`\`\`
$ curl -fsSL "https://api.github.com/repos/silent-suite/silentsuite/releases?per_page=30" \
    | grep "browser_download_url.*silentsuite-bridge-linux-x86_64\""
"browser_download_url": "https://github.com/silent-suite/silentsuite/releases/download/v0.1.1-bridge/silentsuite-bridge-linux-x86_64"
\`\`\`

## Test plan

- [ ] Linux: `curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/bridge/install-namespace-fix/bridge/install.sh | sh` on a clean machine — resolves and downloads the existing `v0.1.1-bridge/silentsuite-bridge-linux-x86_64`.
- [ ] macOS: same, via the macOS asset.
- [ ] Windows: PowerShell `irm` against the branch's `install.ps1` — same.
- [ ] Verified once a `bridge-v0.1.2`-prefixed release is cut: install.sh picks up the new prefix correctly.

(Manual smoke testing is the verification path here — these scripts don't have unit tests in-repo.)

Closes silent-suite/silentsuite-internal#52
Refs silent-suite/silentsuite-internal#51