### PR TITLE
Android: defensive patches for first-login crash (#119)

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/EtebaseLocalCache.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/EtebaseLocalCache.kt
@@ -5,12 +5,20 @@ import com.etebase.client.*
 import com.etebase.client.Collection
 import com.etebase.client.exceptions.EtebaseException
 import com.etebase.client.exceptions.UrlParseException
+import io.silentsuite.sync.log.Logger
 import okhttp3.OkHttpClient
 import java.io.File
 import java.util.*
 
 class EtebaseLocalCache private constructor(context: Context, username: String) {
-    private val fsCache: FileSystemCache = FileSystemCache.create(context.filesDir.absolutePath, username)
+    // Issue #119: log the resolved filesDir + username before the JNI FileSystemCache.create
+    // call. Native errors here don't propagate as EtebaseException, so without this breadcrumb
+    // a mangled username (e.g. one containing '@' or '.') is invisible from logcat alone.
+    private val fsCache: FileSystemCache = run {
+        val filesDirPath = context.filesDir.absolutePath
+        Logger.log.info("FileSystemCache.create filesDir=$filesDirPath username=$username")
+        FileSystemCache.create(filesDirPath, username)
+    }
     private val filesDir: File = File(context.filesDir, username)
     private val colsDir: File = File(filesDir, "cols")
 
@@ -129,7 +137,29 @@ class EtebaseLocalCache private constructor(context: Context, username: String) 
             // caller and fall back to the persisted value only if one wasn't supplied.
             val session = sessionOverride
                 ?: settings.etebaseSession
-                ?: throw IllegalStateException("Etebase session is null for account ${settings.account.name}")
+                ?: run {
+                    // Issue #119: distinguish "userData not yet flushed" (sessionOverride was
+                    // not provided AND persisted session is missing) from "session genuinely
+                    // missing." Logging the userData keys also surfaces partial-state account
+                    // collisions where the Android account row exists but setUserData hasn't
+                    // landed yet.
+                    // AccountSettings's key constants are private; keep this list in sync with
+                    // AccountSettings.companion. Logging only the *names* of keys present (not
+                    // values) avoids leaking session tokens or URIs into the log file.
+                    val accountManager = android.accounts.AccountManager.get(context)
+                    val userDataKeys = listOf(
+                        "version",
+                        "uri",
+                        "user_name",
+                        "etebase_session",
+                    ).filter { accountManager.getUserData(settings.account, it) != null }
+                    Logger.log.severe(
+                        "Etebase session is null: account=${settings.account.name} " +
+                                "sessionOverrideProvided=${sessionOverride != null} " +
+                                "userDataKeys=$userDataKeys"
+                    )
+                    throw IllegalStateException("Etebase session is null for account ${settings.account.name}")
+                }
             return Account.restore(client, session, null)
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -634,16 +634,26 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         private fun doLoad(): AccountActivity.AccountInfo {
             val info = AccountActivity.AccountInfo()
             val settings: AccountSettings
+            val etebaseLocalCache: EtebaseLocalCache
+            val colMgr: CollectionManager
             try {
                 settings = AccountSettings(context, account)
+                etebaseLocalCache = EtebaseLocalCache.getInstance(context, account.name)
+                val httpClient = HttpClient.Builder(context).build().okHttpClient
+                // Issue #119: getEtebase throws IllegalStateException when userData hasn't yet
+                // propagated (first-login race) or when the persisted session is genuinely
+                // missing. Previously this propagated to viewModelScope.launch and crashed the
+                // app via the default uncaught-exception handler. Return an empty AccountInfo
+                // so the UI shows nothing rather than dying.
+                val etebase = EtebaseLocalCache.getEtebase(context, httpClient, settings)
+                colMgr = etebase.collectionManager
             } catch (e: InvalidAccountException) {
                 return info
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Logger.log.log(Level.SEVERE, "AccountInfoViewModel.doLoad failed for ${account.name}", e)
+                return info
             }
-
-            val etebaseLocalCache = EtebaseLocalCache.getInstance(context, account.name)
-            val httpClient = HttpClient.Builder(context).build().okHttpClient
-            val etebase = EtebaseLocalCache.getEtebase(context, httpClient, settings)
-            val colMgr = etebase.collectionManager
 
             info.carddav = AccountInfo.ServiceInfo()
             info.carddav!!.refreshing = ContentResolver.isSyncActive(account, App.addressBooksAuthority)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -24,12 +24,15 @@ import io.silentsuite.sync.Constants.ETEBASE_TYPE_ADDRESS_BOOK
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_CALENDAR
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_TASKS
 import io.silentsuite.sync.R
+import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.syncadapter.requestSync
 import io.silentsuite.sync.ui.BaseActivity
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
 
 class NewAccountWizardActivity : BaseActivity() {
     private lateinit var account: Account
@@ -206,7 +209,14 @@ class WizardFragment : Fragment() {
                     requestSync(requireContext(), accountHolder.account)
                 }
                 activity?.finish()
-            } catch (e: EtebaseException) {
+            } catch (e: Exception) {
+                // Cooperate with structured concurrency — never swallow cancellation.
+                if (e is CancellationException) throw e
+                // Issue #119: previously only EtebaseException was caught, so JNI/IO/IllegalState
+                // failures from the very first FS-cache write escaped the coroutine and crashed
+                // the app via the default uncaught-exception handler. Log first so the next
+                // logcat capture pinpoints the failure class even if the dialog is dismissed.
+                Logger.log.severe("createCollections failed: ${e.javaClass.name}: ${e.message}")
                 reportErrorHelper(requireContext(), e)
             } finally {
                 loadingModel.setLoading(false)
@@ -218,8 +228,21 @@ class WizardFragment : Fragment() {
         val etebaseLocalCache = accountHolder.etebaseLocalCache
         val colMgr = accountHolder.colMgr
         colMgr.upload(col)
-        synchronized(etebaseLocalCache) {
-            etebaseLocalCache.collectionSet(colMgr, col)
+        try {
+            synchronized(etebaseLocalCache) {
+                etebaseLocalCache.collectionSet(colMgr, col)
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            // Issue #119: this is the very first on-disk Etebase write per username. If the
+            // per-username cols/<colUid>/items directory creation fails, surface enough detail
+            // to disambiguate the cause before the exception propagates up to createCollections.
+            val colsPath = File(File(requireContext().filesDir, accountHolder.account.name), "cols").absolutePath
+            Logger.log.severe(
+                "etebaseLocalCache.collectionSet failed for colUid=${col.uid} path=$colsPath: " +
+                        "${e.javaClass.name}: ${e.message}"
+            )
+            throw e
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
@@ -48,6 +48,14 @@ class CreateAccountFragment : DialogFragment() {
             // isn't always visible to the next activity's read on the first login.
             startActivity(ModeSelectionActivity.newIntent(requireContext(), account, config.etebaseSession))
             activity.finish()
+        } else {
+            // Issue #119: addAccountExplicitly returned false (e.g. partial-state collision
+            // with a previously removed account row that AccountManager hasn't fully
+            // garbage-collected). Previously this branch silently no-op'd, leaving the user
+            // staring at a frozen "setting up encryption" progress dialog. Log the failure
+            // and dismiss the dialog so the operator notices and the user can retry.
+            Logger.log.log(Level.SEVERE, "addAccountExplicitly returned false for ${config.userName}")
+            dismissAllowingStateLoss()
         }
     }
 


### PR DESCRIPTION
## Summary

Best-effort hardening + diagnostics around the Android first-login flow. The underlying root cause of #119 is **unknown** until the operator captures logcat in a future session — at which point a targeted fix lands. These patches:

- prevent a non-`EtebaseException` (JNI / IO / IllegalState) from killing the app via the default uncaught-exception handler in two of the most-suspect spots (the wizard auto-create flow, and `AccountInfoViewModel.doLoad`);
- surface enough breadcrumbs to logcat that the next reproduction pinpoints the failing class, the FS-cache path, and the account-userData state.

This is **Related to #119**, not a `Closes`. The crash may still reproduce — these patches just make the next reproduction much easier to debug, and harden a few clearly-leaky catches along the way.

### The 6 patches

All under `android/app/src/main/java/io/silentsuite/sync/`:

1. `ui/etebase/NewAccountWizardActivity.kt` `WizardFragment.createCollections` — broaden `catch (e: EtebaseException)` to `catch (e: Exception)`; log exception class + message via `Logger.log.severe` before `reportErrorHelper`; re-throw `CancellationException` to cooperate with structured concurrency.
2. `ui/etebase/NewAccountWizardActivity.kt` `WizardFragment.uploadCollection` — wrap the `synchronized(etebaseLocalCache) { ... }` FS-cache write in try/catch that logs `colUid` + the resolved per-username `cols/` path before re-throwing.
3. `EtebaseLocalCache.kt` constructor — log the resolved `context.filesDir.absolutePath` + `username` immediately before `FileSystemCache.create(...)` so a username mangled by the JNI side (e.g. containing `@`) becomes visible.
4. `EtebaseLocalCache.kt` `getEtebase` null-session branch — log `settings.account.name`, whether `sessionOverride` was provided, and the **names** (not values) of userData keys present on the account before throwing. Distinguishes "userData not flushed yet" from "session genuinely missing" without leaking session tokens or URIs into the log file.
5. `ui/AccountActivity.kt` `AccountInfoViewModel.doLoad` — extend the existing `try` to also wrap `EtebaseLocalCache.getInstance`, `HttpClient.Builder(...)`, and `EtebaseLocalCache.getEtebase`. On failure: log + return an empty `AccountInfo`, so an `IllegalStateException` from the first-login userData race no longer reaches `MutableLiveData.value =` on the IO dispatcher and crashes the app. `CancellationException` is re-thrown explicitly.
6. `ui/setup/CreateAccountFragment.kt` — add an `else` branch when `addAccountExplicitly` returns false: log the failure and `dismissAllowingStateLoss()` so the user doesn't sit on a frozen "setting up encryption" progress dialog.

### Coroutine-cancellation note

The existing codebase uses `catch (e: Exception)` inside coroutine scopes without re-throwing `CancellationException` (technically a pre-existing issue, but consistent). The broadened catches in patches 1, 2, and 5 add an explicit `if (e is CancellationException) throw e` re-throw. Patch 6 is not in a coroutine scope (it's `Fragment.onCreate`).

### Build

`./gradlew :app:assembleDebug` is green locally — only pre-existing warnings, no new ones.

## Test plan

- [ ] Build the signed release APK in CI (`build-android.yml` runs on PRs targeting `dev`).
- [ ] Operator: install on the affected device, attempt first login.
  - If the crash is gone: capture `adb logcat` to confirm which defensive path absorbed the failure (look for `Logger.log.severe` lines tagged `silentsuite`).
  - If the crash still reproduces: capture `adb logcat -d "*:E" AndroidRuntime:V > crash.log` plus the `silentsuite` log lines from the new breadcrumbs. Attach to #119.
- [ ] Verify happy-path first login (logcat should show one `FileSystemCache.create` info line and **zero** `severe` lines from the new patches).
- [ ] Verify second-login / re-login still works (regression check around `AccountInfoViewModel.doLoad`).

Refs #119