### PR TITLE
feat(web): gate onboarding popup on server-side onboarded_at flag

### DIFF
--- a/apps/web/app/components/OnboardingModal.tsx
+++ b/apps/web/app/components/OnboardingModal.tsx
@@ -1,15 +1,13 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Calendar, CheckSquare, Users, Shield, Check, Lock, EyeOff, Sun, Moon, Monitor, X } from 'lucide-react'
+import { Shield, Check, Lock, EyeOff, Sun, Moon, Monitor, X } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { Button } from '@silentsuite/ui'
 import CalendarImport from '@/app/components/import/CalendarImport'
 import TaskImport from '@/app/components/import/TaskImport'
 import ContactImport from '@/app/components/import/ContactImport'
-import { useCalendarStore } from '@/app/stores/use-calendar-store'
-import { useContactStore } from '@/app/stores/use-contact-store'
-import { useTaskStore } from '@/app/stores/use-task-store'
+import { useAuthStore } from '@/app/stores/use-auth-store'
 
 interface ImportCounts {
   calendar: number
@@ -213,35 +211,34 @@ export function OnboardingModal() {
   const [counts, setCounts] = useState<ImportCounts>({ calendar: 0, tasks: 0, contacts: 0 })
   const backdropRef = useRef<HTMLDivElement>(null)
 
-  const events = useCalendarStore((s) => s.events)
-  const contacts = useContactStore((s) => s.contacts)
-  const tasks = useTaskStore((s) => s.tasks)
+  // Server-side onboardedAt is the authoritative gate (issue #113). The
+  // localStorage 'onboardingCompleted' flag remains as a synchronous
+  // flash-suppressor: if it's present we never show the modal, even if
+  // the user object hasn't loaded yet. Once user.onboardedAt resolves,
+  // the server is the source of truth.
+  const user = useAuthStore((s) => s.user)
+  const markOnboarded = useAuthStore((s) => s.markOnboarded)
 
   useEffect(() => {
-    const completed = localStorage.getItem('onboardingCompleted')
-    if (completed) return
+    // Flash-suppressor: if a previous dismissal flagged completion in
+    // localStorage, never re-show. Server-side onboardedAt remains the
+    // real gate, but the localStorage hint stops the modal flickering on
+    // top of an already-onboarded user before the auth store hydrates.
+    if (localStorage.getItem('onboardingCompleted')) return
 
-    // If user already has synced data or has imported items into any store, skip onboarding
-    const totalItems = events.length + contacts.length + tasks.length
-    if (totalItems > 0) {
+    // No user yet — wait for auth hydration before deciding.
+    if (!user) return
+
+    // Server says onboarded — record the hint for fast suppression on
+    // future loads and don't show.
+    if (user.onboardedAt) {
       localStorage.setItem('onboardingCompleted', 'true')
       return
     }
 
-    // If user has been active for 7+ days, skip onboarding
-    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
-    const firstLogin = localStorage.getItem('firstLoginDate')
-    if (firstLogin) {
-      if (Date.now() - Number(firstLogin) > SEVEN_DAYS_MS) {
-        localStorage.setItem('onboardingCompleted', 'true')
-        return
-      }
-    } else {
-      localStorage.setItem('firstLoginDate', String(Date.now()))
-    }
-
+    // user.onboardedAt === null → fresh user, show the modal.
     setShow(true)
-  }, [events.length, contacts.length, tasks.length])
+  }, [user])
 
   const goTo = useCallback(
     (nextStep: number, dir: Direction) => {
@@ -259,15 +256,21 @@ export function OnboardingModal() {
   const next = useCallback(() => goTo(step + 1, 'left'), [goTo, step])
   const back = useCallback(() => goTo(step - 1, 'right'), [goTo, step])
 
-  const finish = useCallback(() => {
+  // Dismissal handler shared by finish, skipAll, the X button and the
+  // backdrop click. Fires markOnboarded() at the auth store (which POSTs
+  // /account/onboarded — fire-and-forget; on failure user.onboardedAt
+  // stays null and the modal will retry next session) and stamps the
+  // localStorage flash-suppression hint synchronously so the modal stays
+  // gone for the rest of this session even if the network call is in
+  // flight or fails.
+  const dismiss = useCallback(() => {
+    void markOnboarded()
     localStorage.setItem('onboardingCompleted', 'true')
     setShow(false)
-  }, [])
+  }, [markOnboarded])
 
-  const skipAll = useCallback(() => {
-    localStorage.setItem('onboardingCompleted', 'true')
-    setShow(false)
-  }, [])
+  const finish = dismiss
+  const skipAll = dismiss
 
   const handleCalendarImport = useCallback((count: number) => {
     setCounts((prev) => ({ ...prev, calendar: count }))

--- a/apps/web/app/components/__tests__/OnboardingModal.test.tsx
+++ b/apps/web/app/components/__tests__/OnboardingModal.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { User } from '@/app/stores/use-auth-store'
+
+// In-memory replica of the auth store the modal reads from. We mock the
+// entire module so we don't need to wire up the real Zustand store, the
+// secure storage, etc. — the modal only uses two slices: `user` and
+// `markOnboarded`.
+const mockState = {
+  user: null as User | null,
+  markOnboarded: vi.fn(async () => true),
+}
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: <T,>(selector: (s: typeof mockState) => T) => selector(mockState),
+}))
+
+// next-themes pulls in matchMedia which jsdom doesn't provide; mock it to
+// keep the welcome / theme-choice slides happy without polluting the test.
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'system', setTheme: vi.fn() }),
+}))
+
+// Heavy import slides are out of scope for the gate tests — stub them so
+// rendering a deeper step (we never do, but defensive) doesn't blow up on
+// the etebase dependency tree.
+vi.mock('@/app/components/import/CalendarImport', () => ({
+  default: () => null,
+}))
+vi.mock('@/app/components/import/TaskImport', () => ({
+  default: () => null,
+}))
+vi.mock('@/app/components/import/ContactImport', () => ({
+  default: () => null,
+}))
+
+import { OnboardingModal } from '../OnboardingModal'
+
+function setUser(user: User | null) {
+  mockState.user = user
+}
+
+describe('OnboardingModal — gate logic (issue #113)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    setUser(null)
+    mockState.markOnboarded.mockClear()
+    mockState.markOnboarded.mockResolvedValue(true)
+  })
+
+  it('does not render while user is null (auth still hydrating)', () => {
+    setUser(null)
+    const { container } = render(<OnboardingModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders when user.onboardedAt is null', () => {
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+    expect(screen.getByLabelText('Close onboarding')).toBeInTheDocument()
+  })
+
+  it('does not render when user.onboardedAt is a recent timestamp', () => {
+    setUser({
+      id: 'u1',
+      email: 'a@b.com',
+      planId: 'pro',
+      onboardedAt: new Date().toISOString(),
+    })
+    const { container } = render(<OnboardingModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does not render when user.onboardedAt is an old timestamp', () => {
+    setUser({
+      id: 'u1',
+      email: 'a@b.com',
+      planId: 'pro',
+      onboardedAt: '2024-01-01T00:00:00.000Z',
+    })
+    const { container } = render(<OnboardingModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('respects the localStorage flash-suppression hint when set', () => {
+    // Even if server says onboardedAt is null, the synchronous hint
+    // suppresses the modal so we don't flash it on top of an
+    // already-onboarded session before the auth store hydrates.
+    localStorage.setItem('onboardingCompleted', 'true')
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    const { container } = render(<OnboardingModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('writes the localStorage hint when onboardedAt is non-null', () => {
+    setUser({
+      id: 'u1',
+      email: 'a@b.com',
+      planId: 'pro',
+      onboardedAt: '2025-06-01T00:00:00.000Z',
+    })
+    render(<OnboardingModal />)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+
+  it('X button calls markOnboarded and sets the localStorage hint', () => {
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+
+    fireEvent.click(screen.getByLabelText('Close onboarding'))
+
+    expect(mockState.markOnboarded).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+
+  it('Skip all button calls markOnboarded and sets the localStorage hint', () => {
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+
+    fireEvent.click(screen.getByText('Skip all'))
+
+    expect(mockState.markOnboarded).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+
+  it('Escape key calls markOnboarded and sets the localStorage hint', () => {
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(mockState.markOnboarded).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+
+  it('does not block dismissal when markOnboarded fails', () => {
+    // Network error — markOnboarded resolves false; the modal must still
+    // close and the localStorage hint must still be set so the user
+    // isn't trapped in the popup for the rest of this session.
+    mockState.markOnboarded.mockResolvedValueOnce(false)
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+
+    fireEvent.click(screen.getByLabelText('Close onboarding'))
+
+    expect(mockState.markOnboarded).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+})

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -74,6 +74,179 @@ describe('useAuthStore', () => {
     expect(state.isLoading).toBe(false)
   })
 
+  // --- onboardedAt hydration (issue #113) ---
+
+  describe('onboardedAt hydration', () => {
+    it('login hydrates onboardedAt from token-exchange response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 'user-1',
+          email: 'a@b.com',
+          planId: 'pro',
+          isAdmin: false,
+          onboardedAt: '2025-01-01T00:00:00.000Z',
+        }),
+      } as Response)
+
+      await useAuthStore.getState().login('a@b.com', 'pw')
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBe('2025-01-01T00:00:00.000Z')
+    })
+
+    it('login defaults onboardedAt to null when omitted', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'user-1', email: 'a@b.com', planId: 'pro', isAdmin: false }),
+      } as Response)
+
+      await useAuthStore.getState().login('a@b.com', 'pw')
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('refreshSession hydrates onboardedAt', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'u1',
+          email: 'x@y.com',
+          planId: 'free',
+          isAdmin: false,
+          onboardedAt: '2024-12-01T00:00:00.000Z',
+        }),
+      } as Response)
+
+      await useAuthStore.getState().refreshSession()
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBe('2024-12-01T00:00:00.000Z')
+    })
+
+    it('restoreSession hydrates onboardedAt', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'u1',
+          email: 'x@y.com',
+          planId: 'free',
+          isAdmin: false,
+          onboardedAt: null,
+        }),
+      } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('completeSignup sets onboardedAt to null for fresh accounts', () => {
+      useAuthStore.setState({
+        pendingSignup: {
+          email: 'new@user.com',
+          etebaseAuthToken: 'tok',
+          provisionedUser: { id: 'new-1', planId: 'pro', isAdmin: false },
+          provisionedSubscriptionStatus: 'trialing',
+        },
+      })
+
+      useAuthStore.getState().completeSignup()
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+  })
+
+  // --- markOnboarded action (issue #113) ---
+
+  describe('markOnboarded', () => {
+    it('POSTs to /account/onboarded and updates user.onboardedAt on success', async () => {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', onboardedAt: null },
+        isAuthenticated: true,
+      })
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ onboardedAt: '2026-05-04T12:00:00.000Z' }),
+      } as Response)
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(true)
+      expect(useAuthStore.getState().user!.onboardedAt).toBe('2026-05-04T12:00:00.000Z')
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/account/onboarded'),
+        expect.objectContaining({ method: 'POST', credentials: 'include' }),
+      )
+    })
+
+    it('returns false and leaves onboardedAt null on network failure', async () => {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', onboardedAt: null },
+        isAuthenticated: true,
+      })
+
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(false)
+      // onboardedAt stays null so the modal will retry next session.
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('returns false and leaves onboardedAt null on non-OK response', async () => {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', onboardedAt: null },
+        isAuthenticated: true,
+      })
+
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(false)
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('is idempotent: returns true without a network call when already onboarded', async () => {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', onboardedAt: '2025-01-01T00:00:00.000Z' },
+        isAuthenticated: true,
+      })
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(true)
+      expect(fetch).not.toHaveBeenCalled()
+      // Existing timestamp untouched.
+      expect(useAuthStore.getState().user!.onboardedAt).toBe('2025-01-01T00:00:00.000Z')
+    })
+
+    it('returns false when there is no user to mark', async () => {
+      useAuthStore.setState({ user: null, isAuthenticated: false })
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(false)
+      expect(fetch).not.toHaveBeenCalled()
+    })
+
+    it('skips network for self-hosted user and stamps onboardedAt locally', async () => {
+      useAuthStore.setState({
+        user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true, onboardedAt: null },
+        isAuthenticated: true,
+      })
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(true)
+      expect(fetch).not.toHaveBeenCalled()
+      expect(useAuthStore.getState().user!.onboardedAt).toEqual(expect.any(String))
+    })
+  })
+
   it('logout clears state', async () => {
     // Set up logged-in state
     useAuthStore.setState({
@@ -159,7 +332,10 @@ describe('useAuthStore', () => {
       const state = useAuthStore.getState()
       expect(state.isAuthenticated).toBe(true)
       expect(state.subscriptionStatus).toBe('billing_unavailable')
-      expect(state.user).toEqual({ id: 'degraded', email: '', planId: 'unknown', isAdmin: false })
+      // Degraded users get a non-null onboardedAt so we don't pop the
+      // OnboardingModal at users while billing is unreachable.
+      expect(state.user).toMatchObject({ id: 'degraded', email: '', planId: 'unknown', isAdmin: false })
+      expect(state.user!.onboardedAt).toEqual(expect.any(String))
     })
 
     it('restoreSession does not enter degraded mode on network error without etebase session', async () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -13,6 +13,13 @@ export interface User {
   email: string
   planId: string
   emailVerified?: boolean
+  /**
+   * ISO timestamp of when the user completed (or was assumed to have completed)
+   * onboarding. NULL means the user has not yet been onboarded and should see
+   * the OnboardingModal. Hydrated from the billing API in /auth/refresh,
+   * /account, and the response of POST /account/onboarded.
+   */
+  onboardedAt?: string | null
 }
 
 interface PendingSignup {
@@ -57,6 +64,16 @@ interface AuthState {
   restoreSession: () => Promise<void>
   fetchSubscription: () => Promise<void>
   retryBillingConnection: () => Promise<boolean>
+  /**
+   * Mark the current user as onboarded. POSTs to the billing API
+   * (idempotent), then updates the local user state with the returned
+   * timestamp. Self-hosted users skip the network call and just set a
+   * local timestamp. Network failures are logged and swallowed: leaving
+   * onboardedAt null means the popup will retry next session, which is
+   * the correct degraded behaviour. Returns true on success, false if
+   * the network call failed.
+   */
+  markOnboarded: () => Promise<boolean>
   setUser: (user: User | null) => void
   clearError: () => void
   /**
@@ -253,6 +270,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         email: pending.email,
         planId: pending.provisionedUser.planId,
         isAdmin: pending.provisionedUser.isAdmin,
+        // A brand-new account is by definition not onboarded yet — the
+        // OnboardingModal needs onboardedAt === null to fire on first login.
+        onboardedAt: null,
       },
       isAuthenticated: true,
       isLoading: false,
@@ -272,7 +292,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         if (serverUrl) localStorage.setItem('silentsuite-server-url', serverUrl)
         syncAdminCookie(true)
         set({
-          user: { id: 'self-hosted', email, planId: 'self-hosted', isAdmin: true },
+          user: { id: 'self-hosted', email, planId: 'self-hosted', isAdmin: true, onboardedAt: null },
           isAuthenticated: true,
           isLoading: false,
           subscriptionStatus: 'active',
@@ -304,7 +324,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const isAdmin = data.isAdmin === true
       syncAdminCookie(isAdmin)
       set({
-        user: { id: data.id, email: data.email ?? email, planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false },
+        user: { id: data.id, email: data.email ?? email, planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null },
         isAuthenticated: true,
         isLoading: false,
       })
@@ -367,7 +387,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const hasSession = !!(await secureGet('etebase_session'))
       if (hasSession) {
         syncAdminCookie(true)
-        set({ user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true }, isAuthenticated: true, subscriptionStatus: 'active' })
+        set({ user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true, onboardedAt: null }, isAuthenticated: true, subscriptionStatus: 'active' })
         return true
       }
       syncAdminCookie(false)
@@ -381,7 +401,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const data = await res.json()
       const isAdmin = data.isAdmin === true
       syncAdminCookie(isAdmin)
-      set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false }, isAuthenticated: true })
+      set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true })
       return true
     } catch (err) {
       logger.warn('[auth-store] Session refresh failed:', err)
@@ -408,7 +428,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const hasSession = !!(await secureGet('etebase_session'))
       if (hasSession) {
         syncAdminCookie(true)
-        set({ user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true }, isAuthenticated: true, isLoading: false, subscriptionStatus: 'active' })
+        set({ user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true, onboardedAt: null }, isAuthenticated: true, isLoading: false, subscriptionStatus: 'active' })
       } else {
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, isLoading: false })
@@ -423,7 +443,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         const data = await res.json()
         const isAdmin = data.isAdmin === true
         syncAdminCookie(isAdmin)
-        set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false }, isAuthenticated: true, isLoading: false })
+        set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true, isLoading: false })
       } else {
         // HTTP error (401/403 etc.) — billing responded, auth is invalid
         syncAdminCookie(false)
@@ -435,8 +455,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // If a valid Etebase session exists, enter degraded mode instead of kicking the user out.
       const hasEtebaseSession = !!(await secureGet('etebase_session'))
       if (hasEtebaseSession) {
+        // Degraded users get a non-null onboardedAt so they don't get the
+        // popup pushed at them while billing is down — they may already be
+        // onboarded, we just can't tell. Better to err on the quiet side.
         set({
-          user: { id: 'degraded', email: '', planId: 'unknown', isAdmin: false },
+          user: { id: 'degraded', email: '', planId: 'unknown', isAdmin: false, onboardedAt: new Date().toISOString() },
           isAuthenticated: true,
           isLoading: false,
           subscriptionStatus: 'billing_unavailable',
@@ -481,13 +504,64 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const isAdmin = refreshData.isAdmin === true
       syncAdminCookie(isAdmin)
       set({
-        user: { id: refreshData.id, email: refreshData.email ?? '', planId: refreshData.planId ?? 'free', isAdmin, emailVerified: refreshData.emailVerified ?? false },
+        user: { id: refreshData.id, email: refreshData.email ?? '', planId: refreshData.planId ?? 'free', isAdmin, emailVerified: refreshData.emailVerified ?? false, onboardedAt: refreshData.onboardedAt ?? null },
         isAuthenticated: true,
         subscriptionStatus: subData.status,
       })
       return true
     } catch (err) {
       logger.warn('[auth-store] retryBillingConnection failed:', err)
+      return false
+    }
+  },
+
+  markOnboarded: async () => {
+    const current = get().user
+    if (!current) {
+      // Defensive: nothing to update against. Caller should only invoke
+      // this from a path that already has an authenticated user, but a
+      // race during logout could land us here.
+      return false
+    }
+
+    // Already onboarded — nothing to do, treat as success so callers can
+    // chain UI dismissal without worrying about the state.
+    if (current.onboardedAt) return true
+
+    // Self-hosted has no billing API to call. Just stamp locally so the
+    // modal hides for the rest of the session and doesn't reappear on
+    // restoreSession (which also sets onboardedAt: null for self-hosted —
+    // the localStorage flash-suppressor in the modal covers that case).
+    const storedServerUrl = typeof window !== 'undefined' ? localStorage.getItem('silentsuite-server-url') : null
+    if (isSelfHosted || isCustomServer(storedServerUrl ?? undefined) || current.id === 'self-hosted') {
+      set({ user: { ...current, onboardedAt: new Date().toISOString() } })
+      return true
+    }
+
+    try {
+      const res = await fetch(`${BILLING_API_URL}/account/onboarded`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      })
+      if (!res.ok) {
+        // Don't update local state on failure: leaving onboardedAt null
+        // means the modal will re-appear next session, which is the
+        // correct degraded behaviour. A localStorage hint in the modal
+        // suppresses the flash within this session.
+        logger.warn('[auth-store] markOnboarded failed:', res.status)
+        return false
+      }
+      const data = await res.json()
+      // Re-read user inside the success path — it may have changed during
+      // the await (logout race). Only patch if the same user is still
+      // signed in.
+      const after = get().user
+      if (!after || after.id !== current.id) return false
+      set({ user: { ...after, onboardedAt: data.onboardedAt ?? new Date().toISOString() } })
+      return true
+    } catch (err) {
+      logger.warn('[auth-store] markOnboarded network error:', err)
       return false
     }
   },


### PR DESCRIPTION
**DEPENDS ON silent-suite/silentsuite-internal#79 — DO NOT MERGE UNTIL THAT'S MERGED + DEPLOYED.** The `/account/onboarded` endpoint and the `onboardedAt` field do not exist in the billing API until #79 is live. Merging webapp first would break dismissal: every user would 404 on `POST /account/onboarded` and stay stuck in the popup.

Closes #113

## Plan

Implements the webapp side of the plan in https://github.com/silent-suite/silentsuite/issues/113#issuecomment-4370297481.

The previous gate (`localStorage('onboardingCompleted')` plus an in-memory `events.length + contacts.length + tasks.length` check) re-fired on cleared storage and raced store hydration on re-login. The fix is to make the server authoritative: `billing.users.onboarded_at` is now hydrated into the auth store and read by the modal, with localStorage demoted to a flash-suppression hint.

## Summary

- **`apps/web/app/stores/use-auth-store.ts`**
  - `User.onboardedAt: string | null` added.
  - Hydrated from server response in all four sites: `login` (token-exchange), `refreshSession`, `restoreSession`, `completeSignup` (explicit `null` — brand-new accounts must see the modal once). `retryBillingConnection` also threads it through. The degraded-mode user gets a fresh `new Date().toISOString()` so we don't pop a modal at users while billing is unreachable.
  - New `markOnboarded()` action: POSTs to `/account/onboarded` (idempotent), updates local user state on success. Self-hosted skips the network. Network failures are logged and swallowed — `onboardedAt` stays `null`, so the modal will retry next session. Returns `true`/`false` so callers can observe success.

- **`apps/web/app/components/OnboardingModal.tsx`**
  - Gate is now `user.onboardedAt === null`. The events/contacts/tasks race check is gone (it was the bug). The 7-day "firstLoginDate" heuristic is gone too — that's now handled in the billing migration backfill.
  - All four dismissal paths (`finish` slide button, `Skip all` button, X close button, backdrop click) collapse into one `dismiss` handler that fires `markOnboarded()` (fire-and-forget), sets the localStorage flash hint, then closes the modal.
  - localStorage `onboardingCompleted` is preserved as a synchronous flash-suppressor: present → never show, absent → fall back to server signal once the user object hydrates.

- **Tests**
  - `apps/web/app/stores/__tests__/use-auth-store.test.ts`: extends the existing degraded-mode test (degraded user gets non-null `onboardedAt`), adds 4 hydration tests (login/refresh/restore/completeSignup all populate `onboardedAt`), adds 6 `markOnboarded` tests covering success, network failure, non-OK response, idempotent already-onboarded, no-user, and self-hosted-skip-network paths.
  - `apps/web/app/components/__tests__/OnboardingModal.test.tsx` (new): 10 tests covering the three gate states (`null` shows, recent timestamp doesn't, old timestamp doesn't), `user === null` doesn't render, the localStorage flash-suppressor wins, dismissal via X / Skip all / Escape all call `markOnboarded()` + set the localStorage hint, and dismissal still works when `markOnboarded()` rejects.

All 130 webapp tests pass. `pnpm --filter @silentsuite/web type-check` and `build` are green.

## Test plan

- [ ] `pnpm --filter @silentsuite/web test` passes (130/130 in CI)
- [ ] `pnpm --filter @silentsuite/web type-check` passes
- [ ] `pnpm --filter @silentsuite/web build` passes
- [ ] After billing #79 deploys, smoke-test on a Pages preview: log in as an existing user with backfilled `onboarded_at` → no modal; log in as a fresh signup → modal shows once; dismiss any path → check `billing.users.onboarded_at` is set in the DB; reload → modal stays gone even after `localStorage.clear()`.
- [ ] Self-hosted: modal flow still works locally without any billing calls (no /account/onboarded request in DevTools network tab).
- [ ] Degraded mode (kill billing): no modal pops.

## Adjacent work

A sister PR for issue #111 also touches `use-auth-store.ts`. My changes are additive (added `onboardedAt`, added `markOnboarded`); if a conflict surfaces at merge time, the second-merger resolves.