### PR TITLE
fix(web): refresh session on tab focus while verify banner is shown

### DIFF
--- a/apps/web/app/components/EmailVerificationBanner.tsx
+++ b/apps/web/app/components/EmailVerificationBanner.tsx
@@ -1,19 +1,52 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { MailWarning, Loader2 } from 'lucide-react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { isSelfHosted } from '@/app/lib/self-hosted'
 import { BILLING_API_URL } from '@/app/lib/config'
 
+// Minimum gap between focus-triggered refreshes. Cheap guard against burst
+// refreshes when the tab visibility flickers (e.g. fast alt-tab) or when
+// React strict mode double-invokes the effect in dev.
+const REFRESH_THROTTLE_MS = 5_000
+
 export function EmailVerificationBanner() {
   const user = useAuthStore((s) => s.user)
+  const refreshSession = useAuthStore((s) => s.refreshSession)
   const [resending, setResending] = useState(false)
   const [resent, setResent] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const lastRefreshRef = useRef(0)
+
+  const shouldShow = !isSelfHosted && user && user.emailVerified === false
+
+  // When the banner is mounted (i.e. the user is signed in but unverified),
+  // re-check the session whenever the tab regains focus. This handles the
+  // common path of "user clicks the verify link in a new tab → comes back
+  // here" — without this, the banner sticks until a hard reload because
+  // refreshSession() otherwise only runs once on initial app mount.
+  useEffect(() => {
+    if (!shouldShow) return
+
+    const maybeRefresh = () => {
+      if (document.visibilityState !== 'visible') return
+      const now = Date.now()
+      if (now - lastRefreshRef.current < REFRESH_THROTTLE_MS) return
+      lastRefreshRef.current = now
+      void refreshSession()
+    }
+
+    document.addEventListener('visibilitychange', maybeRefresh)
+    window.addEventListener('focus', maybeRefresh)
+    return () => {
+      document.removeEventListener('visibilitychange', maybeRefresh)
+      window.removeEventListener('focus', maybeRefresh)
+    }
+  }, [shouldShow, refreshSession])
 
   // Don't show for self-hosted, unauthenticated, or already verified
-  if (isSelfHosted || !user || user.emailVerified !== false) {
+  if (!shouldShow) {
     return null
   }
 


### PR DESCRIPTION
## Summary

Fixes the stale email-verification banner that persists after the user confirms their email in another tab. The banner now re-checks the session whenever the tab regains focus.

- `EmailVerificationBanner` now installs a `visibilitychange` + `window.focus` listener while it is mounted (i.e. while the user is signed in but unverified) and calls `refreshSession()` on visible.
- Listener is scoped to the banner's lifetime, so it is removed automatically when the user verifies (banner unmounts) or signs out — no global cost.
- Throttled to one refresh per 5s to absorb visibility flicker and React strict-mode double-invoke.
- No polling, no new long-lived timers, no changes to `auth-provider.tsx` or `use-auth-store.ts`.

Closes #110

## Adjacent issue (not addressed here)

The original issue notes a server-side anomaly: rows with `email_verified=true` but `email_verification_sent_at=NULL`. That is being investigated separately in `silentsuite-internal#72` (whether the billing-side `email_verified` flag transitions correctly). The refresh-on-focus fix in this PR is the right client-side behavior regardless of that audit, but full user-visible resolution depends on the server-side check landing as well.

## Test plan

- [ ] Sign up a fresh hosted account, confirm banner is visible.
- [ ] Open the verification link in a new tab, complete verification.
- [ ] Switch back to the app tab — banner disappears within one refresh cycle (no hard reload required).
- [ ] Verify rapid alt-tabbing does not produce a burst of `/auth/refresh` calls (throttle).
- [ ] Sign out — confirm no lingering listeners (banner unmounts, effect cleanup runs).
- [ ] Self-hosted build: banner is never mounted, so listener is never installed (no behavior change).