### PR TITLE
release: dev → main (umbrella v* tag-cut flow)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -75,7 +75,16 @@ jobs:
           path: android/app/build/outputs/apk/release/*.apk
           retention-days: 30
 
-      - name: Attach APK to umbrella GitHub Release (tag push only)
+      - name: Rename APK for release (tag push only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          mv app/build/outputs/apk/release/app-release.apk \
+             "app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk"
+          cd app/build/outputs/apk/release
+          sha256sum "silentsuite-android-${{ github.ref_name }}.apk" \
+            > "silentsuite-android-${{ github.ref_name }}.apk.sha256"
+
+      - name: Attach APK + checksum to umbrella GitHub Release (tag push only)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
@@ -84,7 +93,9 @@ jobs:
           draft: true
           prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           fail_on_unmatched_files: true
-          files: android/app/build/outputs/apk/release/*.apk
+          files: |
+            android/app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk
+            android/app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk.sha256
 
       - name: Cleanup keystore
         if: always()

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -3,6 +3,8 @@ name: Build Android APK
 on:
   push:
     branches: [dev, main]
+    tags:
+      - 'v*'
     paths:
       - 'android/**'
       - '.github/workflows/build-android.yml'
@@ -16,6 +18,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: android
@@ -70,6 +74,17 @@ jobs:
           name: silentsuite-release-${{ github.sha }}
           path: android/app/build/outputs/apk/release/*.apk
           retention-days: 30
+
+      - name: Attach APK to umbrella GitHub Release (tag push only)
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: SilentSuite ${{ github.ref_name }}
+          draft: true
+          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          fail_on_unmatched_files: true
+          files: android/app/build/outputs/apk/release/*.apk
 
       - name: Cleanup keystore
         if: always()

--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -3,7 +3,7 @@ name: Build Bridge Binaries
 on:
   push:
     tags:
-      - "v*-bridge"
+      - "v*"
   workflow_dispatch:
     inputs:
       create_release:
@@ -289,47 +289,18 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Release tag: $TAG"
 
-      # Create the release and upload all binaries + checksums
-      - name: Create GitHub Release
+      # Create / append to the umbrella GitHub Release.
+      # We deliberately do NOT set body/body_path here — the release notes
+      # live in the umbrella release notes the operator pastes at publish
+      # time. softprops/action-gh-release is idempotent: first workflow to
+      # run creates the draft release, subsequent runs append assets without
+      # clobbering an existing body.
+      - name: Attach bridge binaries to umbrella GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          name: SilentSuite Bridge ${{ steps.tag.outputs.tag }}
-          draft: false
+          name: SilentSuite ${{ steps.tag.outputs.tag }}
+          draft: true
           prerelease: ${{ contains(steps.tag.outputs.tag, 'alpha') || contains(steps.tag.outputs.tag, 'beta') || contains(steps.tag.outputs.tag, 'rc') }}
-          body: |
-            ## SilentSuite Bridge ${{ steps.tag.outputs.tag }}
-
-            Local CalDAV/CardDAV ↔ Etebase bridge daemon.
-
-            ### Installation
-
-            **macOS / Linux:**
-            ```sh
-            curl -fsSL https://silentsuite.io/bridge/install.sh | sh
-            ```
-
-            **Windows (PowerShell):**
-            ```powershell
-            irm silentsuite.io/bridge/install.ps1 | iex
-            ```
-
-            Or download the binary for your platform below.
-
-            ### Supported Platforms
-
-            | Binary | Platform |
-            |--------|----------|
-            | `silentsuite-bridge-linux-x86_64` | Linux (x86_64) |
-            | `silentsuite-bridge-linux-arm64` | Linux (ARM64 / Raspberry Pi) |
-            | `silentsuite-bridge-macos-x86_64` | macOS (Intel) |
-            | `silentsuite-bridge-windows-x86_64.exe` | Windows (x86_64) |
-
-            > **macOS Apple Silicon:** Run from source with Python (`pip install silentsuite-bridge`).
-
-            ### Verify checksum
-
-            ```sh
-            sha256sum -c SHA256SUMS.txt
-            ```
+          fail_on_unmatched_files: true
           files: flat/*


### PR DESCRIPTION
Promotes the umbrella tag-cut flow from \`dev\` so a real \`v0.1.0-beta\` push to \`main\` produces the draft GitHub Release with all assets.

Bundled commits on \`dev\` since the last promotion (#102):

- **#103 (\`189bd9e\`)** — \`ci: umbrella tag triggers signed APK + bridge binaries on draft release\`. Adds \`tags: ['v*']\` push trigger to \`build-android.yml\`, switches \`build-bridge.yml\` trigger from \`v*-bridge\` to \`v*\`, both workflows attach to a \`draft: true\` umbrella release named \`SilentSuite \${tag}\` via \`softprops/action-gh-release@v2\`.
- **#103 (\`4cc26a7\`)** — \`ci(android): rename APK to silentsuite-android-\${tag}.apk + sha256 sidecar\`. Renames the APK from Gradle's default \`app-release.apk\` to user-friendly \`silentsuite-android-\${tag}.apk\` + adds per-file sha256.
- **Merge commit** for #103.

**Verified end-to-end** (per PR #103): pushed throwaway \`v0.0.0-test-attach\` against the feature branch HEAD; both workflows fired and the draft release contained the signed APK + 4 bridge binaries + per-file sha256 + combined SHA256SUMS.txt. Test tag + draft cleaned up after.

PR #103 was subagent-reviewed and the reviewer verified softprops/action-gh-release@v2 idempotency by reading the action source — body, name, draft state are all safe under the two-workflow concurrent-attach pattern.