### PR TITLE
Render calendar in user timezone, edit form in event timezone

### DIFF
--- a/apps/web/app/(app)/calendar/components/AgendaView.tsx
+++ b/apps/web/app/(app)/calendar/components/AgendaView.tsx
@@ -4,6 +4,8 @@ import { useMemo } from 'react'
 import { Clock, MapPin } from 'lucide-react'
 import { CalendarEmptyState } from '@/app/components/empty-state'
 import type { CalendarEvent } from '@silentsuite/core'
+import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { resolveUserTimezone, shortTimezoneLabel } from '@/app/lib/tz'
 
 interface AgendaViewProps {
   events: CalendarEvent[]
@@ -11,8 +13,8 @@ interface AgendaViewProps {
   onEventClick?: (eventId: string) => void
 }
 
-function formatTime(date: Date): string {
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+function formatTime(date: Date, tz: string): string {
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: tz })
 }
 
 function isSameDay(a: Date, b: Date): boolean {
@@ -24,6 +26,8 @@ function isSameDay(a: Date, b: Date): boolean {
 }
 
 export function AgendaView({ events, currentDate, onEventClick }: AgendaViewProps) {
+  const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
+  const userTz = resolveUserTimezone(defaultTimezonePref)
   const dayEvents = useMemo(() => {
     const currentDayStart = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate())
     const currentDayEnd = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate(), 23, 59, 59, 999)
@@ -68,8 +72,13 @@ export function AgendaView({ events, currentDate, onEventClick }: AgendaViewProp
                 <div className="mt-1 flex items-center gap-1 text-xs text-[rgb(var(--muted))]">
                   <Clock className="h-3 w-3" />
                   <span>
-                    {formatTime(event.startDate)} – {formatTime(event.endDate)}
+                    {formatTime(event.startDate, userTz)} – {formatTime(event.endDate, userTz)}
                   </span>
+                  {event.timezone && event.timezone !== userTz && (
+                    <span className="ml-1 rounded bg-[rgb(var(--surface-muted))] px-1 py-0.5 text-[10px] font-medium text-[rgb(var(--muted))]">
+                      {shortTimezoneLabel(event.timezone, event.startDate)}
+                    </span>
+                  )}
                 </div>
               )}
               {event.allDay && (

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -15,6 +15,7 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { expandRecurrence } from '@silentsuite/core'
 import type { CalendarEvent, DateRange } from '@silentsuite/core'
+import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
 
 import '@schedule-x/theme-default/dist/index.css'
 
@@ -34,15 +35,13 @@ function toPlainDate(date: Date): Temporal.PlainDate {
   })
 }
 
-/** Convert a JS Date to a Temporal.ZonedDateTime in the local timezone.
+/** Convert a JS Date to a Temporal.ZonedDateTime in the given timezone.
  * Schedule-X v4 requires a real ZonedDateTime — it calls .withTimeZone() on the
- * stored value, so plain strings or casts will throw at runtime and events will
- * silently not render.
+ * stored value to convert into the calendar's configured timezone, so the input
+ * zone here is effectively a label; what matters is the underlying instant.
  */
-function toScheduleXDateTime(date: Date): Temporal.ZonedDateTime {
-  return Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO(
-    Temporal.Now.timeZoneId(),
-  )
+function toScheduleXDateTime(date: Date, tz: string): Temporal.ZonedDateTime {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO(tz)
 }
 
 /** Expanded event used for display — may be a recurring instance */
@@ -148,14 +147,15 @@ function expandEventsForRange(
 function toScheduleXEvents(
   displayEvents: DisplayEvent[],
   calendarColors: Map<string, string>,
+  userTz: string,
 ): CalendarEventExternal[] {
   return displayEvents.map((e) => {
     const color = calendarColors.get(e.calendarId ?? 'default') ?? '#10b981'
     return {
       id: e.id,
       title: e.isRecurring ? `↻ ${e.title}` : e.title,
-      start: e.allDay ? toPlainDate(e.startDate) : toScheduleXDateTime(e.startDate),
-      end: e.allDay ? toPlainDate(e.endDate) : toScheduleXDateTime(e.endDate),
+      start: e.allDay ? toPlainDate(e.startDate) : toScheduleXDateTime(e.startDate, userTz),
+      end: e.allDay ? toPlainDate(e.endDate) : toScheduleXDateTime(e.endDate, userTz),
       description: e.description || undefined,
       location: e.location || undefined,
       calendarId: e.calendarId ?? 'default',
@@ -282,6 +282,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
 
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
   const use12h = timeFormat !== '24h'
+  const defaultTimezone = usePreferencesStore((s) => s.defaultTimezone)
+  const userTz = useMemo(() => resolveUserTimezone(defaultTimezone), [defaultTimezone])
 
   const lastClickPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
 
@@ -312,7 +314,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const displayEventMapRef = useRef(displayEventMap)
   displayEventMapRef.current = displayEventMap
 
-  const sxEvents = useMemo(() => toScheduleXEvents(displayEvents, calendarColors), [displayEvents, calendarColors])
+  const sxEvents = useMemo(() => toScheduleXEvents(displayEvents, calendarColors, userTz), [displayEvents, calendarColors, userTz])
 
   // Inject calendar color styles via useInsertionEffect (avoids dangerouslySetInnerHTML)
   useInsertionEffect(() => {
@@ -451,6 +453,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const initialDateRef = useRef(selectedDate)
   // Capture time format at mount — Schedule-X locale can't change after init
   const initialLocaleRef = useRef(timeFormat === '24h' ? 'en-GB' : 'en-US')
+  // Capture initial timezone for Schedule-X config (changes are pushed via signal below)
+  const initialTimezoneRef = useRef(userTz)
 
   // Memoize the event click handler
   const handleEventClick = useCallback(
@@ -487,6 +491,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     locale: initialLocaleRef.current,
     firstDayOfWeek: 1, // Monday — must match getViewRange() and formatDateRange()
     dayBoundaries: { start: '06:00', end: '22:00' },
+    timezone: initialTimezoneRef.current,
     weekOptions: {
       gridHeight: 800,
       eventWidth: 95,
@@ -498,6 +503,21 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       onClickDate: handleClickDate,
     },
   })
+
+  // Push timezone changes to the Schedule-X config signal so the grid re-renders
+  // when the user updates their preference in Settings without a full page reload.
+  useEffect(() => {
+    if (!calendar) return
+    try {
+      const app = (calendar as any).$app
+      const tzSignal = app?.config?.timezone
+      if (tzSignal && tzSignal.value !== userTz) {
+        tzSignal.value = userTz
+      }
+    } catch {
+      // Schedule-X internals may not be ready
+    }
+  }, [calendar, userTz])
 
   // Sync view AND date changes from store → Schedule-X via internal API.
   // CalendarApp has NO public navigation methods. We access the private $app
@@ -656,14 +676,25 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     [viewRange],
   )
 
-  /** Build a Date from a day + fractional hour */
-  const buildDateFromHour = useCallback((day: Date, hour: number): Date => {
-    const d = new Date(day.getFullYear(), day.getMonth(), day.getDate())
-    const h = Math.floor(hour)
-    const m = Math.round((hour - h) * 60)
-    d.setHours(h, m, 0, 0)
-    return d
-  }, [])
+  /** Build a Date from a day + fractional hour, interpreting the wall-clock in userTz.
+   * `day` carries the user's clicked day as browser-local Y/M/D (constructed from
+   * viewRange.start). We treat those Y/M/D as the wall-clock day in userTz so the
+   * resulting instant aligns with the rendered grid regardless of browser TZ. */
+  const buildDateFromHour = useCallback(
+    (day: Date, hour: number): Date => {
+      const h = Math.floor(hour)
+      const m = Math.round((hour - h) * 60)
+      return instantFromWallClock(
+        day.getFullYear(),
+        day.getMonth() + 1,
+        day.getDate(),
+        h,
+        m,
+        userTz,
+      )
+    },
+    [userTz],
+  )
 
   /** Shared helper: compute drag-move preview from cursor coordinates */
   const updateDragMovePosition = useCallback(
@@ -696,10 +727,12 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         hour: 'numeric',
         minute: '2-digit',
         hour12: use12h,
+        timeZone: userTz,
       })} \u2013 ${clampedEnd.toLocaleTimeString('en-US', {
         hour: 'numeric',
         minute: '2-digit',
         hour12: use12h,
+        timeZone: userTz,
       })}`
 
       const de = displayEventMapRef.current.get(dragMoveStartRef.current.eventId)
@@ -715,7 +748,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         newEnd: clampedEnd,
       })
     },
-    [getDayColumnInfo, getTimeFromY, buildDateFromHour, use12h],
+    [getDayColumnInfo, getTimeFromY, buildDateFromHour, use12h, userTz],
   )
 
   /** Shared helper: complete drag-move drop */
@@ -957,10 +990,12 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
           hour: 'numeric',
           minute: '2-digit',
           hour12: use12h,
+          timeZone: userTz,
         })} \u2013 ${newEnd.toLocaleTimeString('en-US', {
           hour: 'numeric',
           minute: '2-digit',
           hour12: use12h,
+          timeZone: userTz,
         })}`
 
         setDragResizePreview({
@@ -1102,7 +1137,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         endTime,
       })
     },
-    [getTimeFromY, buildDateFromHour, getDayColumnInfo, updateDragMovePosition, viewRange, use12h],
+    [getTimeFromY, buildDateFromHour, getDayColumnInfo, updateDragMovePosition, viewRange, use12h, userTz],
   )
 
   const handleMouseUp = useCallback(
@@ -1398,6 +1433,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
                     hour: 'numeric',
                     minute: '2-digit',
                     hour12: use12h,
+                    timeZone: userTz,
                   })}
                 </span>
                 <span className="text-[11px] font-medium text-[rgb(var(--primary))] leading-none self-end">
@@ -1405,6 +1441,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
                     hour: 'numeric',
                     minute: '2-digit',
                     hour12: use12h,
+                    timeZone: userTz,
                   })}
                 </span>
               </>

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -12,17 +12,25 @@ import { buildAlarmTrigger, parseAlarmTriggerMinutes } from '@silentsuite/core'
 import { useNotifications } from '@/app/providers/notification-provider'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { Globe } from 'lucide-react'
+import {
+  formatDateForInputInZone,
+  formatTimeForInputInZone,
+  instantFromWallClock,
+  resolveUserTimezone,
+  shortTimezoneLabel,
+} from '@/app/lib/tz'
 
 // ---------------------------------------------------------------------------
 // Time formatting (respects user preference)
 // ---------------------------------------------------------------------------
 
-function makeFormatTime(hour12: boolean) {
+function makeFormatTime(hour12: boolean, tz: string) {
   return function formatTime(date: Date): string {
     return date.toLocaleTimeString('en-US', {
       hour: 'numeric',
       minute: '2-digit',
       hour12,
+      timeZone: tz,
     })
   }
 }
@@ -55,25 +63,35 @@ interface EventDialogProps {
 
 // formatTime is created per-render via makeFormatTime — see below
 
-function formatTimeForInput(date: Date): string {
-  const h = String(date.getHours()).padStart(2, '0')
-  const m = String(date.getMinutes()).padStart(2, '0')
-  return `${h}:${m}`
+/** All-day events have undefined event.timezone and are stored as local-midnight
+ * Date objects, so their wall-clock components are read in browser-local. Timed
+ * events use the event's TZ (or user default) to read/write wall-clock components. */
+function formatTimeForInput(date: Date, tz: string | undefined): string {
+  if (!tz) {
+    const h = String(date.getHours()).padStart(2, '0')
+    const m = String(date.getMinutes()).padStart(2, '0')
+    return `${h}:${m}`
+  }
+  return formatTimeForInputInZone(date, tz)
 }
 
-function formatDateForInput(date: Date): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
+function formatDateForInput(date: Date, tz: string | undefined): string {
+  if (!tz) {
+    const y = date.getFullYear()
+    const m = String(date.getMonth() + 1).padStart(2, '0')
+    const d = String(date.getDate()).padStart(2, '0')
+    return `${y}-${m}-${d}`
+  }
+  return formatDateForInputInZone(date, tz)
 }
 
-function formatDateForDisplay(date: Date): string {
+function formatDateForDisplay(date: Date, tz: string | undefined): string {
   return date.toLocaleDateString('en-US', {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    ...(tz ? { timeZone: tz } : {}),
   })
 }
 
@@ -101,8 +119,9 @@ export function EventDialog({
   const notifications = useNotifications()
   const defaultReminder = usePreferencesStore((s) => s.defaultReminder)
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
-  const defaultTimezone = usePreferencesStore((s) => s.defaultTimezone)
-  const formatTime = makeFormatTime(timeFormat !== '24h')
+  const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
+  const userTz = resolveUserTimezone(defaultTimezonePref)
+  const defaultTimezone = userTz
 
   // ---------------------------------------------------------------------------
   // Derive initial state
@@ -117,6 +136,15 @@ export function EventDialog({
     ? event.endDate
     : (initialEndDate ?? new Date(defaultStart.getTime() + 30 * 60 * 1000))
 
+  // Initial all-day flag — needed before form state so we can pick the right
+  // TZ for formatting the initial date/time strings.
+  const initialIsAllDay = isEdit ? event.allDay : initialAllDay
+  const initialFormTz: string | undefined = initialIsAllDay
+    ? undefined
+    : isEdit
+      ? (event.timezone ?? userTz)
+      : userTz
+
   // ---------------------------------------------------------------------------
   // Form state
   // ---------------------------------------------------------------------------
@@ -124,11 +152,11 @@ export function EventDialog({
   const [title, setTitle] = useState(isEdit ? event.title : '')
   const [location, setLocation] = useState(isEdit ? (event.location || '') : '')
   const [description, setDescription] = useState(isEdit ? (event.description || '') : '')
-  const [allDay, setAllDay] = useState(isEdit ? event.allDay : initialAllDay)
-  const [startDate, setStartDate] = useState(formatDateForInput(defaultStart))
-  const [startTime, setStartTime] = useState(formatTimeForInput(defaultStart))
-  const [endDate, setEndDate] = useState(formatDateForInput(defaultEnd))
-  const [endTime, setEndTime] = useState(formatTimeForInput(defaultEnd))
+  const [allDay, setAllDay] = useState(initialIsAllDay)
+  const [startDate, setStartDate] = useState(formatDateForInput(defaultStart, initialFormTz))
+  const [startTime, setStartTime] = useState(formatTimeForInput(defaultStart, initialFormTz))
+  const [endDate, setEndDate] = useState(formatDateForInput(defaultEnd, initialFormTz))
+  const [endTime, setEndTime] = useState(formatTimeForInput(defaultEnd, initialFormTz))
   const [recurrenceRule, setRecurrenceRule] = useState<string | null>(
     isEdit ? event.recurrenceRule : null,
   )
@@ -148,6 +176,10 @@ export function EventDialog({
   const [timezone, setTimezone] = useState(
     isEdit ? (event.timezone ?? defaultTimezone) : defaultTimezone,
   )
+  // Active TZ for form fields and subtitle: undefined for all-day (local-midnight)
+  // semantics, otherwise the picker's value.
+  const formTz: string | undefined = allDay ? undefined : timezone
+  const formatTime = makeFormatTime(timeFormat !== '24h', formTz ?? userTz)
   const allTimezones = (() => {
     try { return Intl.supportedValuesOf('timeZone') } catch { return ['UTC'] }
   })()
@@ -212,22 +244,22 @@ export function EventDialog({
   const buildStartDate = useCallback((): Date => {
     const [y, m, d] = startDate.split('-').map(Number)
     if (allDay) {
-      const dt = new Date(y, m - 1, d, 0, 0, 0, 0)
-      return dt
+      // All-day events stored as browser-local midnight; matches how the
+      // import path and core ical parser handle DATE-only DTSTART.
+      return new Date(y, m - 1, d, 0, 0, 0, 0)
     }
     const [h, min] = startTime.split(':').map(Number)
-    return new Date(y, m - 1, d, h, min, 0, 0)
-  }, [startDate, startTime, allDay])
+    return instantFromWallClock(y, m, d, h, min, timezone)
+  }, [startDate, startTime, allDay, timezone])
 
   const buildEndDate = useCallback((): Date => {
     const [y, m, d] = endDate.split('-').map(Number)
     if (allDay) {
-      const dt = new Date(y, m - 1, d, 23, 59, 59, 0)
-      return dt
+      return new Date(y, m - 1, d, 23, 59, 59, 0)
     }
     const [h, min] = endTime.split(':').map(Number)
-    return new Date(y, m - 1, d, h, min, 0, 0)
-  }, [endDate, endTime, allDay])
+    return instantFromWallClock(y, m, d, h, min, timezone)
+  }, [endDate, endTime, allDay, timezone])
 
   // ---------------------------------------------------------------------------
   // Save handler
@@ -405,11 +437,13 @@ export function EventDialog({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
       setStartTime(value)
-      // Auto-adjust end time to 30 min after start if on same day
+      // Auto-adjust end time to 30 min after start if on same day. Pure HH:MM
+      // arithmetic via a synthetic local Date; format back as browser-local
+      // since we only need the wall-clock string back.
       if (startDate === endDate) {
         const [h, m] = value.split(':').map(Number)
         const newEnd = new Date(2000, 0, 1, h, m + 30)
-        setEndTime(formatTimeForInput(newEnd))
+        setEndTime(formatTimeForInput(newEnd, undefined))
       }
     },
     [startDate, endDate],
@@ -449,16 +483,16 @@ export function EventDialog({
 
   const subtitle = (() => {
     if (allDay) {
-      const sd = formatDateForDisplay(buildStartDate())
-      const ed = formatDateForDisplay(buildEndDate())
+      const sd = formatDateForDisplay(buildStartDate(), undefined)
+      const ed = formatDateForDisplay(buildEndDate(), undefined)
       return startDate === endDate ? sd : `${sd} – ${ed}`
     }
     const s = buildStartDate()
     const e = buildEndDate()
     if (startDate === endDate) {
-      return `${formatDateForDisplay(s)}, ${formatTime(s)} – ${formatTime(e)}`
+      return `${formatDateForDisplay(s, formTz)}, ${formatTime(s)} – ${formatTime(e)}`
     }
-    return `${formatDateForDisplay(s)}, ${formatTime(s)} – ${formatDateForDisplay(e)}, ${formatTime(e)}`
+    return `${formatDateForDisplay(s, formTz)}, ${formatTime(s)} – ${formatDateForDisplay(e, formTz)}, ${formatTime(e)}`
   })()
 
   // ---------------------------------------------------------------------------
@@ -674,19 +708,26 @@ export function EventDialog({
 
                 {/* Timezone row — hidden for all-day events */}
                 {!allDay && (
-                  <div className="flex items-center gap-3">
-                    <Globe className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
-                    <select
-                      value={timezone}
-                      onChange={(e) => setTimezone(e.target.value)}
-                      disabled={!canWrite}
-                      aria-label="Event timezone"
-                      className={`flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-xs text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
-                    >
-                      {allTimezones.map((tz) => (
-                        <option key={tz} value={tz}>{tz.replace(/_/g, ' ')}</option>
-                      ))}
-                    </select>
+                  <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-3">
+                      <Globe className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                      <select
+                        value={timezone}
+                        onChange={(e) => setTimezone(e.target.value)}
+                        disabled={!canWrite}
+                        aria-label="Event timezone"
+                        className={`flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-xs text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
+                      >
+                        {allTimezones.map((tz) => (
+                          <option key={tz} value={tz}>{tz.replace(/_/g, ' ')}</option>
+                        ))}
+                      </select>
+                    </div>
+                    {timezone !== userTz && (
+                      <span className="ml-7 text-[11px] text-[rgb(var(--muted))]">
+                        Event anchored in {shortTimezoneLabel(timezone, buildStartDate())}; your calendar shows {shortTimezoneLabel(userTz, buildStartDate())}.
+                      </span>
+                    )}
                   </div>
                 )}
 

--- a/apps/web/app/lib/__tests__/tz.test.ts
+++ b/apps/web/app/lib/__tests__/tz.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import {
+  partsInZone,
+  formatDateForInputInZone,
+  formatTimeForInputInZone,
+  instantFromWallClock,
+  resolveUserTimezone,
+} from '../tz'
+
+describe('tz helpers', () => {
+  it('reads wall-clock parts in the requested zone', () => {
+    // 2025-06-15 12:00 UTC = 14:00 Europe/Berlin (CEST)
+    const utcInstant = new Date(Date.UTC(2025, 5, 15, 12, 0, 0))
+    const berlin = partsInZone(utcInstant, 'Europe/Berlin')
+    expect(berlin).toEqual({ year: 2025, month: 6, day: 15, hour: 14, minute: 0, second: 0 })
+
+    const tokyo = partsInZone(utcInstant, 'Asia/Tokyo')
+    expect(tokyo).toEqual({ year: 2025, month: 6, day: 15, hour: 21, minute: 0, second: 0 })
+  })
+
+  it('round-trips a wall-clock through instantFromWallClock + partsInZone', () => {
+    const tz = 'America/New_York'
+    const instant = instantFromWallClock(2025, 11, 4, 9, 30, tz)
+    const parts = partsInZone(instant, tz)
+    expect(parts).toEqual({ year: 2025, month: 11, day: 4, hour: 9, minute: 30, second: 0 })
+  })
+
+  it('handles different DST/standard time correctly', () => {
+    // 09:00 NY in June (EDT, UTC-4) -> 13:00 UTC
+    const summer = instantFromWallClock(2025, 6, 15, 9, 0, 'America/New_York')
+    expect(summer.toISOString()).toBe('2025-06-15T13:00:00.000Z')
+
+    // 09:00 NY in January (EST, UTC-5) -> 14:00 UTC
+    const winter = instantFromWallClock(2025, 1, 15, 9, 0, 'America/New_York')
+    expect(winter.toISOString()).toBe('2025-01-15T14:00:00.000Z')
+  })
+
+  it('formats date/time inputs in the target zone', () => {
+    // 2025-06-15 23:30 UTC = 2025-06-16 08:30 Tokyo
+    const instant = new Date(Date.UTC(2025, 5, 15, 23, 30, 0))
+    expect(formatDateForInputInZone(instant, 'Asia/Tokyo')).toBe('2025-06-16')
+    expect(formatTimeForInputInZone(instant, 'Asia/Tokyo')).toBe('08:30')
+    expect(formatDateForInputInZone(instant, 'America/New_York')).toBe('2025-06-15')
+    expect(formatTimeForInputInZone(instant, 'America/New_York')).toBe('19:30')
+  })
+
+  it('falls back to browser-local when the preferred TZ is invalid', () => {
+    const browser = Intl.DateTimeFormat().resolvedOptions().timeZone
+    expect(resolveUserTimezone(undefined)).toBe(browser)
+    expect(resolveUserTimezone('Not/A_Real_Zone')).toBe(browser)
+    expect(resolveUserTimezone('Europe/Berlin')).toBe('Europe/Berlin')
+  })
+})

--- a/apps/web/app/lib/tz.ts
+++ b/apps/web/app/lib/tz.ts
@@ -1,0 +1,93 @@
+import 'temporal-polyfill/global'
+
+/** Return the IANA TZ name to use for the calendar grid: user preference, then browser local. */
+export function resolveUserTimezone(preferred: string | undefined): string {
+  if (preferred) {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: preferred })
+      return preferred
+    } catch {
+      // fall through
+    }
+  }
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
+/** Wall-clock components of `date` as observed in `tz`. */
+export function partsInZone(date: Date, tz: string): {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+} {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  })
+  const parts = fmt.formatToParts(date)
+  const get = (type: string) => parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10)
+  let hour = get('hour')
+  if (hour === 24) hour = 0 // Intl midnight edge case
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour,
+    minute: get('minute'),
+    second: get('second'),
+  }
+}
+
+/** YYYY-MM-DD wall-clock date in `tz`, suitable for <input type="date">. */
+export function formatDateForInputInZone(date: Date, tz: string): string {
+  const p = partsInZone(date, tz)
+  return `${p.year}-${String(p.month).padStart(2, '0')}-${String(p.day).padStart(2, '0')}`
+}
+
+/** HH:MM 24h wall-clock time in `tz`, suitable for <input type="time">. */
+export function formatTimeForInputInZone(date: Date, tz: string): string {
+  const p = partsInZone(date, tz)
+  return `${String(p.hour).padStart(2, '0')}:${String(p.minute).padStart(2, '0')}`
+}
+
+/** Build a UTC instant from a wall-clock interpreted in `tz`. */
+export function instantFromWallClock(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  tz: string,
+): Date {
+  const zdt = Temporal.PlainDateTime.from({
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second: 0,
+  }).toZonedDateTime(tz)
+  return new Date(zdt.epochMilliseconds)
+}
+
+/** Short timezone label for badges, e.g. "GMT+2" or city name. */
+export function shortTimezoneLabel(tz: string, refDate: Date = new Date()): string {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      timeZoneName: 'short',
+    })
+    const parts = fmt.formatToParts(refDate)
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz
+  } catch {
+    return tz
+  }
+}

--- a/packages/core/src/models/calendar-event.test.ts
+++ b/packages/core/src/models/calendar-event.test.ts
@@ -468,6 +468,26 @@ describe('DST timezone conversion (two-pass offset)', () => {
     expect(event.startDate.getUTCMinutes()).toBe(0);
   });
 
+  it('returns the same UTC instant regardless of runtime TZ for TZID values', () => {
+    // Regression for #109: parseICalDateValue used `new Date(y, m, ...)` which
+    // interprets in the runtime's local TZ, causing the parsed instant to drift
+    // by the runtime's UTC offset whenever it wasn't UTC. Vitest defaults to
+    // TZ=UTC so the bug was invisible — this test pins the expected absolute
+    // UTC instant so any reintroduction of the local-time math will fail.
+    const ical = [
+      'BEGIN:VEVENT',
+      'UID:tzid-stability',
+      'DTSTART;TZID=Europe/Vienna:20250604T100000', // 10:00 Vienna in CEST = 08:00 UTC
+      'DTEND;TZID=Europe/Vienna:20250604T110000',   // 11:00 Vienna in CEST = 09:00 UTC
+      'SUMMARY:Vienna 10am',
+      'END:VEVENT',
+    ].join('\r\n');
+
+    const event = fromVEvent(ical);
+    expect(event.startDate.toISOString()).toBe('2025-06-04T08:00:00.000Z');
+    expect(event.endDate.toISOString()).toBe('2025-06-04T09:00:00.000Z');
+  });
+
   it('uses local time when no TZID is provided', () => {
     // No TZID and no Z → local time interpretation
     const ical = [

--- a/packages/core/src/models/calendar-event.ts
+++ b/packages/core/src/models/calendar-event.ts
@@ -99,8 +99,15 @@ export function parseICalDateValue(value: string, tzid?: string): { date: Date; 
         });
         const parts = formatter.formatToParts(new Date(utcMs));
         const p = (type: string) => parseInt(parts.find((x) => x.type === type)?.value ?? '0', 10);
-        const localDate = new Date(p('year'), p('month') - 1, p('day'), p('hour'), p('minute'), p('second'));
-        return localDate.getTime() - utcMs;
+        // Use Date.UTC, not `new Date(...)` — the latter interprets in the
+        // runtime's local TZ, which makes this whole calculation dependent on
+        // the browser/server's TZ (returning 0 when browser TZ matches tzid,
+        // and arbitrary wrong offsets otherwise). Date.UTC always returns
+        // the UTC ms for the given wall-clock components, so the diff
+        // measures purely the tzid's offset from UTC at this instant.
+        const hour = p('hour') === 24 ? 0 : p('hour'); // Intl midnight edge case
+        const localUtcMs = Date.UTC(p('year'), p('month') - 1, p('day'), hour, p('minute'), p('second'));
+        return localUtcMs - utcMs;
       }
 
       // Two-pass approach: the first offset may be wrong when a DST


### PR DESCRIPTION
## Summary

Fixes #107 (display layer) and #109 (data layer / sync round-trip). Both bugs combined to produce the user-visible "I created an event at 10 AM and it briefly shows at 7 AM before snapping back to 10 AM" — the parser shift compounded with the display layer's TZ blindness.

### 1. Display: render in user TZ, edit in event TZ

- **CalendarGrid** passes the resolved user TZ to Schedule-X via the `timezone` config option, so the grid hour axis renders in the user's preferred zone (or browser-local fallback). A `useEffect` updates the Schedule-X Preact signal when the preference changes so updates propagate live without a full reload. `buildDateFromHour` interprets click positions as wall-clock in the grid's TZ via `instantFromWallClock`, and drag-preview time labels pass `timeZone: userTz` to `toLocaleTimeString`.
- **EventDialog** reads and writes form date/time fields in the event's own TZ (or the user default for new events). `buildStartDate` / `buildEndDate` use `Temporal.PlainDateTime → toZonedDateTime` to produce the correct UTC instant. A small hint under the timezone picker calls out when the event TZ differs from the viewer's TZ.
- **AgendaView** formats event times in the user's TZ and badges events whose anchor TZ differs.
- New helper module `apps/web/app/lib/tz.ts` (Temporal-backed) with five unit tests covering DST/standard-time round-trips and invalid-TZ fallback.

### 2. Core: parser was browser-TZ-dependent (#109)

`parseICalDateValue` built `localDate = new Date(y, m-1, d, h, ...)` to compute the tzid's UTC offset. JS interprets that constructor in the **runtime's local TZ**, so the calculation drifted by the runtime offset whenever it wasn't UTC. Vitest runs in TZ=UTC by default, so the bug was invisible to existing tests, but it broke every Etebase sync round-trip in the browser:

```
parse("20250604T100000", TZID=Europe/Vienna):
  TZ=UTC           → 2025-06-04T08:00:00.000Z   ✅
  TZ=Europe/Vienna → 2025-06-04T10:00:00.000Z  ❌ (off by +2h)
  TZ=Europe/Moscow → 2025-06-04T11:00:00.000Z  ❌ (off by +3h)
```

Replaced with `Date.UTC(...)` so the diff measures purely the tzid's offset. Added a regression test pinning the absolute UTC instant. Verified via standalone Node script under TZ=UTC, Europe/Vienna, Europe/Moscow, America/New_York — all stable now.

## Test plan

- [x] `pnpm type-check` clean
- [x] `pnpm lint` no new warnings
- [x] `pnpm -F @silentsuite/web test --run` — 109 existing + 5 new TZ tests pass (114 total)
- [x] `pnpm -F @silentsuite/core test` — 204 tests pass (1 new regression test for #109)
- [x] Standalone round-trip script under TZ=UTC, TZ=Europe/Vienna, TZ=Europe/Moscow, TZ=America/New_York — all preserve the original UTC instant exactly
- [ ] Manual smoke on Cloudflare branch preview: create event, verify it stays at the typed time after sync; pick a non-local TZ in Settings → Account → verify week grid hour axis shifts

Closes #107, #109
