### PR TITLE
docs(user-guide): write v0.1.0-beta user guide

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,23 +1,23 @@
 # User Guide
 
-How-to guides for using SilentSuite -- your private, end-to-end encrypted sync for calendar, contacts, and tasks.
+How to use SilentSuite — your end-to-end encrypted sync for calendar, contacts, and tasks. Everything in this guide is grounded in what's actually shipped in [v0.1.0-beta](https://github.com/silent-suite/silentsuite/releases/tag/v0.1.0-beta).
 
 ---
 
 | Guide | Description |
 |---|---|
-| [Getting Started](./getting-started.md) | Create an account and set up your first device |
-| [Calendar](./calendar.md) | How to manage your encrypted calendar |
-| [Contacts](./contacts.md) | How to manage your encrypted contacts |
-| [Tasks](./tasks.md) | How to manage your encrypted tasks |
-| [How Encryption Works](./encryption-explained.md) | Understand what's encrypted, how, and why it matters |
-| [FAQ](./faq.md) | Frequently asked questions |
+| [Getting Started](./getting-started.md) | Sign up, pick a plan, install on a second device, confirm sync |
+| [Calendar](./calendar.md) | Events, recurrence, timezones, ICS import/export |
+| [Contacts](./contacts.md) | Contact CRUD, vCard import/export |
+| [Tasks](./tasks.md) | Tasks, priorities, due dates, ICS task export |
+| [How Encryption Works](./encryption-explained.md) | What's encrypted, how, and what the server can and can't see |
+| [FAQ](./faq.md) | Common questions |
 
 ---
 
 ## How SilentSuite Works
 
-All your data -- events, contacts, tasks -- is encrypted on your device before it leaves. The server only ever stores and syncs encrypted blobs. Nobody, including the SilentSuite team, can read your data.
+All your data — events, contacts, tasks — is encrypted on your device before it leaves. The server only ever stores and syncs ciphertext. Nobody, including the SilentSuite team, can read your data.
 
 ```
 Your Device          SilentSuite Server          Your Other Device
@@ -28,3 +28,10 @@ Your Device          SilentSuite Server          Your Other Device
     |                      |                          |
     |   Server never has the keys. Never sees plaintext.
 ```
+
+## Where to Use SilentSuite
+
+- **Web** — [app.silentsuite.io](https://app.silentsuite.io) (offline-first PWA, installable to any desktop or mobile home screen)
+- **Android** — signed APK, sideloadable. QR-code download in *Settings → Mobile* once you're signed in
+- **Desktop (CalDAV / CardDAV)** — the SilentSuite bridge runs a local DAV daemon for Thunderbird, Apple Calendar, Evolution, GNOME Calendar, etc. Install commands in *Settings → Desktop*
+- **iOS** — no native app yet; the [EteSync iOS app](https://www.etesync.com/) works against your SilentSuite account in the meantime

--- a/docs/user-guide/calendar.md
+++ b/docs/user-guide/calendar.md
@@ -1,32 +1,69 @@
-# How to Manage Your Calendar
+# Calendar
 
-Your calendar events are end-to-end encrypted. Only your devices can read them.
-
-<!-- TODO: Expand with specific UI walkthroughs once client apps are available -->
+Your calendar lives at [app.silentsuite.io/calendar](https://app.silentsuite.io/calendar). Events are encrypted on your device before they sync — title, location, description, attendees, alarms, the lot.
 
 ## Create an Event
 
-1. Open the Calendar view.
-2. Tap or click the date and time for your event.
-3. Enter the event details (title, location, notes, reminders).
-4. Save. The event is encrypted on your device and synced.
+1. Click any cell in the week or month grid, or press the **+** button.
+2. Fill in the event:
+   - Title, location, description
+   - Start / end (or *all-day*)
+   - Timezone — defaults to your browser's, change per event if needed
+   - Reminders (`VALARM`) — relative offsets (e.g. 15 min before start) or absolute times
+   - Recurrence — see below
+3. Save. The event is serialized to iCalendar (`VEVENT`), encrypted, and synced.
 
-## Edit an Event
+## Edit / Delete
 
-1. Open the event you want to change.
-2. Make your changes.
-3. Save. The updated event is re-encrypted and synced to your other devices.
-
-## Delete an Event
-
-1. Open the event.
-2. Select delete.
-3. The deletion syncs across all your devices.
+Click the event in any view. Edit the same fields and save, or hit delete. Changes are re-encrypted and synced to your other devices.
 
 ## Recurring Events
 
-<!-- TODO: Document recurring event support -->
+Recurring events use standard `RRULE` strings (daily, weekly, monthly, yearly, with intervals, weekdays, by-day-of-month, etc.).
 
-## Sharing Events
+When you edit or delete an instance of a recurring event, SilentSuite asks for the **scope**:
 
-SilentSuite is designed around personal privacy. Shared calendars are not currently supported -- your calendar is visible only to you, across your own devices.
+- **This event only** — split a single occurrence into an exception (`EXDATE` for delete, override `VEVENT` for edit)
+- **This and all following** — close out the original `RRULE` with `UNTIL` and start a new one from the chosen instance
+- **All events in the series** — apply the change to the whole `RRULE`
+
+This matches the behaviour you'd expect from any CalDAV-compliant client.
+
+## Views
+
+| View | Best for |
+|---|---|
+| **Week** | Day-by-day planning, dragging events across days |
+| **Month** | Glance overview |
+| **Agenda** | Linear list of upcoming events (mobile-friendly) |
+| **Mini calendar** | Sidebar quick-jump |
+
+## Timezones
+
+Timezones are stored as `TZID` references on each event, not converted to UTC on save. When an event is imported with a `TZID` that isn't your local one, the original timezone is preserved through round-trips so the event stays meaningful when you travel.
+
+## Import
+
+**Settings → Import** accepts `.ics` files. Parsing happens entirely in your browser — the file's contents never reach the server in plaintext. Imported events keep their original `TZID`s and `VALARM`s.
+
+## Export
+
+**Settings → Export** gives you:
+
+- **Calendar (`.ics`)** — all calendar events as a single iCalendar file
+- **Everything (`.zip`)** — calendars, contacts, and tasks together
+
+The export is built from your locally decrypted data, so it works offline once your data is loaded.
+
+## Sharing
+
+Shared calendars between accounts are not supported in v0.1.0-beta. Your calendar is visible only to you, across your own devices.
+
+## Bridge / DAV clients
+
+If you've installed the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge), your CalDAV client (Thunderbird, Apple Calendar, etc.) can read and write the same calendar through `localhost:37358`. Edits there sync the same way as edits in the web app.
+
+## Limits in this beta
+
+- A single default calendar collection per account. Managing multiple calendars is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
+- No invitations / RSVP / scheduling — SilentSuite is single-user, by design.

--- a/docs/user-guide/calendar.md
+++ b/docs/user-guide/calendar.md
@@ -31,12 +31,14 @@ This matches the behaviour you'd expect from any CalDAV-compliant client.
 
 ## Views
 
+The view switcher in the calendar header offers two views:
+
 | View | Best for |
 |---|---|
 | **Week** | Day-by-day planning, dragging events across days |
 | **Month** | Glance overview |
-| **Agenda** | Linear list of upcoming events (mobile-friendly) |
-| **Mini calendar** | Sidebar quick-jump |
+
+On narrow viewports the calendar automatically renders as a vertical **agenda list** of upcoming events. A **mini calendar** in the sidebar acts as a quick-jump date picker.
 
 ## Timezones
 

--- a/docs/user-guide/contacts.md
+++ b/docs/user-guide/contacts.md
@@ -1,32 +1,43 @@
-# How to Manage Your Contacts
+# Contacts
 
-Your contacts are end-to-end encrypted. Only your devices can read them.
-
-<!-- TODO: Expand with specific UI walkthroughs once client apps are available -->
+Your address book lives at [app.silentsuite.io/contacts](https://app.silentsuite.io/contacts). Names, emails, phone numbers, addresses, notes, photos — every field is encrypted on your device before sync.
 
 ## Add a Contact
 
-1. Open the Contacts view.
-2. Tap or click "Add Contact."
-3. Enter the contact details (name, email, phone, address, notes).
-4. Save. The contact is encrypted on your device and synced.
+1. Click **+ Add Contact**.
+2. Fill in the fields you want — at minimum a name. Email, phone, address, organisation, birthday, notes, and photo are all optional.
+3. Save. The contact is serialized to vCard (`VCARD`), encrypted, and synced.
 
-## Edit a Contact
+## Edit / Delete
 
-1. Open the contact you want to change.
-2. Make your changes.
-3. Save. The updated contact is re-encrypted and synced to your other devices.
+Open a contact, edit its fields, save. Or open and delete. Changes are re-encrypted and synced.
 
-## Delete a Contact
+## Search
 
-1. Open the contact.
-2. Select delete.
-3. The deletion syncs across all your devices.
+The search box at the top of the contacts list filters by name, email, phone, or organisation. Search runs against your locally decrypted data, so it's fast and works offline.
 
-## Import Contacts
+## Import
 
-<!-- TODO: Document import functionality (vCard, CSV) -->
+**Settings → Import** accepts `.vcf` files (vCard 3.0 and 4.0). Parsing is local-only — the file content never leaves your browser unencrypted. Multi-contact files are supported (one big `.vcf` with many `BEGIN:VCARD` blocks).
 
-## Export Contacts
+## Export
 
-<!-- TODO: Document export functionality -->
+**Settings → Export** gives you:
+
+- **Contacts (`.vcf`)** — all contacts as a single vCard file
+- **Everything (`.zip`)** — calendars, contacts, and tasks together
+
+Both are built from your locally decrypted data.
+
+## Bridge / CardDAV clients
+
+With the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge) installed, any CardDAV client (Thunderbird, Apple Contacts, GNOME Contacts, Evolution) can read and write the same contacts through `localhost:37358`.
+
+## Sharing
+
+Shared address books between accounts are not supported in v0.1.0-beta. Your contacts are visible only to you, across your own devices.
+
+## Limits in this beta
+
+- A single default contacts collection per account. Managing multiple address books is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
+- No OAuth-based one-click import from Google or iCloud yet — file-based `.vcf` import only. (On the roadmap.)

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -4,38 +4,84 @@
 
 ### What is SilentSuite?
 
-SilentSuite is a privacy-focused, end-to-end encrypted sync service for calendar, contacts, and tasks. Your data is encrypted on your device before it reaches the server. The server never sees plaintext.
+A privacy-focused, end-to-end encrypted sync service for calendar, contacts, and tasks. Your data is encrypted on your device before it reaches the server. The server never sees plaintext — not even item counts or collection names.
+
+### What's available right now?
+
+The v0.1.0-beta release covers:
+
+- **Web app** at [app.silentsuite.io](https://app.silentsuite.io) — calendar, contacts, tasks, import/export, settings, admin
+- **Android** — signed APK for sideloading (download via QR code in the app's *Settings → Mobile*)
+- **Desktop bridge** — CalDAV/CardDAV bridge for Thunderbird, Apple Calendar, Evolution, etc., on Linux / macOS / Windows
+- **Self-hosting** — two-container Docker stack (PostgreSQL + SilentSuite server)
+
+See the [v0.1.0-beta release notes](https://github.com/silent-suite/silentsuite/releases/tag/v0.1.0-beta) for the full list.
+
+### What's *not* in this beta?
+
+On the roadmap, not yet shipped:
+
+- Native iOS app (the [EteSync iOS app](https://www.etesync.com/) works against your account in the meantime — same Etebase protocol)
+- Google Play / F-Droid listings (Android ships as a sideload APK)
+- OAuth-based one-click import from Google / iCloud
+- Push notifications
+- Multiple collections per account ([#88](https://github.com/silent-suite/silentsuite/issues/88))
+- First-class encrypted notes ([#45](https://github.com/silent-suite/silentsuite/issues/45))
 
 ### Is SilentSuite free?
 
-SilentSuite offers a hosted service with paid plans to fund development. Self-hosting is free and includes all features. See [Self-Hosting](../self-hosting/) for details.
-
-### What platforms are supported?
-
-<!-- TODO: Update as client apps launch -->
-
-SilentSuite is in active development. Web, Android, and iOS clients are planned.
+The hosted service has paid plans (Monthly or Annual; 30-day free trial available). Self-hosting is free and includes every feature with no subscription. See [Self-Hosting](../self-hosting/).
 
 ## Privacy & Security
 
 ### Can SilentSuite read my data?
 
-No. All data is encrypted on your device before it reaches the server. The server only stores encrypted blobs. Even if compelled by a court order, SilentSuite cannot produce plaintext data because it does not have the encryption keys.
+No. All data is encrypted on your device before it reaches the server. The server only stores ciphertext and cannot decrypt it. Even when compelled, SilentSuite cannot produce plaintext data because the keys never reach the server.
+
+See [How Encryption Works](./encryption-explained.md) for the full picture.
 
 ### What encryption does SilentSuite use?
 
-SilentSuite uses the [Etebase protocol](https://www.etebase.com/) with XChaCha20-Poly1305 for encryption and Argon2 for key derivation. See [How Encryption Works](./encryption-explained.md) for details.
+The [Etebase protocol](https://www.etebase.com/) — XChaCha20-Poly1305 for symmetric encryption, Argon2 for password-based key derivation. The protocol spec is at [docs.etebase.com](https://docs.etebase.com/).
 
 ### Can I reset my password?
 
-No. Your encryption keys are derived from your password, and the server never has access to them. If you forget your password, your data cannot be recovered. Use a password manager.
+No. Your encryption keys are derived from your password, and the server never sees them. If you forget your password, your data cannot be recovered. Use a password manager.
+
+### Are imports and exports also private?
+
+Yes. Both happen entirely in your browser — `.ics` and `.vcf` files are parsed and encrypted (or decrypted and serialized) locally; the file contents never reach the server in plaintext.
 
 ## Self-Hosting
 
 ### Can I run SilentSuite on my own server?
 
-Yes. See the [Self-Hosting guide](../self-hosting/) for instructions. Self-hosting gives you full data sovereignty and all features unlocked with no subscription.
+Yes. See the [Self-Hosting guide](../self-hosting/) for the install flow. Self-hosting gives you full data sovereignty with every feature unlocked and no subscription.
 
 ### What do I need to self-host?
 
-A Linux server with Docker, 2 GB RAM, and a domain name. See [Requirements](../self-hosting/requirements.md) for full details.
+A Linux server with Docker, ~1 GB RAM, a domain name, and a reverse proxy you control (Caddy, nginx, Traefik, or Cloudflare Tunnel) for TLS. See [Requirements](../self-hosting/requirements.md).
+
+### Can the same account talk to a self-hosted server *and* the hosted service?
+
+No — an account belongs to a single server. Pick one when you sign up. To migrate later, export from one and import into the other.
+
+## Apps & Devices
+
+### How do I get the Android APK?
+
+Sign in to [app.silentsuite.io](https://app.silentsuite.io) on a device with a screen, open *Settings → Mobile*, and either scan the QR code or use the direct download link to the latest GitHub Release.
+
+### Why is the Android app not on Google Play?
+
+Distribution channels (Google Play, F-Droid) are on the roadmap — see [#58](https://github.com/silent-suite/silentsuite-internal/issues/58) and [#59](https://github.com/silent-suite/silentsuite-internal/issues/59). For now it's a signed sideloadable APK.
+
+### How does the desktop bridge work?
+
+It runs a tiny CalDAV/CardDAV daemon bound to `localhost:37358`. Standard PIM clients (Thunderbird, Apple Calendar, Evolution, etc.) talk to it like any other DAV server. The bridge handles encryption/decryption against your SilentSuite account; plaintext stays inside `localhost`.
+
+Install commands are in *Settings → Desktop* in the web app.
+
+### Will offline edits sync when I reconnect?
+
+Yes. The web app is an offline-first PWA — encrypted writes queue while offline and flush on reconnect.

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -30,7 +30,7 @@ On the roadmap, not yet shipped:
 
 ### Is SilentSuite free?
 
-The hosted service has paid plans (Monthly or Annual; 30-day free trial available). Self-hosting is free and includes every feature with no subscription. See [Self-Hosting](../self-hosting/).
+The hosted service has paid plans (Monthly or Annual). Two free trials are offered at signup: a **7-day trial with no credit card required**, and a **30-day card-secured trial** (you're not charged until day 30 and can cancel any time before then). Self-hosting is free and includes every feature with no subscription. See [Self-Hosting](../self-hosting/).
 
 ## Privacy & Security
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,31 +1,65 @@
 # Getting Started
 
-Set up SilentSuite and start syncing your calendar, contacts, and tasks with end-to-end encryption.
+A walkthrough of creating your account and getting your first event syncing across two devices.
 
 ## 1. Create an Account
 
-<!-- TODO: Add specific steps once client apps are available -->
+Go to [app.silentsuite.io](https://app.silentsuite.io/signup). The signup flow is four steps:
 
-Visit [silentsuite.io](https://silentsuite.io) to create your account. Your password is used to derive your encryption keys -- it never leaves your device.
+1. **Account** — email and password.
+2. **Plan** — pick Monthly or Annual (Annual saves 17%) and choose either *Subscribe now* or the *30-day free trial*. The trial requires a card to start, but you are not charged until day 30 and can cancel any time before then.
+3. **Vault & Recovery** — your encryption keys are derived from your password on this device. Store the password somewhere safe; without it, your data cannot be recovered. SilentSuite has no way to reset it because the server never sees your keys.
+4. **Verify your email** — open the link sent to the address you registered with. Until verified, an inline banner stays visible across the app.
 
-**Important:** Choose a strong password. Since all encryption is derived from your password, there is no way to recover your data if you forget it. SilentSuite cannot reset your password because the server never has access to your keys.
+Self-hosting your own server? Expand **Advanced Settings** on the signup page and enter your server URL before submitting. See the [Self-Hosting guide](../self-hosting/) for the server side of that.
 
-## 2. Set Up Your First Device
+## 2. Add Your First Event
 
-<!-- TODO: Add platform-specific setup guides (Android, iOS, web) -->
+After signup you land on the calendar. Click any cell or tap the **+** button to create an event:
 
-After creating your account, set up SilentSuite on your device. Your encryption keys are generated locally during setup.
+- Title, location, description, all-day, start/end with timezone, reminders (`VALARM`), recurrence rule
+- Save — the event is encrypted in your browser before it leaves the page
 
-## 3. Add Your Data
+See [Calendar](./calendar.md), [Contacts](./contacts.md), and [Tasks](./tasks.md) for what each section covers.
 
-Once set up, you can start adding:
+## 3. Add a Second Device
 
-- **Calendar events** -- see [Calendar](./calendar.md)
-- **Contacts** -- see [Contacts](./contacts.md)
-- **Tasks** -- see [Tasks](./tasks.md)
+Your data is only useful if you can read it on the device you're carrying. Three supported surfaces, all talking to the same encrypted account:
 
-All data is encrypted on your device before syncing.
+### Web (any device with a browser)
 
-## 4. Add More Devices
+Open [app.silentsuite.io](https://app.silentsuite.io/login) on the second device and log in with the same email and password. The web app is an offline-first PWA — you can install it to your home screen or dock from your browser's "install app" menu.
 
-To sync across multiple devices, sign in with the same account on each device. Your encryption keys are derived from your password on each device independently -- the server never sees them.
+### Android
+
+In **Settings → Mobile** there's a QR code that links to the latest signed APK on GitHub Releases. Scan it from your phone or download manually. Sideload, open the app, log in. The Android app supports a custom server URL in advanced settings if you self-host.
+
+> Currently distributed as a sideloadable APK. Google Play and F-Droid listings are on the roadmap.
+
+### Desktop (CalDAV / CardDAV via the bridge)
+
+If you'd rather use Thunderbird, Apple Calendar, GNOME Calendar, Evolution, or any other standard CalDAV/CardDAV client, install the **SilentSuite bridge**. It runs a local DAV daemon on `localhost:37358` that translates between your client and the encrypted Etebase backend.
+
+Install commands are in **Settings → Desktop** in the web app.
+
+> The bridge keeps plaintext on `localhost` only — every byte that leaves your machine is encrypted by the bridge first.
+
+### iOS
+
+There's no SilentSuite iOS app yet (on the roadmap). In the meantime, the [EteSync iOS app](https://www.etesync.com/) speaks the same Etebase protocol and works against your SilentSuite account.
+
+## 4. Confirm Sync Works
+
+Create an event on device A. Within a few seconds it should appear on device B. If it doesn't:
+
+- Check that both devices are signed in to the **same** account
+- Check that both devices report a successful sync in their status indicator
+- See the [FAQ](./faq.md) for common issues
+
+That's the success state for setup. From here, see the per-section guides:
+
+- [Calendar](./calendar.md) — events, recurrence, timezones, import/export
+- [Contacts](./contacts.md) — vCard CRUD and import/export
+- [Tasks](./tasks.md) — priorities, due dates, ICS task export
+- [How Encryption Works](./encryption-explained.md) — what the server can and can't see
+- [FAQ](./faq.md) — anything we get asked twice

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -4,14 +4,17 @@ A walkthrough of creating your account and getting your first event syncing acro
 
 ## 1. Create an Account
 
-Go to [app.silentsuite.io](https://app.silentsuite.io/signup). The signup flow is four steps:
+Go to [app.silentsuite.io](https://app.silentsuite.io/signup). For the hosted service the signup flow is three steps:
 
 1. **Account** — email and password.
-2. **Plan** — pick Monthly or Annual (Annual saves 17%) and choose either *Subscribe now* or the *30-day free trial*. The trial requires a card to start, but you are not charged until day 30 and can cancel any time before then.
-3. **Vault & Recovery** — your encryption keys are derived from your password on this device. Store the password somewhere safe; without it, your data cannot be recovered. SilentSuite has no way to reset it because the server never sees your keys.
-4. **Verify your email** — open the link sent to the address you registered with. Until verified, an inline banner stays visible across the app.
+2. **Plan** — pick Monthly or Annual (Annual saves 17%) and choose your trial:
+   - **7-day free trial** — full access, no credit card required.
+   - **30-day free trial** — card secures the trial; you're not charged until day 30 and can cancel any time before then.
+3. **Setup** — your encryption keys are derived from your password on this device. Store the password somewhere safe; without it, your data cannot be recovered. SilentSuite has no way to reset it because the server never sees your keys.
 
-Self-hosting your own server? Expand **Advanced Settings** on the signup page and enter your server URL before submitting. See the [Self-Hosting guide](../self-hosting/) for the server side of that.
+After signup, an inline **Verify your email** banner stays at the top of the app until you click the link sent to your registered address. (No banner on self-hosted accounts.)
+
+Self-hosting your own server? Expand **Advanced Settings** on the signup page and enter your server URL before submitting. The flow becomes four steps (Account → Self-Hosting → Admin Setup → Setup) and skips the plan / billing entirely. See the [Self-Hosting guide](../self-hosting/) for the server side of that.
 
 ## 2. Add Your First Event
 

--- a/docs/user-guide/tasks.md
+++ b/docs/user-guide/tasks.md
@@ -8,7 +8,7 @@ Your tasks live at [app.silentsuite.io/tasks](https://app.silentsuite.io/tasks).
 2. Fill in:
    - Title (required)
    - Due date — a calendar day, or a specific date+time
-   - Priority — low / medium / high
+   - Priority — low / medium / high / urgent
    - Notes
 3. Save. The task is serialized to iCalendar (`VTODO`), encrypted, and synced.
 

--- a/docs/user-guide/tasks.md
+++ b/docs/user-guide/tasks.md
@@ -1,33 +1,46 @@
-# How to Manage Your Tasks
+# Tasks
 
-Your tasks are end-to-end encrypted. Only your devices can read them.
-
-<!-- TODO: Expand with specific UI walkthroughs once client apps are available -->
+Your tasks live at [app.silentsuite.io/tasks](https://app.silentsuite.io/tasks). Title, due date, priority, notes — every field is encrypted on your device before sync.
 
 ## Create a Task
 
-1. Open the Tasks view.
-2. Tap or click "Add Task."
-3. Enter the task details (title, due date, priority, notes).
-4. Save. The task is encrypted on your device and synced.
+1. Click **+ Add Task** or use the keyboard shortcut.
+2. Fill in:
+   - Title (required)
+   - Due date — a calendar day, or a specific date+time
+   - Priority — low / medium / high
+   - Notes
+3. Save. The task is serialized to iCalendar (`VTODO`), encrypted, and synced.
 
-## Complete a Task
+## Complete / Reopen
 
-1. Tap or click the checkbox next to the task.
-2. The completion status syncs across all your devices.
+Click the checkbox next to a task to mark it complete. The completion status (and timestamp) syncs across all your devices. Click again to reopen.
 
-## Edit a Task
+## Edit / Delete
 
-1. Open the task you want to change.
-2. Make your changes.
-3. Save. The updated task is re-encrypted and synced.
+Open a task, change its fields, save — or delete. Changes are re-encrypted and synced.
 
-## Delete a Task
+## Filter and Sort
 
-1. Open the task.
-2. Select delete.
-3. The deletion syncs across all your devices.
+The list can be filtered by completion state and sorted by due date or priority. Both run against your locally decrypted data.
 
-## Task Lists
+## Import
 
-<!-- TODO: Document task list/collection support -->
+**Settings → Import** accepts `.ics` files containing `VTODO` entries. Parsing is local-only.
+
+## Export
+
+**Settings → Export** gives you:
+
+- **Tasks (`.ics`)** — all tasks as a single iCalendar file with `VTODO` entries
+- **Everything (`.zip`)** — calendars, contacts, and tasks together
+
+## Bridge / DAV clients
+
+With the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge) installed, any CalDAV client that speaks `VTODO` can read and write the same tasks through `localhost:37358`.
+
+## Limits in this beta
+
+- A single default tasks collection per account. Managing multiple task lists is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
+- Date-only `DUE` values round-trip cleanly. Full timezone (`TZID`) preservation on date-time `DUE` values is being tightened up — see [issue #66](https://github.com/silent-suite/silentsuite/issues/66).
+- No subtasks or dependencies — a flat task list per collection.


### PR DESCRIPTION
## Summary

Replaces the placeholder user-guide pages flagged in #127 with grounded how-to docs covering what actually shipped in [v0.1.0-beta](https://github.com/silent-suite/silentsuite/releases/tag/v0.1.0-beta). The previous pages were a string of \`<!-- TODO -->\` stubs and didn't describe a single feature accurately.

Source-of-truth references used:
- The release notes (`silentsuite-internal/planning/_bmad-output/planning-artifacts/v0.1.0-beta-release-notes.md`)
- The signup flow at `apps/web/app/(auth)/signup/page.tsx` (4 steps, Monthly/Annual toggle, 30-day trial, Save 17%)
- The calendar store at `apps/web/app/stores/use-calendar-store.ts` (recurrence scopes: this / this-and-following / all)
- Settings → Mobile, Settings → Desktop, Settings → Import, Settings → Export pages

## What changed

- **getting-started.md** — 4-step signup, where to install on each device (web PWA, Android sideload, desktop bridge), iOS interim via EteSync app, sync confirmation steps.
- **calendar.md** — event CRUD, recurring-event edit/delete scope dialog, week / month / agenda / mini views, TZID preservation, ICS import/export, bridge access. Calls out the single-default-collection limit (#88).
- **contacts.md** — contact CRUD, local search, vCard 3.0/4.0 import/export, CardDAV via bridge. Calls out the single-default-collection limit (#88).
- **tasks.md** — VTODO CRUD, priority, due dates, completion checkbox, ICS task import/export. Honestly notes partial DUE TZID parity (#66) and single-default-collection limit (#88).
- **faq.md** — full rewrite: General / Privacy & Security / Self-Hosting / Apps & Devices. Replaces the \"iOS clients are planned\" stub with a pointer to the EteSync iOS app on the same Etebase protocol, and lists what's *not* in the beta with issue links.
- **README.md** — TOC + a surfaces section reflecting the four actual entry points (web, Android, desktop bridge, iOS-via-EteSync).

## Notes / decisions

- **Multi-collection** (\"multiple calendars / address books / task lists\") is *not* claimed as a v0.1.0-beta feature, despite the release notes' line about \"multiple collections per type.\" The web app provisions a single default collection per type (`Personal Calendar` / `Personal Tasks` / `Personal Contacts`) and there's no UI to manage more. The docs match what users can actually do, with a forward-link to #88.
- **Tasks DUE TZID parity** is described accurately: date-only DUE round-trips cleanly; date-time DUE TZID is being tightened in #66.
- The `encryption-explained.md` page is unchanged — it was already accurate.

## Test plan

- [ ] Read each page top-to-bottom; check no `<!-- TODO -->` comments remain.
- [ ] Walk the signup flow and the import/export/mobile/desktop settings pages and confirm the docs match.
- [ ] Spot-check Cloudflare Pages docs preview once it deploys.
- [ ] Skim for over-promises against the actual app (multi-collection, OAuth import, iOS app, push notifications — all should be on the not-yet list, not promised).

Closes #127