### PR TITLE
fix(android): relaunch AccountActivity from setup wizard (#119)

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -26,6 +26,7 @@ import io.silentsuite.sync.Constants.ETEBASE_TYPE_TASKS
 import io.silentsuite.sync.R
 import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.syncadapter.requestSync
+import io.silentsuite.sync.ui.AccountActivity
 import io.silentsuite.sync.ui.BaseActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CancellationException
@@ -54,6 +55,19 @@ class NewAccountWizardActivity : BaseActivity() {
                 replace(R.id.fragment_container, WizardCheckFragment())
             }
         }
+    }
+
+    // Issue #119: by the time this wizard finishes, LoginActivity, CreateAccountFragment,
+    // and ModeSelectionActivity have all already finish()ed up the back stack. Without an
+    // explicit relaunch, the task is left empty and the user is dropped to the home screen
+    // — indistinguishable from a crash. Re-launching AccountActivity (the LAUNCHER) keeps
+    // the user inside the app on the just-created account.
+    override fun finish() {
+        startActivity(
+            Intent(this, AccountActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+        super.finish()
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Fixes #119. The reported "first-login crash" is not actually a crash — there is no FATAL EXCEPTION, no native crash, no signal. After a successful login the activity chain

```
LoginActivity → CreateAccountFragment → ModeSelectionActivity → NewAccountWizardActivity
```

calls `finish()` at every step. By the time `NewAccountWizardActivity` exits, the task is empty and the user is dropped on the launcher home screen — visually indistinguishable from a crash.

## Root cause

`NewAccountWizardActivity` exits via `activity?.finish()` from three places:

- `WizardCheckFragment.checkAccountInit` when `collections.size > 0` (existing account path) — `NewAccountWizardActivity.kt:126`
- `WizardFragment.createCollections` after fresh-signup auto-create — line 211
- The skip button — line 168

In each case the underlying activities have already finished, so `finish()` empties the task instead of returning to a sensible screen.

## Fix

Override `NewAccountWizardActivity.finish()` to `startActivity(AccountActivity)` (the `LAUNCHER`) with `FLAG_ACTIVITY_CLEAR_TASK | FLAG_ACTIVITY_NEW_TASK` before calling `super.finish()`. The user lands on the just-created account view, which is what every code path was implicitly assuming.

+14 lines, single file: `android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt`.

## Relationship to PR #131

PR #131 (commit `c13f87b`, "Android: defensive patches for first-login crash (#119)") addressed a *different* failure mode under the same issue — uncaught JNI/IO exceptions in `createCollections`. This PR is complementary, not a replacement: #131 stops the wizard from throwing on a real failure; this PR stops a successful wizard run from looking like a crash.

## Logcat evidence

Pixel 9 / Android 16, app `v1.0.0-beta.1`, account `newmain@mailtear.com` with existing collections on the server:

```
09:53:00.317  DetectConfigurationFragment: Found Etebase account
09:53:00.325  CreateAccountFragment: addAccountExplicitly("newmain@…") ✓
09:53:00.443  ModeSelectionActivity launched, sets MODE_BRIDGE, finish()
09:53:00.488  StrictMode: WizardCheckFragment$checkAccountInit$1$collections$1
              → CollectionManager.list (native) → okhttp
09:53:01.462  NewAccountWizardActivity → invisible (finish() ran)
09:53:01.535  cert4android service destroyed
09:53:13      Launcher adds SilentSuite icon (post-account side effect)
09:53:16      User taps icon → AccountActivity opens, fully logged in
```

No FATAL EXCEPTION, no `killProcess`, no signal — pid 28571 stayed alive throughout. That is the smoking gun: the "crash" is the empty-task drop.

## Test plan

- [ ] Rebuild `:app:assembleStandardDebug` and install on a connected device
- [ ] `adb shell pm clear io.silentsuite.sync` → open → log in
- [ ] Confirm `AccountActivity` opens immediately after the wizard exits, instead of the home screen
- [ ] Repeat with an account that has no collections yet (fresh-signup path through `createCollections`)
- [ ] Repeat with the skip button