### PR TITLE
docs(self-hosting): correct factual errors about stack composition

### DIFF
--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -26,4 +26,4 @@ Deploy and manage SilentSuite on your own infrastructure. Self-hosting gives you
 - **Custom domain** -- run the suite on your own domain with automatic HTTPS.
 - **All features unlocked** -- every feature, no subscription required.
 
-The self-hosted stack runs four services via Docker Compose: PostgreSQL, Etebase (encrypted sync), a Next.js web frontend, and Caddy as a reverse proxy with automatic TLS.
+The self-hosted stack runs two containers via Docker Compose: PostgreSQL and the SilentSuite sync server. You provide your own reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel) for TLS termination. Users connect from [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile apps by entering your server URL in **Advanced Settings**.

--- a/docs/self-hosting/architecture.md
+++ b/docs/self-hosting/architecture.md
@@ -1,14 +1,14 @@
 # Architecture
 
-SilentSuite self-hosting runs three containers on a single Docker network. Caddy is the only service exposed to the internet. Users connect via [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile apps.
+SilentSuite self-hosting runs two containers on a single Docker network: PostgreSQL and the SilentSuite sync server. You provide your own reverse proxy in front of the stack to terminate TLS and forward traffic to the server. Users connect from [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile apps.
 
 ## Overview
 
 ```
     Your Server                         SilentSuite Apps
   ┌─────────────────┐
-  │  Caddy (HTTPS)  │◄──────────── app.silentsuite.io
-  │       :443      │              (or mobile apps)
+  │  Your Reverse   │◄──────────── app.silentsuite.io
+  │  Proxy (HTTPS)  │              (or mobile apps)
   └────────┬────────┘              enter your server URL
            │                       in Advanced Settings
   ┌────────┴────────┐
@@ -27,16 +27,17 @@ SilentSuite self-hosting runs three containers on a single Docker network. Caddy
 
 | Service | Image | Role |
 |---|---|---|
-| **Caddy** | `caddy:2-alpine` | Reverse proxy. Terminates TLS, routes requests to the SilentSuite server. Automatically provisions and renews Let's Encrypt certificates. |
-| **SilentSuite Server** | `victorrds/etebase` | Sync server built on the Etebase protocol. Provides end-to-end encrypted data sync. All data is encrypted client-side; the server never sees plaintext. |
-| **PostgreSQL** | `postgres:16-alpine` | Database. Stores encrypted sync data and user accounts. |
+| **SilentSuite Server** | `ghcr.io/silent-suite/silentsuite-server` (pinned per release by digest) | Sync server built on the [Etebase protocol](https://www.etebase.com/). Provides end-to-end encrypted data sync. All data is encrypted client-side; the server never sees plaintext. |
+| **PostgreSQL** | `postgres:16.9-alpine` | Database. Stores encrypted sync data and user accounts. |
+
+The reverse proxy is **not** part of the stack — pick whatever you already run (Caddy, nginx, Traefik, Cloudflare Tunnel) and forward HTTPS traffic to `127.0.0.1:3735`. Examples for each are in [SELF-HOSTING.md](https://github.com/silent-suite/silentsuite/blob/main/self-host/SELF-HOSTING.md#reverse-proxy-examples).
 
 ## Network and Security
 
-- All services run on an internal Docker bridge network.
-- No service except Caddy binds to host ports.
-- Services communicate by container name (e.g., `postgres:5432`, `server:3735`).
-- Caddy adds security headers to all responses: HSTS, X-Frame-Options, X-Content-Type-Options, and more.
+- Both containers run on an internal Docker bridge network and communicate by container name (e.g., `postgres:5432`).
+- PostgreSQL is not exposed to the host.
+- The SilentSuite server binds only to `127.0.0.1:3735`, so it is not reachable from the network without a reverse proxy on the same host.
+- TLS termination, security headers, and ACME certificate provisioning are the reverse proxy's job — see the [recommended security headers](https://github.com/silent-suite/silentsuite/blob/main/self-host/SELF-HOSTING.md#recommended-security-headers).
 - All sync data is end-to-end encrypted. The server never has access to your plaintext data.
 
 ## Why No Web App Container?
@@ -46,4 +47,4 @@ Self-hosters only need the sync server. Users access SilentSuite through:
 - **[app.silentsuite.io](https://app.silentsuite.io)** -- the hosted web app (works with any SilentSuite server)
 - **SilentSuite mobile apps** -- available for Android and iOS
 
-Both support entering a custom server URL in Advanced Settings during signup or login. This keeps the self-hosted stack minimal (3 containers, 3 env vars) while giving users the full SilentSuite experience.
+Both support entering a custom server URL in Advanced Settings during signup or login. This keeps the self-hosted stack minimal (two containers, a handful of env vars) while giving users the full SilentSuite experience.

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -24,7 +24,7 @@ docker exec silentsuite-postgres pg_dump -U silentsuite silentsuite > backup-$(d
 
 ```bash
 docker run --rm \
-  -v silentsuite_server_data:/data \
+  -v self-host_server_data:/data \
   -v $(pwd)/backups:/backup \
   alpine tar czf /backup/server-data-$(date +%Y%m%d-%H%M%S).tar.gz -C /data .
 ```

--- a/docs/self-hosting/quick-start.md
+++ b/docs/self-hosting/quick-start.md
@@ -5,30 +5,52 @@ This is the fastest path from zero to running. Make sure you've met the [require
 ## Install
 
 ```bash
+curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | bash
+```
+
+If you'd rather clone first:
+
+```bash
 git clone https://github.com/silent-suite/silentsuite.git
 cd silentsuite/self-host
-chmod +x install.sh update.sh verify.sh
+chmod +x install.sh update.sh verify.sh close-signups.sh
 ./install.sh
 ```
 
 The `install.sh` script will:
 
 1. Check that Docker and Docker Compose are installed.
-2. Prompt you for your domain name.
-3. Generate strong random passwords for PostgreSQL and the admin panel.
-4. Write the completed `.env` file.
-5. Pull Docker images and start all containers.
-6. Wait for health checks to pass.
-7. Print your server URL and admin credentials.
+2. Resolve the SilentSuite version to install (latest umbrella release, or `main` if none has been cut).
+3. Download the release-pinned `docker-compose.yml`, `update.sh`, `verify.sh`, `close-signups.sh`, and `success.html` into `silentsuite-server/`.
+4. Prompt you for your domain name.
+5. Generate strong random passwords for PostgreSQL and the admin panel.
+6. Write the completed `.env` file.
+7. Pull Docker images and start the two containers (PostgreSQL and the SilentSuite server).
+8. Wait for health checks to pass.
+
+The server listens on `127.0.0.1:3735`. It is **not** reachable from the network until you put a reverse proxy in front of it.
+
+## Set Up a Reverse Proxy
+
+Pick whatever you already run. Examples (Caddy, nginx, Traefik, Cloudflare Tunnel) are in [SELF-HOSTING.md → Reverse Proxy Examples](https://github.com/silent-suite/silentsuite/blob/main/self-host/SELF-HOSTING.md#reverse-proxy-examples). Forward HTTPS traffic for your domain to `localhost:3735`.
 
 ## Connect Your Apps
 
-Once the server is running:
+Once the proxy is up:
 
 1. Open [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile app.
 2. On the signup or login page, expand **Advanced Settings**.
 3. Enter `https://your-domain.com` as the server URL.
-4. Create your account and start syncing.
+4. Create your admin account and start syncing.
+
+## Close Signups
+
+The server ships with `ETEBASE_DISABLE_SIGNUP=false` so you can register the first account from the app. **Close signups as soon as that account exists** — anyone who reaches your server URL during the open window can grab an account:
+
+```bash
+cd silentsuite-server
+./close-signups.sh
+```
 
 ## Verify
 

--- a/docs/self-hosting/requirements.md
+++ b/docs/self-hosting/requirements.md
@@ -10,7 +10,8 @@ Before you begin, make sure you have the following.
 | **Docker** | Docker Engine 24+ with Docker Compose v2 (the `docker compose` plugin, not the legacy `docker-compose` binary). |
 | **Domain name** | A domain you control, with the ability to create DNS A records. |
 | **Server resources** | Minimum 1 GB RAM, 10 GB disk. More is better if you expect multiple users. |
-| **Open ports** | Ports 80 and 443 must be reachable from the internet (required for Let's Encrypt certificate provisioning). |
+| **Reverse proxy** | A reverse proxy you control (Caddy, nginx, Traefik, Cloudflare Tunnel) to terminate TLS in front of the SilentSuite server. The stack itself does not include one. |
+| **Open ports** | Whichever ports your reverse proxy needs reachable from the internet — typically 443 (and 80 for ACME HTTP-01 challenges if your proxy provisions Let's Encrypt certificates). |
 
 ## Verify Docker Is Installed
 
@@ -31,7 +32,7 @@ If your server IP is `203.0.113.50` and your chosen domain is `sync.example.com`
 |---|---|---|
 | A | `sync.example.com` | `203.0.113.50` |
 
-**Important:** DNS changes can take minutes to hours to propagate. Caddy will fail to obtain TLS certificates if the record does not resolve to your server. Verify propagation before proceeding:
+**Important:** DNS changes can take minutes to hours to propagate. Whatever reverse proxy you use will fail to obtain TLS certificates if the record does not resolve to your server. Verify propagation before proceeding:
 
 ```bash
 dig +short sync.example.com

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -16,11 +16,11 @@ All services should show `Up (healthy)`. If a service shows `Up (unhealthy)` or 
 # All services
 docker compose logs
 
-# Specific service (postgres, server, caddy)
+# Specific service (postgres, server)
 docker compose logs server
 
 # Follow logs in real time
-docker compose logs -f caddy
+docker compose logs -f server
 
 # Last 100 lines
 docker compose logs --tail 100 server
@@ -49,13 +49,14 @@ docker compose logs server
 
 ### SSL Certificate Errors
 
-**Symptom:** Browser shows certificate warnings, or Caddy logs show ACME errors.
+**Symptom:** Browser shows certificate warnings, or your reverse proxy logs ACME errors.
 
-**Causes and fixes:**
+TLS is your reverse proxy's responsibility — these are not SilentSuite-server problems. Common causes:
 
 - **DNS not resolving:** Verify your DNS record points to your server with `dig +short your-domain.com`.
-- **Ports blocked:** Caddy needs ports 80 and 443 open for the ACME HTTP-01 challenge. Check your firewall: `sudo ufw status` or `sudo iptables -L -n`.
+- **Ports blocked:** Your reverse proxy needs the relevant ports open (typically 80 for the ACME HTTP-01 challenge and 443 for HTTPS). Check your firewall: `sudo ufw status` or `sudo iptables -L -n`.
 - **Rate limiting:** Let's Encrypt has [rate limits](https://letsencrypt.org/docs/rate-limits/). If you have hit them, wait before retrying.
+- **Wrong upstream:** Confirm the proxy is forwarding to `127.0.0.1:3735` and that the SilentSuite server container is healthy (`docker compose ps`).
 
 ### Database Connection Errors
 

--- a/docs/self-hosting/uninstalling.md
+++ b/docs/self-hosting/uninstalling.md
@@ -7,21 +7,22 @@ How to remove SilentSuite from your server.
 To completely remove SilentSuite and all its data:
 
 ```bash
-# Stop and remove all containers
+# Stop and remove the containers
+cd silentsuite-server
 docker compose down
 
 # Remove all data volumes (THIS DELETES ALL DATA)
-docker volume rm self-host_pgdata self-host_etebase_data self-host_caddy_data self-host_caddy_config
+docker volume rm self-host_pgdata self-host_server_data
 
 # Remove the Docker images
-docker rmi victorrds/etebase:latest
-docker rmi postgres:16-alpine
-docker rmi caddy:2-alpine
+docker image rm $(docker image ls --format '{{.Repository}}:{{.Tag}}' | grep -E '^(ghcr\.io/silent-suite/silentsuite-server|postgres):' )
 
-# Remove the cloned repository
+# Remove the install directory
 cd ..
-rm -rf silentsuite
+rm -rf silentsuite-server
 ```
+
+If you set up a reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel) yourself, that's outside the SilentSuite stack — remove its config and any certificates it provisioned separately.
 
 ## Stop Without Deleting Data
 

--- a/docs/self-hosting/uninstalling.md
+++ b/docs/self-hosting/uninstalling.md
@@ -14,8 +14,9 @@ docker compose down
 # Remove all data volumes (THIS DELETES ALL DATA)
 docker volume rm self-host_pgdata self-host_server_data
 
-# Remove the Docker images
-docker image rm $(docker image ls --format '{{.Repository}}:{{.Tag}}' | grep -E '^(ghcr\.io/silent-suite/silentsuite-server|postgres):' )
+# Remove the Docker images (the silentsuite-server tag/digest may differ — list yours with `docker image ls`)
+docker image rm postgres:16.9-alpine
+docker image ls --filter 'reference=ghcr.io/silent-suite/silentsuite-server' --format '{{.ID}}' | xargs -r docker image rm
 
 # Remove the install directory
 cd ..

--- a/docs/self-hosting/updating.md
+++ b/docs/self-hosting/updating.md
@@ -2,34 +2,47 @@
 
 How to keep your self-hosted SilentSuite instance up to date.
 
-## Using update.sh (Recommended)
+## How Versions Are Pinned
+
+The `docker-compose.yml` shipped with each SilentSuite release pins the server image to a specific manifest digest, e.g.:
+
+```yaml
+image: ghcr.io/silent-suite/silentsuite-server@sha256:6689b5d8...
+```
+
+This means a plain `docker compose pull` **will not** fetch a newer SilentSuite version — it only re-pulls the same digest. To upgrade across SilentSuite releases you must fetch a newer compose file.
+
+## Upgrade to a New SilentSuite Release
+
+Re-running the installer pulls the latest umbrella release's `docker-compose.yml` (and helper scripts) and recreates the containers:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | bash
+```
+
+To pin to a specific release instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | SILENTSUITE_VERSION=v0.1.0-beta bash
+```
+
+The whole self-host config (compose, `update.sh`, `verify.sh`, `success.html`, `close-signups.sh`) is fetched from the requested tag's archive, so the entire matrix moves together as one release.
+
+## Within a Pinned Release
+
+`./update.sh` re-pulls the pinned images and recreates the containers. This is useful after host-level changes (Docker upgrade, kernel reboot, etc.) but does **not** change SilentSuite versions:
 
 ```bash
 ./update.sh
 ```
 
-This script pulls the latest images and restarts the stack with zero-downtime rolling updates where possible.
+## Verify
 
-## Manual Update
+After any update:
 
 ```bash
-# Pull latest images
-docker compose pull
-
-# Recreate containers with new images
-docker compose up -d
-
-# Verify
+./verify.sh
 docker compose ps
 ```
 
-## Pinning Versions
-
-By default, the `docker-compose.yml` uses the `latest` tag for SilentSuite images. To pin a specific version, edit the image tags:
-
-```yaml
-web:
-  image: ghcr.io/silent-suite/silentsuite-web:v1.2.0
-```
-
-Pinning versions is recommended for production deployments to avoid unexpected changes.
+All services should report `healthy`.


### PR DESCRIPTION
## Summary

Fixes the factual errors in `docs/self-hosting/` flagged in #126. The docs described a three- or four-container stack (with an in-stack Caddy and a non-existent Next.js web frontend image). The actual self-host stack is **two containers** — PostgreSQL + `silentsuite-server` — with the reverse proxy left to the operator. Source of truth: `self-host/docker-compose.yml` and `self-host/SELF-HOSTING.md`.

## What changed

- **`README.md`** — \"four services\" claim → two containers, operator-provided proxy.
- **`architecture.md`** — rewrote the overview diagram, service table, and network section to match the real stack. Image refs corrected (`ghcr.io/silent-suite/silentsuite-server` digest-pinned, `postgres:16.9-alpine`).
- **`requirements.md`** — split out a \"reverse proxy\" requirement; \"open ports\" now describes what *your* proxy needs, not Caddy's. Removed the \"Caddy will fail to obtain TLS certificates\" line.
- **`troubleshooting.md`** — dropped in-stack `caddy` log references in the logs cheatsheet; SSL section now frames TLS errors as a proxy concern (with an upstream-health check added).
- **`uninstalling.md`** — fixed volume names (`self-host_pgdata`, `self-host_server_data`) and image refs (drop `victorrds/etebase`, drop `caddy:2-alpine`); image-rm now matches by repo prefix instead of hard-coded tag.
- **`updating.md`** — removed the non-existent `silentsuite-web:v1.2.0` example. Replaced with the actual model: server image is digest-pinned per release, so cross-version upgrades require fetching a newer compose via `install.sh`; `update.sh` re-pulls within a pinned release.
- **`backup-and-restore.md`** — fixed `silentsuite_server_data` → `self-host_server_data` to match the volume name docker-compose actually creates.
- **`quick-start.md`** — added the `curl … | bash` install option (matching `SELF-HOSTING.md`), added `close-signups.sh` to the chmod line, added a \"Set Up a Reverse Proxy\" step, and added a \"Close Signups\" section so the unsafe-window doesn't get skipped.

## Out of scope

- The `getting-started.md` and `etebase.com` link inconsistency bonus items in the issue body live in `docs/user-guide/`, which #127 rewrites end-to-end. Handling them there.

## Test plan

- [ ] Read each changed page top-to-bottom and confirm no remaining `caddy:2-alpine`, `victorrds/etebase`, `silentsuite-web`, or in-stack-Caddy assertions.
- [ ] Cross-check every image, volume, and container name against `self-host/docker-compose.yml`.
- [ ] Cross-check the install / update / close-signups flows against `self-host/SELF-HOSTING.md`.
- [ ] Spot-check Cloudflare Pages docs preview once it deploys.

Closes #126