### PR TITLE
ci: umbrella tag (v*) auto-attaches signed APK + bridge binaries to draft release

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -75,7 +75,16 @@ jobs:
           path: android/app/build/outputs/apk/release/*.apk
           retention-days: 30
 
-      - name: Attach APK to umbrella GitHub Release (tag push only)
+      - name: Rename APK for release (tag push only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mv app/build/outputs/apk/release/app-release.apk \
+             "app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk"
+          cd app/build/outputs/apk/release
+          sha256sum "silentsuite-android-${{ github.ref_name }}.apk" \
+            > "silentsuite-android-${{ github.ref_name }}.apk.sha256"
+
+      - name: Attach APK + checksum to umbrella GitHub Release (tag push only)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
@@ -84,7 +93,9 @@ jobs:
           draft: true
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           fail_on_unmatched_files: true
-          files: android/app/build/outputs/apk/release/*.apk
+          files: |
+            android/app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk
+            android/app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk.sha256
 
       - name: Cleanup keystore
         if: always()

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -3,6 +3,8 @@ name: Build Android APK
 on:
   push:
     branches: [dev, main]
+    tags:
+      - 'v*'
     paths:
       - 'android/**'
       - '.github/workflows/build-android.yml'
@@ -16,6 +18,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: android
@@ -70,6 +74,17 @@ jobs:
           name: silentsuite-release-${{ github.sha }}
           path: android/app/build/outputs/apk/release/*.apk
           retention-days: 30
+
+      - name: Attach APK to umbrella GitHub Release (tag push only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: SilentSuite ${{ github.ref_name }}
+          draft: true
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          fail_on_unmatched_files: true
+          files: android/app/build/outputs/apk/release/*.apk
 
       - name: Cleanup keystore
         if: always()

--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -3,7 +3,7 @@ name: Build Bridge Binaries
 on:
   push:
     tags:
-      - "v*-bridge"
+      - "v*"
   workflow_dispatch:
     inputs:
       create_release:
@@ -289,47 +289,18 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Release tag: $TAG"
 
-      # Create the release and upload all binaries + checksums
-      - name: Create GitHub Release
+      # Create / append to the umbrella GitHub Release.
+      # We deliberately do NOT set body/body_path here — the release notes
+      # live in the umbrella release notes the operator pastes at publish
+      # time. softprops/action-gh-release is idempotent: first workflow to
+      # run creates the draft release, subsequent runs append assets without
+      # clobbering an existing body.
+      - name: Attach bridge binaries to umbrella GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          name: SilentSuite Bridge ${{ steps.tag.outputs.tag }}
-          draft: false
+          name: SilentSuite ${{ steps.tag.outputs.tag }}
+          draft: true
           prerelease: ${{ contains(steps.tag.outputs.tag, 'alpha') || contains(steps.tag.outputs.tag, 'beta') || contains(steps.tag.outputs.tag, 'rc') }}
-          body: |
-            ## SilentSuite Bridge ${{ steps.tag.outputs.tag }}
-
-            Local CalDAV/CardDAV ↔ Etebase bridge daemon.
-
-            ### Installation
-
-            **macOS / Linux:**
-            ```sh
-            curl -fsSL https://silentsuite.io/bridge/install.sh | sh
-            ```
-
-            **Windows (PowerShell):**
-            ```powershell
-            irm silentsuite.io/bridge/install.ps1 | iex
-            ```
-
-            Or download the binary for your platform below.
-
-            ### Supported Platforms
-
-            | Binary | Platform |
-            |--------|----------|
-            | `silentsuite-bridge-linux-x86_64` | Linux (x86_64) |
-            | `silentsuite-bridge-linux-arm64` | Linux (ARM64 / Raspberry Pi) |
-            | `silentsuite-bridge-macos-x86_64` | macOS (Intel) |
-            | `silentsuite-bridge-windows-x86_64.exe` | Windows (x86_64) |
-
-            > **macOS Apple Silicon:** Run from source with Python (`pip install silentsuite-bridge`).
-
-            ### Verify checksum
-
-            ```sh
-            sha256sum -c SHA256SUMS.txt
-            ```
+          fail_on_unmatched_files: true
           files: flat/*


### PR DESCRIPTION
Wires the umbrella tag-cut flow agreed in the v0.1.0-beta plan: pushing \`v0.1.0-beta\` (or any \`v*\` tag) automatically:

1. Builds the signed Android APK (already proven by PR #101).
2. Builds the bridge for Linux x86_64/arm64, macOS x86_64, Windows x86_64 (matrix already exists).
3. Creates a **draft** GitHub Release named \`SilentSuite \${tag}\` and attaches all binaries + sha256 sidecars + combined \`SHA256SUMS.txt\`.

Operator pastes the umbrella release notes (kept in \`silentsuite-internal/planning/_bmad-output/planning-artifacts/v0.1.0-beta-release-notes.md\`) and clicks publish.

## Changes

### \`.github/workflows/build-android.yml\`
- \`tags: ['v*']\` added to push trigger; \`permissions: contents: write\` added.
- New tag-conditional steps:
  - **Rename APK** \`app-release.apk\` → \`silentsuite-android-\${tag}.apk\` + per-file sha256.
  - **Attach** the renamed APK + sha256 to the draft umbrella release via \`softprops/action-gh-release@v2\`.

### \`.github/workflows/build-bridge.yml\`
- Tag trigger \`v*-bridge\` → \`v*\`. Per the umbrella model, no more component tags.
- \`Create GitHub Release\` step → \`draft: true\`, body removed (the umbrella notes live in the operator-pasted body), name simplified from \`SilentSuite Bridge \${tag}\` to \`SilentSuite \${tag}\`. \`softprops/action-gh-release@v2\` is idempotent — whichever workflow finishes first creates the draft, the other appends without clobbering the body.

## Verified end-to-end

Pushed \`v0.0.0-test-attach\` against this branch HEAD; both workflows fired and the resulting draft release contained:

- \`app-release.apk\` (this was before the rename commit; post-rename it would be \`silentsuite-android-v0.0.0-test-attach.apk\` + \`.sha256\`)
- 4 bridge binaries (linux x86_64/arm64, macos x86_64, windows x86_64) + per-file \`.sha256\`
- combined \`SHA256SUMS.txt\` from the bridge release job

Test tag + draft release deleted after verification — state is clean. The post-rename change has not been re-tested with another throwaway tag (rename is one \`mv\` + one \`sha256sum\`, very low risk), but happy to retest if the reviewer prefers.

## Followups (not in this PR)

- Node.js 20 deprecation warnings on \`actions/{checkout,cache,setup-java,setup-python,upload-artifact,download-artifact}@v4\` and \`softprops/action-gh-release@v2\`. GitHub is forcing Node 24 on June 2nd, 2026 — quiet maintenance window job.