### PR TITLE
Release: v0.1.1-beta (dev → main)

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/EtebaseLocalCache.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/EtebaseLocalCache.kt
@@ -5,12 +5,20 @@ import com.etebase.client.*
 import com.etebase.client.Collection
 import com.etebase.client.exceptions.EtebaseException
 import com.etebase.client.exceptions.UrlParseException
+import io.silentsuite.sync.log.Logger
 import okhttp3.OkHttpClient
 import java.io.File
 import java.util.*
 
 class EtebaseLocalCache private constructor(context: Context, username: String) {
-    private val fsCache: FileSystemCache = FileSystemCache.create(context.filesDir.absolutePath, username)
+    // Issue #119: log the resolved filesDir + username before the JNI FileSystemCache.create
+    // call. Native errors here don't propagate as EtebaseException, so without this breadcrumb
+    // a mangled username (e.g. one containing '@' or '.') is invisible from logcat alone.
+    private val fsCache: FileSystemCache = run {
+        val filesDirPath = context.filesDir.absolutePath
+        Logger.log.info("FileSystemCache.create filesDir=$filesDirPath username=$username")
+        FileSystemCache.create(filesDirPath, username)
+    }
     private val filesDir: File = File(context.filesDir, username)
     private val colsDir: File = File(filesDir, "cols")
 
@@ -129,7 +137,29 @@ class EtebaseLocalCache private constructor(context: Context, username: String) 
             // caller and fall back to the persisted value only if one wasn't supplied.
             val session = sessionOverride
                 ?: settings.etebaseSession
-                ?: throw IllegalStateException("Etebase session is null for account ${settings.account.name}")
+                ?: run {
+                    // Issue #119: distinguish "userData not yet flushed" (sessionOverride was
+                    // not provided AND persisted session is missing) from "session genuinely
+                    // missing." Logging the userData keys also surfaces partial-state account
+                    // collisions where the Android account row exists but setUserData hasn't
+                    // landed yet.
+                    // AccountSettings's key constants are private; keep this list in sync with
+                    // AccountSettings.companion. Logging only the *names* of keys present (not
+                    // values) avoids leaking session tokens or URIs into the log file.
+                    val accountManager = android.accounts.AccountManager.get(context)
+                    val userDataKeys = listOf(
+                        "version",
+                        "uri",
+                        "user_name",
+                        "etebase_session",
+                    ).filter { accountManager.getUserData(settings.account, it) != null }
+                    Logger.log.severe(
+                        "Etebase session is null: account=${settings.account.name} " +
+                                "sessionOverrideProvided=${sessionOverride != null} " +
+                                "userDataKeys=$userDataKeys"
+                    )
+                    throw IllegalStateException("Etebase session is null for account ${settings.account.name}")
+                }
             return Account.restore(client, session, null)
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -634,16 +634,26 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         private fun doLoad(): AccountActivity.AccountInfo {
             val info = AccountActivity.AccountInfo()
             val settings: AccountSettings
+            val etebaseLocalCache: EtebaseLocalCache
+            val colMgr: CollectionManager
             try {
                 settings = AccountSettings(context, account)
+                etebaseLocalCache = EtebaseLocalCache.getInstance(context, account.name)
+                val httpClient = HttpClient.Builder(context).build().okHttpClient
+                // Issue #119: getEtebase throws IllegalStateException when userData hasn't yet
+                // propagated (first-login race) or when the persisted session is genuinely
+                // missing. Previously this propagated to viewModelScope.launch and crashed the
+                // app via the default uncaught-exception handler. Return an empty AccountInfo
+                // so the UI shows nothing rather than dying.
+                val etebase = EtebaseLocalCache.getEtebase(context, httpClient, settings)
+                colMgr = etebase.collectionManager
             } catch (e: InvalidAccountException) {
                 return info
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                Logger.log.log(Level.SEVERE, "AccountInfoViewModel.doLoad failed for ${account.name}", e)
+                return info
             }
-
-            val etebaseLocalCache = EtebaseLocalCache.getInstance(context, account.name)
-            val httpClient = HttpClient.Builder(context).build().okHttpClient
-            val etebase = EtebaseLocalCache.getEtebase(context, httpClient, settings)
-            val colMgr = etebase.collectionManager
 
             info.carddav = AccountInfo.ServiceInfo()
             info.carddav!!.refreshing = ContentResolver.isSyncActive(account, App.addressBooksAuthority)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -24,12 +24,15 @@ import io.silentsuite.sync.Constants.ETEBASE_TYPE_ADDRESS_BOOK
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_CALENDAR
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_TASKS
 import io.silentsuite.sync.R
+import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.syncadapter.requestSync
 import io.silentsuite.sync.ui.BaseActivity
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
 
 class NewAccountWizardActivity : BaseActivity() {
     private lateinit var account: Account
@@ -206,7 +209,14 @@ class WizardFragment : Fragment() {
                     requestSync(requireContext(), accountHolder.account)
                 }
                 activity?.finish()
-            } catch (e: EtebaseException) {
+            } catch (e: Exception) {
+                // Cooperate with structured concurrency — never swallow cancellation.
+                if (e is CancellationException) throw e
+                // Issue #119: previously only EtebaseException was caught, so JNI/IO/IllegalState
+                // failures from the very first FS-cache write escaped the coroutine and crashed
+                // the app via the default uncaught-exception handler. Log first so the next
+                // logcat capture pinpoints the failure class even if the dialog is dismissed.
+                Logger.log.severe("createCollections failed: ${e.javaClass.name}: ${e.message}")
                 reportErrorHelper(requireContext(), e)
             } finally {
                 loadingModel.setLoading(false)
@@ -218,8 +228,21 @@ class WizardFragment : Fragment() {
         val etebaseLocalCache = accountHolder.etebaseLocalCache
         val colMgr = accountHolder.colMgr
         colMgr.upload(col)
-        synchronized(etebaseLocalCache) {
-            etebaseLocalCache.collectionSet(colMgr, col)
+        try {
+            synchronized(etebaseLocalCache) {
+                etebaseLocalCache.collectionSet(colMgr, col)
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            // Issue #119: this is the very first on-disk Etebase write per username. If the
+            // per-username cols/<colUid>/items directory creation fails, surface enough detail
+            // to disambiguate the cause before the exception propagates up to createCollections.
+            val colsPath = File(File(requireContext().filesDir, accountHolder.account.name), "cols").absolutePath
+            Logger.log.severe(
+                "etebaseLocalCache.collectionSet failed for colUid=${col.uid} path=$colsPath: " +
+                        "${e.javaClass.name}: ${e.message}"
+            )
+            throw e
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -26,6 +26,7 @@ import io.silentsuite.sync.Constants.ETEBASE_TYPE_TASKS
 import io.silentsuite.sync.R
 import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.syncadapter.requestSync
+import io.silentsuite.sync.ui.AccountActivity
 import io.silentsuite.sync.ui.BaseActivity
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CancellationException
@@ -54,6 +55,19 @@ class NewAccountWizardActivity : BaseActivity() {
                 replace(R.id.fragment_container, WizardCheckFragment())
             }
         }
+    }
+
+    // Issue #119: by the time this wizard finishes, LoginActivity, CreateAccountFragment,
+    // and ModeSelectionActivity have all already finish()ed up the back stack. Without an
+    // explicit relaunch, the task is left empty and the user is dropped to the home screen
+    // — indistinguishable from a crash. Re-launching AccountActivity (the LAUNCHER) keeps
+    // the user inside the app on the just-created account.
+    override fun finish() {
+        startActivity(
+            Intent(this, AccountActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+        super.finish()
     }
 
     companion object {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
@@ -48,6 +48,14 @@ class CreateAccountFragment : DialogFragment() {
             // isn't always visible to the next activity's read on the first login.
             startActivity(ModeSelectionActivity.newIntent(requireContext(), account, config.etebaseSession))
             activity.finish()
+        } else {
+            // Issue #119: addAccountExplicitly returned false (e.g. partial-state collision
+            // with a previously removed account row that AccountManager hasn't fully
+            // garbage-collected). Previously this branch silently no-op'd, leaving the user
+            // staring at a frozen "setting up encryption" progress dialog. Log the failure
+            // and dismiss the dialog so the operator notices and the user can retry.
+            Logger.log.log(Level.SEVERE, "addAccountExplicitly returned false for ${config.userName}")
+            dismissAllowingStateLoss()
         }
     }
 

--- a/apps/docs/user-guide/apps/android.md
+++ b/apps/docs/user-guide/apps/android.md
@@ -8,9 +8,26 @@ Once set up, your SilentSuite data syncs directly into Android's system calendar
 
 ## Install
 
-Download the **SilentSuite** Android app:
+Choose one of the install options below. Both deliver the same APK from the same GitHub release.
 
-- [GitHub (APK)](https://github.com/silent-suite/silentsuite/releases) -- download the latest release APK from the monorepo.
+### Option 1: Obtainium (recommended)
+
+[Obtainium](https://github.com/ImranR98/Obtainium) is an open-source Android app that installs and auto-updates apps directly from their GitHub releases -- no Google Play, no tracking, no account needed.
+
+1. Install Obtainium from [GitHub Releases](https://github.com/ImranR98/Obtainium/releases) or [F-Droid](https://f-droid.org/packages/dev.imranr.obtainium.fdroid/).
+2. In Obtainium, tap **Add App** and paste this URL:
+   ```
+   https://github.com/silent-suite/silentsuite
+   ```
+3. Obtainium will detect the latest SilentSuite release and install the APK. It will notify you whenever a new release is published.
+
+### Option 2: Direct APK download
+
+Grab the latest APK directly from GitHub Releases:
+
+- [github.com/silent-suite/silentsuite/releases/latest](https://github.com/silent-suite/silentsuite/releases/latest)
+
+Look for the asset named `silentsuite-android-vX.Y.Z-beta.apk` and install it. You'll need to allow installation from unknown sources the first time.
 
 ::: tip
 The SilentSuite Android app is a fork of the [EteSync Android app](https://github.com/etesync/android) with SilentSuite branding and `server.silentsuite.io` pre-configured as the default server. If you prefer, the original EteSync app from [Google Play](https://play.google.com/store/apps/details?id=com.etesync.syncadapter) or [F-Droid](https://f-droid.org/packages/com.etesync.syncadapter/) also works -- just enter the SilentSuite server URL manually.

--- a/apps/web/app/(app)/admin/admin-dashboard.tsx
+++ b/apps/web/app/(app)/admin/admin-dashboard.tsx
@@ -23,6 +23,11 @@ import {
   TrendingUp,
   Mail,
   Loader2,
+  Database,
+  Zap,
+  CheckCircle2,
+  XCircle,
+  ArrowRight,
 } from 'lucide-react'
 import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
 
@@ -159,6 +164,40 @@ function daysSince(iso: string): number {
   return Math.floor((Date.now() - new Date(iso).getTime()) / 86_400_000)
 }
 
+function relativeTime(from: number | null, now: number): string {
+  if (from == null) return '—'
+  const seconds = Math.max(0, Math.round((now - from) / 1000))
+  if (seconds < 5) return 'just now'
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+// Re-renders every 5s so "Updated Xs ago" labels stay live.
+function useNowTick(intervalMs = 5000): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), intervalMs)
+    return () => clearInterval(id)
+  }, [intervalMs])
+  return now
+}
+
+function FreshnessPill({ fetchedAt, ok = true, now }: { fetchedAt: number | null; ok?: boolean; now: number }) {
+  const label = relativeTime(fetchedAt, now)
+  const stale = fetchedAt != null && now - fetchedAt > 5 * 60_000
+  const tone = !ok ? 'text-red-400' : stale ? 'text-amber-500' : 'text-[rgb(var(--muted))]'
+  return (
+    <span className={`inline-flex items-center gap-1 text-[10px] font-medium ${tone}`}>
+      <Clock className="h-2.5 w-2.5" />
+      {label}
+    </span>
+  )
+}
+
 function StatusBadge({ status }: { status: string }) {
   const config: Record<string, { bg: string; text: string; label: string }> = {
     active: { bg: 'bg-emerald-500/10', text: 'text-emerald-500', label: 'Active' },
@@ -258,7 +297,7 @@ export default function AdminDashboard() {
         ))}
       </div>
 
-      {activeTab === 'overview' && (isSelfHosted ? <SelfHostedOverviewTab /> : <OverviewTab />)}
+      {activeTab === 'overview' && (isSelfHosted ? <SelfHostedOverviewTab /> : <OverviewTab onNavigate={setActiveTab} />)}
       {activeTab === 'payments' && !isSelfHosted && <FailedPaymentsTab />}
       {activeTab === 'users' && (isSelfHosted ? <SelfHostedUsersTab /> : <UserLookupTab />)}
       {activeTab === 'subscribers' && !isSelfHosted && <SubscribersTab />}
@@ -272,8 +311,48 @@ export default function AdminDashboard() {
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 function SelfHostedOverviewTab() {
+  const now = useNowTick()
+  const [etebaseStatus, setEtebaseStatus] = useState<'checking' | 'ok' | 'error'>('checking')
+  const [etebaseAt, setEtebaseAt] = useState<number | null>(null)
+
+  const pingEtebase = useCallback(async () => {
+    setEtebaseStatus('checking')
+    try {
+      const res = await fetch(ETEBASE_SERVER_URL, { method: 'GET', mode: 'no-cors' })
+      setEtebaseStatus(res.ok || res.type === 'opaque' ? 'ok' : 'error')
+    } catch {
+      setEtebaseStatus('error')
+    }
+    setEtebaseAt(Date.now())
+  }, [])
+
+  useEffect(() => { pingEtebase() }, [pingEtebase])
+
+  const ok = etebaseStatus === 'ok'
+
   return (
     <div className="space-y-6">
+      {/* Status bar */}
+      <div className="flex flex-col gap-3 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+          <div className="flex items-center gap-2">
+            <span
+              className={`h-2.5 w-2.5 rounded-full ${ok ? 'bg-emerald-500' : etebaseStatus === 'checking' ? 'bg-[rgb(var(--muted))] animate-pulse' : 'bg-red-400'}`}
+            />
+            <span className={`text-xs font-medium ${ok ? 'text-emerald-500' : etebaseStatus === 'checking' ? 'text-[rgb(var(--muted))]' : 'text-red-400'}`}>
+              {ok ? 'Etebase reachable' : etebaseStatus === 'checking' ? 'Checking…' : 'Etebase unreachable'}
+            </span>
+          </div>
+          <FreshnessPill fetchedAt={etebaseAt} ok={ok} now={now} />
+        </div>
+        <button
+          onClick={pingEtebase}
+          className="flex items-center gap-1.5 self-start rounded-md border border-[rgb(var(--border))] px-3 py-1.5 text-xs text-[rgb(var(--muted))] hover:border-[rgb(var(--primary))] hover:text-[rgb(var(--foreground))] transition-colors sm:self-auto"
+        >
+          <RefreshCw className={`h-3 w-3 ${etebaseStatus === 'checking' ? 'animate-spin' : ''}`} /> Re-check
+        </button>
+      </div>
+
       {/* Instance Info Card */}
       <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-5">
         <div className="flex items-center gap-3 mb-4">
@@ -486,16 +565,33 @@ function SelfHostedHealthTab() {
 // SaaS Tabs
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-// ─── Overview Tab ─────────────────────────────────────────────────────
-function OverviewTab() {
+// ─── Overview Tab — single-pane landing for all admin signals ─────────
+function OverviewTab({ onNavigate }: { onNavigate: (tab: string) => void }) {
+  const now = useNowTick()
+
   const [metrics, setMetrics] = useState<Metrics | null>(null)
   const [metricsLoading, setMetricsLoading] = useState(true)
   const [metricsError, setMetricsError] = useState<string | null>(null)
-  const [events, setEvents] = useState<EventsPage | null>(null)
-  const [eventsLoading, setEventsLoading] = useState(true)
+  const [metricsAt, setMetricsAt] = useState<number | null>(null)
+
+  const [health, setHealth] = useState<Health | null>(null)
+  const [healthError, setHealthError] = useState<string | null>(null)
+  const [healthAt, setHealthAt] = useState<number | null>(null)
+
+  const [events, setEvents] = useState<WebhookEvent[]>([])
+  const [eventsTotal, setEventsTotal] = useState<number>(0)
   const [eventsError, setEventsError] = useState<string | null>(null)
-  const [eventsOffset, setEventsOffset] = useState(0)
-  const eventsLimit = 20
+  const [eventsAt, setEventsAt] = useState<number | null>(null)
+
+  const [recentSignups, setRecentSignups] = useState<UserListItem[]>([])
+  const [recentTotal, setRecentTotal] = useState<number>(0)
+  const [recentError, setRecentError] = useState<string | null>(null)
+  const [recentAt, setRecentAt] = useState<number | null>(null)
+
+  const [contacts, setContacts] = useState<Subscriber[]>([])
+  const [contactsTotal, setContactsTotal] = useState<number>(0)
+  const [contactsError, setContactsError] = useState<string | null>(null)
+  const [contactsAt, setContactsAt] = useState<number | null>(null)
 
   const fetchMetrics = useCallback(async () => {
     setMetricsError(null)
@@ -503,43 +599,156 @@ function OverviewTab() {
       const res = await adminFetch(`${BILLING_API_URL}/admin/metrics`)
       if (res.ok) {
         setMetrics(await res.json())
+        setMetricsAt(Date.now())
       } else {
         setMetricsError('Failed to load metrics')
       }
     } catch {
-      setMetricsError('Failed to load metrics — API unavailable')
+      setMetricsError('API unavailable')
     }
     setMetricsLoading(false)
   }, [])
 
-  const fetchEvents = useCallback(async (offset: number) => {
-    setEventsLoading(true)
+  const fetchHealth = useCallback(async () => {
+    setHealthError(null)
+    try {
+      const res = await adminFetch(`${BILLING_API_URL}/admin/health`)
+      if (res.ok) {
+        setHealth(await res.json())
+        setHealthAt(Date.now())
+      } else {
+        setHealthError('Failed to load health')
+      }
+    } catch {
+      setHealthError('API unavailable')
+    }
+  }, [])
+
+  const fetchEvents = useCallback(async () => {
     setEventsError(null)
     try {
-      const res = await adminFetch(
-        `${BILLING_API_URL}/admin/events?limit=${eventsLimit}&offset=${offset}`,
-      )
+      const res = await adminFetch(`${BILLING_API_URL}/admin/events?limit=5&offset=0`)
       if (res.ok) {
-        setEvents(await res.json())
+        const data: EventsPage = await res.json()
+        setEvents(data.events)
+        setEventsTotal(data.total)
+        setEventsAt(Date.now())
       } else {
         setEventsError('Failed to load events')
       }
     } catch {
-      setEventsError('Failed to load events — API unavailable')
+      setEventsError('API unavailable')
     }
-    setEventsLoading(false)
-  }, [eventsLimit])
+  }, [])
 
-  useEffect(() => { fetchMetrics() }, [fetchMetrics])
-  useEffect(() => { fetchEvents(eventsOffset) }, [fetchEvents, eventsOffset])
+  const fetchRecentSignups = useCallback(async () => {
+    setRecentError(null)
+    try {
+      const res = await adminFetch(`${BILLING_API_URL}/admin/users?limit=5&offset=0`)
+      if (res.ok) {
+        const data: UsersPage = await res.json()
+        setRecentSignups(data.users)
+        setRecentTotal(data.total)
+        setRecentAt(Date.now())
+      } else {
+        setRecentError('Failed to load users')
+      }
+    } catch {
+      setRecentError('API unavailable')
+    }
+  }, [])
+
+  const fetchContacts = useCallback(async () => {
+    setContactsError(null)
+    try {
+      const res = await adminFetch(`${BILLING_API_URL}/admin/contacts?limit=5&offset=0`)
+      if (res.ok) {
+        const data = await res.json()
+        setContacts(data.contacts ?? [])
+        setContactsTotal(typeof data.total === 'number' ? data.total : (data.contacts?.length ?? 0))
+        setContactsAt(Date.now())
+      } else {
+        setContactsError('Failed to load contacts')
+      }
+    } catch {
+      setContactsError('API unavailable')
+    }
+  }, [])
+
+  const refreshAll = useCallback(() => {
+    fetchMetrics()
+    fetchHealth()
+    fetchEvents()
+    fetchRecentSignups()
+    fetchContacts()
+  }, [fetchMetrics, fetchHealth, fetchEvents, fetchRecentSignups, fetchContacts])
+
+  useEffect(() => { refreshAll() }, [refreshAll])
 
   const totalUsers = metrics
     ? metrics.subscribers.active + metrics.subscribers.trialing + metrics.subscribers.past_due + metrics.subscribers.cancelled + metrics.subscribers.none
     : 0
 
+  const dbOk = health?.database === 'ok'
+  const apiUp = !!health || !!metrics
+  const pastDue = metrics?.subscribers.past_due ?? 0
+
   return (
     <div className="space-y-6">
-      {/* Quick Stats Cards */}
+      {/* System Status Bar */}
+      <div className="flex flex-col gap-3 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+          <div className="flex items-center gap-2">
+            <span
+              className={`h-2.5 w-2.5 rounded-full ${apiUp ? 'bg-emerald-500' : 'bg-red-400'} ${apiUp ? '' : 'animate-pulse'}`}
+              title={apiUp ? 'API up' : 'API unreachable'}
+            />
+            <span className={`text-xs font-medium ${apiUp ? 'text-emerald-500' : 'text-red-400'}`}>
+              {apiUp ? 'API up' : 'API unreachable'}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Database className={`h-3.5 w-3.5 ${health == null ? 'text-[rgb(var(--muted))]' : dbOk ? 'text-emerald-500' : 'text-red-400'}`} />
+            <span className="text-xs text-[rgb(var(--muted))]">
+              DB <span className={health == null ? 'text-[rgb(var(--muted))]' : dbOk ? 'text-emerald-500' : 'text-red-400'}>
+                {health == null ? '…' : dbOk ? 'connected' : 'error'}
+              </span>
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Zap className="h-3.5 w-3.5 text-[rgb(var(--muted))]" />
+            <span className="text-xs text-[rgb(var(--muted))]">
+              Uptime <span className="text-[rgb(var(--foreground))]">{health ? formatUptime(health.uptime) : '—'}</span>
+            </span>
+          </div>
+          <FreshnessPill fetchedAt={healthAt} ok={dbOk && !healthError} now={now} />
+        </div>
+        <button
+          onClick={refreshAll}
+          className="flex items-center gap-1.5 self-start rounded-md border border-[rgb(var(--border))] px-3 py-1.5 text-xs text-[rgb(var(--muted))] hover:border-[rgb(var(--primary))] hover:text-[rgb(var(--foreground))] transition-colors sm:self-auto"
+        >
+          <RefreshCw className="h-3 w-3" /> Refresh all
+        </button>
+      </div>
+
+      {/* Past-due banner — only when there's something to act on */}
+      {pastDue > 0 && (
+        <button
+          onClick={() => onNavigate('payments')}
+          className="flex w-full items-center gap-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-left transition-colors hover:border-amber-500/60"
+        >
+          <AlertTriangle className="h-5 w-5 shrink-0 text-amber-500" />
+          <div className="flex-1">
+            <p className="text-sm font-medium text-amber-500">
+              {pastDue} past-due {pastDue === 1 ? 'subscriber' : 'subscribers'}
+            </p>
+            <p className="text-xs text-amber-500/80">Payment failed — likely needs follow-up</p>
+          </div>
+          <ArrowRight className="h-4 w-4 text-amber-500" />
+        </button>
+      )}
+
+      {/* KPI tiles */}
       {metricsLoading ? (
         <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
           {Array.from({ length: 4 }).map((_, i) => (
@@ -550,176 +759,420 @@ function OverviewTab() {
           ))}
         </div>
       ) : metrics ? (
-        <>
-          {/* Quick Stats Row */}
-          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-            <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
-              <div className="flex items-center gap-2">
-                <Users className="h-4 w-4 text-[rgb(var(--muted))]" />
-                <p className="text-xs text-[rgb(var(--muted))]">Total Users</p>
-              </div>
-              <p className="mt-1 text-2xl font-bold text-[rgb(var(--foreground))]">{totalUsers}</p>
-            </div>
-            <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
-              <div className="flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-emerald-500" />
-                <p className="text-xs text-[rgb(var(--muted))]">Active Subscribers</p>
-              </div>
-              <p className="mt-1 text-2xl font-bold text-emerald-500">{metrics.subscribers.active}</p>
-            </div>
-            <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
-              <div className="flex items-center gap-2">
-                <DollarSign className="h-4 w-4 text-[rgb(var(--primary))]" />
-                <p className="text-xs text-[rgb(var(--muted))]">MRR</p>
-              </div>
-              <p className="mt-1 text-2xl font-bold text-[rgb(var(--foreground))]">${metrics.mrr.toFixed(2)}</p>
-            </div>
-            <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
-              <div className="flex items-center gap-2">
-                <UserPlus className="h-4 w-4 text-blue-400" />
-                <p className="text-xs text-[rgb(var(--muted))]">Signups Today</p>
-              </div>
-              <p className="mt-1 text-2xl font-bold text-[rgb(var(--foreground))]">{metrics.signups.today}</p>
-            </div>
-          </div>
-
-          {/* MRR Card with Subscriber Breakdown */}
-          <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-5">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[rgb(var(--primary))]/10">
-                <CreditCard className="h-5 w-5 text-[rgb(var(--primary))]" />
-              </div>
-              <div>
-                <p className="text-xs text-[rgb(var(--muted))]">Monthly Recurring Revenue</p>
-                <p className="text-2xl font-bold text-[rgb(var(--foreground))]">
-                  ${metrics.mrr.toFixed(2)}
-                </p>
-              </div>
-            </div>
-
-            {/* Subscriber breakdown */}
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
-              {([
-                { label: 'Active', value: metrics.subscribers.active, color: 'text-emerald-500', bg: 'bg-emerald-500' },
-                { label: 'Trialing', value: metrics.subscribers.trialing, color: 'text-blue-400', bg: 'bg-blue-400' },
-                { label: 'Past Due', value: metrics.subscribers.past_due, color: 'text-amber-500', bg: 'bg-amber-500' },
-                { label: 'Cancelled', value: metrics.subscribers.cancelled, color: 'text-red-400', bg: 'bg-red-400' },
-                { label: 'No Plan', value: metrics.subscribers.none, color: 'text-[rgb(var(--muted))]', bg: 'bg-[rgb(var(--muted))]' },
-              ] as const).map(({ label, value, color, bg }) => (
-                <div key={label} className="flex items-center gap-3 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2">
-                  <div className={`h-2 w-2 rounded-full ${bg}`} />
-                  <div>
-                    <p className="text-xs text-[rgb(var(--muted))]">{label}</p>
-                    <p className={`text-lg font-semibold ${color}`}>{value}</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-
-          {/* Signups */}
-          <div className="grid grid-cols-3 gap-3">
-            {([
-              { label: 'Signups Today', value: metrics.signups.today },
-              { label: 'This Week', value: metrics.signups.thisWeek },
-              { label: 'This Month', value: metrics.signups.thisMonth },
-            ] as const).map(({ label, value }) => (
-              <div
-                key={label}
-                className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4"
-              >
-                <div className="flex items-center gap-2">
-                  <UserPlus className="h-4 w-4 text-[rgb(var(--muted))]" />
-                  <p className="text-xs text-[rgb(var(--muted))]">{label}</p>
-                </div>
-                <p className="mt-1 text-xl font-semibold text-[rgb(var(--foreground))]">{value}</p>
-              </div>
-            ))}
-          </div>
-        </>
-      ) : metricsError ? (
-        <p className="text-sm text-red-400">{metricsError}</p>
+        <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+          <KpiTile
+            label="Total Users"
+            value={totalUsers}
+            icon={<Users className="h-4 w-4 text-[rgb(var(--muted))]" />}
+            onDrill={() => onNavigate('users')}
+            fetchedAt={metricsAt}
+            now={now}
+          />
+          <KpiTile
+            label="Active Subscribers"
+            value={metrics.subscribers.active}
+            valueClass="text-emerald-500"
+            icon={<TrendingUp className="h-4 w-4 text-emerald-500" />}
+            onDrill={() => onNavigate('users')}
+            fetchedAt={metricsAt}
+            now={now}
+          />
+          <KpiTile
+            label="MRR"
+            value={`€${metrics.mrr.toFixed(2)}`}
+            icon={<DollarSign className="h-4 w-4 text-[rgb(var(--primary))]" />}
+            fetchedAt={metricsAt}
+            now={now}
+          />
+          <KpiTile
+            label="Signups Today"
+            value={metrics.signups.today}
+            icon={<UserPlus className="h-4 w-4 text-blue-400" />}
+            fetchedAt={metricsAt}
+            now={now}
+          />
+        </div>
       ) : (
-        <p className="text-sm text-red-400">Failed to load metrics</p>
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4 text-sm text-red-400">
+          {metricsError ?? 'Failed to load metrics'}
+        </div>
       )}
 
-      {/* Event Log */}
-      <div className="space-y-3">
+      {/* Subscriber funnel + signup velocity */}
+      {metrics && (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {/* Subscriber breakdown */}
+          <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-5">
+            <div className="mb-4 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <CreditCard className="h-4 w-4 text-[rgb(var(--primary))]" />
+                <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">Subscriber breakdown</h2>
+              </div>
+              <FreshnessPill fetchedAt={metricsAt} now={now} />
+            </div>
+
+            <SubscriberBars subs={metrics.subscribers} />
+          </div>
+
+          {/* Signup velocity */}
+          <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-5">
+            <div className="mb-4 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <UserPlus className="h-4 w-4 text-blue-400" />
+                <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">Signup velocity</h2>
+              </div>
+              <FreshnessPill fetchedAt={metricsAt} now={now} />
+            </div>
+            <SignupBars signups={metrics.signups} />
+          </div>
+        </div>
+      )}
+
+      {/* Recent activity: webhook events + recent signups */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <RecentEventsCard
+          events={events}
+          total={eventsTotal}
+          error={eventsError}
+          fetchedAt={eventsAt}
+          now={now}
+          onRefresh={fetchEvents}
+        />
+        <RecentSignupsCard
+          users={recentSignups}
+          total={recentTotal}
+          error={recentError}
+          fetchedAt={recentAt}
+          now={now}
+          onRefresh={fetchRecentSignups}
+          onDrill={() => onNavigate('users')}
+        />
+      </div>
+
+      {/* Contacts / newsletter */}
+      <RecentContactsCard
+        contacts={contacts}
+        total={contactsTotal}
+        error={contactsError}
+        fetchedAt={contactsAt}
+        now={now}
+        onRefresh={fetchContacts}
+        onDrill={() => onNavigate('subscribers')}
+      />
+    </div>
+  )
+}
+
+// ─── Overview helper components ──────────────────────────────────────
+
+function KpiTile({
+  label,
+  value,
+  icon,
+  valueClass,
+  onDrill,
+  fetchedAt,
+  now,
+}: {
+  label: string
+  value: string | number
+  icon: React.ReactNode
+  valueClass?: string
+  onDrill?: () => void
+  fetchedAt: number | null
+  now: number
+}) {
+  const inner = (
+    <>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {icon}
+          <p className="text-xs text-[rgb(var(--muted))]">{label}</p>
+        </div>
+        <FreshnessPill fetchedAt={fetchedAt} now={now} />
+      </div>
+      <p className={`mt-1 text-2xl font-bold ${valueClass ?? 'text-[rgb(var(--foreground))]'}`}>{value}</p>
+    </>
+  )
+  const cls = 'block rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 text-left transition-colors'
+  if (onDrill) {
+    return (
+      <button onClick={onDrill} className={`${cls} hover:border-[rgb(var(--primary))]`}>
+        {inner}
+      </button>
+    )
+  }
+  return <div className={cls}>{inner}</div>
+}
+
+function SubscriberBars({ subs }: { subs: Metrics['subscribers'] }) {
+  const total = subs.active + subs.trialing + subs.past_due + subs.cancelled + subs.none
+  const rows = [
+    { label: 'Active', value: subs.active, bar: 'bg-emerald-500', text: 'text-emerald-500' },
+    { label: 'Trialing', value: subs.trialing, bar: 'bg-blue-400', text: 'text-blue-400' },
+    { label: 'Past due', value: subs.past_due, bar: 'bg-amber-500', text: 'text-amber-500' },
+    { label: 'Cancelled', value: subs.cancelled, bar: 'bg-red-400', text: 'text-red-400' },
+    { label: 'No plan', value: subs.none, bar: 'bg-[rgb(var(--muted))]', text: 'text-[rgb(var(--muted))]' },
+  ]
+  return (
+    <div className="space-y-2.5">
+      {rows.map(({ label, value, bar, text }) => {
+        const pct = total === 0 ? 0 : Math.round((value / total) * 100)
+        return (
+          <div key={label}>
+            <div className="mb-1 flex items-baseline justify-between text-xs">
+              <span className="text-[rgb(var(--muted))]">{label}</span>
+              <span className={`font-semibold ${text}`}>
+                {value} <span className="text-[rgb(var(--muted))] font-normal">({pct}%)</span>
+              </span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-[rgb(var(--background))]">
+              <div className={`h-full rounded-full ${bar}`} style={{ width: `${total === 0 ? 0 : Math.max(2, pct)}%` }} />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function SignupBars({ signups }: { signups: Metrics['signups'] }) {
+  const max = Math.max(signups.today, signups.thisWeek, signups.thisMonth, 1)
+  const rows = [
+    { label: 'Today', value: signups.today },
+    { label: 'This week', value: signups.thisWeek },
+    { label: 'This month', value: signups.thisMonth },
+  ]
+  return (
+    <div className="space-y-3">
+      {rows.map(({ label, value }) => {
+        const pct = Math.round((value / max) * 100)
+        return (
+          <div key={label}>
+            <div className="mb-1 flex items-baseline justify-between text-xs">
+              <span className="text-[rgb(var(--muted))]">{label}</span>
+              <span className="font-semibold text-[rgb(var(--foreground))]">{value}</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-[rgb(var(--background))]">
+              <div
+                className="h-full rounded-full bg-blue-400"
+                style={{ width: `${value === 0 ? 0 : Math.max(4, pct)}%` }}
+              />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function RecentEventsCard({
+  events,
+  total,
+  error,
+  fetchedAt,
+  now,
+  onRefresh,
+}: {
+  events: WebhookEvent[]
+  total: number
+  error: string | null
+  fetchedAt: number | null
+  now: number
+  onRefresh: () => void
+}) {
+  return (
+    <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-5">
+      <div className="mb-3 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Activity className="h-4 w-4 text-[rgb(var(--muted))]" />
-          <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">Webhook Events</h2>
+          <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">Recent webhook events</h2>
+          <span className="text-xs text-[rgb(var(--muted))]">({total} total)</span>
         </div>
-
-        {eventsError && (
-          <p className="text-sm text-red-400">{eventsError}</p>
-        )}
-
-        {eventsLoading ? (
-          <p className="text-sm text-[rgb(var(--muted))]">Loading events...</p>
-        ) : events && events.events.length > 0 ? (
-          <>
-            <div className="overflow-x-auto rounded-lg border border-[rgb(var(--border))]">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b border-[rgb(var(--border))] bg-[rgb(var(--surface))]">
-                    <th className="px-4 py-2 text-left text-xs font-medium text-[rgb(var(--muted))]">Type</th>
-                    <th className="px-4 py-2 text-left text-xs font-medium text-[rgb(var(--muted))]">Stripe Event</th>
-                    <th className="px-4 py-2 text-left text-xs font-medium text-[rgb(var(--muted))]">Processed</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {events.events.map((event) => {
-                    const isFailed = event.eventType.includes('payment_failed') || event.eventType.includes('charge.failed')
-                    return (
-                      <tr
-                        key={event.id}
-                        className={`border-b border-[rgb(var(--border))] last:border-0 ${
-                          isFailed ? 'bg-red-500/5' : ''
-                        }`}
-                      >
-                        <td className={`px-4 py-2 font-mono text-xs ${isFailed ? 'text-red-400 font-medium' : 'text-[rgb(var(--foreground))]'}`}>
-                          {event.eventType}
-                        </td>
-                        <td className="px-4 py-2 font-mono text-xs text-[rgb(var(--muted))]">
-                          {event.stripeEventId.slice(0, 24)}...
-                        </td>
-                        <td className="px-4 py-2 text-xs text-[rgb(var(--muted))]">
-                          {formatDate(event.processedAt)}
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
-
-            {/* Pagination */}
-            <div className="flex items-center justify-between text-xs text-[rgb(var(--muted))]">
-              <span>
-                Showing {eventsOffset + 1}–{Math.min(eventsOffset + eventsLimit, events.total)} of {events.total}
-              </span>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => setEventsOffset(Math.max(0, eventsOffset - eventsLimit))}
-                  disabled={eventsOffset === 0}
-                  className="flex items-center gap-1 rounded px-2 py-1 hover:bg-[rgb(var(--surface))] disabled:opacity-30"
-                >
-                  <ChevronLeft className="h-3 w-3" /> Prev
-                </button>
-                <button
-                  onClick={() => setEventsOffset(eventsOffset + eventsLimit)}
-                  disabled={eventsOffset + eventsLimit >= events.total}
-                  className="flex items-center gap-1 rounded px-2 py-1 hover:bg-[rgb(var(--surface))] disabled:opacity-30"
-                >
-                  Next <ChevronRight className="h-3 w-3" />
-                </button>
-              </div>
-            </div>
-          </>
-        ) : (
-          <p className="text-sm text-[rgb(var(--muted))]">No webhook events recorded</p>
-        )}
+        <div className="flex items-center gap-2">
+          <FreshnessPill fetchedAt={fetchedAt} ok={!error} now={now} />
+          <button
+            onClick={onRefresh}
+            className="rounded p-1 text-[rgb(var(--muted))] hover:bg-[rgb(var(--background))] hover:text-[rgb(var(--foreground))]"
+            aria-label="Refresh events"
+          >
+            <RefreshCw className="h-3 w-3" />
+          </button>
+        </div>
       </div>
+
+      {error ? (
+        <p className="text-sm text-red-400">{error}</p>
+      ) : fetchedAt == null ? (
+        <p className="text-sm text-[rgb(var(--muted))]">Loading…</p>
+      ) : events.length === 0 ? (
+        <p className="text-sm text-[rgb(var(--muted))]">No webhook events yet</p>
+      ) : (
+        <ul className="divide-y divide-[rgb(var(--border))]">
+          {events.map((event) => {
+            const isFailed = event.eventType.includes('payment_failed') || event.eventType.includes('charge.failed')
+            return (
+              <li key={event.id} className="flex items-center justify-between gap-3 py-2 text-xs">
+                <div className="flex items-center gap-2 min-w-0">
+                  {isFailed ? (
+                    <XCircle className="h-3.5 w-3.5 shrink-0 text-red-400" />
+                  ) : (
+                    <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-500/80" />
+                  )}
+                  <span className={`font-mono truncate ${isFailed ? 'text-red-400 font-medium' : 'text-[rgb(var(--foreground))]'}`}>
+                    {event.eventType}
+                  </span>
+                </div>
+                <span className="shrink-0 text-[rgb(var(--muted))]">{relativeTime(new Date(event.processedAt).getTime(), now)}</span>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function RecentSignupsCard({
+  users,
+  total,
+  error,
+  fetchedAt,
+  now,
+  onRefresh,
+  onDrill,
+}: {
+  users: UserListItem[]
+  total: number
+  error: string | null
+  fetchedAt: number | null
+  now: number
+  onRefresh: () => void
+  onDrill: () => void
+}) {
+  return (
+    <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <UserPlus className="h-4 w-4 text-blue-400" />
+          <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">Recent signups</h2>
+          <span className="text-xs text-[rgb(var(--muted))]">({total} total)</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <FreshnessPill fetchedAt={fetchedAt} ok={!error} now={now} />
+          <button
+            onClick={onRefresh}
+            className="rounded p-1 text-[rgb(var(--muted))] hover:bg-[rgb(var(--background))] hover:text-[rgb(var(--foreground))]"
+            aria-label="Refresh signups"
+          >
+            <RefreshCw className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-red-400">{error}</p>
+      ) : fetchedAt == null ? (
+        <p className="text-sm text-[rgb(var(--muted))]">Loading…</p>
+      ) : users.length === 0 ? (
+        <p className="text-sm text-[rgb(var(--muted))]">No users yet</p>
+      ) : (
+        <>
+          <ul className="divide-y divide-[rgb(var(--border))]">
+            {users.map((u) => (
+              <li key={u.id} className="flex items-center justify-between gap-3 py-2 text-xs">
+                <div className="flex items-center gap-2 min-w-0">
+                  <StatusBadge status={u.subscriptionStatus} />
+                  <span className="font-mono truncate text-[rgb(var(--foreground))]">{u.email}</span>
+                </div>
+                <span className="shrink-0 text-[rgb(var(--muted))]">{relativeTime(new Date(u.createdAt).getTime(), now)}</span>
+              </li>
+            ))}
+          </ul>
+          <button
+            onClick={onDrill}
+            className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-[rgb(var(--primary))] hover:underline"
+          >
+            View all users <ArrowRight className="h-3 w-3" />
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+
+function RecentContactsCard({
+  contacts,
+  total,
+  error,
+  fetchedAt,
+  now,
+  onRefresh,
+  onDrill,
+}: {
+  contacts: Subscriber[]
+  total: number
+  error: string | null
+  fetchedAt: number | null
+  now: number
+  onRefresh: () => void
+  onDrill: () => void
+}) {
+  return (
+    <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Mail className="h-4 w-4 text-[rgb(var(--muted))]" />
+          <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">Newsletter / contact submissions</h2>
+          <span className="text-xs text-[rgb(var(--muted))]">({total} total)</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <FreshnessPill fetchedAt={fetchedAt} ok={!error} now={now} />
+          <button
+            onClick={onRefresh}
+            className="rounded p-1 text-[rgb(var(--muted))] hover:bg-[rgb(var(--background))] hover:text-[rgb(var(--foreground))]"
+            aria-label="Refresh contacts"
+          >
+            <RefreshCw className="h-3 w-3" />
+          </button>
+        </div>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-red-400">{error}</p>
+      ) : fetchedAt == null ? (
+        <p className="text-sm text-[rgb(var(--muted))]">Loading…</p>
+      ) : contacts.length === 0 ? (
+        <p className="text-sm text-[rgb(var(--muted))]">No contacts yet</p>
+      ) : (
+        <>
+          <ul className="divide-y divide-[rgb(var(--border))]">
+            {contacts.map((c) => (
+              <li
+                key={`${c.email}-${c.createdAt}`}
+                className={`flex items-center justify-between gap-3 py-2 text-xs ${c.unsubscribedAt ? 'opacity-60' : ''}`}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="font-mono truncate text-[rgb(var(--foreground))]">{c.email}</span>
+                  <span className="shrink-0 rounded-sm bg-[rgb(var(--background))] px-1.5 py-0.5 text-[10px] text-[rgb(var(--muted))] capitalize">
+                    {c.source}
+                  </span>
+                  {c.doiConfirmed && (
+                    <CheckCircle2 className="h-3 w-3 shrink-0 text-emerald-500" aria-label="Double opt-in confirmed" />
+                  )}
+                </div>
+                <span className="shrink-0 text-[rgb(var(--muted))]">{relativeTime(new Date(c.createdAt).getTime(), now)}</span>
+              </li>
+            ))}
+          </ul>
+          <button
+            onClick={onDrill}
+            className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-[rgb(var(--primary))] hover:underline"
+          >
+            View all subscribers <ArrowRight className="h-3 w-3" />
+          </button>
+        </>
+      )}
     </div>
   )
 }

--- a/apps/web/app/(app)/calendar/components/AgendaView.tsx
+++ b/apps/web/app/(app)/calendar/components/AgendaView.tsx
@@ -4,6 +4,8 @@ import { useMemo } from 'react'
 import { Clock, MapPin } from 'lucide-react'
 import { CalendarEmptyState } from '@/app/components/empty-state'
 import type { CalendarEvent } from '@silentsuite/core'
+import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { resolveUserTimezone, shortTimezoneLabel } from '@/app/lib/tz'
 
 interface AgendaViewProps {
   events: CalendarEvent[]
@@ -11,8 +13,8 @@ interface AgendaViewProps {
   onEventClick?: (eventId: string) => void
 }
 
-function formatTime(date: Date): string {
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+function formatTime(date: Date, tz: string): string {
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: tz })
 }
 
 function isSameDay(a: Date, b: Date): boolean {
@@ -24,6 +26,8 @@ function isSameDay(a: Date, b: Date): boolean {
 }
 
 export function AgendaView({ events, currentDate, onEventClick }: AgendaViewProps) {
+  const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
+  const userTz = resolveUserTimezone(defaultTimezonePref)
   const dayEvents = useMemo(() => {
     const currentDayStart = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate())
     const currentDayEnd = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate(), 23, 59, 59, 999)
@@ -68,8 +72,13 @@ export function AgendaView({ events, currentDate, onEventClick }: AgendaViewProp
                 <div className="mt-1 flex items-center gap-1 text-xs text-[rgb(var(--muted))]">
                   <Clock className="h-3 w-3" />
                   <span>
-                    {formatTime(event.startDate)} – {formatTime(event.endDate)}
+                    {formatTime(event.startDate, userTz)} – {formatTime(event.endDate, userTz)}
                   </span>
+                  {event.timezone && event.timezone !== userTz && (
+                    <span className="ml-1 rounded bg-[rgb(var(--surface-muted))] px-1 py-0.5 text-[10px] font-medium text-[rgb(var(--muted))]">
+                      {shortTimezoneLabel(event.timezone, event.startDate)}
+                    </span>
+                  )}
                 </div>
               )}
               {event.allDay && (

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -15,6 +15,7 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { expandRecurrence } from '@silentsuite/core'
 import type { CalendarEvent, DateRange } from '@silentsuite/core'
+import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
 
 import '@schedule-x/theme-default/dist/index.css'
 
@@ -34,15 +35,13 @@ function toPlainDate(date: Date): Temporal.PlainDate {
   })
 }
 
-/** Convert a JS Date to a Temporal.ZonedDateTime in the local timezone.
+/** Convert a JS Date to a Temporal.ZonedDateTime in the given timezone.
  * Schedule-X v4 requires a real ZonedDateTime — it calls .withTimeZone() on the
- * stored value, so plain strings or casts will throw at runtime and events will
- * silently not render.
+ * stored value to convert into the calendar's configured timezone, so the input
+ * zone here is effectively a label; what matters is the underlying instant.
  */
-function toScheduleXDateTime(date: Date): Temporal.ZonedDateTime {
-  return Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO(
-    Temporal.Now.timeZoneId(),
-  )
+function toScheduleXDateTime(date: Date, tz: string): Temporal.ZonedDateTime {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO(tz)
 }
 
 /** Expanded event used for display — may be a recurring instance */
@@ -148,14 +147,15 @@ function expandEventsForRange(
 function toScheduleXEvents(
   displayEvents: DisplayEvent[],
   calendarColors: Map<string, string>,
+  userTz: string,
 ): CalendarEventExternal[] {
   return displayEvents.map((e) => {
     const color = calendarColors.get(e.calendarId ?? 'default') ?? '#10b981'
     return {
       id: e.id,
       title: e.isRecurring ? `↻ ${e.title}` : e.title,
-      start: e.allDay ? toPlainDate(e.startDate) : toScheduleXDateTime(e.startDate),
-      end: e.allDay ? toPlainDate(e.endDate) : toScheduleXDateTime(e.endDate),
+      start: e.allDay ? toPlainDate(e.startDate) : toScheduleXDateTime(e.startDate, userTz),
+      end: e.allDay ? toPlainDate(e.endDate) : toScheduleXDateTime(e.endDate, userTz),
       description: e.description || undefined,
       location: e.location || undefined,
       calendarId: e.calendarId ?? 'default',
@@ -282,6 +282,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
 
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
   const use12h = timeFormat !== '24h'
+  const defaultTimezone = usePreferencesStore((s) => s.defaultTimezone)
+  const userTz = useMemo(() => resolveUserTimezone(defaultTimezone), [defaultTimezone])
 
   const lastClickPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
 
@@ -312,7 +314,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const displayEventMapRef = useRef(displayEventMap)
   displayEventMapRef.current = displayEventMap
 
-  const sxEvents = useMemo(() => toScheduleXEvents(displayEvents, calendarColors), [displayEvents, calendarColors])
+  const sxEvents = useMemo(() => toScheduleXEvents(displayEvents, calendarColors, userTz), [displayEvents, calendarColors, userTz])
 
   // Inject calendar color styles via useInsertionEffect (avoids dangerouslySetInnerHTML)
   useInsertionEffect(() => {
@@ -451,6 +453,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const initialDateRef = useRef(selectedDate)
   // Capture time format at mount — Schedule-X locale can't change after init
   const initialLocaleRef = useRef(timeFormat === '24h' ? 'en-GB' : 'en-US')
+  // Capture initial timezone for Schedule-X config (changes are pushed via signal below)
+  const initialTimezoneRef = useRef(userTz)
 
   // Memoize the event click handler
   const handleEventClick = useCallback(
@@ -487,6 +491,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     locale: initialLocaleRef.current,
     firstDayOfWeek: 1, // Monday — must match getViewRange() and formatDateRange()
     dayBoundaries: { start: '06:00', end: '22:00' },
+    timezone: initialTimezoneRef.current,
     weekOptions: {
       gridHeight: 800,
       eventWidth: 95,
@@ -498,6 +503,21 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       onClickDate: handleClickDate,
     },
   })
+
+  // Push timezone changes to the Schedule-X config signal so the grid re-renders
+  // when the user updates their preference in Settings without a full page reload.
+  useEffect(() => {
+    if (!calendar) return
+    try {
+      const app = (calendar as any).$app
+      const tzSignal = app?.config?.timezone
+      if (tzSignal && tzSignal.value !== userTz) {
+        tzSignal.value = userTz
+      }
+    } catch {
+      // Schedule-X internals may not be ready
+    }
+  }, [calendar, userTz])
 
   // Sync view AND date changes from store → Schedule-X via internal API.
   // CalendarApp has NO public navigation methods. We access the private $app
@@ -656,14 +676,25 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     [viewRange],
   )
 
-  /** Build a Date from a day + fractional hour */
-  const buildDateFromHour = useCallback((day: Date, hour: number): Date => {
-    const d = new Date(day.getFullYear(), day.getMonth(), day.getDate())
-    const h = Math.floor(hour)
-    const m = Math.round((hour - h) * 60)
-    d.setHours(h, m, 0, 0)
-    return d
-  }, [])
+  /** Build a Date from a day + fractional hour, interpreting the wall-clock in userTz.
+   * `day` carries the user's clicked day as browser-local Y/M/D (constructed from
+   * viewRange.start). We treat those Y/M/D as the wall-clock day in userTz so the
+   * resulting instant aligns with the rendered grid regardless of browser TZ. */
+  const buildDateFromHour = useCallback(
+    (day: Date, hour: number): Date => {
+      const h = Math.floor(hour)
+      const m = Math.round((hour - h) * 60)
+      return instantFromWallClock(
+        day.getFullYear(),
+        day.getMonth() + 1,
+        day.getDate(),
+        h,
+        m,
+        userTz,
+      )
+    },
+    [userTz],
+  )
 
   /** Shared helper: compute drag-move preview from cursor coordinates */
   const updateDragMovePosition = useCallback(
@@ -696,10 +727,12 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         hour: 'numeric',
         minute: '2-digit',
         hour12: use12h,
+        timeZone: userTz,
       })} \u2013 ${clampedEnd.toLocaleTimeString('en-US', {
         hour: 'numeric',
         minute: '2-digit',
         hour12: use12h,
+        timeZone: userTz,
       })}`
 
       const de = displayEventMapRef.current.get(dragMoveStartRef.current.eventId)
@@ -715,7 +748,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         newEnd: clampedEnd,
       })
     },
-    [getDayColumnInfo, getTimeFromY, buildDateFromHour, use12h],
+    [getDayColumnInfo, getTimeFromY, buildDateFromHour, use12h, userTz],
   )
 
   /** Shared helper: complete drag-move drop */
@@ -957,10 +990,12 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
           hour: 'numeric',
           minute: '2-digit',
           hour12: use12h,
+          timeZone: userTz,
         })} \u2013 ${newEnd.toLocaleTimeString('en-US', {
           hour: 'numeric',
           minute: '2-digit',
           hour12: use12h,
+          timeZone: userTz,
         })}`
 
         setDragResizePreview({
@@ -1102,7 +1137,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         endTime,
       })
     },
-    [getTimeFromY, buildDateFromHour, getDayColumnInfo, updateDragMovePosition, viewRange, use12h],
+    [getTimeFromY, buildDateFromHour, getDayColumnInfo, updateDragMovePosition, viewRange, use12h, userTz],
   )
 
   const handleMouseUp = useCallback(
@@ -1398,6 +1433,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
                     hour: 'numeric',
                     minute: '2-digit',
                     hour12: use12h,
+                    timeZone: userTz,
                   })}
                 </span>
                 <span className="text-[11px] font-medium text-[rgb(var(--primary))] leading-none self-end">
@@ -1405,6 +1441,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
                     hour: 'numeric',
                     minute: '2-digit',
                     hour12: use12h,
+                    timeZone: userTz,
                   })}
                 </span>
               </>

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -12,17 +12,25 @@ import { buildAlarmTrigger, parseAlarmTriggerMinutes } from '@silentsuite/core'
 import { useNotifications } from '@/app/providers/notification-provider'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { Globe } from 'lucide-react'
+import {
+  formatDateForInputInZone,
+  formatTimeForInputInZone,
+  instantFromWallClock,
+  resolveUserTimezone,
+  shortTimezoneLabel,
+} from '@/app/lib/tz'
 
 // ---------------------------------------------------------------------------
 // Time formatting (respects user preference)
 // ---------------------------------------------------------------------------
 
-function makeFormatTime(hour12: boolean) {
+function makeFormatTime(hour12: boolean, tz: string) {
   return function formatTime(date: Date): string {
     return date.toLocaleTimeString('en-US', {
       hour: 'numeric',
       minute: '2-digit',
       hour12,
+      timeZone: tz,
     })
   }
 }
@@ -55,25 +63,35 @@ interface EventDialogProps {
 
 // formatTime is created per-render via makeFormatTime — see below
 
-function formatTimeForInput(date: Date): string {
-  const h = String(date.getHours()).padStart(2, '0')
-  const m = String(date.getMinutes()).padStart(2, '0')
-  return `${h}:${m}`
+/** All-day events have undefined event.timezone and are stored as local-midnight
+ * Date objects, so their wall-clock components are read in browser-local. Timed
+ * events use the event's TZ (or user default) to read/write wall-clock components. */
+function formatTimeForInput(date: Date, tz: string | undefined): string {
+  if (!tz) {
+    const h = String(date.getHours()).padStart(2, '0')
+    const m = String(date.getMinutes()).padStart(2, '0')
+    return `${h}:${m}`
+  }
+  return formatTimeForInputInZone(date, tz)
 }
 
-function formatDateForInput(date: Date): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
+function formatDateForInput(date: Date, tz: string | undefined): string {
+  if (!tz) {
+    const y = date.getFullYear()
+    const m = String(date.getMonth() + 1).padStart(2, '0')
+    const d = String(date.getDate()).padStart(2, '0')
+    return `${y}-${m}-${d}`
+  }
+  return formatDateForInputInZone(date, tz)
 }
 
-function formatDateForDisplay(date: Date): string {
+function formatDateForDisplay(date: Date, tz: string | undefined): string {
   return date.toLocaleDateString('en-US', {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
     year: 'numeric',
+    ...(tz ? { timeZone: tz } : {}),
   })
 }
 
@@ -101,8 +119,9 @@ export function EventDialog({
   const notifications = useNotifications()
   const defaultReminder = usePreferencesStore((s) => s.defaultReminder)
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
-  const defaultTimezone = usePreferencesStore((s) => s.defaultTimezone)
-  const formatTime = makeFormatTime(timeFormat !== '24h')
+  const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
+  const userTz = resolveUserTimezone(defaultTimezonePref)
+  const defaultTimezone = userTz
 
   // ---------------------------------------------------------------------------
   // Derive initial state
@@ -117,6 +136,15 @@ export function EventDialog({
     ? event.endDate
     : (initialEndDate ?? new Date(defaultStart.getTime() + 30 * 60 * 1000))
 
+  // Initial all-day flag — needed before form state so we can pick the right
+  // TZ for formatting the initial date/time strings.
+  const initialIsAllDay = isEdit ? event.allDay : initialAllDay
+  const initialFormTz: string | undefined = initialIsAllDay
+    ? undefined
+    : isEdit
+      ? (event.timezone ?? userTz)
+      : userTz
+
   // ---------------------------------------------------------------------------
   // Form state
   // ---------------------------------------------------------------------------
@@ -124,11 +152,11 @@ export function EventDialog({
   const [title, setTitle] = useState(isEdit ? event.title : '')
   const [location, setLocation] = useState(isEdit ? (event.location || '') : '')
   const [description, setDescription] = useState(isEdit ? (event.description || '') : '')
-  const [allDay, setAllDay] = useState(isEdit ? event.allDay : initialAllDay)
-  const [startDate, setStartDate] = useState(formatDateForInput(defaultStart))
-  const [startTime, setStartTime] = useState(formatTimeForInput(defaultStart))
-  const [endDate, setEndDate] = useState(formatDateForInput(defaultEnd))
-  const [endTime, setEndTime] = useState(formatTimeForInput(defaultEnd))
+  const [allDay, setAllDay] = useState(initialIsAllDay)
+  const [startDate, setStartDate] = useState(formatDateForInput(defaultStart, initialFormTz))
+  const [startTime, setStartTime] = useState(formatTimeForInput(defaultStart, initialFormTz))
+  const [endDate, setEndDate] = useState(formatDateForInput(defaultEnd, initialFormTz))
+  const [endTime, setEndTime] = useState(formatTimeForInput(defaultEnd, initialFormTz))
   const [recurrenceRule, setRecurrenceRule] = useState<string | null>(
     isEdit ? event.recurrenceRule : null,
   )
@@ -148,6 +176,10 @@ export function EventDialog({
   const [timezone, setTimezone] = useState(
     isEdit ? (event.timezone ?? defaultTimezone) : defaultTimezone,
   )
+  // Active TZ for form fields and subtitle: undefined for all-day (local-midnight)
+  // semantics, otherwise the picker's value.
+  const formTz: string | undefined = allDay ? undefined : timezone
+  const formatTime = makeFormatTime(timeFormat !== '24h', formTz ?? userTz)
   const allTimezones = (() => {
     try { return Intl.supportedValuesOf('timeZone') } catch { return ['UTC'] }
   })()
@@ -212,22 +244,22 @@ export function EventDialog({
   const buildStartDate = useCallback((): Date => {
     const [y, m, d] = startDate.split('-').map(Number)
     if (allDay) {
-      const dt = new Date(y, m - 1, d, 0, 0, 0, 0)
-      return dt
+      // All-day events stored as browser-local midnight; matches how the
+      // import path and core ical parser handle DATE-only DTSTART.
+      return new Date(y, m - 1, d, 0, 0, 0, 0)
     }
     const [h, min] = startTime.split(':').map(Number)
-    return new Date(y, m - 1, d, h, min, 0, 0)
-  }, [startDate, startTime, allDay])
+    return instantFromWallClock(y, m, d, h, min, timezone)
+  }, [startDate, startTime, allDay, timezone])
 
   const buildEndDate = useCallback((): Date => {
     const [y, m, d] = endDate.split('-').map(Number)
     if (allDay) {
-      const dt = new Date(y, m - 1, d, 23, 59, 59, 0)
-      return dt
+      return new Date(y, m - 1, d, 23, 59, 59, 0)
     }
     const [h, min] = endTime.split(':').map(Number)
-    return new Date(y, m - 1, d, h, min, 0, 0)
-  }, [endDate, endTime, allDay])
+    return instantFromWallClock(y, m, d, h, min, timezone)
+  }, [endDate, endTime, allDay, timezone])
 
   // ---------------------------------------------------------------------------
   // Save handler
@@ -405,11 +437,13 @@ export function EventDialog({
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
       setStartTime(value)
-      // Auto-adjust end time to 30 min after start if on same day
+      // Auto-adjust end time to 30 min after start if on same day. Pure HH:MM
+      // arithmetic via a synthetic local Date; format back as browser-local
+      // since we only need the wall-clock string back.
       if (startDate === endDate) {
         const [h, m] = value.split(':').map(Number)
         const newEnd = new Date(2000, 0, 1, h, m + 30)
-        setEndTime(formatTimeForInput(newEnd))
+        setEndTime(formatTimeForInput(newEnd, undefined))
       }
     },
     [startDate, endDate],
@@ -449,16 +483,16 @@ export function EventDialog({
 
   const subtitle = (() => {
     if (allDay) {
-      const sd = formatDateForDisplay(buildStartDate())
-      const ed = formatDateForDisplay(buildEndDate())
+      const sd = formatDateForDisplay(buildStartDate(), undefined)
+      const ed = formatDateForDisplay(buildEndDate(), undefined)
       return startDate === endDate ? sd : `${sd} – ${ed}`
     }
     const s = buildStartDate()
     const e = buildEndDate()
     if (startDate === endDate) {
-      return `${formatDateForDisplay(s)}, ${formatTime(s)} – ${formatTime(e)}`
+      return `${formatDateForDisplay(s, formTz)}, ${formatTime(s)} – ${formatTime(e)}`
     }
-    return `${formatDateForDisplay(s)}, ${formatTime(s)} – ${formatDateForDisplay(e)}, ${formatTime(e)}`
+    return `${formatDateForDisplay(s, formTz)}, ${formatTime(s)} – ${formatDateForDisplay(e, formTz)}, ${formatTime(e)}`
   })()
 
   // ---------------------------------------------------------------------------
@@ -674,19 +708,26 @@ export function EventDialog({
 
                 {/* Timezone row — hidden for all-day events */}
                 {!allDay && (
-                  <div className="flex items-center gap-3">
-                    <Globe className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
-                    <select
-                      value={timezone}
-                      onChange={(e) => setTimezone(e.target.value)}
-                      disabled={!canWrite}
-                      aria-label="Event timezone"
-                      className={`flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-xs text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
-                    >
-                      {allTimezones.map((tz) => (
-                        <option key={tz} value={tz}>{tz.replace(/_/g, ' ')}</option>
-                      ))}
-                    </select>
+                  <div className="flex flex-col gap-1">
+                    <div className="flex items-center gap-3">
+                      <Globe className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                      <select
+                        value={timezone}
+                        onChange={(e) => setTimezone(e.target.value)}
+                        disabled={!canWrite}
+                        aria-label="Event timezone"
+                        className={`flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-xs text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
+                      >
+                        {allTimezones.map((tz) => (
+                          <option key={tz} value={tz}>{tz.replace(/_/g, ' ')}</option>
+                        ))}
+                      </select>
+                    </div>
+                    {timezone !== userTz && (
+                      <span className="ml-7 text-[11px] text-[rgb(var(--muted))]">
+                        Event anchored in {shortTimezoneLabel(timezone, buildStartDate())}; your calendar shows {shortTimezoneLabel(userTz, buildStartDate())}.
+                      </span>
+                    )}
                   </div>
                 )}
 

--- a/apps/web/app/(app)/settings/desktop/page.tsx
+++ b/apps/web/app/(app)/settings/desktop/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { Monitor, ExternalLink, Copy, CheckCircle, ShieldCheck } from 'lucide-react'
+
+const INSTALL_COMMAND = 'curl -fsSL https://silentsuite.io/bridge/install.sh | sh'
+const INSTALL_COMMAND_PS = 'irm https://silentsuite.io/bridge/install.ps1 | iex'
+const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
+const DOCS_URL = 'https://docs.silentsuite.io/user-guide/apps/dav-bridge'
+
+export default function DesktopSettingsPage() {
+  const [copied, setCopied] = useState<'sh' | 'ps' | null>(null)
+
+  const handleCopy = useCallback(async (variant: 'sh' | 'ps') => {
+    const text = variant === 'sh' ? INSTALL_COMMAND : INSTALL_COMMAND_PS
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(variant)
+      setTimeout(() => setCopied(null), 2000)
+    } catch {
+      // Clipboard access may be blocked; users can still select manually
+    }
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">
+          Desktop bridge
+        </h2>
+        <p className="text-sm text-[rgb(var(--muted))]">
+          Install the SilentSuite bridge to use SilentSuite from Thunderbird, Apple Calendar,
+          GNOME Calendar, Evolution, or any standard CalDAV/CardDAV client.
+        </p>
+      </div>
+
+      {/* Install one-liner — macOS / Linux */}
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <Monitor className="h-5 w-5 text-[rgb(var(--primary))]" />
+          <div>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+              Install on macOS or Linux
+            </p>
+            <p className="text-xs text-[rgb(var(--muted))]">
+              Run this in your terminal.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-stretch gap-2">
+          <pre className="flex-1 overflow-x-auto rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs text-[rgb(var(--foreground))] font-mono">
+            <code>{INSTALL_COMMAND}</code>
+          </pre>
+          <button
+            type="button"
+            onClick={() => handleCopy('sh')}
+            aria-label="Copy install command"
+            className="flex items-center gap-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
+          >
+            {copied === 'sh' ? (
+              <CheckCircle className="h-4 w-4 text-emerald-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+            {copied === 'sh' ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      </div>
+
+      {/* Install one-liner — Windows */}
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
+        <div className="flex items-center gap-3">
+          <Monitor className="h-5 w-5 text-[rgb(var(--primary))]" />
+          <div>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+              Install on Windows
+            </p>
+            <p className="text-xs text-[rgb(var(--muted))]">
+              Run this in PowerShell.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-stretch gap-2">
+          <pre className="flex-1 overflow-x-auto rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs text-[rgb(var(--foreground))] font-mono">
+            <code>{INSTALL_COMMAND_PS}</code>
+          </pre>
+          <button
+            type="button"
+            onClick={() => handleCopy('ps')}
+            aria-label="Copy PowerShell install command"
+            className="flex items-center gap-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
+          >
+            {copied === 'ps' ? (
+              <CheckCircle className="h-4 w-4 text-emerald-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+            {copied === 'ps' ? 'Copied' : 'Copy'}
+          </button>
+        </div>
+      </div>
+
+      {/* Direct downloads + docs */}
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
+        <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+          Or download binaries directly
+        </p>
+        <div className="flex flex-col gap-2">
+          <a
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"
+          >
+            <ExternalLink className="h-4 w-4" />
+            View latest release on GitHub
+          </a>
+          <a
+            href={DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center gap-2 rounded-lg border border-[rgb(var(--border))] px-4 py-2.5 text-sm font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
+          >
+            Read the bridge documentation
+          </a>
+        </div>
+      </div>
+
+      {/* Privacy note */}
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
+        <div className="flex items-start gap-3">
+          <ShieldCheck className="h-5 w-5 text-[rgb(var(--primary))] mt-0.5 flex-shrink-0" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+              Stays end-to-end encrypted
+            </p>
+            <p className="text-xs text-[rgb(var(--muted))]">
+              The bridge runs locally on{' '}
+              <code className="font-mono text-[rgb(var(--foreground))]">localhost:37358</code>.
+              Plain DAV stays inside <code className="font-mono text-[rgb(var(--foreground))]">localhost</code>;
+              all upstream traffic is end-to-end encrypted Etebase.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
@@ -98,6 +98,9 @@ vi.mock('lucide-react', () => ({
   Download: ({ className }: { className?: string }) => (
     <svg data-testid="download-icon" className={className} />
   ),
+  Loader2: ({ className }: { className?: string }) => (
+    <svg data-testid="loader-icon" className={className} />
+  ),
 }))
 
 // Mock jszip

--- a/apps/web/app/(app)/settings/export/page.tsx
+++ b/apps/web/app/(app)/settings/export/page.tsx
@@ -1,12 +1,24 @@
 'use client'
 
+import { useState } from 'react'
 import { Button } from '@silentsuite/ui'
 import { toVEvent, toVTodo, toVCard } from '@silentsuite/core'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
-import { Download } from 'lucide-react'
+import {
+  showErrorToast,
+  showWarningToast,
+} from '@/app/stores/use-toast-store'
+import { Download, Loader2 } from 'lucide-react'
 import JSZip from 'jszip'
+
+/**
+ * Above this combined item count we surface a "this may take a minute" warning
+ * before kicking off the ZIP export. The previous in-memory implementation was
+ * known to silently fail at ~2000 events; 1000 is a conservative early warning.
+ */
+const LARGE_EXPORT_THRESHOLD = 1000
 
 function downloadFile(content: string | Blob, filename: string, mimeType: string) {
   const blob =
@@ -34,6 +46,9 @@ export default function ExportPage() {
   const contacts = useContactStore((s) => s.contacts)
   const events = useCalendarStore((s) => s.events)
 
+  const [isExportingAll, setIsExportingAll] = useState(false)
+  const [exportProgress, setExportProgress] = useState(0)
+
   function exportCalendar() {
     const vevents = events.map((e) => toVEvent(e))
     const ics = buildCalendarIcs(vevents)
@@ -53,20 +68,63 @@ export default function ExportPage() {
   }
 
   async function exportAll() {
-    const zip = new JSZip()
+    if (isExportingAll) return
 
-    const vevents = events.map((e) => toVEvent(e))
-    zip.file('silentsuite-calendar.ics', buildCalendarIcs(vevents))
+    const totalItems = events.length + tasks.length + contacts.length
 
-    const vtodos = tasks.map((t) => toVTodo(t))
-    zip.file('silentsuite-tasks.ics', buildCalendarIcs(vtodos))
+    setIsExportingAll(true)
+    setExportProgress(0)
 
-    const vcards = contacts.map((c) => toVCard(c))
-    zip.file('silentsuite-contacts.vcf', vcards.join('\n'))
+    if (totalItems > LARGE_EXPORT_THRESHOLD) {
+      showWarningToast(
+        `Preparing export of ${totalItems.toLocaleString()} items. This may take a minute…`,
+      )
+    }
 
-    const blob = await zip.generateAsync({ type: 'blob' })
-    downloadFile(blob, 'silentsuite-export.zip', 'application/zip')
+    try {
+      const zip = new JSZip()
+
+      const vevents = events.map((e) => toVEvent(e))
+      zip.file('silentsuite-calendar.ics', buildCalendarIcs(vevents))
+
+      const vtodos = tasks.map((t) => toVTodo(t))
+      zip.file('silentsuite-tasks.ics', buildCalendarIcs(vtodos))
+
+      const vcards = contacts.map((c) => toVCard(c))
+      zip.file('silentsuite-contacts.vcf', vcards.join('\n'))
+
+      // Throttle progress updates: only re-render when the integer percent
+      // changes. JSZip can fire onUpdate hundreds of times per second on
+      // large archives, which would otherwise spam React renders.
+      let lastReportedPercent = -1
+
+      const blob = await zip.generateAsync(
+        { type: 'blob', streamFiles: true },
+        (metadata) => {
+          const percent = Math.floor(metadata.percent)
+          if (percent !== lastReportedPercent) {
+            lastReportedPercent = percent
+            setExportProgress(percent)
+          }
+        },
+      )
+
+      downloadFile(blob, 'silentsuite-export.zip', 'application/zip')
+    } catch (err) {
+      // Log enough detail for a useful bug report. The original bug was that
+      // generateAsync rejected silently with no console output at all.
+      console.error('[export] Failed to build ZIP archive:', err)
+      showErrorToast(
+        'Failed to build ZIP. Try exporting calendar, tasks, and contacts separately.',
+      )
+    } finally {
+      setIsExportingAll(false)
+      setExportProgress(0)
+    }
   }
+
+  const totalItems = events.length + tasks.length + contacts.length
+  const exportAllDisabled = totalItems === 0 || isExportingAll
 
   return (
     <div className="space-y-6">
@@ -78,7 +136,7 @@ export default function ExportPage() {
       <div className="flex flex-col gap-3">
         <Button
           className="w-full sm:w-auto"
-          disabled={events.length === 0}
+          disabled={events.length === 0 || isExportingAll}
           onClick={exportCalendar}
         >
           <Download className="mr-2 h-4 w-4" />
@@ -86,7 +144,7 @@ export default function ExportPage() {
         </Button>
         <Button
           className="w-full sm:w-auto"
-          disabled={tasks.length === 0}
+          disabled={tasks.length === 0 || isExportingAll}
           onClick={exportTasks}
         >
           <Download className="mr-2 h-4 w-4" />
@@ -94,7 +152,7 @@ export default function ExportPage() {
         </Button>
         <Button
           className="w-full sm:w-auto"
-          disabled={contacts.length === 0}
+          disabled={contacts.length === 0 || isExportingAll}
           onClick={exportContacts}
         >
           <Download className="mr-2 h-4 w-4" />
@@ -103,11 +161,21 @@ export default function ExportPage() {
         <Button
           variant="outline"
           className="w-full sm:w-auto"
-          disabled={events.length === 0 && tasks.length === 0 && contacts.length === 0}
+          disabled={exportAllDisabled}
           onClick={exportAll}
+          aria-busy={isExportingAll}
         >
-          <Download className="mr-2 h-4 w-4" />
-          Export All Data (.zip)
+          {isExportingAll ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Preparing… {exportProgress}%
+            </>
+          ) : (
+            <>
+              <Download className="mr-2 h-4 w-4" />
+              Export All Data (.zip)
+            </>
+          )}
         </Button>
       </div>
     </div>

--- a/apps/web/app/(app)/settings/layout.tsx
+++ b/apps/web/app/(app)/settings/layout.tsx
@@ -9,6 +9,7 @@ const allTabs = [
   { label: 'Subscription', href: '/settings/subscription' },
   { label: 'Security', href: '/settings/security' },
   { label: 'Mobile', href: '/settings/mobile' },
+  { label: 'Desktop', href: '/settings/desktop' },
   { label: 'Import', href: '/settings/import' },
   { label: 'Export', href: '/settings/export' },
 ]

--- a/apps/web/app/(app)/settings/mobile/page.tsx
+++ b/apps/web/app/(app)/settings/mobile/page.tsx
@@ -1,9 +1,18 @@
 'use client'
 
-import { Smartphone, ExternalLink, QrCode } from 'lucide-react'
+import { Smartphone, ExternalLink, Monitor } from 'lucide-react'
+import Link from 'next/link'
+import { QRCodeSVG } from 'qrcode.react'
+
+// TODO: make this version-dynamic at build time (see issue #116) — currently
+// the version-pinned filename will break when the umbrella tag bumps past
+// v0.1.0-beta. Tracked as the "approach 2" follow-up in #116.
+const APK_DOWNLOAD_URL =
+  'https://github.com/silent-suite/silentsuite/releases/latest/download/silentsuite-android-v0.1.0-beta.apk'
+const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
 
 export default function MobileSettingsPage() {
-  const downloadUrl = 'https://docs.silentsuite.io/mobile'
+  const docsUrl = 'https://docs.silentsuite.io/mobile'
 
   return (
     <div className="space-y-6">
@@ -19,19 +28,29 @@ export default function MobileSettingsPage() {
       {/* QR Code section */}
       <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-6">
         <div className="flex flex-col items-center gap-4">
-          <div className="flex h-48 w-48 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))]">
-            <div className="flex flex-col items-center gap-2 text-[rgb(var(--muted))]">
-              <QrCode className="h-24 w-24" />
-              <span className="text-[10px]">Scan to download</span>
-            </div>
+          <div className="flex h-48 w-48 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-white p-3">
+            <QRCodeSVG
+              value={APK_DOWNLOAD_URL}
+              size={168}
+              level="M"
+              marginSize={0}
+              aria-label="QR code linking to the latest SilentSuite Android APK"
+            />
           </div>
           <p className="text-sm text-[rgb(var(--foreground))] font-medium">
             Scan with your phone camera
           </p>
           <p className="text-xs text-[rgb(var(--muted))] text-center">
-            The QR code will take you to the mobile app download page.
-            Currently available for Android. iOS coming soon.
+            The QR code links to the latest SilentSuite Android APK.
           </p>
+          <a
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[rgb(var(--primary))] hover:underline"
+          >
+            Or download manually from GitHub Releases
+          </a>
         </div>
       </div>
 
@@ -49,7 +68,7 @@ export default function MobileSettingsPage() {
 
         <div className="flex flex-col gap-2">
           <a
-            href={downloadUrl}
+            href={docsUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"
@@ -71,17 +90,39 @@ export default function MobileSettingsPage() {
       {/* Supported platforms */}
       <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
         <p className="text-sm font-medium text-[rgb(var(--foreground))]">Supported platforms</p>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
           <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3 text-center">
             <p className="text-sm font-medium text-[rgb(var(--foreground))]">Android</p>
             <p className="text-xs text-[rgb(var(--primary))]">Available now</p>
           </div>
-          <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3 text-center">
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">iOS</p>
-            <p className="text-xs text-[rgb(var(--muted))]">Coming soon</p>
+          <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3 text-left space-y-1">
+            <p className="text-sm font-medium text-[rgb(var(--foreground))] text-center">iOS</p>
+            <p className="text-xs text-[rgb(var(--muted))] text-center">Native app coming soon</p>
+            <p className="text-xs text-[rgb(var(--muted))] pt-1">
+              Compatible with the{' '}
+              <a
+                href="https://apps.apple.com/us/app/apple-store/id1489574285"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[rgb(var(--primary))] hover:underline"
+              >
+                EteSync iOS app
+              </a>{' '}
+              on the App Store — same Etebase protocol, sign in with your SilentSuite credentials.
+            </p>
           </div>
         </div>
       </div>
+
+      {/* Footer note pointing at desktop integration */}
+      <p className="text-xs text-[rgb(var(--muted))] text-center">
+        <Monitor className="inline h-3 w-3 mr-1 -mt-0.5" />
+        Looking for desktop integration?{' '}
+        <Link href="/settings/desktop" className="text-[rgb(var(--primary))] hover:underline">
+          See Settings → Desktop
+        </Link>
+        .
+      </p>
     </div>
   )
 }

--- a/apps/web/app/(app)/settings/mobile/page.tsx
+++ b/apps/web/app/(app)/settings/mobile/page.tsx
@@ -4,16 +4,10 @@ import { Smartphone, ExternalLink, Monitor } from 'lucide-react'
 import Link from 'next/link'
 import { QRCodeSVG } from 'qrcode.react'
 
-// TODO: make this version-dynamic at build time (see issue #116) — currently
-// the version-pinned filename will break when the umbrella tag bumps past
-// v0.1.0-beta. Tracked as the "approach 2" follow-up in #116.
-const APK_DOWNLOAD_URL =
-  'https://github.com/silent-suite/silentsuite/releases/latest/download/silentsuite-android-v0.1.0-beta.apk'
+const INSTALL_DOCS_URL = 'https://docs.silentsuite.io/user-guide/apps/android'
 const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
 
 export default function MobileSettingsPage() {
-  const docsUrl = 'https://docs.silentsuite.io/mobile'
-
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -30,18 +24,18 @@ export default function MobileSettingsPage() {
         <div className="flex flex-col items-center gap-4">
           <div className="flex h-48 w-48 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-white p-3">
             <QRCodeSVG
-              value={APK_DOWNLOAD_URL}
+              value={INSTALL_DOCS_URL}
               size={168}
               level="M"
               marginSize={0}
-              aria-label="QR code linking to the latest SilentSuite Android APK"
+              aria-label="QR code linking to the SilentSuite Android install guide"
             />
           </div>
           <p className="text-sm text-[rgb(var(--foreground))] font-medium">
             Scan with your phone camera
           </p>
           <p className="text-xs text-[rgb(var(--muted))] text-center">
-            The QR code links to the latest SilentSuite Android APK.
+            The QR code opens the install guide with options for Obtainium (auto-updates) or a direct APK download.
           </p>
           <a
             href={RELEASES_URL}
@@ -49,7 +43,7 @@ export default function MobileSettingsPage() {
             rel="noopener noreferrer"
             className="text-xs text-[rgb(var(--primary))] hover:underline"
           >
-            Or download manually from GitHub Releases
+            Or jump straight to GitHub Releases
           </a>
         </div>
       </div>
@@ -68,7 +62,7 @@ export default function MobileSettingsPage() {
 
         <div className="flex flex-col gap-2">
           <a
-            href={docsUrl}
+            href={INSTALL_DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -23,10 +23,17 @@ const PRIORITY_ORDER: Record<Priority, number> = {
 }
 
 const PRIORITY_COLORS: Record<Priority, string> = {
-  low: 'bg-emerald-500/30 text-emerald-300',
-  medium: 'bg-amber-500/30 text-amber-300',
-  high: 'bg-orange-500/30 text-orange-300',
-  urgent: 'bg-red-500/30 text-red-300',
+  low: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/30 dark:text-emerald-300',
+  medium: 'bg-amber-100 text-amber-800 dark:bg-amber-500/30 dark:text-amber-300',
+  high: 'bg-orange-100 text-orange-800 dark:bg-orange-500/30 dark:text-orange-300',
+  urgent: 'bg-red-100 text-red-800 dark:bg-red-500/30 dark:text-red-300',
+}
+
+const PRIORITY_DOT_COLORS: Record<Priority, string> = {
+  low: 'bg-emerald-500 dark:bg-emerald-400',
+  medium: 'bg-amber-500 dark:bg-amber-400',
+  high: 'bg-orange-500 dark:bg-orange-400',
+  urgent: 'bg-red-500 dark:bg-red-400',
 }
 
 const PRIORITY_LABELS: Record<Priority, string> = {
@@ -132,10 +139,10 @@ function TaskQuickAdd() {
 // ── TaskDialog (full task creation/edit form) ──
 
 const PRIORITY_BUTTON_ACTIVE: Record<Priority, string> = {
-  low: 'bg-emerald-500/30 text-emerald-300',
-  medium: 'bg-amber-500/30 text-amber-300',
-  high: 'bg-orange-500/30 text-orange-300',
-  urgent: 'bg-red-500/30 text-red-300',
+  low: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-500/30 dark:text-emerald-300',
+  medium: 'bg-amber-100 text-amber-800 dark:bg-amber-500/30 dark:text-amber-300',
+  high: 'bg-orange-100 text-orange-800 dark:bg-orange-500/30 dark:text-orange-300',
+  urgent: 'bg-red-100 text-red-800 dark:bg-red-500/30 dark:text-red-300',
 }
 
 function TaskDialog({
@@ -445,7 +452,7 @@ function PrioritySelector({
                 p === value ? 'font-medium' : ''
               }`}
             >
-              <span className={`inline-block h-2 w-2 rounded-full ${PRIORITY_COLORS[p].split(' ')[0]}`} />
+              <span className={`inline-block h-2 w-2 rounded-full ${PRIORITY_DOT_COLORS[p]}`} />
               <span className="text-[rgb(var(--foreground))]">{PRIORITY_LABELS[p]}</span>
             </button>
           ))}

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -161,24 +161,23 @@ function BillingToggle({
 }
 
 // ---------------------------------------------------------------------------
-// Price display helper
+// Price display helper — used inline in the trial subhead, intentionally
+// modest in size so it doesn't dominate the "30-day free trial" headline.
 // ---------------------------------------------------------------------------
 
 function PriceDisplay({ interval }: { interval: BillingInterval }) {
   if (interval === 'monthly') {
     return (
-      <div className="flex items-baseline gap-1">
-        <span className="text-2xl font-bold text-[rgb(var(--foreground))]">&euro;3.60</span>
-        <span className="text-sm text-[rgb(var(--muted))]">/month</span>
-      </div>
+      <span className="text-sm text-[rgb(var(--muted))]">
+        Then <span className="font-semibold text-[rgb(var(--foreground))]">&euro;3.60/month</span>. Cancel anytime before day 30, no charge.
+      </span>
     )
   }
   return (
-    <div className="flex items-baseline gap-1">
-      <span className="text-2xl font-bold text-[rgb(var(--foreground))]">&euro;3.00</span>
-      <span className="text-sm text-[rgb(var(--muted))]">/month</span>
-      <span className="ml-2 text-xs font-medium text-emerald-400">&middot; Save 17%</span>
-    </div>
+    <span className="text-sm text-[rgb(var(--muted))]">
+      Then <span className="font-semibold text-[rgb(var(--foreground))]">&euro;3.00/month</span> billed annually. Cancel anytime before day 30, no charge.
+      <span className="ml-1 text-xs font-medium text-emerald-400">Save 17%</span>
+    </span>
   )
 }
 
@@ -450,7 +449,7 @@ function StepChoosePlan({
             <span className="text-sm text-[rgb(var(--foreground))]">{priceLabel}</span>
           </div>
           <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-            30-day free trial included. Cancel anytime before.
+            Card secures your trial &mdash; no charge until day 30. Cancel anytime before.
           </p>
           <div className="mt-2 flex items-center gap-1.5 text-xs text-[rgb(var(--muted))]">
             <Lock className="h-3 w-3 text-emerald-500" />
@@ -557,10 +556,10 @@ function StepChoosePlan({
           </div>
         </button>
 
-        {/* Card B: 30 Day Free Trial — credit card required */}
+        {/* Card B: 30 Day Free Trial — card secures the trial, no charge for 30 days */}
         <button
           onClick={() => setSelectedTrial('30day')}
-          aria-label={`30 Day Free Trial — ${interval === 'monthly' ? '€3.60/month' : '€3.00/month billed annually'}, credit card required, cancel anytime`}
+          aria-label={`30-day free trial — then ${interval === 'monthly' ? '€3.60/month' : '€3.00/month billed annually'}, cancel anytime before day 30 with no charge`}
           className={`group w-full rounded-xl border-2 p-4 sm:p-6 text-left transition-all ${
             selectedTrial === '30day'
               ? 'border-emerald-500 bg-emerald-500/5'
@@ -573,14 +572,14 @@ function StepChoosePlan({
             </div>
             <div className="flex-1">
               <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
-                <h3 className="text-base sm:text-lg font-semibold text-[rgb(var(--foreground))] whitespace-nowrap">30 Day Free Trial</h3>
+                <h3 className="text-xl sm:text-2xl font-bold text-[rgb(var(--foreground))] leading-tight">30-day free trial</h3>
                 <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400 uppercase tracking-wide">
                   Recommended
                 </span>
               </div>
-              <div className="mt-2">
+              <p className="mt-1.5 leading-snug">
                 <PriceDisplay interval={interval} />
-              </div>
+              </p>
               <ul className="mt-3 space-y-1.5">
                 <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
                   <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
@@ -588,11 +587,7 @@ function StepChoosePlan({
                 </li>
                 <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
                   <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-                  Credit card required
-                </li>
-                <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
-                  <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-                  Cancel anytime
+                  Card secures your trial &mdash; no charge until day 30
                 </li>
                 <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
                   <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />

--- a/apps/web/app/components/EmailVerificationBanner.tsx
+++ b/apps/web/app/components/EmailVerificationBanner.tsx
@@ -1,19 +1,52 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { MailWarning, Loader2 } from 'lucide-react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { isSelfHosted } from '@/app/lib/self-hosted'
 import { BILLING_API_URL } from '@/app/lib/config'
 
+// Minimum gap between focus-triggered refreshes. Cheap guard against burst
+// refreshes when the tab visibility flickers (e.g. fast alt-tab) or when
+// React strict mode double-invokes the effect in dev.
+const REFRESH_THROTTLE_MS = 5_000
+
 export function EmailVerificationBanner() {
   const user = useAuthStore((s) => s.user)
+  const refreshSession = useAuthStore((s) => s.refreshSession)
   const [resending, setResending] = useState(false)
   const [resent, setResent] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const lastRefreshRef = useRef(0)
+
+  const shouldShow = !isSelfHosted && user && user.emailVerified === false
+
+  // When the banner is mounted (i.e. the user is signed in but unverified),
+  // re-check the session whenever the tab regains focus. This handles the
+  // common path of "user clicks the verify link in a new tab → comes back
+  // here" — without this, the banner sticks until a hard reload because
+  // refreshSession() otherwise only runs once on initial app mount.
+  useEffect(() => {
+    if (!shouldShow) return
+
+    const maybeRefresh = () => {
+      if (document.visibilityState !== 'visible') return
+      const now = Date.now()
+      if (now - lastRefreshRef.current < REFRESH_THROTTLE_MS) return
+      lastRefreshRef.current = now
+      void refreshSession()
+    }
+
+    document.addEventListener('visibilitychange', maybeRefresh)
+    window.addEventListener('focus', maybeRefresh)
+    return () => {
+      document.removeEventListener('visibilitychange', maybeRefresh)
+      window.removeEventListener('focus', maybeRefresh)
+    }
+  }, [shouldShow, refreshSession])
 
   // Don't show for self-hosted, unauthenticated, or already verified
-  if (isSelfHosted || !user || user.emailVerified !== false) {
+  if (!shouldShow) {
     return null
   }
 

--- a/apps/web/app/components/MobileAppDialog.tsx
+++ b/apps/web/app/components/MobileAppDialog.tsx
@@ -25,7 +25,7 @@ export function MobileAppDialog({ open, onClose }: MobileAppDialogProps) {
 
   // Generate a simple QR-code-like placeholder using CSS
   // In production, you'd use a QR code library or pre-generated image
-  const downloadUrl = 'https://docs.silentsuite.io/mobile'
+  const installGuideUrl = 'https://docs.silentsuite.io/user-guide/apps/android'
 
   return (
     <>
@@ -85,7 +85,7 @@ export function MobileAppDialog({ open, onClose }: MobileAppDialogProps) {
             {/* Links */}
             <div className="space-y-2">
               <a
-                href={downloadUrl}
+                href={installGuideUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex w-full items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"

--- a/apps/web/app/components/OnboardingModal.tsx
+++ b/apps/web/app/components/OnboardingModal.tsx
@@ -1,15 +1,13 @@
 'use client'
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Calendar, CheckSquare, Users, Shield, Check, Lock, EyeOff, Sun, Moon, Monitor, X } from 'lucide-react'
+import { Shield, Check, Lock, EyeOff, Sun, Moon, Monitor, X } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { Button } from '@silentsuite/ui'
 import CalendarImport from '@/app/components/import/CalendarImport'
 import TaskImport from '@/app/components/import/TaskImport'
 import ContactImport from '@/app/components/import/ContactImport'
-import { useCalendarStore } from '@/app/stores/use-calendar-store'
-import { useContactStore } from '@/app/stores/use-contact-store'
-import { useTaskStore } from '@/app/stores/use-task-store'
+import { useAuthStore } from '@/app/stores/use-auth-store'
 
 interface ImportCounts {
   calendar: number
@@ -213,35 +211,34 @@ export function OnboardingModal() {
   const [counts, setCounts] = useState<ImportCounts>({ calendar: 0, tasks: 0, contacts: 0 })
   const backdropRef = useRef<HTMLDivElement>(null)
 
-  const events = useCalendarStore((s) => s.events)
-  const contacts = useContactStore((s) => s.contacts)
-  const tasks = useTaskStore((s) => s.tasks)
+  // Server-side onboardedAt is the authoritative gate (issue #113). The
+  // localStorage 'onboardingCompleted' flag remains as a synchronous
+  // flash-suppressor: if it's present we never show the modal, even if
+  // the user object hasn't loaded yet. Once user.onboardedAt resolves,
+  // the server is the source of truth.
+  const user = useAuthStore((s) => s.user)
+  const markOnboarded = useAuthStore((s) => s.markOnboarded)
 
   useEffect(() => {
-    const completed = localStorage.getItem('onboardingCompleted')
-    if (completed) return
+    // Flash-suppressor: if a previous dismissal flagged completion in
+    // localStorage, never re-show. Server-side onboardedAt remains the
+    // real gate, but the localStorage hint stops the modal flickering on
+    // top of an already-onboarded user before the auth store hydrates.
+    if (localStorage.getItem('onboardingCompleted')) return
 
-    // If user already has synced data or has imported items into any store, skip onboarding
-    const totalItems = events.length + contacts.length + tasks.length
-    if (totalItems > 0) {
+    // No user yet — wait for auth hydration before deciding.
+    if (!user) return
+
+    // Server says onboarded — record the hint for fast suppression on
+    // future loads and don't show.
+    if (user.onboardedAt) {
       localStorage.setItem('onboardingCompleted', 'true')
       return
     }
 
-    // If user has been active for 7+ days, skip onboarding
-    const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
-    const firstLogin = localStorage.getItem('firstLoginDate')
-    if (firstLogin) {
-      if (Date.now() - Number(firstLogin) > SEVEN_DAYS_MS) {
-        localStorage.setItem('onboardingCompleted', 'true')
-        return
-      }
-    } else {
-      localStorage.setItem('firstLoginDate', String(Date.now()))
-    }
-
+    // user.onboardedAt === null → fresh user, show the modal.
     setShow(true)
-  }, [events.length, contacts.length, tasks.length])
+  }, [user])
 
   const goTo = useCallback(
     (nextStep: number, dir: Direction) => {
@@ -259,15 +256,21 @@ export function OnboardingModal() {
   const next = useCallback(() => goTo(step + 1, 'left'), [goTo, step])
   const back = useCallback(() => goTo(step - 1, 'right'), [goTo, step])
 
-  const finish = useCallback(() => {
+  // Dismissal handler shared by finish, skipAll, the X button and the
+  // backdrop click. Fires markOnboarded() at the auth store (which POSTs
+  // /account/onboarded — fire-and-forget; on failure user.onboardedAt
+  // stays null and the modal will retry next session) and stamps the
+  // localStorage flash-suppression hint synchronously so the modal stays
+  // gone for the rest of this session even if the network call is in
+  // flight or fails.
+  const dismiss = useCallback(() => {
+    void markOnboarded()
     localStorage.setItem('onboardingCompleted', 'true')
     setShow(false)
-  }, [])
+  }, [markOnboarded])
 
-  const skipAll = useCallback(() => {
-    localStorage.setItem('onboardingCompleted', 'true')
-    setShow(false)
-  }, [])
+  const finish = dismiss
+  const skipAll = dismiss
 
   const handleCalendarImport = useCallback((count: number) => {
     setCounts((prev) => ({ ...prev, calendar: count }))

--- a/apps/web/app/components/__tests__/OnboardingModal.test.tsx
+++ b/apps/web/app/components/__tests__/OnboardingModal.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { User } from '@/app/stores/use-auth-store'
+
+// In-memory replica of the auth store the modal reads from. We mock the
+// entire module so we don't need to wire up the real Zustand store, the
+// secure storage, etc. — the modal only uses two slices: `user` and
+// `markOnboarded`.
+const mockState = {
+  user: null as User | null,
+  markOnboarded: vi.fn(async () => true),
+}
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: <T,>(selector: (s: typeof mockState) => T) => selector(mockState),
+}))
+
+// next-themes pulls in matchMedia which jsdom doesn't provide; mock it to
+// keep the welcome / theme-choice slides happy without polluting the test.
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'system', setTheme: vi.fn() }),
+}))
+
+// Heavy import slides are out of scope for the gate tests — stub them so
+// rendering a deeper step (we never do, but defensive) doesn't blow up on
+// the etebase dependency tree.
+vi.mock('@/app/components/import/CalendarImport', () => ({
+  default: () => null,
+}))
+vi.mock('@/app/components/import/TaskImport', () => ({
+  default: () => null,
+}))
+vi.mock('@/app/components/import/ContactImport', () => ({
+  default: () => null,
+}))
+
+import { OnboardingModal } from '../OnboardingModal'
+
+function setUser(user: User | null) {
+  mockState.user = user
+}
+
+describe('OnboardingModal — gate logic (issue #113)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    setUser(null)
+    mockState.markOnboarded.mockClear()
+    mockState.markOnboarded.mockResolvedValue(true)
+  })
+
+  it('does not render while user is null (auth still hydrating)', () => {
+    setUser(null)
+    const { container } = render(<OnboardingModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders when user.onboardedAt is null', () => {
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+    expect(screen.getByLabelText('Close onboarding')).toBeInTheDocument()
+  })
+
+  it('does not render when user.onboardedAt is a recent timestamp', () => {
+    setUser({
+      id: 'u1',
+      email: 'a@b.com',
+      planId: 'pro',
+      onboardedAt: new Date().toISOString(),
+    })
+    const { container } = render(<OnboardingModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('does not render when user.onboardedAt is an old timestamp', () => {
+    setUser({
+      id: 'u1',
+      email: 'a@b.com',
+      planId: 'pro',
+      onboardedAt: '2024-01-01T00:00:00.000Z',
+    })
+    const { container } = render(<OnboardingModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('respects the localStorage flash-suppression hint when set', () => {
+    // Even if server says onboardedAt is null, the synchronous hint
+    // suppresses the modal so we don't flash it on top of an
+    // already-onboarded session before the auth store hydrates.
+    localStorage.setItem('onboardingCompleted', 'true')
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    const { container } = render(<OnboardingModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('writes the localStorage hint when onboardedAt is non-null', () => {
+    setUser({
+      id: 'u1',
+      email: 'a@b.com',
+      planId: 'pro',
+      onboardedAt: '2025-06-01T00:00:00.000Z',
+    })
+    render(<OnboardingModal />)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+
+  it('X button calls markOnboarded and sets the localStorage hint', () => {
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+
+    fireEvent.click(screen.getByLabelText('Close onboarding'))
+
+    expect(mockState.markOnboarded).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+
+  it('Skip all button calls markOnboarded and sets the localStorage hint', () => {
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+
+    fireEvent.click(screen.getByText('Skip all'))
+
+    expect(mockState.markOnboarded).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+
+  it('Escape key calls markOnboarded and sets the localStorage hint', () => {
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    expect(mockState.markOnboarded).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+
+  it('does not block dismissal when markOnboarded fails', () => {
+    // Network error — markOnboarded resolves false; the modal must still
+    // close and the localStorage hint must still be set so the user
+    // isn't trapped in the popup for the rest of this session.
+    mockState.markOnboarded.mockResolvedValueOnce(false)
+    setUser({ id: 'u1', email: 'a@b.com', planId: 'pro', onboardedAt: null })
+    render(<OnboardingModal />)
+
+    fireEvent.click(screen.getByLabelText('Close onboarding'))
+
+    expect(mockState.markOnboarded).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('onboardingCompleted')).toBe('true')
+  })
+})

--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import 'fake-indexeddb/auto'
+import {
+  getItemsByType,
+  putItem,
+  putItems,
+  deleteItem,
+  replaceItemsForType,
+  getCollection,
+  putCollection,
+  getStoken,
+  setStoken,
+  clearStoken,
+  getMeta,
+  putMeta,
+  clearAll,
+  ensureFingerprint,
+  CACHE_SCHEMA_VERSION,
+  _resetForTests,
+  type CachedItem,
+} from '../data-cache'
+
+beforeEach(async () => {
+  await _resetForTests()
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase('silentsuite-data-cache')
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+    req.onblocked = () => resolve()
+  })
+})
+
+function makeItem(uid: string, type: 'tasks' | 'contacts' | 'calendar' = 'tasks', content = 'CONTENT'): CachedItem {
+  return {
+    itemUid: uid,
+    collectionType: type,
+    collectionUid: 'col-1',
+    content,
+    lastModified: Date.now(),
+  }
+}
+
+describe('data-cache', () => {
+  describe('items CRUD', () => {
+    it('starts empty', async () => {
+      const items = await getItemsByType('tasks')
+      expect(items).toEqual([])
+    })
+
+    it('persists and reads back a single item', async () => {
+      await putItem(makeItem('task-1', 'tasks', 'A'))
+      const items = await getItemsByType('tasks')
+      expect(items).toHaveLength(1)
+      expect(items[0]!.itemUid).toBe('task-1')
+      expect(items[0]!.content).toBe('A')
+    })
+
+    it('bulk-inserts via putItems', async () => {
+      await putItems([
+        makeItem('a', 'tasks'),
+        makeItem('b', 'tasks'),
+        makeItem('c', 'contacts'),
+      ])
+      const tasks = await getItemsByType('tasks')
+      const contacts = await getItemsByType('contacts')
+      expect(tasks).toHaveLength(2)
+      expect(contacts).toHaveLength(1)
+    })
+
+    it('separates items by collection type via the index', async () => {
+      await putItem(makeItem('a', 'tasks'))
+      await putItem(makeItem('b', 'contacts'))
+      await putItem(makeItem('c', 'calendar'))
+
+      expect(await getItemsByType('tasks')).toHaveLength(1)
+      expect(await getItemsByType('contacts')).toHaveLength(1)
+      expect(await getItemsByType('calendar')).toHaveLength(1)
+    })
+
+    it('overwrites by uid on put', async () => {
+      await putItem(makeItem('x', 'tasks', 'old'))
+      await putItem(makeItem('x', 'tasks', 'new'))
+      const items = await getItemsByType('tasks')
+      expect(items).toHaveLength(1)
+      expect(items[0]!.content).toBe('new')
+    })
+
+    it('deletes a single item by uid', async () => {
+      await putItem(makeItem('x', 'tasks'))
+      await putItem(makeItem('y', 'tasks'))
+      await deleteItem('x')
+      const items = await getItemsByType('tasks')
+      expect(items.map((i) => i.itemUid)).toEqual(['y'])
+    })
+
+    it('replaceItemsForType drops existing of that type and inserts the new set', async () => {
+      await putItems([
+        makeItem('a', 'tasks'),
+        makeItem('b', 'tasks'),
+        makeItem('c', 'contacts'),
+      ])
+      await replaceItemsForType('tasks', [makeItem('z', 'tasks', 'fresh')])
+
+      const tasks = await getItemsByType('tasks')
+      expect(tasks).toHaveLength(1)
+      expect(tasks[0]!.itemUid).toBe('z')
+
+      // Other types untouched
+      const contacts = await getItemsByType('contacts')
+      expect(contacts).toHaveLength(1)
+      expect(contacts[0]!.itemUid).toBe('c')
+    })
+  })
+
+  describe('collections / stokens', () => {
+    it('returns null for an unknown collection', async () => {
+      expect(await getCollection('tasks')).toBeNull()
+      expect(await getStoken('tasks')).toBeNull()
+    })
+
+    it('persists a collection record', async () => {
+      await putCollection({
+        collectionType: 'tasks',
+        collectionUid: 'col-tasks',
+        stoken: 'stk-1',
+        lastFullSyncAt: 12345,
+      })
+      const col = await getCollection('tasks')
+      expect(col).not.toBeNull()
+      expect(col!.stoken).toBe('stk-1')
+      expect(col!.collectionUid).toBe('col-tasks')
+    })
+
+    it('setStoken creates and updates the cursor', async () => {
+      await setStoken('tasks', 'col-tasks', 'stk-a')
+      expect(await getStoken('tasks')).toBe('stk-a')
+      await setStoken('tasks', 'col-tasks', 'stk-b')
+      expect(await getStoken('tasks')).toBe('stk-b')
+    })
+
+    it('clearStoken nulls the stoken but preserves the row', async () => {
+      await setStoken('tasks', 'col-tasks', 'stk-a')
+      await clearStoken('tasks')
+      expect(await getStoken('tasks')).toBeNull()
+      const col = await getCollection('tasks')
+      expect(col).not.toBeNull()
+      expect(col!.collectionUid).toBe('col-tasks')
+    })
+  })
+
+  describe('meta / fingerprint', () => {
+    it('returns null when meta is missing', async () => {
+      expect(await getMeta()).toBeNull()
+    })
+
+    it('persists meta', async () => {
+      await putMeta({
+        accountFingerprint: 'alice@example.com',
+        cacheSchemaVersion: CACHE_SCHEMA_VERSION,
+        lastInvalidatedAt: null,
+      })
+      const meta = await getMeta()
+      expect(meta?.accountFingerprint).toBe('alice@example.com')
+    })
+
+    it('ensureFingerprint seeds meta on first run', async () => {
+      const ok = await ensureFingerprint('alice@example.com')
+      expect(ok).toBe(true)
+      const meta = await getMeta()
+      expect(meta?.accountFingerprint).toBe('alice@example.com')
+      expect(meta?.cacheSchemaVersion).toBe(CACHE_SCHEMA_VERSION)
+    })
+
+    it('ensureFingerprint wipes when accounts differ', async () => {
+      await setStoken('tasks', 'col-tasks', 'stk-a')
+      await ensureFingerprint('alice@example.com')
+
+      const ok = await ensureFingerprint('bob@example.com')
+      expect(ok).toBe(false)
+
+      // Cache should be wiped for the new account.
+      expect(await getStoken('tasks')).toBeNull()
+      const meta = await getMeta()
+      expect(meta?.accountFingerprint).toBe('bob@example.com')
+      expect(meta?.lastInvalidatedAt).not.toBeNull()
+    })
+
+    it('ensureFingerprint accepts the same account on subsequent calls', async () => {
+      await ensureFingerprint('alice@example.com')
+      await setStoken('tasks', 'col-tasks', 'stk-a')
+
+      const ok = await ensureFingerprint('alice@example.com')
+      expect(ok).toBe(true)
+      expect(await getStoken('tasks')).toBe('stk-a')
+    })
+  })
+
+  describe('clearAll', () => {
+    it('wipes items, collections, and meta', async () => {
+      await putItem(makeItem('x', 'tasks'))
+      await setStoken('tasks', 'col-tasks', 'stk')
+      await putMeta({
+        accountFingerprint: 'a',
+        cacheSchemaVersion: CACHE_SCHEMA_VERSION,
+        lastInvalidatedAt: null,
+      })
+
+      await clearAll()
+
+      expect(await getItemsByType('tasks')).toEqual([])
+      expect(await getStoken('tasks')).toBeNull()
+      expect(await getMeta()).toBeNull()
+    })
+
+    it('is safe to call repeatedly', async () => {
+      await clearAll()
+      await clearAll()
+      expect(await getItemsByType('tasks')).toEqual([])
+    })
+  })
+})

--- a/apps/web/app/lib/__tests__/tz.test.ts
+++ b/apps/web/app/lib/__tests__/tz.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import {
+  partsInZone,
+  formatDateForInputInZone,
+  formatTimeForInputInZone,
+  instantFromWallClock,
+  resolveUserTimezone,
+} from '../tz'
+
+describe('tz helpers', () => {
+  it('reads wall-clock parts in the requested zone', () => {
+    // 2025-06-15 12:00 UTC = 14:00 Europe/Berlin (CEST)
+    const utcInstant = new Date(Date.UTC(2025, 5, 15, 12, 0, 0))
+    const berlin = partsInZone(utcInstant, 'Europe/Berlin')
+    expect(berlin).toEqual({ year: 2025, month: 6, day: 15, hour: 14, minute: 0, second: 0 })
+
+    const tokyo = partsInZone(utcInstant, 'Asia/Tokyo')
+    expect(tokyo).toEqual({ year: 2025, month: 6, day: 15, hour: 21, minute: 0, second: 0 })
+  })
+
+  it('round-trips a wall-clock through instantFromWallClock + partsInZone', () => {
+    const tz = 'America/New_York'
+    const instant = instantFromWallClock(2025, 11, 4, 9, 30, tz)
+    const parts = partsInZone(instant, tz)
+    expect(parts).toEqual({ year: 2025, month: 11, day: 4, hour: 9, minute: 30, second: 0 })
+  })
+
+  it('handles different DST/standard time correctly', () => {
+    // 09:00 NY in June (EDT, UTC-4) -> 13:00 UTC
+    const summer = instantFromWallClock(2025, 6, 15, 9, 0, 'America/New_York')
+    expect(summer.toISOString()).toBe('2025-06-15T13:00:00.000Z')
+
+    // 09:00 NY in January (EST, UTC-5) -> 14:00 UTC
+    const winter = instantFromWallClock(2025, 1, 15, 9, 0, 'America/New_York')
+    expect(winter.toISOString()).toBe('2025-01-15T14:00:00.000Z')
+  })
+
+  it('formats date/time inputs in the target zone', () => {
+    // 2025-06-15 23:30 UTC = 2025-06-16 08:30 Tokyo
+    const instant = new Date(Date.UTC(2025, 5, 15, 23, 30, 0))
+    expect(formatDateForInputInZone(instant, 'Asia/Tokyo')).toBe('2025-06-16')
+    expect(formatTimeForInputInZone(instant, 'Asia/Tokyo')).toBe('08:30')
+    expect(formatDateForInputInZone(instant, 'America/New_York')).toBe('2025-06-15')
+    expect(formatTimeForInputInZone(instant, 'America/New_York')).toBe('19:30')
+  })
+
+  it('falls back to browser-local when the preferred TZ is invalid', () => {
+    const browser = Intl.DateTimeFormat().resolvedOptions().timeZone
+    expect(resolveUserTimezone(undefined)).toBe(browser)
+    expect(resolveUserTimezone('Not/A_Real_Zone')).toBe(browser)
+    expect(resolveUserTimezone('Europe/Berlin')).toBe('Europe/Berlin')
+  })
+})

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -1,0 +1,357 @@
+/**
+ * Local data cache for instant reload — IndexedDB-backed, plain JSON values.
+ *
+ * Stores already-decrypted item content (iCal/vCard/vTodo strings) plus
+ * per-collection sync cursors (stokens) so that on the next page load the
+ * UI can paint from the cache before the network sync completes.
+ *
+ * SCOPE: This module follows the same raw-IDB pattern as `secure-storage.ts`
+ * and `offline-queue.ts` — no `idb` / Dexie dependency.
+ *
+ * AT-REST ENCRYPTION: NOT applied. Decrypted item content sits in plain
+ * IndexedDB. This is consistent with the bridge's behavior (it stores its
+ * cache in plain SQLite, not sqlcipher) and with the wider PWA ecosystem
+ * (Slack, Linear, Notion all do the same). Encrypting the cache at rest is
+ * tracked in a separate follow-up that covers webapp + bridge + Android
+ * together.
+ *
+ * Gated by the `NEXT_PUBLIC_LOCAL_CACHE_ENABLED` feature flag in callers.
+ * This module itself does not check the flag — the flag is checked at the
+ * caller boundaries (sync-provider, etebase-store, auth-store) so this
+ * module stays pure and easy to test.
+ */
+import { logger } from '@/app/lib/logger'
+
+export type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts'
+
+export interface CachedItem {
+  itemUid: string
+  collectionType: CollectionTypeKey
+  collectionUid: string
+  /** Already-decrypted iCal / vCard / vTodo string */
+  content: string
+  /** Last time we wrote this record to the cache (ms epoch) */
+  lastModified: number
+}
+
+export interface CachedCollection {
+  collectionType: CollectionTypeKey
+  collectionUid: string
+  stoken: string | null
+  lastFullSyncAt: number | null
+}
+
+export interface CacheMeta {
+  /** Hash or username of the Etebase account this cache belongs to */
+  accountFingerprint: string | null
+  /** Schema version of the cache; bumped when shapes change to force re-sync */
+  cacheSchemaVersion: number
+  /** Last time the cache was wholesale invalidated (logout, schema bump) */
+  lastInvalidatedAt: number | null
+}
+
+/** Bumped on shape changes to the cached records. */
+export const CACHE_SCHEMA_VERSION = 1
+
+const DB_NAME = 'silentsuite-data-cache'
+const DB_VERSION = 1
+const STORE_ITEMS = 'items'
+const STORE_COLLECTIONS = 'collections'
+const STORE_META = 'meta'
+
+const META_KEY = 'singleton'
+
+let dbPromise: Promise<IDBDatabase> | null = null
+
+function openDB(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise
+  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB is not available'))
+      return
+    }
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(STORE_ITEMS)) {
+        const items = db.createObjectStore(STORE_ITEMS, { keyPath: 'itemUid' })
+        items.createIndex('byCollectionType', 'collectionType', { unique: false })
+        items.createIndex('byCollectionUid', 'collectionUid', { unique: false })
+      }
+      if (!db.objectStoreNames.contains(STORE_COLLECTIONS)) {
+        db.createObjectStore(STORE_COLLECTIONS, { keyPath: 'collectionType' })
+      }
+      if (!db.objectStoreNames.contains(STORE_META)) {
+        db.createObjectStore(STORE_META)
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => {
+      dbPromise = null
+      reject(request.error)
+    }
+  })
+  return dbPromise
+}
+
+function withStore<T>(
+  storeName: string,
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return openDB().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const tx = db.transaction(storeName, mode)
+        const store = tx.objectStore(storeName)
+        const req = fn(store)
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error)
+      }),
+  )
+}
+
+// ── Items ──
+
+/**
+ * Read all cached items for a collection type.
+ * Returns an empty array if the cache is empty or unavailable.
+ */
+export async function getItemsByType(type: CollectionTypeKey): Promise<CachedItem[]> {
+  try {
+    const db = await openDB()
+    return await new Promise<CachedItem[]>((resolve, reject) => {
+      const tx = db.transaction(STORE_ITEMS, 'readonly')
+      const idx = tx.objectStore(STORE_ITEMS).index('byCollectionType')
+      const req = idx.getAll(type)
+      req.onsuccess = () => resolve((req.result as CachedItem[]) ?? [])
+      req.onerror = () => reject(req.error)
+    })
+  } catch (err) {
+    logger.warn('[data-cache] getItemsByType failed', err)
+    return []
+  }
+}
+
+/** Insert/update a single item. Failures are logged and swallowed. */
+export async function putItem(item: CachedItem): Promise<void> {
+  try {
+    await withStore(STORE_ITEMS, 'readwrite', (store) => store.put(item))
+  } catch (err) {
+    logger.warn('[data-cache] putItem failed', err)
+  }
+}
+
+/** Bulk insert/update — single transaction for efficiency. */
+export async function putItems(items: CachedItem[]): Promise<void> {
+  if (items.length === 0) return
+  try {
+    const db = await openDB()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_ITEMS, 'readwrite')
+      const store = tx.objectStore(STORE_ITEMS)
+      for (const item of items) store.put(item)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch (err) {
+    logger.warn('[data-cache] putItems failed', err)
+  }
+}
+
+export async function deleteItem(itemUid: string): Promise<void> {
+  try {
+    await withStore(STORE_ITEMS, 'readwrite', (store) => store.delete(itemUid))
+  } catch (err) {
+    logger.warn('[data-cache] deleteItem failed', err)
+  }
+}
+
+/**
+ * Replace all cached items for a collection type with the given list.
+ * Used after a full refresh so removed-on-server items don't linger.
+ */
+export async function replaceItemsForType(
+  type: CollectionTypeKey,
+  items: CachedItem[],
+): Promise<void> {
+  try {
+    const db = await openDB()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_ITEMS, 'readwrite')
+      const store = tx.objectStore(STORE_ITEMS)
+      const idx = store.index('byCollectionType')
+      const cursorReq = idx.openCursor(type)
+      cursorReq.onsuccess = () => {
+        const cursor = cursorReq.result
+        if (cursor) {
+          cursor.delete()
+          cursor.continue()
+        } else {
+          for (const item of items) store.put(item)
+        }
+      }
+      cursorReq.onerror = () => reject(cursorReq.error)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch (err) {
+    logger.warn('[data-cache] replaceItemsForType failed', err)
+  }
+}
+
+// ── Collections / stokens ──
+
+export async function getCollection(type: CollectionTypeKey): Promise<CachedCollection | null> {
+  try {
+    const value = await withStore(STORE_COLLECTIONS, 'readonly', (store) => store.get(type))
+    return (value as CachedCollection | undefined) ?? null
+  } catch (err) {
+    logger.warn('[data-cache] getCollection failed', err)
+    return null
+  }
+}
+
+export async function putCollection(record: CachedCollection): Promise<void> {
+  try {
+    await withStore(STORE_COLLECTIONS, 'readwrite', (store) => store.put(record))
+  } catch (err) {
+    logger.warn('[data-cache] putCollection failed', err)
+  }
+}
+
+export async function getStoken(type: CollectionTypeKey): Promise<string | null> {
+  const col = await getCollection(type)
+  return col?.stoken ?? null
+}
+
+export async function setStoken(
+  type: CollectionTypeKey,
+  collectionUid: string,
+  stoken: string | null,
+): Promise<void> {
+  const existing = await getCollection(type)
+  await putCollection({
+    collectionType: type,
+    collectionUid,
+    stoken,
+    lastFullSyncAt: existing?.lastFullSyncAt ?? Date.now(),
+  })
+}
+
+/**
+ * Mark a collection's stoken as stale (server returned an unknown-stoken error).
+ * Caller should fall back to a full refresh.
+ */
+export async function clearStoken(type: CollectionTypeKey): Promise<void> {
+  const existing = await getCollection(type)
+  if (!existing) return
+  await putCollection({ ...existing, stoken: null })
+}
+
+// ── Meta ──
+
+export async function getMeta(): Promise<CacheMeta | null> {
+  try {
+    const value = await withStore(STORE_META, 'readonly', (store) => store.get(META_KEY))
+    return (value as CacheMeta | undefined) ?? null
+  } catch (err) {
+    logger.warn('[data-cache] getMeta failed', err)
+    return null
+  }
+}
+
+export async function putMeta(meta: CacheMeta): Promise<void> {
+  try {
+    await withStore(STORE_META, 'readwrite', (store) => store.put(meta, META_KEY))
+  } catch (err) {
+    logger.warn('[data-cache] putMeta failed', err)
+  }
+}
+
+// ── Whole-cache operations ──
+
+/**
+ * Wipe everything — items, collections, meta. Called on logout, password
+ * change, account fingerprint mismatch, or schema bump.
+ */
+export async function clearAll(): Promise<void> {
+  try {
+    const db = await openDB()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([STORE_ITEMS, STORE_COLLECTIONS, STORE_META], 'readwrite')
+      tx.objectStore(STORE_ITEMS).clear()
+      tx.objectStore(STORE_COLLECTIONS).clear()
+      tx.objectStore(STORE_META).clear()
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch (err) {
+    logger.warn('[data-cache] clearAll failed', err)
+  }
+}
+
+/**
+ * Verify the cache belongs to the expected account and is on the current
+ * schema version. If not, wipe and reseed the meta record. Returns true if
+ * the cache survived the check (callers can use it), false if it was wiped.
+ */
+export async function ensureFingerprint(accountFingerprint: string): Promise<boolean> {
+  const meta = await getMeta()
+  const current: CacheMeta = {
+    accountFingerprint,
+    cacheSchemaVersion: CACHE_SCHEMA_VERSION,
+    lastInvalidatedAt: meta?.lastInvalidatedAt ?? null,
+  }
+
+  if (!meta) {
+    await putMeta(current)
+    return true
+  }
+
+  const fingerprintMismatch =
+    meta.accountFingerprint !== null && meta.accountFingerprint !== accountFingerprint
+  const schemaMismatch = meta.cacheSchemaVersion !== CACHE_SCHEMA_VERSION
+
+  if (fingerprintMismatch || schemaMismatch) {
+    logger.warn('[data-cache] fingerprint or schema mismatch, clearing cache', {
+      fingerprintMismatch,
+      schemaMismatch,
+    })
+    await clearAll()
+    await putMeta({ ...current, lastInvalidatedAt: Date.now() })
+    return false
+  }
+
+  // First-time fingerprint write (e.g. legacy cache without fingerprint)
+  if (meta.accountFingerprint === null) {
+    await putMeta(current)
+  }
+  return true
+}
+
+// ── Feature flag helper ──
+
+/**
+ * Returns true if the local cache feature is enabled via the env flag.
+ * Off by default — when false, the cache is never read or written and
+ * the app behaves identically to pre-PR.
+ */
+export function isCacheEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED === 'true'
+}
+
+// ── Test helpers ──
+
+/** Reset the module-level DB promise — for tests only. */
+export async function _resetForTests(): Promise<void> {
+  if (dbPromise) {
+    try {
+      const db = await dbPromise
+      db.close()
+    } catch {
+      // ignore
+    }
+  }
+  dbPromise = null
+}

--- a/apps/web/app/lib/tz.ts
+++ b/apps/web/app/lib/tz.ts
@@ -1,0 +1,93 @@
+import 'temporal-polyfill/global'
+
+/** Return the IANA TZ name to use for the calendar grid: user preference, then browser local. */
+export function resolveUserTimezone(preferred: string | undefined): string {
+  if (preferred) {
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: preferred })
+      return preferred
+    } catch {
+      // fall through
+    }
+  }
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
+/** Wall-clock components of `date` as observed in `tz`. */
+export function partsInZone(date: Date, tz: string): {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+} {
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  })
+  const parts = fmt.formatToParts(date)
+  const get = (type: string) => parseInt(parts.find((p) => p.type === type)?.value ?? '0', 10)
+  let hour = get('hour')
+  if (hour === 24) hour = 0 // Intl midnight edge case
+  return {
+    year: get('year'),
+    month: get('month'),
+    day: get('day'),
+    hour,
+    minute: get('minute'),
+    second: get('second'),
+  }
+}
+
+/** YYYY-MM-DD wall-clock date in `tz`, suitable for <input type="date">. */
+export function formatDateForInputInZone(date: Date, tz: string): string {
+  const p = partsInZone(date, tz)
+  return `${p.year}-${String(p.month).padStart(2, '0')}-${String(p.day).padStart(2, '0')}`
+}
+
+/** HH:MM 24h wall-clock time in `tz`, suitable for <input type="time">. */
+export function formatTimeForInputInZone(date: Date, tz: string): string {
+  const p = partsInZone(date, tz)
+  return `${String(p.hour).padStart(2, '0')}:${String(p.minute).padStart(2, '0')}`
+}
+
+/** Build a UTC instant from a wall-clock interpreted in `tz`. */
+export function instantFromWallClock(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  tz: string,
+): Date {
+  const zdt = Temporal.PlainDateTime.from({
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second: 0,
+  }).toZonedDateTime(tz)
+  return new Date(zdt.epochMilliseconds)
+}
+
+/** Short timezone label for badges, e.g. "GMT+2" or city name. */
+export function shortTimezoneLabel(tz: string, refDate: Date = new Date()): string {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      timeZoneName: 'short',
+    })
+    const parts = fmt.formatToParts(refDate)
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz
+  } catch {
+    return tz
+  }
+}

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -8,6 +8,12 @@ import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
+import {
+  getItemsByType as cacheGetItemsByType,
+  replaceItemsForType as cacheReplaceItemsForType,
+  isCacheEnabled as isLocalCacheEnabled,
+  type CachedItem,
+} from '@/app/lib/data-cache'
 
 /**
  * SyncProvider orchestrates:
@@ -49,6 +55,13 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       try {
         setSyncStatus('syncing')
 
+        // Cache-first hydration: when the feature flag is on, paint the UI
+        // from IndexedDB before the network sync starts. This is best-effort
+        // — failures are logged and the normal init path proceeds.
+        if (isLocalCacheEnabled()) {
+          await hydrateFromCache()
+        }
+
         // Restore session, create/fetch collections, load items, start SyncEngine
         await etebaseInitialize()
 
@@ -71,8 +84,92 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       }
     }
 
+    /**
+     * Cache-first paint. Reads decrypted item content out of IndexedDB and
+     * pushes it into the domain stores so the UI renders from cache before
+     * the network sync settles. The subsequent etebaseInitialize() +
+     * loadItemsIntoStores() pass overwrites with server data, which is the
+     * source of truth.
+     *
+     * Cheap (~10-50ms for a typical vault) and fully off the network path.
+     * Failures here are non-fatal; we just skip the optimistic paint.
+     */
+    async function hydrateFromCache() {
+      try {
+        const [taskItems, contactItems, eventItems, core] = await Promise.all([
+          cacheGetItemsByType('tasks'),
+          cacheGetItemsByType('contacts'),
+          cacheGetItemsByType('calendar'),
+          import('@silentsuite/core'),
+        ])
+
+        if (taskItems.length > 0) {
+          try {
+            const tasks = taskItems.map((it) => {
+              const task = core.deserializeTask(it.content)
+              return { ...task, id: it.itemUid, uid: it.itemUid }
+            })
+            useTaskStore.getState().syncFromRemote(tasks)
+            logger.log(`[sync-provider] Hydrated ${tasks.length} tasks from cache`)
+          } catch (err) {
+            logger.warn('[sync-provider] Failed to hydrate tasks from cache', err)
+          }
+        }
+
+        if (contactItems.length > 0) {
+          try {
+            const contacts = contactItems.map((it) => {
+              const contact = core.deserializeContact(it.content)
+              return { ...contact, id: it.itemUid, uid: it.itemUid }
+            })
+            useContactStore.getState().syncFromRemote(contacts)
+            logger.log(`[sync-provider] Hydrated ${contacts.length} contacts from cache`)
+          } catch (err) {
+            logger.warn('[sync-provider] Failed to hydrate contacts from cache', err)
+          }
+        }
+
+        if (eventItems.length > 0) {
+          try {
+            const events = eventItems.map((it) => {
+              const event = core.deserializeCalendarEvent(it.content)
+              return { ...event, id: it.itemUid, uid: it.itemUid }
+            })
+            useCalendarStore.getState().syncFromRemote(events)
+            logger.log(`[sync-provider] Hydrated ${events.length} events from cache`)
+          } catch (err) {
+            logger.warn('[sync-provider] Failed to hydrate calendar events from cache', err)
+          }
+        }
+      } catch (err) {
+        logger.warn('[sync-provider] Cache hydration failed', err)
+      }
+    }
+
     async function loadItemsIntoStores() {
       const etebase = useEtebaseStore.getState()
+      const cacheEnabled = isLocalCacheEnabled()
+
+      async function mirrorToCache(
+        type: 'tasks' | 'contacts' | 'calendar',
+        items: { uid: string; content: string }[],
+      ) {
+        if (!cacheEnabled || items.length === 0) return
+        const collectionUid = useEtebaseStore.getState().collections[type]?.uid
+        if (!collectionUid) return
+        const records: CachedItem[] = items.map((it) => ({
+          itemUid: it.uid,
+          collectionType: type,
+          collectionUid,
+          content: it.content,
+          lastModified: Date.now(),
+        }))
+        try {
+          await cacheReplaceItemsForType(type, records)
+        } catch (err) {
+          logger.warn(`[sync-provider] Failed to mirror ${type} to cache`, err)
+        }
+      }
 
       // Load tasks
       try {
@@ -87,6 +184,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           })
           useTaskStore.getState().syncFromRemote(tasks)
           logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
+          await mirrorToCache('tasks', taskItems)
         }
       } catch (err) {
         Sentry.captureException(err)
@@ -104,6 +202,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           })
           useContactStore.getState().syncFromRemote(contacts)
           logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
+          await mirrorToCache('contacts', contactItems)
         }
       } catch (err) {
         Sentry.captureException(err)
@@ -121,6 +220,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           })
           useCalendarStore.getState().syncFromRemote(events)
           logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
+          await mirrorToCache('calendar', eventItems)
         }
       } catch (err) {
         Sentry.captureException(err)

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -4,6 +4,15 @@ import { useAuthStore } from '../use-auth-store'
 // Mock fetch globally
 vi.stubGlobal('fetch', vi.fn())
 
+// Mock data-cache (used on logout). We use vi.hoisted so the mock fn is
+// declared before vi.mock factory runs (vi.mock is hoisted to the top).
+const { dataCacheClearAll } = vi.hoisted(() => {
+  return { dataCacheClearAll: vi.fn(async () => {}) }
+})
+vi.mock('@/app/lib/data-cache', () => ({
+  clearAll: dataCacheClearAll,
+}))
+
 // In-memory store for secure storage mock
 let secureStore: Record<string, string> = {}
 
@@ -52,6 +61,7 @@ describe('useAuthStore', () => {
   beforeEach(() => {
     resetStore()
     vi.mocked(fetch).mockReset()
+    dataCacheClearAll.mockClear()
     secureStore = {}
     localStorage.clear()
     sessionStorage.clear()
@@ -255,6 +265,33 @@ describe('useAuthStore', () => {
     })
 
     vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response)
+
+    await useAuthStore.getState().logout()
+
+    const state = useAuthStore.getState()
+    expect(state.user).toBeNull()
+    expect(state.isAuthenticated).toBe(false)
+  })
+
+  it('logout wipes the local data cache', async () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'test@example.com', planId: 'pro' },
+      isAuthenticated: true,
+    })
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response)
+
+    await useAuthStore.getState().logout()
+
+    expect(dataCacheClearAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('logout still completes when the data-cache wipe throws', async () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'test@example.com', planId: 'pro' },
+      isAuthenticated: true,
+    })
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response)
+    dataCacheClearAll.mockRejectedValueOnce(new Error('idb went sideways'))
 
     await useAuthStore.getState().logout()
 

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -445,6 +445,67 @@ describe('useAuthStore', () => {
     })
   })
 
+  // --- refreshSession non-destructive on transient errors ---
+  // Regression: the EmailVerificationBanner re-checks the session on every
+  // tab focus while the user is unverified. A transient billing 5xx or a
+  // network blip used to null the session, silently logging out users who
+  // had only alt-tabbed away.
+
+  describe('refreshSession on transient errors', () => {
+    function loggedIn() {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', emailVerified: false, onboardedAt: null },
+        isAuthenticated: true,
+      })
+    }
+
+    it('leaves the session intact on a 5xx response', async () => {
+      loggedIn()
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 502 } as Response)
+
+      const result = await useAuthStore.getState().refreshSession()
+
+      expect(result).toBe(false)
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(true)
+      expect(state.user).not.toBeNull()
+    })
+
+    it('leaves the session intact on a network error', async () => {
+      loggedIn()
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      const result = await useAuthStore.getState().refreshSession()
+
+      expect(result).toBe(false)
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(true)
+      expect(state.user).not.toBeNull()
+    })
+
+    it('nulls the session on 401 (auth genuinely invalid)', async () => {
+      loggedIn()
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 401 } as Response)
+
+      const result = await useAuthStore.getState().refreshSession()
+
+      expect(result).toBe(false)
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(false)
+      expect(state.user).toBeNull()
+    })
+
+    it('nulls the session on 403', async () => {
+      loggedIn()
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 403 } as Response)
+
+      const result = await useAuthStore.getState().refreshSession()
+
+      expect(result).toBe(false)
+      expect(useAuthStore.getState().user).toBeNull()
+    })
+  })
+
   // --- Stripe redirect signup state (issue #20) ---
 
   describe('signup redirect state storage', () => {

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -74,6 +74,179 @@ describe('useAuthStore', () => {
     expect(state.isLoading).toBe(false)
   })
 
+  // --- onboardedAt hydration (issue #113) ---
+
+  describe('onboardedAt hydration', () => {
+    it('login hydrates onboardedAt from token-exchange response', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 'user-1',
+          email: 'a@b.com',
+          planId: 'pro',
+          isAdmin: false,
+          onboardedAt: '2025-01-01T00:00:00.000Z',
+        }),
+      } as Response)
+
+      await useAuthStore.getState().login('a@b.com', 'pw')
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBe('2025-01-01T00:00:00.000Z')
+    })
+
+    it('login defaults onboardedAt to null when omitted', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'user-1', email: 'a@b.com', planId: 'pro', isAdmin: false }),
+      } as Response)
+
+      await useAuthStore.getState().login('a@b.com', 'pw')
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('refreshSession hydrates onboardedAt', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'u1',
+          email: 'x@y.com',
+          planId: 'free',
+          isAdmin: false,
+          onboardedAt: '2024-12-01T00:00:00.000Z',
+        }),
+      } as Response)
+
+      await useAuthStore.getState().refreshSession()
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBe('2024-12-01T00:00:00.000Z')
+    })
+
+    it('restoreSession hydrates onboardedAt', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'u1',
+          email: 'x@y.com',
+          planId: 'free',
+          isAdmin: false,
+          onboardedAt: null,
+        }),
+      } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('completeSignup sets onboardedAt to null for fresh accounts', () => {
+      useAuthStore.setState({
+        pendingSignup: {
+          email: 'new@user.com',
+          etebaseAuthToken: 'tok',
+          provisionedUser: { id: 'new-1', planId: 'pro', isAdmin: false },
+          provisionedSubscriptionStatus: 'trialing',
+        },
+      })
+
+      useAuthStore.getState().completeSignup()
+
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+  })
+
+  // --- markOnboarded action (issue #113) ---
+
+  describe('markOnboarded', () => {
+    it('POSTs to /account/onboarded and updates user.onboardedAt on success', async () => {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', onboardedAt: null },
+        isAuthenticated: true,
+      })
+
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ onboardedAt: '2026-05-04T12:00:00.000Z' }),
+      } as Response)
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(true)
+      expect(useAuthStore.getState().user!.onboardedAt).toBe('2026-05-04T12:00:00.000Z')
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/account/onboarded'),
+        expect.objectContaining({ method: 'POST', credentials: 'include' }),
+      )
+    })
+
+    it('returns false and leaves onboardedAt null on network failure', async () => {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', onboardedAt: null },
+        isAuthenticated: true,
+      })
+
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(false)
+      // onboardedAt stays null so the modal will retry next session.
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('returns false and leaves onboardedAt null on non-OK response', async () => {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', onboardedAt: null },
+        isAuthenticated: true,
+      })
+
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(false)
+      expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('is idempotent: returns true without a network call when already onboarded', async () => {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', onboardedAt: '2025-01-01T00:00:00.000Z' },
+        isAuthenticated: true,
+      })
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(true)
+      expect(fetch).not.toHaveBeenCalled()
+      // Existing timestamp untouched.
+      expect(useAuthStore.getState().user!.onboardedAt).toBe('2025-01-01T00:00:00.000Z')
+    })
+
+    it('returns false when there is no user to mark', async () => {
+      useAuthStore.setState({ user: null, isAuthenticated: false })
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(false)
+      expect(fetch).not.toHaveBeenCalled()
+    })
+
+    it('skips network for self-hosted user and stamps onboardedAt locally', async () => {
+      useAuthStore.setState({
+        user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true, onboardedAt: null },
+        isAuthenticated: true,
+      })
+
+      const result = await useAuthStore.getState().markOnboarded()
+
+      expect(result).toBe(true)
+      expect(fetch).not.toHaveBeenCalled()
+      expect(useAuthStore.getState().user!.onboardedAt).toEqual(expect.any(String))
+    })
+  })
+
   it('logout clears state', async () => {
     // Set up logged-in state
     useAuthStore.setState({
@@ -159,7 +332,10 @@ describe('useAuthStore', () => {
       const state = useAuthStore.getState()
       expect(state.isAuthenticated).toBe(true)
       expect(state.subscriptionStatus).toBe('billing_unavailable')
-      expect(state.user).toEqual({ id: 'degraded', email: '', planId: 'unknown', isAdmin: false })
+      // Degraded users get a non-null onboardedAt so we don't pop the
+      // OnboardingModal at users while billing is unreachable.
+      expect(state.user).toMatchObject({ id: 'degraded', email: '', planId: 'unknown', isAdmin: false })
+      expect(state.user!.onboardedAt).toEqual(expect.any(String))
     })
 
     it('restoreSession does not enter degraded mode on network error without etebase session', async () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -6,6 +6,7 @@ import { logger } from '@/app/lib/logger'
 import { BILLING_API_URL } from '@/app/lib/config'
 import { COOKIE_MAX_AGE_SELF_HOSTED, COOKIE_MAX_AGE_HOSTED } from '@/app/lib/constants'
 import { secureGet, secureSet, secureRemove, secureClear, migrateFromLocalStorage } from '@/app/lib/secure-storage'
+import { clearAll as clearLocalDataCache } from '@/app/lib/data-cache'
 
 export interface User {
   isAdmin?: boolean
@@ -361,6 +362,17 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       useEtebaseStore.getState().destroy()
     } catch (err) {
       logger.warn('[auth-store] Failed to destroy Etebase store during logout:', err)
+    }
+
+    // Clear the local data cache (decrypted iCal/vCard/vTodo on disk).
+    // Runs unconditionally — even if the feature flag was just turned off,
+    // any cache left from a previous session must not survive logout.
+    // Order matters: clear before invalidating session state, so a
+    // background read can't repopulate from a still-live store.
+    try {
+      await clearLocalDataCache()
+    } catch (err) {
+      logger.warn('[auth-store] Failed to clear local data cache during logout:', err)
     }
 
     // Clear signup-in-progress flag

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -409,16 +409,26 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     try {
       const res = await fetch(`${BILLING_API_URL}/auth/refresh`, { method: 'POST', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-      if (!res.ok) { syncAdminCookie(false); set({ user: null, isAuthenticated: false }); return false }
+      // Only treat the session as invalid on explicit auth failures. A 5xx
+      // response or network blip would otherwise log out e.g. an unverified
+      // user when the verify-banner re-checks on tab focus (see
+      // EmailVerificationBanner).
+      if (res.status === 401 || res.status === 403) {
+        syncAdminCookie(false)
+        set({ user: null, isAuthenticated: false })
+        return false
+      }
+      if (!res.ok) {
+        logger.warn('[auth-store] Session refresh got non-OK response, leaving session intact:', res.status)
+        return false
+      }
       const data = await res.json()
       const isAdmin = data.isAdmin === true
       syncAdminCookie(isAdmin)
       set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true })
       return true
     } catch (err) {
-      logger.warn('[auth-store] Session refresh failed:', err)
-      syncAdminCookie(false)
-      set({ user: null, isAuthenticated: false })
+      logger.warn('[auth-store] Session refresh failed (network), leaving session intact:', err)
       return false
     }
   },

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -13,6 +13,13 @@ export interface User {
   email: string
   planId: string
   emailVerified?: boolean
+  /**
+   * ISO timestamp of when the user completed (or was assumed to have completed)
+   * onboarding. NULL means the user has not yet been onboarded and should see
+   * the OnboardingModal. Hydrated from the billing API in /auth/refresh,
+   * /account, and the response of POST /account/onboarded.
+   */
+  onboardedAt?: string | null
 }
 
 interface PendingSignup {
@@ -57,6 +64,16 @@ interface AuthState {
   restoreSession: () => Promise<void>
   fetchSubscription: () => Promise<void>
   retryBillingConnection: () => Promise<boolean>
+  /**
+   * Mark the current user as onboarded. POSTs to the billing API
+   * (idempotent), then updates the local user state with the returned
+   * timestamp. Self-hosted users skip the network call and just set a
+   * local timestamp. Network failures are logged and swallowed: leaving
+   * onboardedAt null means the popup will retry next session, which is
+   * the correct degraded behaviour. Returns true on success, false if
+   * the network call failed.
+   */
+  markOnboarded: () => Promise<boolean>
   setUser: (user: User | null) => void
   clearError: () => void
   /**
@@ -253,6 +270,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         email: pending.email,
         planId: pending.provisionedUser.planId,
         isAdmin: pending.provisionedUser.isAdmin,
+        // A brand-new account is by definition not onboarded yet — the
+        // OnboardingModal needs onboardedAt === null to fire on first login.
+        onboardedAt: null,
       },
       isAuthenticated: true,
       isLoading: false,
@@ -272,7 +292,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         if (serverUrl) localStorage.setItem('silentsuite-server-url', serverUrl)
         syncAdminCookie(true)
         set({
-          user: { id: 'self-hosted', email, planId: 'self-hosted', isAdmin: true },
+          user: { id: 'self-hosted', email, planId: 'self-hosted', isAdmin: true, onboardedAt: null },
           isAuthenticated: true,
           isLoading: false,
           subscriptionStatus: 'active',
@@ -304,7 +324,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const isAdmin = data.isAdmin === true
       syncAdminCookie(isAdmin)
       set({
-        user: { id: data.id, email: data.email ?? email, planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false },
+        user: { id: data.id, email: data.email ?? email, planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null },
         isAuthenticated: true,
         isLoading: false,
       })
@@ -367,7 +387,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const hasSession = !!(await secureGet('etebase_session'))
       if (hasSession) {
         syncAdminCookie(true)
-        set({ user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true }, isAuthenticated: true, subscriptionStatus: 'active' })
+        set({ user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true, onboardedAt: null }, isAuthenticated: true, subscriptionStatus: 'active' })
         return true
       }
       syncAdminCookie(false)
@@ -381,7 +401,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const data = await res.json()
       const isAdmin = data.isAdmin === true
       syncAdminCookie(isAdmin)
-      set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false }, isAuthenticated: true })
+      set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true })
       return true
     } catch (err) {
       logger.warn('[auth-store] Session refresh failed:', err)
@@ -408,7 +428,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const hasSession = !!(await secureGet('etebase_session'))
       if (hasSession) {
         syncAdminCookie(true)
-        set({ user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true }, isAuthenticated: true, isLoading: false, subscriptionStatus: 'active' })
+        set({ user: { id: 'self-hosted', email: '', planId: 'self-hosted', isAdmin: true, onboardedAt: null }, isAuthenticated: true, isLoading: false, subscriptionStatus: 'active' })
       } else {
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, isLoading: false })
@@ -423,7 +443,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         const data = await res.json()
         const isAdmin = data.isAdmin === true
         syncAdminCookie(isAdmin)
-        set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false }, isAuthenticated: true, isLoading: false })
+        set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true, isLoading: false })
       } else {
         // HTTP error (401/403 etc.) — billing responded, auth is invalid
         syncAdminCookie(false)
@@ -435,8 +455,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // If a valid Etebase session exists, enter degraded mode instead of kicking the user out.
       const hasEtebaseSession = !!(await secureGet('etebase_session'))
       if (hasEtebaseSession) {
+        // Degraded users get a non-null onboardedAt so they don't get the
+        // popup pushed at them while billing is down — they may already be
+        // onboarded, we just can't tell. Better to err on the quiet side.
         set({
-          user: { id: 'degraded', email: '', planId: 'unknown', isAdmin: false },
+          user: { id: 'degraded', email: '', planId: 'unknown', isAdmin: false, onboardedAt: new Date().toISOString() },
           isAuthenticated: true,
           isLoading: false,
           subscriptionStatus: 'billing_unavailable',
@@ -481,13 +504,64 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const isAdmin = refreshData.isAdmin === true
       syncAdminCookie(isAdmin)
       set({
-        user: { id: refreshData.id, email: refreshData.email ?? '', planId: refreshData.planId ?? 'free', isAdmin, emailVerified: refreshData.emailVerified ?? false },
+        user: { id: refreshData.id, email: refreshData.email ?? '', planId: refreshData.planId ?? 'free', isAdmin, emailVerified: refreshData.emailVerified ?? false, onboardedAt: refreshData.onboardedAt ?? null },
         isAuthenticated: true,
         subscriptionStatus: subData.status,
       })
       return true
     } catch (err) {
       logger.warn('[auth-store] retryBillingConnection failed:', err)
+      return false
+    }
+  },
+
+  markOnboarded: async () => {
+    const current = get().user
+    if (!current) {
+      // Defensive: nothing to update against. Caller should only invoke
+      // this from a path that already has an authenticated user, but a
+      // race during logout could land us here.
+      return false
+    }
+
+    // Already onboarded — nothing to do, treat as success so callers can
+    // chain UI dismissal without worrying about the state.
+    if (current.onboardedAt) return true
+
+    // Self-hosted has no billing API to call. Just stamp locally so the
+    // modal hides for the rest of the session and doesn't reappear on
+    // restoreSession (which also sets onboardedAt: null for self-hosted —
+    // the localStorage flash-suppressor in the modal covers that case).
+    const storedServerUrl = typeof window !== 'undefined' ? localStorage.getItem('silentsuite-server-url') : null
+    if (isSelfHosted || isCustomServer(storedServerUrl ?? undefined) || current.id === 'self-hosted') {
+      set({ user: { ...current, onboardedAt: new Date().toISOString() } })
+      return true
+    }
+
+    try {
+      const res = await fetch(`${BILLING_API_URL}/account/onboarded`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      })
+      if (!res.ok) {
+        // Don't update local state on failure: leaving onboardedAt null
+        // means the modal will re-appear next session, which is the
+        // correct degraded behaviour. A localStorage hint in the modal
+        // suppresses the flash within this session.
+        logger.warn('[auth-store] markOnboarded failed:', res.status)
+        return false
+      }
+      const data = await res.json()
+      // Re-read user inside the success path — it may have changed during
+      // the await (logout race). Only patch if the same user is still
+      // signed in.
+      const after = get().user
+      if (!after || after.id !== current.id) return false
+      set({ user: { ...after, onboardedAt: data.onboardedAt ?? new Date().toISOString() } })
+      return true
+    } catch (err) {
+      logger.warn('[auth-store] markOnboarded network error:', err)
       return false
     }
   },

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -10,6 +10,18 @@ import { enqueue, isOfflineError } from '@/app/lib/offline-queue'
 import { secureGet } from '@/app/lib/secure-storage'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
+import {
+  ensureFingerprint as cacheEnsureFingerprint,
+  getStoken as cacheGetStoken,
+  setStoken as cacheSetStoken,
+  putItems as cachePutItems,
+  putItem as cachePutItem,
+  deleteItem as cacheDeleteItem,
+  replaceItemsForType as cacheReplaceItemsForType,
+  isCacheEnabled as isLocalCacheEnabled,
+  type CachedItem,
+  type CollectionTypeKey as CacheCollectionTypeKey,
+} from '@/app/lib/data-cache'
 
 /**
  * Holds live Etebase SDK objects (Account, Collections, Items, SyncEngine).
@@ -62,6 +74,28 @@ function collectionTypeToKey(ct: string): CollectionTypeKey | null {
   if (ct === COLLECTION_TYPE_TASKS) return 'tasks'
   if (ct === COLLECTION_TYPE_CONTACTS) return 'contacts'
   return null
+}
+
+/**
+ * Best-effort cache write. Decodes the item content (already decrypted by
+ * the Etebase SDK at this point) and stores it under the item UID. Failures
+ * are swallowed inside data-cache; we never block on cache writes.
+ */
+async function writeItemToCache(
+  type: CollectionTypeKey,
+  collectionUid: string,
+  itemUid: string,
+  content: string,
+): Promise<void> {
+  if (!isLocalCacheEnabled()) return
+  const record: CachedItem = {
+    itemUid,
+    collectionType: type,
+    collectionUid,
+    content,
+    lastModified: Date.now(),
+  }
+  await cachePutItem(record)
 }
 
 interface EtebaseState {
@@ -164,6 +198,19 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       set({ account })
       logger.debug('[etebase-store] Session restored')
 
+      // Local-cache fingerprint check: if a different account previously
+      // hydrated this browser, wipe before reseeding. Belt-and-braces against
+      // the Android-style stale-cache contamination bug.
+      const cacheEnabled = isLocalCacheEnabled()
+      if (cacheEnabled) {
+        try {
+          const username = (account as any)?.user?.username ?? 'unknown'
+          await cacheEnsureFingerprint(String(username))
+        } catch (err) {
+          logger.warn('[etebase-store] Cache fingerprint check failed', err)
+        }
+      }
+
       // 2. Ensure collections exist (create if first login, fetch if returning)
       const collections: Record<CollectionTypeKey, any> = {
         calendar: null,
@@ -231,6 +278,32 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         }
       }
 
+      // Seed persisted stokens before starting so the first sync round
+      // pulls only deltas instead of refetching the whole vault. Wire the
+      // advance handler so subsequent stoken updates are persisted too.
+      if (cacheEnabled) {
+        for (const [key, colType] of typeMap) {
+          const collection = collections[key]
+          if (!collection) continue
+          try {
+            const stoken = await cacheGetStoken(key as CacheCollectionTypeKey)
+            if (stoken) {
+              engine.setStoken(collection.uid, stoken)
+              logger.debug(`[etebase-store] Seeded ${key} stoken from cache`)
+            }
+          } catch (err) {
+            logger.warn(`[etebase-store] Failed to seed ${key} stoken`, err)
+          }
+        }
+
+        engine.onStokenAdvance((event: { collectionType: string; collectionUid: string; stoken: string | null }) => {
+          const key = collectionTypeToKey(event.collectionType)
+          if (!key) return
+          // Fire-and-forget — persistence failures are logged inside the cache module.
+          void cacheSetStoken(key, event.collectionUid, event.stoken)
+        })
+      }
+
       await engine.start(account)
       set({ syncEngine: engine, isInitialized: true })
       logger.debug('[etebase-store] SyncEngine started')
@@ -262,6 +335,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       itemCache.set(item.uid, item)
       itemTypeMap.set(item.uid, type)
       set({ itemCache, itemTypeMap })
+      // Write through to the local persistence cache so a reload paints it.
+      void writeItemToCache(type, collection.uid, item.uid, content)
       return item.uid
     } catch (err) {
       if (isOfflineError(err)) {
@@ -358,17 +433,31 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const itemCache = new Map(get().itemCache)
       const itemTypeMap = new Map(get().itemTypeMap)
       const uids: (string | null)[] = []
+      const cachedRecords: CachedItem[] = []
       for (let i = 0; i < items.length; i++) {
         if (i <= lastSuccessfulItemIndex) {
           const item = items[i]
           itemCache.set(item.uid, item)
           itemTypeMap.set(item.uid, type)
           uids.push(item.uid)
+          const original = contents[i]
+          if (original) {
+            cachedRecords.push({
+              itemUid: item.uid,
+              collectionType: type,
+              collectionUid: collection.uid,
+              content: original.content,
+              lastModified: Date.now(),
+            })
+          }
         } else {
           uids.push(null)
         }
       }
       set({ itemCache, itemTypeMap })
+      if (isLocalCacheEnabled() && cachedRecords.length > 0) {
+        void cachePutItems(cachedRecords)
+      }
 
       if (permanentFailure) {
         const succeeded = lastSuccessfulItemIndex + 1
@@ -418,6 +507,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const newCache = new Map(get().itemCache)
       newCache.set(itemUid, updated)
       set({ itemCache: newCache })
+      void writeItemToCache(type, collection.uid, itemUid, content)
     } catch (err) {
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
@@ -450,6 +540,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       newCache.delete(itemUid)
       newTypeMap.delete(itemUid)
       set({ itemCache: newCache, itemTypeMap: newTypeMap })
+      if (isLocalCacheEnabled()) {
+        void cacheDeleteItem(itemUid)
+      }
     } catch (err) {
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing delete for ${type}/${itemUid}`)
@@ -537,6 +630,19 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const newCollections = { ...get().collections }
       newCollections[type] = freshCollection
       set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, collections: newCollections })
+
+      // Mirror the refresh into the local cache. Use replace-style write so
+      // items deleted upstream are also dropped from disk.
+      if (isLocalCacheEnabled()) {
+        const cached: CachedItem[] = results.map((r) => ({
+          itemUid: r.uid,
+          collectionType: type,
+          collectionUid: freshCollection.uid,
+          content: r.content,
+          lastModified: Date.now(),
+        }))
+        void cacheReplaceItemsForType(type, cached)
+      }
 
       logger.debug(`[etebase-store] Refreshed ${type}: ${results.length} items`)
       return results

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "lucide-react": "^0.400.0",
     "next": "15.1.12",
     "next-themes": "^0.4.4",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.71.2",

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -26,4 +26,4 @@ Deploy and manage SilentSuite on your own infrastructure. Self-hosting gives you
 - **Custom domain** -- run the suite on your own domain with automatic HTTPS.
 - **All features unlocked** -- every feature, no subscription required.
 
-The self-hosted stack runs four services via Docker Compose: PostgreSQL, Etebase (encrypted sync), a Next.js web frontend, and Caddy as a reverse proxy with automatic TLS.
+The self-hosted stack runs two containers via Docker Compose: PostgreSQL and the SilentSuite sync server. You provide your own reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel) for TLS termination. Users connect from [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile apps by entering your server URL in **Advanced Settings**.

--- a/docs/self-hosting/architecture.md
+++ b/docs/self-hosting/architecture.md
@@ -1,14 +1,14 @@
 # Architecture
 
-SilentSuite self-hosting runs three containers on a single Docker network. Caddy is the only service exposed to the internet. Users connect via [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile apps.
+SilentSuite self-hosting runs two containers on a single Docker network: PostgreSQL and the SilentSuite sync server. You provide your own reverse proxy in front of the stack to terminate TLS and forward traffic to the server. Users connect from [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile apps.
 
 ## Overview
 
 ```
     Your Server                         SilentSuite Apps
   ┌─────────────────┐
-  │  Caddy (HTTPS)  │◄──────────── app.silentsuite.io
-  │       :443      │              (or mobile apps)
+  │  Your Reverse   │◄──────────── app.silentsuite.io
+  │  Proxy (HTTPS)  │              (or mobile apps)
   └────────┬────────┘              enter your server URL
            │                       in Advanced Settings
   ┌────────┴────────┐
@@ -27,16 +27,17 @@ SilentSuite self-hosting runs three containers on a single Docker network. Caddy
 
 | Service | Image | Role |
 |---|---|---|
-| **Caddy** | `caddy:2-alpine` | Reverse proxy. Terminates TLS, routes requests to the SilentSuite server. Automatically provisions and renews Let's Encrypt certificates. |
-| **SilentSuite Server** | `victorrds/etebase` | Sync server built on the Etebase protocol. Provides end-to-end encrypted data sync. All data is encrypted client-side; the server never sees plaintext. |
-| **PostgreSQL** | `postgres:16-alpine` | Database. Stores encrypted sync data and user accounts. |
+| **SilentSuite Server** | `ghcr.io/silent-suite/silentsuite-server` (pinned per release by digest) | Sync server built on the [Etebase protocol](https://www.etebase.com/). Provides end-to-end encrypted data sync. All data is encrypted client-side; the server never sees plaintext. |
+| **PostgreSQL** | `postgres:16.9-alpine` | Database. Stores encrypted sync data and user accounts. |
+
+The reverse proxy is **not** part of the stack — pick whatever you already run (Caddy, nginx, Traefik, Cloudflare Tunnel) and forward HTTPS traffic to `127.0.0.1:3735`. Examples for each are in [SELF-HOSTING.md](https://github.com/silent-suite/silentsuite/blob/main/self-host/SELF-HOSTING.md#reverse-proxy-examples).
 
 ## Network and Security
 
-- All services run on an internal Docker bridge network.
-- No service except Caddy binds to host ports.
-- Services communicate by container name (e.g., `postgres:5432`, `server:3735`).
-- Caddy adds security headers to all responses: HSTS, X-Frame-Options, X-Content-Type-Options, and more.
+- Both containers run on an internal Docker bridge network and communicate by container name (e.g., `postgres:5432`).
+- PostgreSQL is not exposed to the host.
+- The SilentSuite server binds only to `127.0.0.1:3735`, so it is not reachable from the network without a reverse proxy on the same host.
+- TLS termination, security headers, and ACME certificate provisioning are the reverse proxy's job — see the [recommended security headers](https://github.com/silent-suite/silentsuite/blob/main/self-host/SELF-HOSTING.md#recommended-security-headers).
 - All sync data is end-to-end encrypted. The server never has access to your plaintext data.
 
 ## Why No Web App Container?
@@ -46,4 +47,4 @@ Self-hosters only need the sync server. Users access SilentSuite through:
 - **[app.silentsuite.io](https://app.silentsuite.io)** -- the hosted web app (works with any SilentSuite server)
 - **SilentSuite mobile apps** -- available for Android and iOS
 
-Both support entering a custom server URL in Advanced Settings during signup or login. This keeps the self-hosted stack minimal (3 containers, 3 env vars) while giving users the full SilentSuite experience.
+Both support entering a custom server URL in Advanced Settings during signup or login. This keeps the self-hosted stack minimal (two containers, a handful of env vars) while giving users the full SilentSuite experience.

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -24,7 +24,7 @@ docker exec silentsuite-postgres pg_dump -U silentsuite silentsuite > backup-$(d
 
 ```bash
 docker run --rm \
-  -v silentsuite_server_data:/data \
+  -v self-host_server_data:/data \
   -v $(pwd)/backups:/backup \
   alpine tar czf /backup/server-data-$(date +%Y%m%d-%H%M%S).tar.gz -C /data .
 ```

--- a/docs/self-hosting/quick-start.md
+++ b/docs/self-hosting/quick-start.md
@@ -5,30 +5,52 @@ This is the fastest path from zero to running. Make sure you've met the [require
 ## Install
 
 ```bash
+curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | bash
+```
+
+If you'd rather clone first:
+
+```bash
 git clone https://github.com/silent-suite/silentsuite.git
 cd silentsuite/self-host
-chmod +x install.sh update.sh verify.sh
+chmod +x install.sh update.sh verify.sh close-signups.sh
 ./install.sh
 ```
 
 The `install.sh` script will:
 
 1. Check that Docker and Docker Compose are installed.
-2. Prompt you for your domain name.
-3. Generate strong random passwords for PostgreSQL and the admin panel.
-4. Write the completed `.env` file.
-5. Pull Docker images and start all containers.
-6. Wait for health checks to pass.
-7. Print your server URL and admin credentials.
+2. Resolve the SilentSuite version to install (latest umbrella release, or `main` if none has been cut).
+3. Download the release-pinned `docker-compose.yml`, `update.sh`, `verify.sh`, `close-signups.sh`, and `success.html` into `silentsuite-server/`.
+4. Prompt you for your domain name.
+5. Generate strong random passwords for PostgreSQL and the admin panel.
+6. Write the completed `.env` file.
+7. Pull Docker images and start the two containers (PostgreSQL and the SilentSuite server).
+8. Wait for health checks to pass.
+
+The server listens on `127.0.0.1:3735`. It is **not** reachable from the network until you put a reverse proxy in front of it.
+
+## Set Up a Reverse Proxy
+
+Pick whatever you already run. Examples (Caddy, nginx, Traefik, Cloudflare Tunnel) are in [SELF-HOSTING.md → Reverse Proxy Examples](https://github.com/silent-suite/silentsuite/blob/main/self-host/SELF-HOSTING.md#reverse-proxy-examples). Forward HTTPS traffic for your domain to `localhost:3735`.
 
 ## Connect Your Apps
 
-Once the server is running:
+Once the proxy is up:
 
 1. Open [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile app.
 2. On the signup or login page, expand **Advanced Settings**.
 3. Enter `https://your-domain.com` as the server URL.
-4. Create your account and start syncing.
+4. Create your admin account and start syncing.
+
+## Close Signups
+
+The server ships with `ETEBASE_DISABLE_SIGNUP=false` so you can register the first account from the app. **Close signups as soon as that account exists** — anyone who reaches your server URL during the open window can grab an account:
+
+```bash
+cd silentsuite-server
+./close-signups.sh
+```
 
 ## Verify
 

--- a/docs/self-hosting/requirements.md
+++ b/docs/self-hosting/requirements.md
@@ -10,7 +10,8 @@ Before you begin, make sure you have the following.
 | **Docker** | Docker Engine 24+ with Docker Compose v2 (the `docker compose` plugin, not the legacy `docker-compose` binary). |
 | **Domain name** | A domain you control, with the ability to create DNS A records. |
 | **Server resources** | Minimum 1 GB RAM, 10 GB disk. More is better if you expect multiple users. |
-| **Open ports** | Ports 80 and 443 must be reachable from the internet (required for Let's Encrypt certificate provisioning). |
+| **Reverse proxy** | A reverse proxy you control (Caddy, nginx, Traefik, Cloudflare Tunnel) to terminate TLS in front of the SilentSuite server. The stack itself does not include one. |
+| **Open ports** | Whichever ports your reverse proxy needs reachable from the internet — typically 443 (and 80 for ACME HTTP-01 challenges if your proxy provisions Let's Encrypt certificates). |
 
 ## Verify Docker Is Installed
 
@@ -31,7 +32,7 @@ If your server IP is `203.0.113.50` and your chosen domain is `sync.example.com`
 |---|---|---|
 | A | `sync.example.com` | `203.0.113.50` |
 
-**Important:** DNS changes can take minutes to hours to propagate. Caddy will fail to obtain TLS certificates if the record does not resolve to your server. Verify propagation before proceeding:
+**Important:** DNS changes can take minutes to hours to propagate. Whatever reverse proxy you use will fail to obtain TLS certificates if the record does not resolve to your server. Verify propagation before proceeding:
 
 ```bash
 dig +short sync.example.com

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -16,11 +16,11 @@ All services should show `Up (healthy)`. If a service shows `Up (unhealthy)` or 
 # All services
 docker compose logs
 
-# Specific service (postgres, server, caddy)
+# Specific service (postgres, server)
 docker compose logs server
 
 # Follow logs in real time
-docker compose logs -f caddy
+docker compose logs -f server
 
 # Last 100 lines
 docker compose logs --tail 100 server
@@ -49,13 +49,14 @@ docker compose logs server
 
 ### SSL Certificate Errors
 
-**Symptom:** Browser shows certificate warnings, or Caddy logs show ACME errors.
+**Symptom:** Browser shows certificate warnings, or your reverse proxy logs ACME errors.
 
-**Causes and fixes:**
+TLS is your reverse proxy's responsibility — these are not SilentSuite-server problems. Common causes:
 
 - **DNS not resolving:** Verify your DNS record points to your server with `dig +short your-domain.com`.
-- **Ports blocked:** Caddy needs ports 80 and 443 open for the ACME HTTP-01 challenge. Check your firewall: `sudo ufw status` or `sudo iptables -L -n`.
+- **Ports blocked:** Your reverse proxy needs the relevant ports open (typically 80 for the ACME HTTP-01 challenge and 443 for HTTPS). Check your firewall: `sudo ufw status` or `sudo iptables -L -n`.
 - **Rate limiting:** Let's Encrypt has [rate limits](https://letsencrypt.org/docs/rate-limits/). If you have hit them, wait before retrying.
+- **Wrong upstream:** Confirm the proxy is forwarding to `127.0.0.1:3735` and that the SilentSuite server container is healthy (`docker compose ps`).
 
 ### Database Connection Errors
 

--- a/docs/self-hosting/uninstalling.md
+++ b/docs/self-hosting/uninstalling.md
@@ -7,21 +7,23 @@ How to remove SilentSuite from your server.
 To completely remove SilentSuite and all its data:
 
 ```bash
-# Stop and remove all containers
+# Stop and remove the containers
+cd silentsuite-server
 docker compose down
 
 # Remove all data volumes (THIS DELETES ALL DATA)
-docker volume rm self-host_pgdata self-host_etebase_data self-host_caddy_data self-host_caddy_config
+docker volume rm self-host_pgdata self-host_server_data
 
-# Remove the Docker images
-docker rmi victorrds/etebase:latest
-docker rmi postgres:16-alpine
-docker rmi caddy:2-alpine
+# Remove the Docker images (the silentsuite-server tag/digest may differ — list yours with `docker image ls`)
+docker image rm postgres:16.9-alpine
+docker image ls --filter 'reference=ghcr.io/silent-suite/silentsuite-server' --format '{{.ID}}' | xargs -r docker image rm
 
-# Remove the cloned repository
+# Remove the install directory
 cd ..
-rm -rf silentsuite
+rm -rf silentsuite-server
 ```
+
+If you set up a reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel) yourself, that's outside the SilentSuite stack — remove its config and any certificates it provisioned separately.
 
 ## Stop Without Deleting Data
 

--- a/docs/self-hosting/updating.md
+++ b/docs/self-hosting/updating.md
@@ -2,34 +2,47 @@
 
 How to keep your self-hosted SilentSuite instance up to date.
 
-## Using update.sh (Recommended)
+## How Versions Are Pinned
+
+The `docker-compose.yml` shipped with each SilentSuite release pins the server image to a specific manifest digest, e.g.:
+
+```yaml
+image: ghcr.io/silent-suite/silentsuite-server@sha256:6689b5d8...
+```
+
+This means a plain `docker compose pull` **will not** fetch a newer SilentSuite version — it only re-pulls the same digest. To upgrade across SilentSuite releases you must fetch a newer compose file.
+
+## Upgrade to a New SilentSuite Release
+
+Re-running the installer pulls the latest umbrella release's `docker-compose.yml` (and helper scripts) and recreates the containers:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | bash
+```
+
+To pin to a specific release instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | SILENTSUITE_VERSION=v0.1.0-beta bash
+```
+
+The whole self-host config (compose, `update.sh`, `verify.sh`, `success.html`, `close-signups.sh`) is fetched from the requested tag's archive, so the entire matrix moves together as one release.
+
+## Within a Pinned Release
+
+`./update.sh` re-pulls the pinned images and recreates the containers. This is useful after host-level changes (Docker upgrade, kernel reboot, etc.) but does **not** change SilentSuite versions:
 
 ```bash
 ./update.sh
 ```
 
-This script pulls the latest images and restarts the stack with zero-downtime rolling updates where possible.
+## Verify
 
-## Manual Update
+After any update:
 
 ```bash
-# Pull latest images
-docker compose pull
-
-# Recreate containers with new images
-docker compose up -d
-
-# Verify
+./verify.sh
 docker compose ps
 ```
 
-## Pinning Versions
-
-By default, the `docker-compose.yml` uses the `latest` tag for SilentSuite images. To pin a specific version, edit the image tags:
-
-```yaml
-web:
-  image: ghcr.io/silent-suite/silentsuite-web:v1.2.0
-```
-
-Pinning versions is recommended for production deployments to avoid unexpected changes.
+All services should report `healthy`.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,23 +1,23 @@
 # User Guide
 
-How-to guides for using SilentSuite -- your private, end-to-end encrypted sync for calendar, contacts, and tasks.
+How to use SilentSuite — your end-to-end encrypted sync for calendar, contacts, and tasks. Everything in this guide is grounded in what's actually shipped in [v0.1.0-beta](https://github.com/silent-suite/silentsuite/releases/tag/v0.1.0-beta).
 
 ---
 
 | Guide | Description |
 |---|---|
-| [Getting Started](./getting-started.md) | Create an account and set up your first device |
-| [Calendar](./calendar.md) | How to manage your encrypted calendar |
-| [Contacts](./contacts.md) | How to manage your encrypted contacts |
-| [Tasks](./tasks.md) | How to manage your encrypted tasks |
-| [How Encryption Works](./encryption-explained.md) | Understand what's encrypted, how, and why it matters |
-| [FAQ](./faq.md) | Frequently asked questions |
+| [Getting Started](./getting-started.md) | Sign up, pick a plan, install on a second device, confirm sync |
+| [Calendar](./calendar.md) | Events, recurrence, timezones, ICS import/export |
+| [Contacts](./contacts.md) | Contact CRUD, vCard import/export |
+| [Tasks](./tasks.md) | Tasks, priorities, due dates, ICS task export |
+| [How Encryption Works](./encryption-explained.md) | What's encrypted, how, and what the server can and can't see |
+| [FAQ](./faq.md) | Common questions |
 
 ---
 
 ## How SilentSuite Works
 
-All your data -- events, contacts, tasks -- is encrypted on your device before it leaves. The server only ever stores and syncs encrypted blobs. Nobody, including the SilentSuite team, can read your data.
+All your data — events, contacts, tasks — is encrypted on your device before it leaves. The server only ever stores and syncs ciphertext. Nobody, including the SilentSuite team, can read your data.
 
 ```
 Your Device          SilentSuite Server          Your Other Device
@@ -28,3 +28,10 @@ Your Device          SilentSuite Server          Your Other Device
     |                      |                          |
     |   Server never has the keys. Never sees plaintext.
 ```
+
+## Where to Use SilentSuite
+
+- **Web** — [app.silentsuite.io](https://app.silentsuite.io) (offline-first PWA, installable to any desktop or mobile home screen)
+- **Android** — signed APK, sideloadable. QR-code download in *Settings → Mobile* once you're signed in
+- **Desktop (CalDAV / CardDAV)** — the SilentSuite bridge runs a local DAV daemon for Thunderbird, Apple Calendar, Evolution, GNOME Calendar, etc. Install commands in *Settings → Desktop*
+- **iOS** — no native app yet; the [EteSync iOS app](https://www.etesync.com/) works against your SilentSuite account in the meantime

--- a/docs/user-guide/calendar.md
+++ b/docs/user-guide/calendar.md
@@ -1,32 +1,71 @@
-# How to Manage Your Calendar
+# Calendar
 
-Your calendar events are end-to-end encrypted. Only your devices can read them.
-
-<!-- TODO: Expand with specific UI walkthroughs once client apps are available -->
+Your calendar lives at [app.silentsuite.io/calendar](https://app.silentsuite.io/calendar). Events are encrypted on your device before they sync — title, location, description, attendees, alarms, the lot.
 
 ## Create an Event
 
-1. Open the Calendar view.
-2. Tap or click the date and time for your event.
-3. Enter the event details (title, location, notes, reminders).
-4. Save. The event is encrypted on your device and synced.
+1. Click any cell in the week or month grid, or press the **+** button.
+2. Fill in the event:
+   - Title, location, description
+   - Start / end (or *all-day*)
+   - Timezone — defaults to your browser's, change per event if needed
+   - Reminders (`VALARM`) — relative offsets (e.g. 15 min before start) or absolute times
+   - Recurrence — see below
+3. Save. The event is serialized to iCalendar (`VEVENT`), encrypted, and synced.
 
-## Edit an Event
+## Edit / Delete
 
-1. Open the event you want to change.
-2. Make your changes.
-3. Save. The updated event is re-encrypted and synced to your other devices.
-
-## Delete an Event
-
-1. Open the event.
-2. Select delete.
-3. The deletion syncs across all your devices.
+Click the event in any view. Edit the same fields and save, or hit delete. Changes are re-encrypted and synced to your other devices.
 
 ## Recurring Events
 
-<!-- TODO: Document recurring event support -->
+Recurring events use standard `RRULE` strings (daily, weekly, monthly, yearly, with intervals, weekdays, by-day-of-month, etc.).
 
-## Sharing Events
+When you edit or delete an instance of a recurring event, SilentSuite asks for the **scope**:
 
-SilentSuite is designed around personal privacy. Shared calendars are not currently supported -- your calendar is visible only to you, across your own devices.
+- **This event only** — split a single occurrence into an exception (`EXDATE` for delete, override `VEVENT` for edit)
+- **This and all following** — close out the original `RRULE` with `UNTIL` and start a new one from the chosen instance
+- **All events in the series** — apply the change to the whole `RRULE`
+
+This matches the behaviour you'd expect from any CalDAV-compliant client.
+
+## Views
+
+The view switcher in the calendar header offers two views:
+
+| View | Best for |
+|---|---|
+| **Week** | Day-by-day planning, dragging events across days |
+| **Month** | Glance overview |
+
+On narrow viewports the calendar automatically renders as a vertical **agenda list** of upcoming events. A **mini calendar** in the sidebar acts as a quick-jump date picker.
+
+## Timezones
+
+Timezones are stored as `TZID` references on each event, not converted to UTC on save. When an event is imported with a `TZID` that isn't your local one, the original timezone is preserved through round-trips so the event stays meaningful when you travel.
+
+## Import
+
+**Settings → Import** accepts `.ics` files. Parsing happens entirely in your browser — the file's contents never reach the server in plaintext. Imported events keep their original `TZID`s and `VALARM`s.
+
+## Export
+
+**Settings → Export** gives you:
+
+- **Calendar (`.ics`)** — all calendar events as a single iCalendar file
+- **Everything (`.zip`)** — calendars, contacts, and tasks together
+
+The export is built from your locally decrypted data, so it works offline once your data is loaded.
+
+## Sharing
+
+Shared calendars between accounts are not supported in v0.1.0-beta. Your calendar is visible only to you, across your own devices.
+
+## Bridge / DAV clients
+
+If you've installed the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge), your CalDAV client (Thunderbird, Apple Calendar, etc.) can read and write the same calendar through `localhost:37358`. Edits there sync the same way as edits in the web app.
+
+## Limits in this beta
+
+- A single default calendar collection per account. Managing multiple calendars is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
+- No invitations / RSVP / scheduling — SilentSuite is single-user, by design.

--- a/docs/user-guide/contacts.md
+++ b/docs/user-guide/contacts.md
@@ -1,32 +1,43 @@
-# How to Manage Your Contacts
+# Contacts
 
-Your contacts are end-to-end encrypted. Only your devices can read them.
-
-<!-- TODO: Expand with specific UI walkthroughs once client apps are available -->
+Your address book lives at [app.silentsuite.io/contacts](https://app.silentsuite.io/contacts). Names, emails, phone numbers, addresses, notes, photos — every field is encrypted on your device before sync.
 
 ## Add a Contact
 
-1. Open the Contacts view.
-2. Tap or click "Add Contact."
-3. Enter the contact details (name, email, phone, address, notes).
-4. Save. The contact is encrypted on your device and synced.
+1. Click **+ Add Contact**.
+2. Fill in the fields you want — at minimum a name. Email, phone, address, organisation, birthday, notes, and photo are all optional.
+3. Save. The contact is serialized to vCard (`VCARD`), encrypted, and synced.
 
-## Edit a Contact
+## Edit / Delete
 
-1. Open the contact you want to change.
-2. Make your changes.
-3. Save. The updated contact is re-encrypted and synced to your other devices.
+Open a contact, edit its fields, save. Or open and delete. Changes are re-encrypted and synced.
 
-## Delete a Contact
+## Search
 
-1. Open the contact.
-2. Select delete.
-3. The deletion syncs across all your devices.
+The search box at the top of the contacts list filters by name, email, phone, or organisation. Search runs against your locally decrypted data, so it's fast and works offline.
 
-## Import Contacts
+## Import
 
-<!-- TODO: Document import functionality (vCard, CSV) -->
+**Settings → Import** accepts `.vcf` files (vCard 3.0 and 4.0). Parsing is local-only — the file content never leaves your browser unencrypted. Multi-contact files are supported (one big `.vcf` with many `BEGIN:VCARD` blocks).
 
-## Export Contacts
+## Export
 
-<!-- TODO: Document export functionality -->
+**Settings → Export** gives you:
+
+- **Contacts (`.vcf`)** — all contacts as a single vCard file
+- **Everything (`.zip`)** — calendars, contacts, and tasks together
+
+Both are built from your locally decrypted data.
+
+## Bridge / CardDAV clients
+
+With the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge) installed, any CardDAV client (Thunderbird, Apple Contacts, GNOME Contacts, Evolution) can read and write the same contacts through `localhost:37358`.
+
+## Sharing
+
+Shared address books between accounts are not supported in v0.1.0-beta. Your contacts are visible only to you, across your own devices.
+
+## Limits in this beta
+
+- A single default contacts collection per account. Managing multiple address books is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
+- No OAuth-based one-click import from Google or iCloud yet — file-based `.vcf` import only. (On the roadmap.)

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -4,38 +4,84 @@
 
 ### What is SilentSuite?
 
-SilentSuite is a privacy-focused, end-to-end encrypted sync service for calendar, contacts, and tasks. Your data is encrypted on your device before it reaches the server. The server never sees plaintext.
+A privacy-focused, end-to-end encrypted sync service for calendar, contacts, and tasks. Your data is encrypted on your device before it reaches the server. The server never sees plaintext — not even item counts or collection names.
+
+### What's available right now?
+
+The v0.1.0-beta release covers:
+
+- **Web app** at [app.silentsuite.io](https://app.silentsuite.io) — calendar, contacts, tasks, import/export, settings, admin
+- **Android** — signed APK for sideloading (download via QR code in the app's *Settings → Mobile*)
+- **Desktop bridge** — CalDAV/CardDAV bridge for Thunderbird, Apple Calendar, Evolution, etc., on Linux / macOS / Windows
+- **Self-hosting** — two-container Docker stack (PostgreSQL + SilentSuite server)
+
+See the [v0.1.0-beta release notes](https://github.com/silent-suite/silentsuite/releases/tag/v0.1.0-beta) for the full list.
+
+### What's *not* in this beta?
+
+On the roadmap, not yet shipped:
+
+- Native iOS app (the [EteSync iOS app](https://www.etesync.com/) works against your account in the meantime — same Etebase protocol)
+- Google Play / F-Droid listings (Android ships as a sideload APK)
+- OAuth-based one-click import from Google / iCloud
+- Push notifications
+- Multiple collections per account ([#88](https://github.com/silent-suite/silentsuite/issues/88))
+- First-class encrypted notes ([#45](https://github.com/silent-suite/silentsuite/issues/45))
 
 ### Is SilentSuite free?
 
-SilentSuite offers a hosted service with paid plans to fund development. Self-hosting is free and includes all features. See [Self-Hosting](../self-hosting/) for details.
-
-### What platforms are supported?
-
-<!-- TODO: Update as client apps launch -->
-
-SilentSuite is in active development. Web, Android, and iOS clients are planned.
+The hosted service has paid plans (Monthly or Annual). Two free trials are offered at signup: a **7-day trial with no credit card required**, and a **30-day card-secured trial** (you're not charged until day 30 and can cancel any time before then). Self-hosting is free and includes every feature with no subscription. See [Self-Hosting](../self-hosting/).
 
 ## Privacy & Security
 
 ### Can SilentSuite read my data?
 
-No. All data is encrypted on your device before it reaches the server. The server only stores encrypted blobs. Even if compelled by a court order, SilentSuite cannot produce plaintext data because it does not have the encryption keys.
+No. All data is encrypted on your device before it reaches the server. The server only stores ciphertext and cannot decrypt it. Even when compelled, SilentSuite cannot produce plaintext data because the keys never reach the server.
+
+See [How Encryption Works](./encryption-explained.md) for the full picture.
 
 ### What encryption does SilentSuite use?
 
-SilentSuite uses the [Etebase protocol](https://www.etebase.com/) with XChaCha20-Poly1305 for encryption and Argon2 for key derivation. See [How Encryption Works](./encryption-explained.md) for details.
+The [Etebase protocol](https://www.etebase.com/) — XChaCha20-Poly1305 for symmetric encryption, Argon2 for password-based key derivation. The protocol spec is at [docs.etebase.com](https://docs.etebase.com/).
 
 ### Can I reset my password?
 
-No. Your encryption keys are derived from your password, and the server never has access to them. If you forget your password, your data cannot be recovered. Use a password manager.
+No. Your encryption keys are derived from your password, and the server never sees them. If you forget your password, your data cannot be recovered. Use a password manager.
+
+### Are imports and exports also private?
+
+Yes. Both happen entirely in your browser — `.ics` and `.vcf` files are parsed and encrypted (or decrypted and serialized) locally; the file contents never reach the server in plaintext.
 
 ## Self-Hosting
 
 ### Can I run SilentSuite on my own server?
 
-Yes. See the [Self-Hosting guide](../self-hosting/) for instructions. Self-hosting gives you full data sovereignty and all features unlocked with no subscription.
+Yes. See the [Self-Hosting guide](../self-hosting/) for the install flow. Self-hosting gives you full data sovereignty with every feature unlocked and no subscription.
 
 ### What do I need to self-host?
 
-A Linux server with Docker, 2 GB RAM, and a domain name. See [Requirements](../self-hosting/requirements.md) for full details.
+A Linux server with Docker, ~1 GB RAM, a domain name, and a reverse proxy you control (Caddy, nginx, Traefik, or Cloudflare Tunnel) for TLS. See [Requirements](../self-hosting/requirements.md).
+
+### Can the same account talk to a self-hosted server *and* the hosted service?
+
+No — an account belongs to a single server. Pick one when you sign up. To migrate later, export from one and import into the other.
+
+## Apps & Devices
+
+### How do I get the Android APK?
+
+Sign in to [app.silentsuite.io](https://app.silentsuite.io) on a device with a screen, open *Settings → Mobile*, and either scan the QR code or use the direct download link to the latest GitHub Release.
+
+### Why is the Android app not on Google Play?
+
+Distribution channels (Google Play, F-Droid) are on the roadmap — see [#58](https://github.com/silent-suite/silentsuite-internal/issues/58) and [#59](https://github.com/silent-suite/silentsuite-internal/issues/59). For now it's a signed sideloadable APK.
+
+### How does the desktop bridge work?
+
+It runs a tiny CalDAV/CardDAV daemon bound to `localhost:37358`. Standard PIM clients (Thunderbird, Apple Calendar, Evolution, etc.) talk to it like any other DAV server. The bridge handles encryption/decryption against your SilentSuite account; plaintext stays inside `localhost`.
+
+Install commands are in *Settings → Desktop* in the web app.
+
+### Will offline edits sync when I reconnect?
+
+Yes. The web app is an offline-first PWA — encrypted writes queue while offline and flush on reconnect.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,31 +1,68 @@
 # Getting Started
 
-Set up SilentSuite and start syncing your calendar, contacts, and tasks with end-to-end encryption.
+A walkthrough of creating your account and getting your first event syncing across two devices.
 
 ## 1. Create an Account
 
-<!-- TODO: Add specific steps once client apps are available -->
+Go to [app.silentsuite.io](https://app.silentsuite.io/signup). For the hosted service the signup flow is three steps:
 
-Visit [silentsuite.io](https://silentsuite.io) to create your account. Your password is used to derive your encryption keys -- it never leaves your device.
+1. **Account** — email and password.
+2. **Plan** — pick Monthly or Annual (Annual saves 17%) and choose your trial:
+   - **7-day free trial** — full access, no credit card required.
+   - **30-day free trial** — card secures the trial; you're not charged until day 30 and can cancel any time before then.
+3. **Setup** — your encryption keys are derived from your password on this device. Store the password somewhere safe; without it, your data cannot be recovered. SilentSuite has no way to reset it because the server never sees your keys.
 
-**Important:** Choose a strong password. Since all encryption is derived from your password, there is no way to recover your data if you forget it. SilentSuite cannot reset your password because the server never has access to your keys.
+After signup, an inline **Verify your email** banner stays at the top of the app until you click the link sent to your registered address. (No banner on self-hosted accounts.)
 
-## 2. Set Up Your First Device
+Self-hosting your own server? Expand **Advanced Settings** on the signup page and enter your server URL before submitting. The flow becomes four steps (Account → Self-Hosting → Admin Setup → Setup) and skips the plan / billing entirely. See the [Self-Hosting guide](../self-hosting/) for the server side of that.
 
-<!-- TODO: Add platform-specific setup guides (Android, iOS, web) -->
+## 2. Add Your First Event
 
-After creating your account, set up SilentSuite on your device. Your encryption keys are generated locally during setup.
+After signup you land on the calendar. Click any cell or tap the **+** button to create an event:
 
-## 3. Add Your Data
+- Title, location, description, all-day, start/end with timezone, reminders (`VALARM`), recurrence rule
+- Save — the event is encrypted in your browser before it leaves the page
 
-Once set up, you can start adding:
+See [Calendar](./calendar.md), [Contacts](./contacts.md), and [Tasks](./tasks.md) for what each section covers.
 
-- **Calendar events** -- see [Calendar](./calendar.md)
-- **Contacts** -- see [Contacts](./contacts.md)
-- **Tasks** -- see [Tasks](./tasks.md)
+## 3. Add a Second Device
 
-All data is encrypted on your device before syncing.
+Your data is only useful if you can read it on the device you're carrying. Three supported surfaces, all talking to the same encrypted account:
 
-## 4. Add More Devices
+### Web (any device with a browser)
 
-To sync across multiple devices, sign in with the same account on each device. Your encryption keys are derived from your password on each device independently -- the server never sees them.
+Open [app.silentsuite.io](https://app.silentsuite.io/login) on the second device and log in with the same email and password. The web app is an offline-first PWA — you can install it to your home screen or dock from your browser's "install app" menu.
+
+### Android
+
+In **Settings → Mobile** there's a QR code that links to the latest signed APK on GitHub Releases. Scan it from your phone or download manually. Sideload, open the app, log in. The Android app supports a custom server URL in advanced settings if you self-host.
+
+> Currently distributed as a sideloadable APK. Google Play and F-Droid listings are on the roadmap.
+
+### Desktop (CalDAV / CardDAV via the bridge)
+
+If you'd rather use Thunderbird, Apple Calendar, GNOME Calendar, Evolution, or any other standard CalDAV/CardDAV client, install the **SilentSuite bridge**. It runs a local DAV daemon on `localhost:37358` that translates between your client and the encrypted Etebase backend.
+
+Install commands are in **Settings → Desktop** in the web app.
+
+> The bridge keeps plaintext on `localhost` only — every byte that leaves your machine is encrypted by the bridge first.
+
+### iOS
+
+There's no SilentSuite iOS app yet (on the roadmap). In the meantime, the [EteSync iOS app](https://www.etesync.com/) speaks the same Etebase protocol and works against your SilentSuite account.
+
+## 4. Confirm Sync Works
+
+Create an event on device A. Within a few seconds it should appear on device B. If it doesn't:
+
+- Check that both devices are signed in to the **same** account
+- Check that both devices report a successful sync in their status indicator
+- See the [FAQ](./faq.md) for common issues
+
+That's the success state for setup. From here, see the per-section guides:
+
+- [Calendar](./calendar.md) — events, recurrence, timezones, import/export
+- [Contacts](./contacts.md) — vCard CRUD and import/export
+- [Tasks](./tasks.md) — priorities, due dates, ICS task export
+- [How Encryption Works](./encryption-explained.md) — what the server can and can't see
+- [FAQ](./faq.md) — anything we get asked twice

--- a/docs/user-guide/tasks.md
+++ b/docs/user-guide/tasks.md
@@ -1,33 +1,46 @@
-# How to Manage Your Tasks
+# Tasks
 
-Your tasks are end-to-end encrypted. Only your devices can read them.
-
-<!-- TODO: Expand with specific UI walkthroughs once client apps are available -->
+Your tasks live at [app.silentsuite.io/tasks](https://app.silentsuite.io/tasks). Title, due date, priority, notes — every field is encrypted on your device before sync.
 
 ## Create a Task
 
-1. Open the Tasks view.
-2. Tap or click "Add Task."
-3. Enter the task details (title, due date, priority, notes).
-4. Save. The task is encrypted on your device and synced.
+1. Click **+ Add Task** or use the keyboard shortcut.
+2. Fill in:
+   - Title (required)
+   - Due date — a calendar day, or a specific date+time
+   - Priority — low / medium / high / urgent
+   - Notes
+3. Save. The task is serialized to iCalendar (`VTODO`), encrypted, and synced.
 
-## Complete a Task
+## Complete / Reopen
 
-1. Tap or click the checkbox next to the task.
-2. The completion status syncs across all your devices.
+Click the checkbox next to a task to mark it complete. The completion status (and timestamp) syncs across all your devices. Click again to reopen.
 
-## Edit a Task
+## Edit / Delete
 
-1. Open the task you want to change.
-2. Make your changes.
-3. Save. The updated task is re-encrypted and synced.
+Open a task, change its fields, save — or delete. Changes are re-encrypted and synced.
 
-## Delete a Task
+## Filter and Sort
 
-1. Open the task.
-2. Select delete.
-3. The deletion syncs across all your devices.
+The list can be filtered by completion state and sorted by due date or priority. Both run against your locally decrypted data.
 
-## Task Lists
+## Import
 
-<!-- TODO: Document task list/collection support -->
+**Settings → Import** accepts `.ics` files containing `VTODO` entries. Parsing is local-only.
+
+## Export
+
+**Settings → Export** gives you:
+
+- **Tasks (`.ics`)** — all tasks as a single iCalendar file with `VTODO` entries
+- **Everything (`.zip`)** — calendars, contacts, and tasks together
+
+## Bridge / DAV clients
+
+With the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge) installed, any CalDAV client that speaks `VTODO` can read and write the same tasks through `localhost:37358`.
+
+## Limits in this beta
+
+- A single default tasks collection per account. Managing multiple task lists is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
+- Date-only `DUE` values round-trip cleanly. Full timezone (`TZID`) preservation on date-time `DUE` values is being tightened up — see [issue #66](https://github.com/silent-suite/silentsuite/issues/66).
+- No subtasks or dependencies — a flat task list per collection.

--- a/packages/core/src/etebase/sync.test.ts
+++ b/packages/core/src/etebase/sync.test.ts
@@ -566,6 +566,189 @@ describe('SyncEngine', () => {
     });
   });
 
+  // ── Stoken persistence hooks ──
+
+  describe('stoken seeding and persistence', () => {
+    it('seeds the stoken via setStoken before start so the first list passes it through', async () => {
+      const { account, mockItemManager } = createMockAccount();
+
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+      engine.setStoken('col-1', 'stk-persisted');
+
+      // @ts-expect-error - mock account doesn't fully implement Etebase.Account
+      await engine.start(account);
+
+      expect(mockItemManager.list).toHaveBeenCalledWith(
+        expect.objectContaining({ stoken: 'stk-persisted' }),
+      );
+
+      engine.stop();
+    });
+
+    it('setStoken on an unknown collection is a no-op', () => {
+      const engine = new SyncEngine(defaultOptions());
+      // No tracked collection — should not throw.
+      expect(() => engine.setStoken('nope', 'stk')).not.toThrow();
+      expect(engine.getStoken('nope')).toBeNull();
+    });
+
+    it('getStoken reflects the latest server-returned stoken', async () => {
+      const items = [createMockItem('item-1')];
+      const { account } = createMockAccount(createMockListResponse(items, 'stk-after-sync'));
+
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+
+      expect(engine.getStoken('col-1')).toBe('stk-after-sync');
+
+      engine.stop();
+    });
+
+    it('emits onStokenAdvance when the server returns a new stoken', async () => {
+      const items = [createMockItem('item-1')];
+      const { account } = createMockAccount(createMockListResponse(items, 'stk-advanced'));
+
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+
+      const advances: { collectionUid: string; stoken: string | null }[] = [];
+      engine.onStokenAdvance((event) => {
+        advances.push({ collectionUid: event.collectionUid, stoken: event.stoken });
+      });
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+
+      expect(advances).toHaveLength(1);
+      expect(advances[0]!.collectionUid).toBe('col-1');
+      expect(advances[0]!.stoken).toBe('stk-advanced');
+
+      engine.stop();
+    });
+
+    it('does not emit onStokenAdvance when the stoken is unchanged', async () => {
+      const { account, mockItemManager } = createMockAccount();
+      // Both calls return the same stoken
+      mockItemManager.list.mockResolvedValue(createMockListResponse([], 'stk-same'));
+
+      const engine = new SyncEngine(defaultOptions({ pollIntervalMs: 60_000 }));
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+      // Pre-seed with the same stoken so the first response doesn't count as advance.
+      engine.setStoken('col-1', 'stk-same');
+
+      const advances: { stoken: string | null }[] = [];
+      engine.onStokenAdvance((event) => advances.push({ stoken: event.stoken }));
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+
+      expect(advances).toHaveLength(0);
+
+      engine.stop();
+    });
+
+    it('falls back to a full fetch when the server rejects a stale stoken', async () => {
+      const { account, mockItemManager } = createMockAccount();
+      const listMock = mockItemManager.list;
+      listMock.mockReset();
+      // First call (with stoken=stale) rejects; second call (with no stoken) succeeds.
+      listMock
+        .mockRejectedValueOnce(new Error('invalid sync token (stoken)'))
+        .mockResolvedValueOnce(createMockListResponse([createMockItem('item-1')], 'stk-fresh'));
+
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+      engine.setStoken('col-1', 'stk-stale');
+
+      const advances: { stoken: string | null }[] = [];
+      engine.onStokenAdvance((event) => advances.push({ stoken: event.stoken }));
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+
+      // Two list calls: stale stoken, then no stoken
+      expect(listMock).toHaveBeenCalledTimes(2);
+      expect(listMock.mock.calls[0]![0]).toEqual({ stoken: 'stk-stale' });
+      expect(listMock.mock.calls[1]![0]).toEqual({ stoken: undefined });
+
+      // Engine should converge on the fresh stoken
+      expect(engine.getStoken('col-1')).toBe('stk-fresh');
+
+      // We expect at least two stoken advances: clear-to-null (fallback)
+      // followed by the new stoken from the successful refetch.
+      expect(advances.length).toBeGreaterThanOrEqual(2);
+      expect(advances[0]!.stoken).toBeNull();
+      expect(advances[advances.length - 1]!.stoken).toBe('stk-fresh');
+
+      engine.stop();
+    });
+
+    it('does not swallow non-stoken errors in syncCollection', async () => {
+      const { account, mockItemManager } = createMockAccount();
+      mockItemManager.list.mockRejectedValue(new Error('connection refused'));
+
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+      engine.setStoken('col-1', 'stk-x');
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+
+      // Promise.allSettled at the syncAll level swallows it as a logged
+      // rejection — but the original error must NOT have been re-tried
+      // as a stoken-stale fallback (only one list call).
+      expect(mockItemManager.list).toHaveBeenCalledTimes(1);
+      // Stoken should remain unchanged on a non-stale error.
+      expect(engine.getStoken('col-1')).toBe('stk-x');
+
+      engine.stop();
+    });
+
+    it('allows unsubscribing from stoken advance events', async () => {
+      const items = [createMockItem('item-1')];
+      const { account } = createMockAccount(createMockListResponse(items, 'stk-x'));
+
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+
+      const advances: unknown[] = [];
+      const unsub = engine.onStokenAdvance((e) => advances.push(e));
+      unsub();
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+
+      expect(advances).toHaveLength(0);
+
+      engine.stop();
+    });
+
+    it('does not break when a stoken-advance handler throws', async () => {
+      const items = [createMockItem('item-1')];
+      const { account } = createMockAccount(createMockListResponse(items, 'stk-x'));
+
+      const engine = new SyncEngine(defaultOptions());
+      engine.trackCollection(COLLECTION_TYPE_CALENDAR, 'col-1');
+
+      const received: unknown[] = [];
+      engine.onStokenAdvance(() => {
+        throw new Error('handler boom');
+      });
+      engine.onStokenAdvance((e) => received.push(e));
+
+      // @ts-expect-error - mock
+      await engine.start(account);
+
+      expect(received).toHaveLength(1);
+
+      engine.stop();
+    });
+  });
+
   // ── Pause / resume ──
 
   describe('pause and resume', () => {

--- a/packages/core/src/etebase/sync.ts
+++ b/packages/core/src/etebase/sync.ts
@@ -5,6 +5,21 @@ import type { SyncStatus, SyncChangeEvent, SyncEngineOptions, ChangeType } from 
 type SyncEventHandler = (event: SyncChangeEvent) => void;
 type StatusChangeHandler = (status: SyncStatus) => void;
 
+/**
+ * Fired after a successful pagination round trip when the engine has
+ * advanced the stoken for a collection. Callers can persist the new
+ * stoken to durable storage so the next process start resumes from
+ * here instead of re-fetching the whole collection.
+ */
+export interface StokenAdvanceEvent {
+  collectionType: CollectionType;
+  collectionUid: string;
+  /** The new stoken returned by the server. null means "no items yet". */
+  stoken: string | null;
+}
+
+type StokenAdvanceHandler = (event: StokenAdvanceEvent) => void;
+
 interface TrackedCollection {
   collectionType: CollectionType;
   collectionUid: string;
@@ -32,6 +47,7 @@ export class SyncEngine {
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
   private changeHandlers: Set<SyncEventHandler> = new Set();
   private statusHandlers: Set<StatusChangeHandler> = new Set();
+  private stokenAdvanceHandlers: Set<StokenAdvanceHandler> = new Set();
   private reconnectAttempt = 0;
   private isDestroyed = false;
   private paused = false;
@@ -96,6 +112,28 @@ export class SyncEngine {
   }
 
   /**
+   * Seed the stoken for a tracked collection from durable storage.
+   * Call this before `start()` to resume incremental sync from where
+   * the previous process left off.
+   *
+   * No-op if the collection is not tracked. Existing stoken is overwritten.
+   */
+  setStoken(collectionUid: string, stoken: string | null): void {
+    const tracked = this.trackedCollections.get(collectionUid);
+    if (!tracked) return;
+    tracked.stoken = stoken;
+  }
+
+  /**
+   * Read the in-memory stoken for a tracked collection. Returns null
+   * if the collection is unknown or has never synced.
+   */
+  getStoken(collectionUid: string): string | null {
+    const tracked = this.trackedCollections.get(collectionUid);
+    return tracked?.stoken ?? null;
+  }
+
+  /**
    * Remove a collection from tracking.
    */
   untrackCollection(collectionUid: string): void {
@@ -119,6 +157,18 @@ export class SyncEngine {
     this.statusHandlers.add(handler);
     return () => {
       this.statusHandlers.delete(handler);
+    };
+  }
+
+  /**
+   * Subscribe to stoken-advance events. Fired each time the engine
+   * successfully advances the stoken for a collection so callers can
+   * persist it. Returns an unsubscribe function.
+   */
+  onStokenAdvance(handler: StokenAdvanceHandler): () => void {
+    this.stokenAdvanceHandlers.add(handler);
+    return () => {
+      this.stokenAdvanceHandlers.delete(handler);
     };
   }
 
@@ -196,6 +246,16 @@ export class SyncEngine {
     }
   }
 
+  private emitStokenAdvance(event: StokenAdvanceEvent): void {
+    for (const handler of this.stokenAdvanceHandlers) {
+      try {
+        handler(event);
+      } catch {
+        // Don't let subscriber errors break the engine
+      }
+    }
+  }
+
   private async syncAll(): Promise<void> {
     if (!this.account) return;
 
@@ -231,11 +291,33 @@ export class SyncEngine {
 
     const itemManager = collectionManager.getItemManager(collection);
 
+    // Stoken-not-found fallback: if the server has pruned the history that
+    // our persisted stoken referenced (e.g. account rotation, server-side
+    // compaction, or a stale cache from a different vault), the first
+    // `list()` call will throw. Drop the stoken, emit an advance event so
+    // callers clear their persisted copy, and retry from scratch.
     let done = false;
     while (!done) {
-      const response = await itemManager.list({
-        stoken: tracked.stoken ?? undefined,
-      });
+      let response: { data: Etebase.Item[]; stoken: string | null; done: boolean };
+      try {
+        response = (await itemManager.list({
+          stoken: tracked.stoken ?? undefined,
+        })) as { data: Etebase.Item[]; stoken: string | null; done: boolean };
+      } catch (err) {
+        if (tracked.stoken !== null && this.isStokenStaleError(err)) {
+          console.warn(
+            `[SyncEngine] Stoken rejected for ${tracked.collectionUid}, falling back to full fetch`,
+          );
+          tracked.stoken = null;
+          this.emitStokenAdvance({
+            collectionType: tracked.collectionType,
+            collectionUid: tracked.collectionUid,
+            stoken: null,
+          });
+          continue;
+        }
+        throw err;
+      }
 
       if (response.data.length > 0) {
         const createdOrUpdated: string[] = [];
@@ -270,9 +352,32 @@ export class SyncEngine {
         }
       }
 
-      tracked.stoken = response.stoken ?? null;
+      const newStoken = response.stoken ?? null;
+      const advanced = newStoken !== tracked.stoken;
+      tracked.stoken = newStoken;
       done = response.done;
+
+      if (advanced) {
+        this.emitStokenAdvance({
+          collectionType: tracked.collectionType,
+          collectionUid: tracked.collectionUid,
+          stoken: newStoken,
+        });
+      }
     }
+  }
+
+  /**
+   * Heuristic for "stoken refers to history we no longer have". Etebase
+   * surfaces this as a 409/stoken-mismatch error; the message text is the
+   * most reliable signal across the various Etebase server versions we
+   * support. Conservative — we only fall back when the message clearly
+   * names the stoken so we don't mask real network errors.
+   */
+  private isStokenStaleError(err: unknown): boolean {
+    if (!err) return false;
+    const msg = err instanceof Error ? err.message : String(err);
+    return /stoken|sync token|history|410|gone/i.test(msg);
   }
 
   private schedulePoll(): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export type { CollectionMeta, ItemListResponse } from './etebase/collections.js'
 
 // Sync engine
 export { SyncEngine } from './etebase/sync.js';
+export type { StokenAdvanceEvent } from './etebase/sync.js';
 
 // Calendar event model
 export {

--- a/packages/core/src/models/calendar-event.test.ts
+++ b/packages/core/src/models/calendar-event.test.ts
@@ -468,6 +468,26 @@ describe('DST timezone conversion (two-pass offset)', () => {
     expect(event.startDate.getUTCMinutes()).toBe(0);
   });
 
+  it('returns the same UTC instant regardless of runtime TZ for TZID values', () => {
+    // Regression for #109: parseICalDateValue used `new Date(y, m, ...)` which
+    // interprets in the runtime's local TZ, causing the parsed instant to drift
+    // by the runtime's UTC offset whenever it wasn't UTC. Vitest defaults to
+    // TZ=UTC so the bug was invisible — this test pins the expected absolute
+    // UTC instant so any reintroduction of the local-time math will fail.
+    const ical = [
+      'BEGIN:VEVENT',
+      'UID:tzid-stability',
+      'DTSTART;TZID=Europe/Vienna:20250604T100000', // 10:00 Vienna in CEST = 08:00 UTC
+      'DTEND;TZID=Europe/Vienna:20250604T110000',   // 11:00 Vienna in CEST = 09:00 UTC
+      'SUMMARY:Vienna 10am',
+      'END:VEVENT',
+    ].join('\r\n');
+
+    const event = fromVEvent(ical);
+    expect(event.startDate.toISOString()).toBe('2025-06-04T08:00:00.000Z');
+    expect(event.endDate.toISOString()).toBe('2025-06-04T09:00:00.000Z');
+  });
+
   it('uses local time when no TZID is provided', () => {
     // No TZID and no Z → local time interpretation
     const ical = [

--- a/packages/core/src/models/calendar-event.ts
+++ b/packages/core/src/models/calendar-event.ts
@@ -99,8 +99,15 @@ export function parseICalDateValue(value: string, tzid?: string): { date: Date; 
         });
         const parts = formatter.formatToParts(new Date(utcMs));
         const p = (type: string) => parseInt(parts.find((x) => x.type === type)?.value ?? '0', 10);
-        const localDate = new Date(p('year'), p('month') - 1, p('day'), p('hour'), p('minute'), p('second'));
-        return localDate.getTime() - utcMs;
+        // Use Date.UTC, not `new Date(...)` — the latter interprets in the
+        // runtime's local TZ, which makes this whole calculation dependent on
+        // the browser/server's TZ (returning 0 when browser TZ matches tzid,
+        // and arbitrary wrong offsets otherwise). Date.UTC always returns
+        // the UTC ms for the given wall-clock components, so the diff
+        // measures purely the tzid's offset from UTC at this instant.
+        const hour = p('hour') === 24 ? 0 : p('hour'); // Intl midnight edge case
+        const localUtcMs = Date.UTC(p('year'), p('month') - 1, p('day'), hour, p('minute'), p('second'));
+        return localUtcMs - utcMs;
       }
 
       // Two-pass approach: the first offset may be wrong when a DST

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       next-themes:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -4493,6 +4496,11 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -5182,6 +5190,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vfile-message@4.0.3:
@@ -10198,6 +10207,10 @@ snapshots:
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
## Summary

Roll-up of the 14 PRs merged to `dev` since v0.1.0-beta (2026-05-03). This is a **bugfix + polish** point release; no new top-level features, no schema/migration risk to self-hosters, no breaking changes.

## What's rolling in

### Bug fixes
- #137 fix(android): relaunch AccountActivity from setup wizard (closes #119)
- #131 Android: defensive patches for first-login crash (#119)
- #122 fix(web): refresh session on tab focus while verify banner is shown
- #123 fix(web/signup): lead 30-day trial card with trial framing, not price
- #125 fix(web/export): surface ZIP export failures with toast + progress
- #121 Tasks: fix priority badge contrast in light mode
- #108 Render calendar in user timezone, edit form in event timezone

### Polish / small features
- #138 mobile: route QR code through docs install guide; add Obtainium
- #124 feat(web): real APK QR, EteSync iOS mention, new Desktop bridge page
- #132 feat(web): local IndexedDB cache for instant reload (behind feature flag)
- #134 admin: redesign overview as single-pane landing dashboard
- #133 feat(web): gate onboarding popup on server-side `onboardedAt` flag

### Docs
- #136 docs(user-guide): write v0.1.0-beta user guide
- #135 docs(self-hosting): correct factual errors about stack composition

## Reviewers

Per workspace policy this PR will be reviewed by **two reviewers** before merge:

## Test plan

- [ ] All constituent PRs were already reviewed + merged into `dev`; this rollup needs sanity-check only
- [ ] Cloudflare Pages preview from `dev` is healthy (web app loads, calendar/contacts/tasks render)
- [ ] Android APK from latest `dev` CI passes the first-login + drawer-logout smoke
- [ ] Bridge binaries still build green in CI
- [ ] No leftover feature-flag code paths enabled by default that shouldn't be