### PR TITLE
fix(android): remove empty overflow menu from account toolbar (#148)

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -14,7 +14,6 @@ import android.content.*
 import android.content.ContentResolver.SYNC_OBSERVER_TYPE_ACTIVE
 import android.content.ContentResolver.SYNC_OBSERVER_TYPE_SETTINGS
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.provider.CalendarContract
@@ -319,36 +318,26 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when (item.itemId) {
-            R.id.sync_now -> requestSync()
-            R.id.settings -> {
-                startActivity(Intent(this, AppSettingsActivity::class.java))
+        return when (item.itemId) {
+            R.id.sync_now -> {
+                requestSync()
+                true
             }
-            R.id.delete_account -> AlertDialog.Builder(this@AccountActivity)
-                    .setIcon(R.drawable.ic_error_dark)
-                    .setTitle(R.string.account_delete_confirmation_title)
-                    .setMessage(R.string.account_delete_confirmation_text)
-                    .setNegativeButton(android.R.string.no, null)
-                    .setPositiveButton(android.R.string.yes) { _, _ -> deleteAccount() }
-                    .show()
-            R.id.show_fingerprint -> {
-                val view = layoutInflater.inflate(R.layout.fingerprint_alertdialog, null)
-                view.findViewById<View>(R.id.body).visibility = View.GONE
-                (view.findViewById<View>(R.id.fingerprint) as TextView).text = formattedFingerprint
-                val dialog = AlertDialog.Builder(this@AccountActivity)
-                        .setIcon(R.drawable.ic_fingerprint_dark)
-                        .setTitle(R.string.show_fingperprint_title)
-                        .setView(view)
-                        .setPositiveButton(android.R.string.yes) { _, _ -> }.create()
-                dialog.show()
-            }
-            R.id.invitations -> {
-                val intent = InvitationsActivity.newIntent(this, account)
-                startActivity(intent)
-            }
-            else -> return super.onOptionsItemSelected(item)
+            else -> super.onOptionsItemSelected(item)
         }
-        return true
+    }
+
+    private fun showFingerprintDialog() {
+        val view = layoutInflater.inflate(R.layout.fingerprint_alertdialog, null)
+        view.findViewById<View>(R.id.body).visibility = View.GONE
+        (view.findViewById<View>(R.id.fingerprint) as TextView).text = formattedFingerprint
+        AlertDialog.Builder(this@AccountActivity)
+                .setIcon(R.drawable.ic_fingerprint_dark)
+                .setTitle(R.string.show_fingperprint_title)
+                .setView(view)
+                .setPositiveButton(android.R.string.yes) { _, _ -> }
+                .create()
+                .show()
     }
 
     fun installPackage(packagename: String) {
@@ -396,6 +385,8 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         when (item.itemId) {
             R.id.nav_about -> startActivity(Intent(this, AboutActivity::class.java))
             R.id.nav_app_settings -> startActivity(Intent(this, AppSettingsActivity::class.java))
+            R.id.nav_invitations -> startActivity(InvitationsActivity.newIntent(this, account))
+            R.id.nav_show_fingerprint -> showFingerprintDialog()
             R.id.nav_website -> startActivity(Intent(Intent.ACTION_VIEW, Constants.webUri))
             R.id.nav_webapp -> startActivity(Intent(Intent.ACTION_VIEW, Constants.webAppUri))
             R.id.nav_guide -> startActivity(Intent(Intent.ACTION_VIEW, Constants.docsUri))
@@ -735,38 +726,11 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
     /* USER ACTIONS */
 
-    private fun deleteAccount() {
-        val accountManager = AccountManager.get(this)
-
-        lifecycleScope.launch {
-            teardownAccountState(account)
-
-            if (Build.VERSION.SDK_INT >= 22)
-                accountManager.removeAccount(account, this@AccountActivity, { future ->
-                    try {
-                        if (future.result.getBoolean(AccountManager.KEY_BOOLEAN_RESULT))
-                            finish()
-                    } catch(e: Exception) {
-                        Logger.log.log(Level.SEVERE, "Couldn't remove account", e)
-                    }
-                }, null)
-            else
-                accountManager.removeAccount(account, { future ->
-                    try {
-                        if (future.result)
-                            finish()
-                    } catch (e: Exception) {
-                        Logger.log.log(Level.SEVERE, "Couldn't remove account", e)
-                    }
-                }, null)
-        }
-    }
-
     // Tear down per-account client state before the Android account is removed.
     // Must run while AccountManager still has the user data, since AccountSettings
-    // (and the etebase session) are read from it. Both deleteAccount() and
-    // confirmLogout() must call this — leaving the Etebase FS cache behind causes
-    // stale stokens on re-login, which makes incremental sync miss historical items.
+    // (and the etebase session) are read from it. confirmLogout() must call this —
+    // leaving the Etebase FS cache behind causes stale stokens on re-login, which
+    // makes incremental sync miss historical items.
     private suspend fun teardownAccountState(account: Account) = withContext(Dispatchers.IO) {
         EtebaseLocalCache.clearUserCache(this@AccountActivity, account.name)
 

--- a/android/app/src/main/res/menu/activity_account.xml
+++ b/android/app/src/main/res/menu/activity_account.xml
@@ -15,22 +15,4 @@
           android:title="@string/account_synchronize_now"
           app:showAsAction="always"/>
 
-    <item android:id="@+id/settings"
-          android:icon="@drawable/ic_settings_dark"
-          android:title="@string/account_settings"
-          app:showAsAction="ifRoom"/>
-
-    <item android:id="@+id/show_fingerprint"
-        android:icon="@drawable/ic_fingerprint_dark"
-        android:title="@string/account_show_fingerprint"
-        app:showAsAction="ifRoom"/>
-
-    <item android:id="@+id/invitations"
-        android:title="@string/invitations_title"
-        app:showAsAction="never"/>
-
-    <item android:id="@+id/delete_account"
-          android:title="@string/account_delete"
-          app:showAsAction="never"/>
-
 </menu>

--- a/android/app/src/main/res/menu/activity_accounts_drawer.xml
+++ b/android/app/src/main/res/menu/activity_accounts_drawer.xml
@@ -20,6 +20,14 @@
             android:icon="@drawable/ic_settings_dark"
             android:title="@string/navigation_drawer_settings"/>
         <item
+            android:id="@+id/nav_invitations"
+            android:icon="@drawable/ic_people_light"
+            android:title="@string/invitations_title"/>
+        <item
+            android:id="@+id/nav_show_fingerprint"
+            android:icon="@drawable/ic_fingerprint_dark"
+            android:title="@string/account_show_fingerprint"/>
+        <item
             android:id="@+id/nav_theme"
             android:icon="@drawable/ic_palette"
             android:title="@string/navigation_drawer_theme"/>


### PR DESCRIPTION
## Summary

- Removes the broken three-dot overflow menu from the main signed-in `AccountActivity` toolbar (it opened an empty white popup in v0.1.1).
- Migrates the two unique features previously hiding behind it — **Invitations** and **Encryption fingerprint** — into the existing navigation drawer.
- Drops the duplicates: the overflow's "Settings" was the same as drawer "Settings", and "Sign out" was the same as drawer "Log out".
- Keeps `Synchronize now` as a primary toolbar icon (`showAsAction="always"`) — it never lived in the overflow.

Closes #148.

## What changes

| File | Change |
|---|---|
| `android/app/src/main/res/menu/activity_account.xml` | Strip to just `sync_now`; no items now overflow → no three-dot indicator. |
| `android/app/src/main/res/menu/activity_accounts_drawer.xml` | Add `nav_invitations` and `nav_show_fingerprint` entries to the main drawer group. |
| `android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt` | Drop dead overflow handlers in `onOptionsItemSelected`. Add drawer handlers for the two migrated entries. Remove the now-unused `deleteAccount()` (drawer's `confirmLogout` is the surviving path). Extract `showFingerprintDialog()` so it's reusable from the drawer. |

## Test plan

- [ ] Build a debug APK in CI and side-load.
- [ ] Sign in. Confirm no three-dot button on the top-right of the toolbar.
- [ ] Confirm `Sync now` icon is still present and works.
- [ ] Open drawer (hamburger). Tap `Invitations` → `InvitationsActivity` opens.
- [ ] Drawer → `Encryption fingerprint` → fingerprint dialog opens with the formatted fingerprint.
- [ ] Drawer → `Log out` still works as before (no regression on the existing logout flow).
- [ ] Multi-account: switch accounts via the nav header, then re-test `Invitations` / `Encryption fingerprint` on the active account.

## Notes

- `account_delete` and `account_settings` strings are now unused in code; left in place to avoid touching every translated `values-*/strings.xml`.