### PR TITLE
ci(android): produce signed release APK from keystore secrets

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -53,10 +53,11 @@ jobs:
       - name: Build signed release APK
         env:
           KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
           ./gradlew assembleRelease --no-daemon \
             -PsigningStoreLocation="$KEYSTORE_PATH" \
-            -PsigningKeyAlias="${{ secrets.ANDROID_KEY_ALIAS }}"
+            -PsigningKeyAlias="$KEY_ALIAS"
 
       - name: Verify APK signature
         run: |
@@ -72,4 +73,4 @@ jobs:
 
       - name: Cleanup keystore
         if: always()
-        run: rm -f "$KEYSTORE_PATH" 2>/dev/null || true
+        run: rm -rf "$RUNNER_TEMP/keystore"

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -5,10 +5,12 @@ on:
     branches: [dev, main]
     paths:
       - 'android/**'
+      - '.github/workflows/build-android.yml'
   pull_request:
     branches: [dev]
     paths:
       - 'android/**'
+      - '.github/workflows/build-android.yml'
   workflow_dispatch:
 
 jobs:
@@ -40,12 +42,34 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      - name: Build debug APK
-        run: ./gradlew assembleDebug --no-daemon
+      - name: Decode release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/keystore"
+          echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/keystore/silentsuite-release.jks"
+          echo "KEYSTORE_PATH=$RUNNER_TEMP/keystore/silentsuite-release.jks" >> "$GITHUB_ENV"
 
-      - name: Upload APK
+      - name: Build signed release APK
+        env:
+          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+        run: |
+          ./gradlew assembleRelease --no-daemon \
+            -PsigningStoreLocation="$KEYSTORE_PATH" \
+            -PsigningKeyAlias="${{ secrets.ANDROID_KEY_ALIAS }}"
+
+      - name: Verify APK signature
+        run: |
+          BUILD_TOOLS=$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -1)
+          "$BUILD_TOOLS/apksigner" verify --print-certs app/build/outputs/apk/release/*.apk
+
+      - name: Upload signed release APK
         uses: actions/upload-artifact@v4
         with:
-          name: silentsuite-debug-${{ github.sha }}
-          path: android/app/build/outputs/apk/debug/*.apk
+          name: silentsuite-release-${{ github.sha }}
+          path: android/app/build/outputs/apk/release/*.apk
           retention-days: 30
+
+      - name: Cleanup keystore
+        if: always()
+        run: rm -f "$KEYSTORE_PATH" 2>/dev/null || true


### PR DESCRIPTION
Wires the existing release-signing block in `android/app/build.gradle` (which expects `signingStoreLocation` + `signingKeyAlias` gradle props and `KSTOREPWD` env) to four new GitHub Actions secrets:

- `ANDROID_KEYSTORE_BASE64` — base64-encoded JKS
- `ANDROID_KEYSTORE_PASSWORD` — store + key password (gradle uses the same for both)
- `ANDROID_KEY_ALIAS` — `silentsuite`
- `ANDROID_KEY_PASSWORD` — same as keystore password

Replaces the prior \`assembleDebug\` step with \`assembleRelease\` + an \`apksigner verify --print-certs\` step that fails the build if the signature doesn't validate. Keystore is decoded into \`\$RUNNER_TEMP\` and removed in an \`if: always()\` cleanup step so it doesn't survive past the job.

**Required for** the upcoming \`v0.1.0-beta\` umbrella release — sideload users need a release-signed APK so future v0.1.x updates can install in-place without uninstall+lose-state.

**Verified:** workflow_dispatch on this branch produced a signed APK in 2m50s. apksigner reports:
- V2 Signer DN: \`CN=SilentSuite, OU=Android, O=SilentSuite\`
- Cert SHA-256: \`8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79\`

**Followup (not in this PR):** wire the umbrella tag (\`v*\`) trigger + auto-attach to GitHub Release once the umbrella tag-cut flow is designed.