### PR TITLE
release: dev → main (bridge install fix + server entrypoint)

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -30,8 +30,9 @@ RUN addgroup -S etebase && adduser -S etebase -G etebase
 # Copy application code
 COPY server/ /app
 
-# Create data directories
+# Create data directories and ensure entrypoint is executable
 RUN mkdir -p /data /data/media /data/static && \
+    chmod +x /app/docker/entrypoint.sh && \
     chown -R etebase:etebase /app /data
 
 WORKDIR /app
@@ -41,7 +42,4 @@ USER etebase
 
 EXPOSE 3735
 
-CMD ["uvicorn", "etebase_server.asgi:application", \
-     "--host", "0.0.0.0", "--port", "3735", \
-     "--workers", "2", "--proxy-headers", \
-     "--forwarded-allow-ips", "*"]
+ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/bridge/install.ps1
+++ b/bridge/install.ps1
@@ -50,19 +50,33 @@ if (Test-Path $ExePath) {
 }
 
 # --- Download latest release ---
+# Fetches the releases list (sorted newest-first) and walks until we find one
+# that carries the bridge asset. Umbrella releases (e.g. v0.1.0-beta) won't
+# have bridge binaries, so we skip past them to the most recent release that
+# actually has a bridge asset (bridge-vX.Y.Z prefix going forward, or the
+# legacy vX.Y.Z-bridge suffix).
 Write-Step "Downloading latest release..."
 $AssetName = "$BinaryName-windows-x86_64.exe"
-$ReleaseUrl = "https://api.github.com/repos/$Repo/releases/latest"
+$ReleaseUrl = "https://api.github.com/repos/$Repo/releases?per_page=100"
 
 try {
-    $Release = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
+    $Releases = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
 } catch {
     Write-Err "Failed to fetch release info from GitHub: $_"
 }
 
-$Asset = $Release.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+$Release = $null
+$Asset = $null
+foreach ($r in $Releases) {
+    $candidate = $r.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+    if ($candidate) {
+        $Release = $r
+        $Asset = $candidate
+        break
+    }
+}
 if (-not $Asset) {
-    Write-Err "No asset found matching $AssetName. Check https://github.com/$Repo/releases"
+    Write-Err "No asset found matching $AssetName across recent releases. Check https://github.com/$Repo/releases"
 }
 
 # Create install directory

--- a/bridge/install.sh
+++ b/bridge/install.sh
@@ -82,18 +82,24 @@ detect_arch() {
 }
 
 # --- Get latest release URL ---
+# Fetches the releases list (sorted newest-first) and picks the first matching
+# asset across all releases. This survives the umbrella-vs-component split:
+# umbrella releases (e.g. v0.1.0-beta) won't carry bridge binaries, so we walk
+# past them to the most recent release that actually has a bridge asset
+# (bridge-vX.Y.Z prefix going forward, or the legacy vX.Y.Z-bridge suffix).
 get_download_url() {
-    RELEASE_URL="https://api.github.com/repos/${REPO}/releases/latest"
+    RELEASE_URL="https://api.github.com/repos/${REPO}/releases?per_page=100"
     ASSET_NAME="${BINARY_NAME}-${OS}-${ARCH}"
 
+    # Trailing `"` anchors the match to the binary itself, not its `.sha256` sidecar.
     if command -v curl >/dev/null 2>&1; then
         DOWNLOAD_URL=$(curl -fsSL "$RELEASE_URL" 2>/dev/null | \
-            grep "browser_download_url.*${ASSET_NAME}" | \
+            grep "browser_download_url.*${ASSET_NAME}\"" | \
             head -1 | \
             cut -d '"' -f 4)
     elif command -v wget >/dev/null 2>&1; then
         DOWNLOAD_URL=$(wget -qO- "$RELEASE_URL" 2>/dev/null | \
-            grep "browser_download_url.*${ASSET_NAME}" | \
+            grep "browser_download_url.*${ASSET_NAME}\"" | \
             head -1 | \
             cut -d '"' -f 4)
     else

--- a/server/docker/entrypoint.sh
+++ b/server/docker/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# SilentSuite server container entrypoint.
+#
+# Responsibilities (each step is idempotent and safe on every container start):
+#   1. Apply Django migrations.
+#   2. Optionally create a Django /admin/ superuser when SUPER_USER and
+#      SUPER_PASS are both set and the user does not already exist.
+#   3. Exec uvicorn.
+#
+# Self-host operators read configuration from /etc/etebase-server/etebase-server.ini
+# (or wherever ETEBASE_EASY_CONFIG_PATH points). The SaaS deployment leaves
+# SUPER_USER / SUPER_PASS unset, so step 2 silently no-ops there.
+
+set -eu
+
+cd /app
+
+# When the user passes a command (e.g. `docker run … python manage.py shell`),
+# skip the default startup sequence and run the command directly.
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
+echo "[entrypoint] applying database migrations..."
+python manage.py migrate --noinput
+
+if [ -n "${SUPER_USER:-}" ] && [ -n "${SUPER_PASS:-}" ]; then
+    python manage.py shell <<'PYEOF'
+import os
+from django.contrib.auth import get_user_model
+User = get_user_model()
+username = os.environ.get("SUPER_USER")
+password = os.environ.get("SUPER_PASS")
+if username and password and not User.objects.filter(username=username).exists():
+    User.objects.create_superuser(
+        username=username,
+        email=f"{username}@localhost",
+        password=password,
+    )
+    print(f"[entrypoint] created Django superuser '{username}'")
+PYEOF
+fi
+
+echo "[entrypoint] starting uvicorn..."
+exec uvicorn etebase_server.asgi:application \
+    --host 0.0.0.0 --port 3735 \
+    --workers 2 --proxy-headers \
+    --forwarded-allow-ips '*'

--- a/server/etebase_server/settings.py
+++ b/server/etebase_server/settings.py
@@ -205,6 +205,12 @@ if "DJANGO_STATIC_ROOT" in os.environ:
 if "DJANGO_MEDIA_ROOT" in os.environ:
     MEDIA_ROOT = os.environ["DJANGO_MEDIA_ROOT"]
 
+# Self-host operators flip this on (via close-signups.sh) once their admin
+# is registered. Replaces the etebase-server.ini-only path so the toggle is
+# runtime-driven without an image rebuild.
+if os.environ.get("ETEBASE_DISABLE_SIGNUP", "").lower() in ("true", "1", "yes"):
+    ETEBASE_CREATE_USER_FUNC = "etebase_server.django.utils.create_user_blocked"
+
 # Make an `etebase_server_settings` module available to override settings.
 try:
     from etebase_server_settings import *  # noqa: F403


### PR DESCRIPTION
## Summary

Routine promotion of dev to main. Triggers `deploy-server.yml` (rebuild + SaaS rollout) for the entrypoint change.

Two commits:
- **#93** `fix(bridge/install): walk releases list to survive umbrella/component split` — bridge install script fix only, no server impact.
- **#94** `feat(server): self-host-grade entrypoint with migrate + superuser + signup-disable hook` — adds an entrypoint that runs `manage.py migrate --noinput` (idempotent), optionally creates a Django admin superuser, and execs uvicorn with the same args the previous CMD used. SaaS does not set `SUPER_USER`/`SUPER_PASS` or `ETEBASE_DISABLE_SIGNUP`, so the only behavioral change in prod is migrate-on-startup, which is a no-op when the schema is up to date.

## Test plan

- [ ] CI green on this PR.
- [ ] `deploy-server.yml` build-and-push completes successfully.
- [ ] SaaS post-deploy healthcheck (`https://server.silentsuite.io/`) passes.
- [ ] After merge: grab the new image digest and pin self-host docker-compose to it in the follow-up PR (`self-host/ghcr-server-pin`, part of silent-suite/silentsuite-internal#54).