### PR TITLE
feat(self-host): close-signups.sh helper + loud post-install warning

### DIFF
--- a/self-host/SELF-HOSTING.md
+++ b/self-host/SELF-HOSTING.md
@@ -192,6 +192,20 @@ Once your server is running and your reverse proxy is configured:
 2. On the signup page, expand **Advanced Settings**
 3. Enter `https://sync.example.com` (your domain) as the server URL
 4. Create your account and start syncing
+5. **Run `./close-signups.sh`** from your install directory — see below.
+
+## Closing Open Signups
+
+The server ships with `ETEBASE_DISABLE_SIGNUP=false` so your first account can be created from the SilentSuite app. **The window between server-up and admin-registered is unsafe** — anyone who reaches your server URL during that gap can grab an account.
+
+Once your admin account is registered, close signups:
+
+```bash
+cd silentsuite-server
+./close-signups.sh
+```
+
+The script flips `ETEBASE_DISABLE_SIGNUP=true` in `.env` and recreates the server container. New registrations are blocked at the API layer thereafter. To re-open (e.g. to add another user), edit `.env`, set `ETEBASE_DISABLE_SIGNUP=false`, and run `docker compose up -d --force-recreate server`.
 
 ## Updating
 

--- a/self-host/close-signups.sh
+++ b/self-host/close-signups.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SilentSuite Self-Hosted: close open signups
+# --------------------------------------------
+# Flips ETEBASE_DISABLE_SIGNUP to "true" in .env and recreates the server
+# container so new user registration is blocked. Run this once your admin
+# account is registered in the SilentSuite app.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+if [ ! -f .env ]; then
+  echo "ERROR: .env not found in $SCRIPT_DIR." >&2
+  echo "       Run this script from the SilentSuite install directory." >&2
+  exit 1
+fi
+
+if grep -qE '^ETEBASE_DISABLE_SIGNUP=true$' .env; then
+  echo "Open signups are already disabled (ETEBASE_DISABLE_SIGNUP=true)."
+  exit 0
+fi
+
+if grep -qE '^ETEBASE_DISABLE_SIGNUP=' .env; then
+  # `-i.bak` works on both GNU and BSD sed; we delete the backup ourselves.
+  sed -i.bak -E 's/^ETEBASE_DISABLE_SIGNUP=.*/ETEBASE_DISABLE_SIGNUP=true/' .env
+  rm -f .env.bak
+else
+  echo "ETEBASE_DISABLE_SIGNUP=true" >> .env
+fi
+
+if docker compose version &>/dev/null; then
+  COMPOSE="docker compose"
+elif command -v docker-compose &>/dev/null; then
+  COMPOSE="docker-compose"
+else
+  echo "ERROR: 'docker compose' is not available." >&2
+  exit 1
+fi
+
+echo "Recreating SilentSuite server with ETEBASE_DISABLE_SIGNUP=true..."
+$COMPOSE up -d --force-recreate server
+
+echo ""
+echo "============================================"
+echo "  Open signups are now DISABLED."
+echo "============================================"
+echo ""
+echo "  New user registration will be blocked at the API level."
+echo ""
+echo "  To re-open signups (e.g. to add another user), edit .env, set"
+echo "  ETEBASE_DISABLE_SIGNUP=false, and run:"
+echo "    $COMPOSE up -d --force-recreate server"
+echo ""

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -179,7 +179,7 @@ curl -fsSL "$GITHUB_RAW_BASE/docker-compose.yml" -o docker-compose.yml
 
 # ── Download helper scripts ───────────────────────────────────────────
 
-for script in update.sh verify.sh; do
+for script in update.sh verify.sh close-signups.sh; do
   echo "Downloading $script..."
   curl -fsSL "$GITHUB_RAW_BASE/$script" -o "$script"
   chmod +x "$script"
@@ -400,6 +400,7 @@ echo "  3. Open https://app.silentsuite.io (or the mobile app)"
 echo "  4. On the signup page, expand 'Advanced Settings'"
 echo "  5. Enter https://$DOMAIN as the server URL"
 echo "  6. Create your account — you'll be the admin!"
+echo "  7. Immediately run ./close-signups.sh to block further registration."
 echo ""
 echo "  Configuration files:"
 echo "    .env                — environment variables"
@@ -408,3 +409,36 @@ echo ""
 echo "  To change the domain or other settings, edit etebase-server.ini"
 echo "  and restart: docker compose restart server"
 echo ""
+
+# ── Loud security warning ─────────────────────────────────────────────
+#
+# Open registration is on by default so the operator's first account can be
+# created via the app. After that registration the operator should immediately
+# close signups, otherwise anyone who finds the server URL can create an
+# account on the box. This banner is the last thing the installer prints so
+# it's the freshest thing in the operator's mind.
+
+if [ -t 1 ]; then
+  C_RED=$'\033[1;31m'
+  C_YELLOW=$'\033[1;33m'
+  C_RESET=$'\033[0m'
+else
+  C_RED=''; C_YELLOW=''; C_RESET=''
+fi
+
+cat <<EOF
+
+${C_RED}┌─────────────────────────────────────────────────────────────────────┐
+│  SECURITY: open registration is currently ENABLED.                  │
+└─────────────────────────────────────────────────────────────────────┘${C_RESET}
+
+  Anyone who reaches https://$DOMAIN/ before you do can grab an account
+  on this server. To stop that:
+
+    ${C_YELLOW}1. Sign up your own account at https://$DOMAIN/ now (step 6 above).${C_RESET}
+    ${C_YELLOW}2. Run ${C_RESET}./close-signups.sh${C_YELLOW} from this directory.${C_RESET}
+
+  ./close-signups.sh sets ETEBASE_DISABLE_SIGNUP=true in .env and recreates
+  the server container — new registrations get blocked at the API layer.
+
+EOF


### PR DESCRIPTION
## Summary

Closes the AUTO_SIGNUP-safety gap from silent-suite/silentsuite-internal#55 with Option B from the original triage (post-install warning + helper script). The compose env var `ETEBASE_DISABLE_SIGNUP` and its `settings.py` hook landed with #54 (PR #94); this PR is the operator-facing UX on top of them.

## Why Option B (not Option A — register-then-disable)

For v0.1.0-beta this avoids:
- An extra round-trip during `install.sh` (call out to the Etebase signup API mid-install with credentials we'd have to either prompt for or generate-then-display).
- An installer that knows enough about the running server's auth model to register a real account through it.

It does keep the unsafe window open between *server up* and *admin signed up*. The mitigation is a banner so loud the operator can't miss it, plus a one-liner helper that flips the toggle the moment they're done. Option A was captured for v0.2.0 in #55's discussion.

## What ships

- **`self-host/close-signups.sh`** — flips `ETEBASE_DISABLE_SIGNUP` from `false` to `true` in `.env` (or appends it if missing) then `docker compose up -d --force-recreate server`. Idempotent; second run prints "already disabled" and exits 0. Cross-shell safe (`sed -i.bak` works on both GNU and BSD sed; the .bak is removed after).
- **`install.sh` updates:**
  - `close-signups.sh` joins `update.sh` / `verify.sh` in the helper-script download loop, so curl-pipe installs end up with it on disk.
  - Tail banner: a colour-coded SECURITY block tells the operator open registration is enabled and points at the two actions (sign up at `https://$DOMAIN`; run `./close-signups.sh`). Colours gated on `[ -t 1 ]` so non-tty captures stay clean.
  - Numbered next-steps gains step 7 ("Immediately run `./close-signups.sh`") so the directive lands twice.
- **`SELF-HOSTING.md`** — new "Closing Open Signups" section spells out the same flow for operators who skipped the banner. The connect-your-apps walkthrough gains a final step pointing at it.

## What this does NOT do

- **Doesn't remove the window** between server-up and admin-registered. Option A (register-then-disable) was deferred to v0.2.0 and would need to live as a follow-up issue.
- **Doesn't block the operator from forgetting.** Banner is loud, but the only enforcement is operator vigilance for v0.1.0-beta.

## Test plan

- [x] `bash -n` passes for `install.sh` and `close-signups.sh`.
- [x] `close-signups.sh` correctly:
  - Errors out when `.env` is missing.
  - Detects already-disabled state (`grep -qE '^ETEBASE_DISABLE_SIGNUP=true$'`) and exits 0.
  - Flips an existing `ETEBASE_DISABLE_SIGNUP=false` line via sed.
  - Appends the line if absent.
- [ ] **Clean-droplet smoke (issue #56):** install → verify banner appears → register an account → run `./close-signups.sh` → attempt second signup → expect 403/permission denied at the API.

Closes silent-suite/silentsuite-internal#55.