### PR TITLE
mobile: route QR code through docs install guide; add Obtainium

### DIFF
--- a/apps/docs/user-guide/apps/android.md
+++ b/apps/docs/user-guide/apps/android.md
@@ -8,9 +8,26 @@ Once set up, your SilentSuite data syncs directly into Android's system calendar
 
 ## Install
 
-Download the **SilentSuite** Android app:
+Choose one of the install options below. Both deliver the same APK from the same GitHub release.
 
-- [GitHub (APK)](https://github.com/silent-suite/silentsuite/releases) -- download the latest release APK from the monorepo.
+### Option 1: Obtainium (recommended)
+
+[Obtainium](https://github.com/ImranR98/Obtainium) is an open-source Android app that installs and auto-updates apps directly from their GitHub releases -- no Google Play, no tracking, no account needed.
+
+1. Install Obtainium from [GitHub Releases](https://github.com/ImranR98/Obtainium/releases) or [F-Droid](https://f-droid.org/packages/dev.imranr.obtainium.fdroid/).
+2. In Obtainium, tap **Add App** and paste this URL:
+   ```
+   https://github.com/silent-suite/silentsuite
+   ```
+3. Obtainium will detect the latest SilentSuite release and install the APK. It will notify you whenever a new release is published.
+
+### Option 2: Direct APK download
+
+Grab the latest APK directly from GitHub Releases:
+
+- [github.com/silent-suite/silentsuite/releases/latest](https://github.com/silent-suite/silentsuite/releases/latest)
+
+Look for the asset named `silentsuite-android-vX.Y.Z-beta.apk` and install it. You'll need to allow installation from unknown sources the first time.
 
 ::: tip
 The SilentSuite Android app is a fork of the [EteSync Android app](https://github.com/etesync/android) with SilentSuite branding and `server.silentsuite.io` pre-configured as the default server. If you prefer, the original EteSync app from [Google Play](https://play.google.com/store/apps/details?id=com.etesync.syncadapter) or [F-Droid](https://f-droid.org/packages/com.etesync.syncadapter/) also works -- just enter the SilentSuite server URL manually.

--- a/apps/web/app/(app)/settings/mobile/page.tsx
+++ b/apps/web/app/(app)/settings/mobile/page.tsx
@@ -8,8 +8,6 @@ const INSTALL_DOCS_URL = 'https://docs.silentsuite.io/user-guide/apps/android'
 const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
 
 export default function MobileSettingsPage() {
-  const docsUrl = INSTALL_DOCS_URL
-
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -64,7 +62,7 @@ export default function MobileSettingsPage() {
 
         <div className="flex flex-col gap-2">
           <a
-            href={docsUrl}
+            href={INSTALL_DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"

--- a/apps/web/app/(app)/settings/mobile/page.tsx
+++ b/apps/web/app/(app)/settings/mobile/page.tsx
@@ -4,15 +4,11 @@ import { Smartphone, ExternalLink, Monitor } from 'lucide-react'
 import Link from 'next/link'
 import { QRCodeSVG } from 'qrcode.react'
 
-// TODO: make this version-dynamic at build time (see issue #116) — currently
-// the version-pinned filename will break when the umbrella tag bumps past
-// v0.1.0-beta. Tracked as the "approach 2" follow-up in #116.
-const APK_DOWNLOAD_URL =
-  'https://github.com/silent-suite/silentsuite/releases/latest/download/silentsuite-android-v0.1.0-beta.apk'
+const INSTALL_DOCS_URL = 'https://docs.silentsuite.io/user-guide/apps/android'
 const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
 
 export default function MobileSettingsPage() {
-  const docsUrl = 'https://docs.silentsuite.io/mobile'
+  const docsUrl = INSTALL_DOCS_URL
 
   return (
     <div className="space-y-6">
@@ -30,18 +26,18 @@ export default function MobileSettingsPage() {
         <div className="flex flex-col items-center gap-4">
           <div className="flex h-48 w-48 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-white p-3">
             <QRCodeSVG
-              value={APK_DOWNLOAD_URL}
+              value={INSTALL_DOCS_URL}
               size={168}
               level="M"
               marginSize={0}
-              aria-label="QR code linking to the latest SilentSuite Android APK"
+              aria-label="QR code linking to the SilentSuite Android install guide"
             />
           </div>
           <p className="text-sm text-[rgb(var(--foreground))] font-medium">
             Scan with your phone camera
           </p>
           <p className="text-xs text-[rgb(var(--muted))] text-center">
-            The QR code links to the latest SilentSuite Android APK.
+            The QR code opens the install guide with options for Obtainium (auto-updates) or a direct APK download.
           </p>
           <a
             href={RELEASES_URL}
@@ -49,7 +45,7 @@ export default function MobileSettingsPage() {
             rel="noopener noreferrer"
             className="text-xs text-[rgb(var(--primary))] hover:underline"
           >
-            Or download manually from GitHub Releases
+            Or jump straight to GitHub Releases
           </a>
         </div>
       </div>

--- a/apps/web/app/components/MobileAppDialog.tsx
+++ b/apps/web/app/components/MobileAppDialog.tsx
@@ -25,7 +25,7 @@ export function MobileAppDialog({ open, onClose }: MobileAppDialogProps) {
 
   // Generate a simple QR-code-like placeholder using CSS
   // In production, you'd use a QR code library or pre-generated image
-  const downloadUrl = 'https://docs.silentsuite.io/user-guide/apps/android'
+  const installGuideUrl = 'https://docs.silentsuite.io/user-guide/apps/android'
 
   return (
     <>
@@ -85,7 +85,7 @@ export function MobileAppDialog({ open, onClose }: MobileAppDialogProps) {
             {/* Links */}
             <div className="space-y-2">
               <a
-                href={downloadUrl}
+                href={installGuideUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex w-full items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"

--- a/apps/web/app/components/MobileAppDialog.tsx
+++ b/apps/web/app/components/MobileAppDialog.tsx
@@ -25,7 +25,7 @@ export function MobileAppDialog({ open, onClose }: MobileAppDialogProps) {
 
   // Generate a simple QR-code-like placeholder using CSS
   // In production, you'd use a QR code library or pre-generated image
-  const downloadUrl = 'https://docs.silentsuite.io/mobile'
+  const downloadUrl = 'https://docs.silentsuite.io/user-guide/apps/android'
 
   return (
     <>


### PR DESCRIPTION
## Summary

- The Connect Mobile QR code (Settings → Mobile) encoded a version-pinned APK URL (`silentsuite-android-v0.1.0-beta.apk`) that 404s on every release bump. Tracked in #129; the inline TODO in `settings/mobile/page.tsx` referenced it as `#116`.
- Two dialog links pointed at `https://docs.silentsuite.io/mobile`, which 404s — the actual page is `/user-guide/apps/android`.
- Closes #129 by sidestepping the build-time URL resolution: the QR now points at the docs install guide (a stable URL that survives version bumps), and the docs page lists install options.

## Changes

- `apps/docs/user-guide/apps/android.md`: rewrite the Install section into two clearly-labelled options:
  - **Option 1 — Obtainium** (recommended): paste the GitHub repo URL, get auto-updates without Play Store / tracking.
  - **Option 2 — Direct APK download**: GitHub Releases.
- `apps/web/app/(app)/settings/mobile/page.tsx`: QR now encodes `https://docs.silentsuite.io/user-guide/apps/android`. Dropped the version-pinned `APK_DOWNLOAD_URL` constant and its TODO. Updated body copy to mention both Obtainium and APK options.
- `apps/web/app/components/MobileAppDialog.tsx`: fix the broken `/mobile` link (was 404'ing) to the same canonical guide URL.

## Why this approach over #129's "resolve at build time"

- QR code becomes immutable — printed materials, screenshots, blog posts all keep working across releases.
- Mobile users land on a real install page where Obtainium is the right default for the privacy-minded crowd.
- Less code, no build-time GitHub API call, no Cloudflare Pages SSG dependency.

## Test plan

- [ ] On preview, scan the QR with a phone — confirm it opens the Android install guide on docs.silentsuite.io.
- [ ] In OnboardingChecklist's mobile dialog, click "View setup instructions" — confirm it lands on the install guide (not 404).
- [ ] In Obtainium, paste `https://github.com/silent-suite/silentsuite` and confirm it picks up the latest release APK.
- [ ] Visual check that the docs Install section renders both options cleanly (VitePress code fences, headings).