### PR TITLE
ci: drop prerelease auto-flag from umbrella tag workflows

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -91,7 +91,6 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: SilentSuite ${{ github.ref_name }}
           draft: true
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           fail_on_unmatched_files: true
           files: |
             android/app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk

--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -301,6 +301,5 @@ jobs:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: SilentSuite ${{ steps.tag.outputs.tag }}
           draft: true
-          prerelease: ${{ contains(steps.tag.outputs.tag, 'alpha') || contains(steps.tag.outputs.tag, 'beta') || contains(steps.tag.outputs.tag, 'rc') }}
           fail_on_unmatched_files: true
           files: flat/*


### PR DESCRIPTION
2-line change: remove the \`prerelease: contains(tag, alpha|beta|rc)\` line from both \`build-android.yml\` and \`build-bridge.yml\`. Future umbrella tags publish as normal \"Latest\" releases instead of yellow-badged \"Pre-release\".

**Why:** Operator preference. The \`-beta\` tag suffix and the release notes copy already communicate beta status; the additional GitHub Pre-release badge added a layer of \"unfinished\" framing the project doesn't want.

**v0.1.0-beta itself:** already converted via \`gh release edit v0.1.0-beta --prerelease=false --latest\` — it now shows as Latest with no Pre-release badge.

**softprops/action-gh-release@v2** defaults to \`prerelease: false\` when unset, so removing the line gives us what we want without an explicit \`prerelease: false\`.