### PR TITLE
feat(self-host): install.sh --version flag fetches from release tag

### DIFF
--- a/self-host/SELF-HOSTING.md
+++ b/self-host/SELF-HOSTING.md
@@ -47,17 +47,32 @@ curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-
 
 The installer will:
 1. Check that Docker and Docker Compose are installed
-2. Create a `silentsuite-server/` directory
-3. Download the Docker Compose configuration
-4. Ask for your domain name
-5. Generate secure random passwords
-6. Write the `.env` file
-7. Pull Docker images and start the containers
-8. Wait for health checks to pass
+2. Resolve which SilentSuite version to install (latest umbrella release, or `main` if none has been cut yet)
+3. Create a `silentsuite-server/` directory
+4. Download the Docker Compose configuration *from the release tag*, so the compose, helper scripts, and pinned image digest all come from one known-good matrix
+5. Ask for your domain name
+6. Generate secure random passwords
+7. Write the `.env` file
+8. Pull Docker images and start the containers
+9. Wait for health checks to pass
 
 The first user to sign up in the SilentSuite app becomes the server admin.
 
 Then set up your reverse proxy to forward HTTPS traffic to `localhost:3735`.
+
+### Installing a specific version
+
+To pin to a specific SilentSuite release rather than the latest:
+
+```bash
+# Curl-pipe style (env var):
+curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | SILENTSUITE_VERSION=v0.1.0-beta bash
+
+# Locally cloned style (CLI flag):
+bash install.sh --version v0.1.0-beta
+```
+
+When pinned, the installer fetches all of `docker-compose.yml`, `update.sh`, `verify.sh`, and `success.html` from the requested tag's archive — the entire self-host config moves together as one release.
 
 ## Manual Setup
 

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -38,8 +38,8 @@ EOF
 while [ $# -gt 0 ]; do
   case "$1" in
     --version)
-      if [ $# -lt 2 ]; then
-        echo "ERROR: --version requires an argument (e.g. --version v0.1.0-beta)" >&2
+      if [ $# -lt 2 ] || [ -z "$2" ] || [ "${2#-}" != "$2" ]; then
+        echo "ERROR: --version requires a non-empty tag (e.g. --version v0.1.0-beta)" >&2
         exit 1
       fi
       REQUESTED_VERSION="$2"
@@ -47,6 +47,10 @@ while [ $# -gt 0 ]; do
       ;;
     --version=*)
       REQUESTED_VERSION="${1#--version=}"
+      if [ -z "$REQUESTED_VERSION" ]; then
+        echo "ERROR: --version requires a non-empty tag (e.g. --version=v0.1.0-beta)" >&2
+        exit 1
+      fi
       shift
       ;;
     -h|--help)

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -6,9 +6,59 @@ set -euo pipefail
 # Sets up the SilentSuite sync server with PostgreSQL.
 # Can be run standalone via:
 #   curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | bash
+#
+# Pin to a specific release:
+#   curl -fsSL .../install.sh | SILENTSUITE_VERSION=v0.1.0-beta bash
+# Or, when running locally:
+#   bash install.sh --version v0.1.0-beta
 
-GITHUB_RAW_BASE="https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host"
+REPO="silent-suite/silentsuite"
 INSTALL_DIR="${SILENTSUITE_DIR:-silentsuite-server}"
+REQUESTED_VERSION=""
+
+# ── Parse arguments ───────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: install.sh [--version <tag>]
+
+  --version <tag>   Install a specific SilentSuite release (e.g. v0.1.0-beta).
+                    Default: the latest umbrella release on GitHub, falling
+                    back to the 'main' branch if no umbrella release exists.
+  -h, --help        Show this message and exit.
+
+Environment:
+  SILENTSUITE_DIR       Install directory (default: silentsuite-server).
+  SILENTSUITE_VERSION   Same as --version. Useful for the curl-pipe pattern:
+                        curl -fsSL .../install.sh | SILENTSUITE_VERSION=v0.1.0-beta bash
+                        (CLI --version takes precedence over the env var.)
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --version requires an argument (e.g. --version v0.1.0-beta)" >&2
+        exit 1
+      fi
+      REQUESTED_VERSION="$2"
+      shift 2
+      ;;
+    --version=*)
+      REQUESTED_VERSION="${1#--version=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument '$1'. Run with --help for usage." >&2
+      exit 1
+      ;;
+  esac
+done
 
 echo "============================================"
 echo "  SilentSuite Self-Hosted Installer"
@@ -39,6 +89,73 @@ fi
 
 echo "Prerequisites OK: docker, $COMPOSE, openssl, curl"
 echo ""
+
+# ── Resolve target version ────────────────────────────────────────────
+#
+# Precedence: --version flag > SILENTSUITE_VERSION env > latest umbrella
+# release on GitHub > 'main' branch (development tip, fallback when no
+# umbrella release exists yet).
+
+resolve_version() {
+  if [ -n "$REQUESTED_VERSION" ]; then
+    echo "$REQUESTED_VERSION"
+    return 0
+  fi
+  if [ -n "${SILENTSUITE_VERSION:-}" ]; then
+    echo "$SILENTSUITE_VERSION"
+    return 0
+  fi
+
+  # Walk the releases list newest-first and pick the first tag that is
+  # neither component-prefixed (bridge-vX, android-vX, server-vX, web-vX)
+  # nor component-suffixed (vX-bridge, vX-android, ...). Mirrors the
+  # filtering convention used by bridge/install.sh — both installers walk
+  # the same release stream, applying the filter that's right for them.
+  local releases tag
+  releases=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20" 2>/dev/null || true)
+  if [ -z "$releases" ]; then
+    echo "main"
+    return 0
+  fi
+
+  tag=$(echo "$releases" \
+    | grep -E '"tag_name":' \
+    | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
+    | grep -vE '^(bridge|android|server|web)-|-(bridge|android|server|web)$' \
+    | head -1)
+
+  if [ -z "$tag" ]; then
+    echo "main"
+  else
+    echo "$tag"
+  fi
+}
+
+verify_ref_exists() {
+  # Skip the check for branches — we treat 'main' / 'dev' as always-valid.
+  case "$1" in
+    main|dev) return 0 ;;
+  esac
+  curl -fsI "https://raw.githubusercontent.com/${REPO}/$1/self-host/docker-compose.yml" >/dev/null 2>&1
+}
+
+VERSION=$(resolve_version)
+if ! verify_ref_exists "$VERSION"; then
+  echo "ERROR: Version '$VERSION' does not exist or has no self-host config." >&2
+  echo "       Check available releases at https://github.com/${REPO}/releases" >&2
+  exit 1
+fi
+
+if [ "$VERSION" = "main" ]; then
+  echo "WARNING: No SilentSuite umbrella release found yet — installing from 'main'"
+  echo "         (development tip). Once a release is cut, this default switches"
+  echo "         automatically. To pin explicitly: --version vX.Y.Z."
+else
+  echo "Installing SilentSuite version: $VERSION"
+fi
+echo ""
+
+GITHUB_RAW_BASE="https://raw.githubusercontent.com/${REPO}/${VERSION}/self-host"
 
 # ── Set up install directory ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds a `--version` flag to `self-host/install.sh` (plus a matching `SILENTSUITE_VERSION` env var for the curl-pipe pattern). When set, the installer fetches `docker-compose.yml`, `update.sh`, `verify.sh`, and `success.html` from the requested tag's archive on raw.githubusercontent.com — rather than always pulling from `main`, which violated the umbrella-release contract.

## Why

Today, a self-hoster running `install.sh` on a random Tuesday gets whatever is currently on `main` — half-merged work, possibly between named versions. After a release matrix is cut, that's a footgun. With `--version`, the entire self-host config (compose pinning + helpers + landing page) moves as one named matrix.

## Resolution precedence

1. `--version <tag>` (CLI flag).
2. `SILENTSUITE_VERSION` env var (env loses to CLI).
3. **Latest umbrella release on GitHub.** Walks `/releases?per_page=20` newest-first and skips component-prefixed (`bridge-v*`, `android-v*`, `server-v*`, `web-v*`) and component-suffixed (`*-bridge`, `*-android`, ...) tags. Mirrors the filter style in `bridge/install.sh` so the two installers walk the same release stream with parallel logic.
4. **Fallback: `main` branch.** When no umbrella release exists yet (today's pre-beta state), the installer prints a clear `WARNING:` and proceeds against `main`. Once `v0.1.0-beta` is cut, the default flips automatically with no installer change required.

## Validation

`--version <tag>` is validated up front via a HEAD on the tag's `docker-compose.yml` URL, so a typo errors immediately with a pointer to `/releases`, instead of failing later inside one of the curl-fsSL chains.

## Manual smoke tests run

- `bash install.sh --help` → prints usage and exits.
- `bash install.sh --bogus` → errors with "Unknown argument".
- `bash install.sh --version` → errors with "requires an argument".
- Resolution pipeline against the live API:
  ```
  curl -fsSL "https://api.github.com/repos/silent-suite/silentsuite/releases?per_page=20" \
    | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/' \
    | grep -vE '^(bridge|android|server|web)-|-(bridge|android|server|web)$' \
    | head -1
  ```
  Output: empty — only existing release is `v0.1.1-bridge`, correctly filtered out. Fallback to `main` activates as designed.

## What this does NOT do

- Does not change behavior for existing self-host installs that re-run install.sh — `.env` overwrite prompt is unchanged. The existing-install fast path (keep `.env`, `pull && up`) still works.
- Does not migrate `etebase-server.ini` across versions. If a future release adds new ini keys, that's documented in release notes; the existing ini is preserved.
- Does not yet handle the AUTO_SIGNUP safety story (issue #55, next).

Closes silent-suite/silentsuite-internal#53.

## Test plan

- [x] `bash -n install.sh` passes.
- [x] `--help`, `--bogus`, `--version` (no arg) all behave as expected.
- [x] Resolution pipeline against live GitHub API matches expectations (filter rejects `v0.1.1-bridge`; falls back to `main`).
- [ ] **Clean-droplet smoke test (issue #56):** `curl -fsSL .../install.sh | bash` (default = main today, will auto-switch to v0.1.0-beta after that's cut).
- [ ] **Clean-droplet smoke test with explicit version (issue #56 once v0.1.0-beta exists):** `curl -fsSL .../install.sh | SILENTSUITE_VERSION=v0.1.0-beta bash`.