### PR TITLE
Settings: real APK QR, iOS EteSync mention, new Desktop page

### DIFF
--- a/apps/web/app/(app)/settings/desktop/page.tsx
+++ b/apps/web/app/(app)/settings/desktop/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { Monitor, ExternalLink, Copy, CheckCircle, ShieldCheck } from 'lucide-react'
+
+const INSTALL_COMMAND = 'curl -fsSL https://silentsuite.io/bridge/install.sh | sh'
+const INSTALL_COMMAND_PS = 'irm https://silentsuite.io/bridge/install.ps1 | iex'
+const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
+const DOCS_URL = 'https://docs.silentsuite.io/user-guide/apps/dav-bridge'
+
+export default function DesktopSettingsPage() {
+  const [copied, setCopied] = useState<'sh' | 'ps' | null>(null)
+
+  const handleCopy = useCallback(async (variant: 'sh' | 'ps') => {
+    const text = variant === 'sh' ? INSTALL_COMMAND : INSTALL_COMMAND_PS
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(variant)
+      setTimeout(() => setCopied(null), 2000)
+    } catch {
+      // Clipboard access may be blocked; users can still select manually
+    }
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">
+          Desktop bridge
+        </h2>
+        <p className="text-sm text-[rgb(var(--muted))]">
+          Install the SilentSuite bridge to use SilentSuite from Thunderbird, Apple Calendar,
+          GNOME Calendar, Evolution, or any standard CalDAV/CardDAV client.
+        </p>
+      </div>
+
+      {/* Install one-liner — macOS / Linux */}
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <Monitor className="h-5 w-5 text-[rgb(var(--primary))]" />
+          <div>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+              Install on macOS or Linux
+            </p>
+            <p className="text-xs text-[rgb(var(--muted))]">
+              Run this in your terminal.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-stretch gap-2">
+          <pre className="flex-1 overflow-x-auto rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs text-[rgb(var(--foreground))] font-mono">
+            <code>{INSTALL_COMMAND}</code>
+          </pre>
+          <button
+            type="button"
+            onClick={() => handleCopy('sh')}
+            aria-label="Copy install command"
+            className="flex items-center gap-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
+          >
+            {copied === 'sh' ? (
+              <CheckCircle className="h-4 w-4 text-emerald-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+            {copied === 'sh' ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      </div>
+
+      {/* Install one-liner — Windows */}
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <Monitor className="h-5 w-5 text-[rgb(var(--primary))]" />
+          <div>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+              Install on Windows
+            </p>
+            <p className="text-xs text-[rgb(var(--muted))]">
+              Run this in PowerShell.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-stretch gap-2">
+          <pre className="flex-1 overflow-x-auto rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs text-[rgb(var(--foreground))] font-mono">
+            <code>{INSTALL_COMMAND_PS}</code>
+          </pre>
+          <button
+            type="button"
+            onClick={() => handleCopy('ps')}
+            aria-label="Copy PowerShell install command"
+            className="flex items-center gap-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
+          >
+            {copied === 'ps' ? (
+              <CheckCircle className="h-4 w-4 text-emerald-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+            {copied === 'ps' ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      </div>
+
+      {/* Direct downloads + docs */}
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
+        <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+          Or download binaries directly
+        </p>
+        <div className="flex flex-col gap-2">
+          <a
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"
+          >
+            <ExternalLink className="h-4 w-4" />
+            View latest release on GitHub
+          </a>
+          <a
+            href={DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-2 rounded-lg border border-[rgb(var(--border))] px-4 py-2.5 text-sm font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
+          >
+            Read the bridge documentation
+          </a>
+        </div>
+      </div>
+
+      {/* Privacy note */}
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="h-5 w-5 text-[rgb(var(--primary))] mt-0.5 flex-shrink-0" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+              Stays end-to-end encrypted
+            </p>
+            <p className="text-xs text-[rgb(var(--muted))]">
+              The bridge runs locally on{' '}
+              <code className="font-mono text-[rgb(var(--foreground))]">localhost:37358</code>.
+              Plain DAV stays inside <code className="font-mono text-[rgb(var(--foreground))]">localhost</code>;
+              all upstream traffic is end-to-end encrypted Etebase.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(app)/settings/layout.tsx
+++ b/apps/web/app/(app)/settings/layout.tsx
@@ -9,6 +9,7 @@ const allTabs = [
   { label: 'Subscription', href: '/settings/subscription' },
   { label: 'Security', href: '/settings/security' },
   { label: 'Mobile', href: '/settings/mobile' },
+  { label: 'Desktop', href: '/settings/desktop' },
   { label: 'Import', href: '/settings/import' },
   { label: 'Export', href: '/settings/export' },
 ]

--- a/apps/web/app/(app)/settings/mobile/page.tsx
+++ b/apps/web/app/(app)/settings/mobile/page.tsx
@@ -1,9 +1,18 @@
 'use client'
 
-import { Smartphone, ExternalLink, QrCode } from 'lucide-react'
+import { Smartphone, ExternalLink, Monitor } from 'lucide-react'
+import Link from 'next/link'
+import { QRCodeSVG } from 'qrcode.react'
+
+// TODO: make this version-dynamic at build time (see issue #116) — currently
+// the version-pinned filename will break when the umbrella tag bumps past
+// v0.1.0-beta. Tracked as the "approach 2" follow-up in #116.
+const APK_DOWNLOAD_URL =
+  'https://github.com/silent-suite/silentsuite/releases/latest/download/silentsuite-android-v0.1.0-beta.apk'
+const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
 
 export default function MobileSettingsPage() {
-  const downloadUrl = 'https://docs.silentsuite.io/mobile'
+  const docsUrl = 'https://docs.silentsuite.io/mobile'
 
   return (
     <div className="space-y-6">
@@ -19,19 +28,29 @@ export default function MobileSettingsPage() {
       {/* QR Code section */}
       <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-6">
         <div className="flex flex-col items-center gap-4">
-          <div className="flex h-48 w-48 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))]">
-            <div className="flex flex-col items-center gap-2 text-[rgb(var(--muted))]">
-              <QrCode className="h-24 w-24" />
-              <span className="text-[10px]">Scan to download</span>
-            </div>
+          <div className="flex h-48 w-48 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-white p-3">
+            <QRCodeSVG
+              value={APK_DOWNLOAD_URL}
+              size={168}
+              level="M"
+              marginSize={0}
+              aria-label="QR code linking to the latest SilentSuite Android APK"
+            />
           </div>
           <p className="text-sm text-[rgb(var(--foreground))] font-medium">
             Scan with your phone camera
           </p>
           <p className="text-xs text-[rgb(var(--muted))] text-center">
-            The QR code will take you to the mobile app download page.
-            Currently available for Android. iOS coming soon.
+            The QR code links to the latest SilentSuite Android APK.
           </p>
+          <a
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[rgb(var(--primary))] hover:underline"
+          >
+            Or download manually from GitHub Releases
+          </a>
         </div>
       </div>
 
@@ -49,7 +68,7 @@ export default function MobileSettingsPage() {
 
         <div className="flex flex-col gap-2">
           <a
-            href={downloadUrl}
+            href={docsUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"
@@ -71,17 +90,39 @@ export default function MobileSettingsPage() {
       {/* Supported platforms */}
       <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
         <p className="text-sm font-medium text-[rgb(var(--foreground))]">Supported platforms</p>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
           <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3 text-center">
             <p className="text-sm font-medium text-[rgb(var(--foreground))]">Android</p>
             <p className="text-xs text-[rgb(var(--primary))]">Available now</p>
           </div>
-          <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3 text-center">
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">iOS</p>
-            <p className="text-xs text-[rgb(var(--muted))]">Coming soon</p>
+          <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3 text-left space-y-1">
+            <p className="text-sm font-medium text-[rgb(var(--foreground))] text-center">iOS</p>
+            <p className="text-xs text-[rgb(var(--muted))] text-center">Native app coming soon</p>
+            <p className="text-xs text-[rgb(var(--muted))] pt-1">
+              Compatible with the{' '}
+              <a
+                href="https://apps.apple.com/us/app/apple-store/id1489574285"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[rgb(var(--primary))] hover:underline"
+              >
+                EteSync iOS app
+              </a>{' '}
+              on the App Store — same Etebase protocol, sign in with your SilentSuite credentials.
+            </p>
           </div>
         </div>
       </div>
+
+      {/* Footer note pointing at desktop integration */}
+      <p className="text-xs text-[rgb(var(--muted))] text-center">
+        <Monitor className="inline h-3 w-3 mr-1 -mt-0.5" />
+        Looking for desktop integration?{' '}
+        <Link href="/settings/desktop" className="text-[rgb(var(--primary))] hover:underline">
+          See Settings → Desktop
+        </Link>
+        .
+      </p>
     </div>
   )
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "^0.400.0",
     "next": "15.1.12",
     "next-themes": "^0.4.4",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.71.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -4493,6 +4496,11 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -5182,6 +5190,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vfile-message@4.0.3:
@@ -10198,6 +10207,10 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
## Summary

Three Settings → Mobile-area issues bundled because they touch the same surface.

- **#116 — real APK QR.** Replaces the `lucide-react` decorative `QrCode` SVG with a real `qrcode.react` QR pointing at the latest Android APK on GitHub Releases. Adds an "or download manually" link to the releases page.
- **#117 — iOS EteSync mention.** The iOS card now spells out the workaround: native app coming soon, but SilentSuite is protocol-compatible with the EteSync iOS app on the App Store (with App Store link).
- **#118 — Desktop bridge page.** New `/settings/desktop` peer to Mobile. Copyable install one-liners (macOS/Linux + Windows PowerShell), direct binaries link, and a privacy note that plain DAV stays inside `localhost:37358` while upstream traffic remains end-to-end encrypted Etebase. Settings nav gets a new "Desktop" tab between Mobile and Import.

Mobile page also gets a small footer note pointing at the new Desktop section.

## Implementation notes

- Adds `qrcode.react` to `apps/web` (small, no native deps).
- APK URL is hardcoded as `silentsuite-android-v0.1.0-beta.apk` with an inline TODO — version-pinned filename will break at v0.1.1-beta. Issue #116 calls this out as the "approach 2" follow-up (resolve at build time via the GitHub API).
- Existing settings page visual idiom (rounded cards on `--surface`, `--border`, `--primary`) is preserved.

## Test plan

- [ ] Visit `/settings/mobile`; QR renders and scans to the v0.1.0-beta APK download URL.
- [ ] Manual download link opens GitHub Releases latest.
- [ ] iOS card shows the EteSync workaround copy with a working App Store link.
- [ ] Mobile footer note routes to `/settings/desktop`.
- [ ] Visit `/settings/desktop`; both install commands render in copyable code blocks. Copy buttons work and show a check-mark for ~2s.
- [ ] Direct binaries button opens GitHub Releases latest.
- [ ] Settings nav shows Desktop tab between Mobile and Import; tab highlights correctly when on `/settings/desktop`.
- [ ] No new TypeScript or ESLint errors introduced (`pnpm --filter @silentsuite/web type-check`, `pnpm --filter @silentsuite/web lint`).

Closes #116
Closes #117
Closes #118

(Note: per the maintainer's GitHub workflow, `Closes #N` does not auto-close issues in this repo — operator closes manually after merge.)