### PR TITLE
fix(web/export): surface ZIP export failures with toast + progress

### DIFF
--- a/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
@@ -98,6 +98,9 @@ vi.mock('lucide-react', () => ({
   Download: ({ className }: { className?: string }) => (
     <svg data-testid="download-icon" className={className} />
   ),
+  Loader2: ({ className }: { className?: string }) => (
+    <svg data-testid="loader-icon" className={className} />
+  ),
 }))
 
 // Mock jszip

--- a/apps/web/app/(app)/settings/export/page.tsx
+++ b/apps/web/app/(app)/settings/export/page.tsx
@@ -1,12 +1,24 @@
 'use client'
 
+import { useState } from 'react'
 import { Button } from '@silentsuite/ui'
 import { toVEvent, toVTodo, toVCard } from '@silentsuite/core'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
-import { Download } from 'lucide-react'
+import {
+  showErrorToast,
+  showWarningToast,
+} from '@/app/stores/use-toast-store'
+import { Download, Loader2 } from 'lucide-react'
 import JSZip from 'jszip'
+
+/**
+ * Above this combined item count we surface a "this may take a minute" warning
+ * before kicking off the ZIP export. The previous in-memory implementation was
+ * known to silently fail at ~2000 events; 1000 is a conservative early warning.
+ */
+const LARGE_EXPORT_THRESHOLD = 1000
 
 function downloadFile(content: string | Blob, filename: string, mimeType: string) {
   const blob =
@@ -34,6 +46,9 @@ export default function ExportPage() {
   const contacts = useContactStore((s) => s.contacts)
   const events = useCalendarStore((s) => s.events)
 
+  const [isExportingAll, setIsExportingAll] = useState(false)
+  const [exportProgress, setExportProgress] = useState(0)
+
   function exportCalendar() {
     const vevents = events.map((e) => toVEvent(e))
     const ics = buildCalendarIcs(vevents)
@@ -53,20 +68,63 @@ export default function ExportPage() {
   }
 
   async function exportAll() {
-    const zip = new JSZip()
+    if (isExportingAll) return
 
-    const vevents = events.map((e) => toVEvent(e))
-    zip.file('silentsuite-calendar.ics', buildCalendarIcs(vevents))
+    const totalItems = events.length + tasks.length + contacts.length
 
-    const vtodos = tasks.map((t) => toVTodo(t))
-    zip.file('silentsuite-tasks.ics', buildCalendarIcs(vtodos))
+    setIsExportingAll(true)
+    setExportProgress(0)
 
-    const vcards = contacts.map((c) => toVCard(c))
-    zip.file('silentsuite-contacts.vcf', vcards.join('\n'))
+    if (totalItems > LARGE_EXPORT_THRESHOLD) {
+      showWarningToast(
+        `Preparing export of ${totalItems.toLocaleString()} items. This may take a minute…`,
+      )
+    }
 
-    const blob = await zip.generateAsync({ type: 'blob' })
-    downloadFile(blob, 'silentsuite-export.zip', 'application/zip')
+    try {
+      const zip = new JSZip()
+
+      const vevents = events.map((e) => toVEvent(e))
+      zip.file('silentsuite-calendar.ics', buildCalendarIcs(vevents))
+
+      const vtodos = tasks.map((t) => toVTodo(t))
+      zip.file('silentsuite-tasks.ics', buildCalendarIcs(vtodos))
+
+      const vcards = contacts.map((c) => toVCard(c))
+      zip.file('silentsuite-contacts.vcf', vcards.join('\n'))
+
+      // Throttle progress updates: only re-render when the integer percent
+      // changes. JSZip can fire onUpdate hundreds of times per second on
+      // large archives, which would otherwise spam React renders.
+      let lastReportedPercent = -1
+
+      const blob = await zip.generateAsync(
+        { type: 'blob', streamFiles: true },
+        (metadata) => {
+          const percent = Math.floor(metadata.percent)
+          if (percent !== lastReportedPercent) {
+            lastReportedPercent = percent
+            setExportProgress(percent)
+          }
+        },
+      )
+
+      downloadFile(blob, 'silentsuite-export.zip', 'application/zip')
+    } catch (err) {
+      // Log enough detail for a useful bug report. The original bug was that
+      // generateAsync rejected silently with no console output at all.
+      console.error('[export] Failed to build ZIP archive:', err)
+      showErrorToast(
+        'Failed to build ZIP. Try exporting calendar, tasks, and contacts separately.',
+      )
+    } finally {
+      setIsExportingAll(false)
+      setExportProgress(0)
+    }
   }
+
+  const totalItems = events.length + tasks.length + contacts.length
+  const exportAllDisabled = totalItems === 0 || isExportingAll
 
   return (
     <div className="space-y-6">
@@ -78,7 +136,7 @@ export default function ExportPage() {
       <div className="flex flex-col gap-3">
         <Button
           className="w-full sm:w-auto"
-          disabled={events.length === 0}
+          disabled={events.length === 0 || isExportingAll}
           onClick={exportCalendar}
         >
           <Download className="mr-2 h-4 w-4" />
@@ -86,7 +144,7 @@ export default function ExportPage() {
         </Button>
         <Button
           className="w-full sm:w-auto"
-          disabled={tasks.length === 0}
+          disabled={tasks.length === 0 || isExportingAll}
           onClick={exportTasks}
         >
           <Download className="mr-2 h-4 w-4" />
@@ -94,7 +152,7 @@ export default function ExportPage() {
         </Button>
         <Button
           className="w-full sm:w-auto"
-          disabled={contacts.length === 0}
+          disabled={contacts.length === 0 || isExportingAll}
           onClick={exportContacts}
         >
           <Download className="mr-2 h-4 w-4" />
@@ -103,11 +161,21 @@ export default function ExportPage() {
         <Button
           variant="outline"
           className="w-full sm:w-auto"
-          disabled={events.length === 0 && tasks.length === 0 && contacts.length === 0}
+          disabled={exportAllDisabled}
           onClick={exportAll}
+          aria-busy={isExportingAll}
         >
-          <Download className="mr-2 h-4 w-4" />
-          Export All Data (.zip)
+          {isExportingAll ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Preparing… {exportProgress}%
+            </>
+          ) : (
+            <>
+              <Download className="mr-2 h-4 w-4" />
+              Export All Data (.zip)
+            </>
+          )}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes #112.

The \"Export All Data (.zip)\" action on `/settings/export` silently failed for accounts with ~2000 calendar events: no download, no toast, no console output. Root cause: `JSZip.generateAsync` rejection was unhandled, and there was no in-flight UI state, so the user had no signal that anything had happened.

This is the operator-preferred minimum-viable scope from the issue:

- Wraps `generateAsync` in `try/catch`. On failure: `console.error` with the underlying error, plus an error toast pointing the user at the per-collection exports as a workaround.
- Passes `streamFiles: true` to `generateAsync` (free peak-memory win, even on small accounts).
- Wires JSZip's `onUpdate` callback into a `useState` percent indicator. **Throttled to integer-percent transitions** (`Math.floor(metadata.percent)` compared against last reported) so React isn't re-rendered hundreds of times per second on large archives.
- Adds an in-flight `isExportingAll` flag that disables **all four** export buttons (so the user can't kick off a competing per-collection export mid-ZIP), swaps the ZIP button label to `Preparing… N%` with a spinning `Loader2`, and sets `aria-busy`. The shared `Button` component already applies `disabled:opacity-50 disabled:pointer-events-none`, so the visual state is obvious.
- Soft-warns via `showWarningToast` when combined item count > 1000 (`LARGE_EXPORT_THRESHOLD`) so the user doesn't refresh / re-click while the ZIP is being built.
- Re-entrancy guard at the top of `exportAll` (`if (isExportingAll) return`) belt-and-braces against rapid double-clicks before the disabled state propagates.

## Out of scope (deferred follow-ups)

- **Streaming directly to a file via the File System Access API** (issue suggestion #3). Bigger surface, needs a polyfill story for Safari/Firefox; intentionally deferred.
- **Local persistence / no full re-sync on reload** (#111). Independent — export reads from the in-memory store either way.
- The per-collection exporters (`exportCalendar`, `exportTasks`, `exportContacts`) were not touched; they already work per the issue repro.

## Test plan

- [ ] Open `/settings/export` on a small account; confirm `Export All Data (.zip)` still produces `silentsuite-export.zip` containing the three files.
- [ ] On a large account (>1000 items), confirm the warning toast appears and the button shows `Preparing… N%` with a spinning loader; download succeeds.
- [ ] While the export is in flight, confirm all four export buttons are disabled (visibly dimmed, no pointer events).
- [ ] Force a failure (e.g. via devtools throttling memory or a `throw` injected at `zip.generateAsync`) and confirm an error toast appears and the underlying error lands in the console.
- [ ] Confirm the button returns to its idle label and is re-enabled after both success and failure paths.