### PR TITLE
fix(web): leave session intact on transient billing errors during refreshSession

### DIFF
--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -445,6 +445,67 @@ describe('useAuthStore', () => {
     })
   })
 
+  // --- refreshSession non-destructive on transient errors ---
+  // Regression: the EmailVerificationBanner re-checks the session on every
+  // tab focus while the user is unverified. A transient billing 5xx or a
+  // network blip used to null the session, silently logging out users who
+  // had only alt-tabbed away.
+
+  describe('refreshSession on transient errors', () => {
+    function loggedIn() {
+      useAuthStore.setState({
+        user: { id: 'u1', email: 'x@y.com', planId: 'pro', emailVerified: false, onboardedAt: null },
+        isAuthenticated: true,
+      })
+    }
+
+    it('leaves the session intact on a 5xx response', async () => {
+      loggedIn()
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 502 } as Response)
+
+      const result = await useAuthStore.getState().refreshSession()
+
+      expect(result).toBe(false)
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(true)
+      expect(state.user).not.toBeNull()
+    })
+
+    it('leaves the session intact on a network error', async () => {
+      loggedIn()
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      const result = await useAuthStore.getState().refreshSession()
+
+      expect(result).toBe(false)
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(true)
+      expect(state.user).not.toBeNull()
+    })
+
+    it('nulls the session on 401 (auth genuinely invalid)', async () => {
+      loggedIn()
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 401 } as Response)
+
+      const result = await useAuthStore.getState().refreshSession()
+
+      expect(result).toBe(false)
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(false)
+      expect(state.user).toBeNull()
+    })
+
+    it('nulls the session on 403', async () => {
+      loggedIn()
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 403 } as Response)
+
+      const result = await useAuthStore.getState().refreshSession()
+
+      expect(result).toBe(false)
+      expect(useAuthStore.getState().user).toBeNull()
+    })
+  })
+
   // --- Stripe redirect signup state (issue #20) ---
 
   describe('signup redirect state storage', () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -409,16 +409,26 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     try {
       const res = await fetch(`${BILLING_API_URL}/auth/refresh`, { method: 'POST', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-      if (!res.ok) { syncAdminCookie(false); set({ user: null, isAuthenticated: false }); return false }
+      // Only treat the session as invalid on explicit auth failures. A 5xx
+      // response or network blip would otherwise log out e.g. an unverified
+      // user when the verify-banner re-checks on tab focus (see
+      // EmailVerificationBanner).
+      if (res.status === 401 || res.status === 403) {
+        syncAdminCookie(false)
+        set({ user: null, isAuthenticated: false })
+        return false
+      }
+      if (!res.ok) {
+        logger.warn('[auth-store] Session refresh got non-OK response, leaving session intact:', res.status)
+        return false
+      }
       const data = await res.json()
       const isAdmin = data.isAdmin === true
       syncAdminCookie(isAdmin)
       set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true })
       return true
     } catch (err) {
-      logger.warn('[auth-store] Session refresh failed:', err)
-      syncAdminCookie(false)
-      set({ user: null, isAuthenticated: false })
+      logger.warn('[auth-store] Session refresh failed (network), leaving session intact:', err)
       return false
     }
   },


### PR DESCRIPTION
## Summary

Caught in the v0.1.1-beta release review (PR #141). `EmailVerificationBanner`
re-checks the session on every tab focus while the user is unverified
(behaviour added in #122). The action it calls — `refreshSession()` — was
written to null \`user\` on any non-OK fetch response or thrown fetch error,
so a 502 from the billing API or a brief network blip silently logged out
anyone who had just alt-tabbed in.

This change makes the failure handling discriminate:

- **401 / 403** → null the user (auth genuinely invalid; existing behaviour)
- **5xx, opaque non-OK, thrown fetch** → leave the session intact, just
  return \`false\`. The banner stays, and the next focus tries again.

## Test plan

- [x] \`pnpm test\` — all 159 tests pass; 4 new tests cover the new
  non-destructive paths and confirm 401/403 still null the user
- [ ] Smoke: open the app while signed in but unverified, kill the billing
  API, alt-tab away and back — session should NOT be cleared