### PR TITLE
feat(server): self-host-grade entrypoint (migrate + signup-disable hook)

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -30,8 +30,9 @@ RUN addgroup -S etebase && adduser -S etebase -G etebase
 # Copy application code
 COPY server/ /app
 
-# Create data directories
+# Create data directories and ensure entrypoint is executable
 RUN mkdir -p /data /data/media /data/static && \
+    chmod +x /app/docker/entrypoint.sh && \
     chown -R etebase:etebase /app /data
 
 WORKDIR /app
@@ -41,7 +42,4 @@ USER etebase
 
 EXPOSE 3735
 
-CMD ["uvicorn", "etebase_server.asgi:application", \
-     "--host", "0.0.0.0", "--port", "3735", \
-     "--workers", "2", "--proxy-headers", \
-     "--forwarded-allow-ips", "*"]
+ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/server/docker/entrypoint.sh
+++ b/server/docker/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# SilentSuite server container entrypoint.
+#
+# Responsibilities (each step is idempotent and safe on every container start):
+#   1. Apply Django migrations.
+#   2. Optionally create a Django /admin/ superuser when SUPER_USER and
+#      SUPER_PASS are both set and the user does not already exist.
+#   3. Exec uvicorn.
+#
+# Self-host operators read configuration from /etc/etebase-server/etebase-server.ini
+# (or wherever ETEBASE_EASY_CONFIG_PATH points). The SaaS deployment leaves
+# SUPER_USER / SUPER_PASS unset, so step 2 silently no-ops there.
+
+set -eu
+
+cd /app
+
+# When the user passes a command (e.g. `docker run … python manage.py shell`),
+# skip the default startup sequence and run the command directly.
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
+echo "[entrypoint] applying database migrations..."
+python manage.py migrate --noinput
+
+if [ -n "${SUPER_USER:-}" ] && [ -n "${SUPER_PASS:-}" ]; then
+    python manage.py shell <<'PYEOF'
+import os
+from django.contrib.auth import get_user_model
+User = get_user_model()
+username = os.environ.get("SUPER_USER")
+password = os.environ.get("SUPER_PASS")
+if username and password and not User.objects.filter(username=username).exists():
+    User.objects.create_superuser(
+        username=username,
+        email=f"{username}@localhost",
+        password=password,
+    )
+    print(f"[entrypoint] created Django superuser '{username}'")
+PYEOF
+fi
+
+echo "[entrypoint] starting uvicorn..."
+exec uvicorn etebase_server.asgi:application \
+    --host 0.0.0.0 --port 3735 \
+    --workers 2 --proxy-headers \
+    --forwarded-allow-ips '*'

--- a/server/etebase_server/settings.py
+++ b/server/etebase_server/settings.py
@@ -205,6 +205,12 @@ if "DJANGO_STATIC_ROOT" in os.environ:
 if "DJANGO_MEDIA_ROOT" in os.environ:
     MEDIA_ROOT = os.environ["DJANGO_MEDIA_ROOT"]
 
+# Self-host operators flip this on (via close-signups.sh) once their admin
+# is registered. Replaces the etebase-server.ini-only path so the toggle is
+# runtime-driven without an image rebuild.
+if os.environ.get("ETEBASE_DISABLE_SIGNUP", "").lower() in ("true", "1", "yes"):
+    ETEBASE_CREATE_USER_FUNC = "etebase_server.django.utils.create_user_blocked"
+
 # Make an `etebase_server_settings` module available to override settings.
 try:
     from etebase_server_settings import *  # noqa: F403


### PR DESCRIPTION
## Summary

The `silentsuite-server` image is currently a thin uvicorn-only runtime — fine for the SaaS (which already had its DB schema migrated manually at first deploy), but unusable for self-hosters because a fresh `docker compose up` would 500 on the first request before Django's tables existed.

This PR adds:

- **`server/docker/entrypoint.sh`** — runs `manage.py migrate --noinput`, optionally creates a Django `/admin/` superuser when `SUPER_USER` and `SUPER_PASS` are both set (and the user does not already exist), then `exec`s `uvicorn` with the same args the old `CMD` used. Honors `docker run … <override>` — when args are passed, it skips the startup sequence and runs them directly, so `manage.py shell`, `bash`, etc. still work for debugging.
- **`Dockerfile.server`** — drops `CMD`, points `ENTRYPOINT` at the new script. `chmod +x` is set in the build to insulate from host-fs permission quirks.
- **`settings.py` env hook** — `ETEBASE_DISABLE_SIGNUP=true` flips `ETEBASE_CREATE_USER_FUNC` to `create_user_blocked`. Default unset → signup enabled. Gives self-host operators a runtime way to close registration after the admin signs up (consumed by issue #55's `close-signups.sh`).

## Why the SaaS auto-deploy is safe

Merging this triggers `deploy-server.yml` and rolls a new image to the SaaS VPS. The new entrypoint:

- Runs `manage.py migrate --noinput` on prod — **idempotent**; with no pending migrations, this is a few-hundred-ms no-op.
- Skips superuser creation (SaaS compose doesn't set `SUPER_USER`/`SUPER_PASS`).
- `ETEBASE_DISABLE_SIGNUP` defaults unset → signup remains enabled, identical to today's prod behavior.

If the SaaS compose at `~/etebase/` has a `command:` override, it'd be silently dropped (entrypoint hard-codes the uvicorn args). I haven't seen that compose file — flag if there's one.

## Why this is a separate PR from the compose pinning

The follow-up PR (`self-host/ghcr-server-pin`) needs a `sha256:` digest from an image **built with this code**. Splitting into two PRs lets `deploy-server.yml` publish the new digest first; the self-host compose change pins to that digest.

Part of silent-suite/silentsuite-internal#54.

## Test plan

- [ ] `ci-server.yml` (Django smoke + py_compile) passes.
- [ ] After merge, `deploy-server.yml` builds and pushes the new image successfully.
- [ ] SaaS VPS healthcheck stays green through the rollout.
- [ ] After merge, grab the new manifest digest for the follow-up self-host pinning PR.