### PR TITLE
release: dev → main (drop prerelease auto-flag from umbrella workflows)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -91,7 +91,6 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: SilentSuite ${{ github.ref_name }}
           draft: true
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           fail_on_unmatched_files: true
           files: |
             android/app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk

--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -301,6 +301,5 @@ jobs:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: SilentSuite ${{ steps.tag.outputs.tag }}
           draft: true
-          prerelease: ${{ contains(steps.tag.outputs.tag, 'alpha') || contains(steps.tag.outputs.tag, 'beta') || contains(steps.tag.outputs.tag, 'rc') }}
           fail_on_unmatched_files: true
           files: flat/*


### PR DESCRIPTION
Promotes the 2-line workflow change from #105 so the next umbrella tag (\`v0.1.1-beta\` or whatever comes after the current \`v0.1.0-beta\`) is automatically published as a normal \"Latest\" release rather than a yellow-badged Pre-release.

Bundled commits on \`dev\` since the last promotion (#104):

- **#105 (\`0c33eaa\`)** — \`ci: drop prerelease auto-flag from umbrella tag workflows\`. Removes the \`prerelease: contains(tag, alpha|beta|rc)\` line from both \`build-android.yml\` and \`build-bridge.yml\`. \`softprops/action-gh-release@v2\` defaults to \`prerelease: false\` when unset.
- **Merge commit** for #105.

PR #105 was subagent-reviewed 🟢: diff is exactly 2 lines, no other workflow has a \`prerelease:\` line that needs the same treatment, no stale comments left behind.

\`v0.1.0-beta\` itself was already converted via \`gh release edit v0.1.0-beta --prerelease=false --latest\`.