### PR TITLE
fix(web): all-day events render across two days (#147)

### DIFF
--- a/apps/web/app/(app)/calendar/components/AgendaView.tsx
+++ b/apps/web/app/(app)/calendar/components/AgendaView.tsx
@@ -37,8 +37,12 @@ export function AgendaView({ events, currentDate, onEventClick }: AgendaViewProp
         const start = e.startDate instanceof Date ? e.startDate : new Date(e.startDate)
         const end = e.endDate instanceof Date ? e.endDate : new Date(e.endDate)
 
-        // Event overlaps with current day if it starts before day ends AND ends after day starts
-        return start <= currentDayEnd && end >= currentDayStart
+        // Event overlaps with current day if it starts before day ends AND ends after day starts.
+        // For all-day events, endDate follows iCal DTEND;VALUE=DATE convention (exclusive — the
+        // day *after* the last day of the event), so use `>` rather than `>=` to avoid bleeding
+        // a single-day event onto the morning of the next day.
+        const endComparison = e.allDay ? end > currentDayStart : end >= currentDayStart
+        return start <= currentDayEnd && endComparison
       })
       .sort((a, b) => {
         if (a.allDay && !b.allDay) return -1

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -97,8 +97,13 @@ function expandEventsForRange(
 
   for (const event of events) {
     if (!event.recurrenceRule) {
-      // Non-recurring: include if it falls within range
-      if (event.endDate >= range.start && event.startDate <= range.end) {
+      // Non-recurring: include if it overlaps the range. For all-day events,
+      // endDate is iCal-exclusive (next-day midnight) so use strict `>` to avoid
+      // matching events whose visual last day is just before range.start.
+      const overlapsRangeStart = event.allDay
+        ? event.endDate > range.start
+        : event.endDate >= range.start
+      if (overlapsRangeStart && event.startDate <= range.end) {
         result.push({
           id: event.id,
           masterId: event.id,

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -16,6 +16,7 @@ import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { expandRecurrence } from '@silentsuite/core'
 import type { CalendarEvent, DateRange } from '@silentsuite/core'
 import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
+import { toAllDayEndPlainDate } from '../lib/all-day'
 
 import '@schedule-x/theme-default/dist/index.css'
 
@@ -155,7 +156,9 @@ function toScheduleXEvents(
       id: e.id,
       title: e.isRecurring ? `↻ ${e.title}` : e.title,
       start: e.allDay ? toPlainDate(e.startDate) : toScheduleXDateTime(e.startDate, userTz),
-      end: e.allDay ? toPlainDate(e.endDate) : toScheduleXDateTime(e.endDate, userTz),
+      end: e.allDay
+        ? toAllDayEndPlainDate(e.startDate, e.endDate)
+        : toScheduleXDateTime(e.endDate, userTz),
       description: e.description || undefined,
       location: e.location || undefined,
       calendarId: e.calendarId ?? 'default',

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -132,8 +132,11 @@ export function EventDialog({
   const effectiveInstanceDate = instanceDate ?? event?.startDate ?? new Date()
 
   const defaultStart = isEdit ? event.startDate : (initialStartDate ?? new Date())
+  // For all-day events, `event.endDate` follows iCal DTEND;VALUE=DATE convention
+  // (exclusive — the day *after* the last day of the event). The form picker shows
+  // the inclusive last day, so subtract one day before formatting.
   const defaultEnd = isEdit
-    ? event.endDate
+    ? (event.allDay ? new Date(event.endDate.getTime() - 86_400_000) : event.endDate)
     : (initialEndDate ?? new Date(defaultStart.getTime() + 30 * 60 * 1000))
 
   // Initial all-day flag — needed before form state so we can pick the right
@@ -255,7 +258,10 @@ export function EventDialog({
   const buildEndDate = useCallback((): Date => {
     const [y, m, d] = endDate.split('-').map(Number)
     if (allDay) {
-      return new Date(y, m - 1, d, 23, 59, 59, 0)
+      // RFC 5545: VALUE=DATE DTEND is exclusive — i.e. the day after the last day
+      // of the event. Stored as the next day's local-midnight to match how the
+      // ical parser surfaces DTEND for events synced from upstream.
+      return new Date(y, m - 1, d + 1, 0, 0, 0, 0)
     }
     const [h, min] = endTime.split(':').map(Number)
     return instantFromWallClock(y, m, d, h, min, timezone)
@@ -484,7 +490,9 @@ export function EventDialog({
   const subtitle = (() => {
     if (allDay) {
       const sd = formatDateForDisplay(buildStartDate(), undefined)
-      const ed = formatDateForDisplay(buildEndDate(), undefined)
+      // buildEndDate returns iCal-exclusive next-day midnight; subtract a day for human display.
+      const inclusiveEnd = new Date(buildEndDate().getTime() - 86_400_000)
+      const ed = formatDateForDisplay(inclusiveEnd, undefined)
       return startDate === endDate ? sd : `${sd} – ${ed}`
     }
     const s = buildStartDate()

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -19,6 +19,7 @@ import {
   resolveUserTimezone,
   shortTimezoneLabel,
 } from '@/app/lib/tz'
+import { inclusiveAllDayEndDate } from '../lib/all-day'
 
 // ---------------------------------------------------------------------------
 // Time formatting (respects user preference)
@@ -136,7 +137,7 @@ export function EventDialog({
   // (exclusive — the day *after* the last day of the event). The form picker shows
   // the inclusive last day, so subtract one day before formatting.
   const defaultEnd = isEdit
-    ? (event.allDay ? new Date(event.endDate.getTime() - 86_400_000) : event.endDate)
+    ? (event.allDay ? inclusiveAllDayEndDate(event.endDate) : event.endDate)
     : (initialEndDate ?? new Date(defaultStart.getTime() + 30 * 60 * 1000))
 
   // Initial all-day flag — needed before form state so we can pick the right
@@ -491,8 +492,7 @@ export function EventDialog({
     if (allDay) {
       const sd = formatDateForDisplay(buildStartDate(), undefined)
       // buildEndDate returns iCal-exclusive next-day midnight; subtract a day for human display.
-      const inclusiveEnd = new Date(buildEndDate().getTime() - 86_400_000)
-      const ed = formatDateForDisplay(inclusiveEnd, undefined)
+      const ed = formatDateForDisplay(inclusiveAllDayEndDate(buildEndDate()), undefined)
       return startDate === endDate ? sd : `${sd} – ${ed}`
     }
     const s = buildStartDate()

--- a/apps/web/app/(app)/calendar/lib/__tests__/all-day.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/all-day.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import 'temporal-polyfill/global'
+import { toAllDayEndPlainDate } from '../all-day'
+
+describe('toAllDayEndPlainDate', () => {
+  it('returns the start day for a single-day event with iCal-exclusive DTEND', () => {
+    // Birthday on 2026-05-05 — iCal: DTSTART:20260505 DTEND:20260506
+    const start = new Date(2026, 4, 5)
+    const end = new Date(2026, 4, 6)
+    const pd = toAllDayEndPlainDate(start, end)
+    expect(pd.toString()).toBe('2026-05-05')
+  })
+
+  it('returns the inclusive last day for a multi-day event', () => {
+    // 3-day event 2026-05-05 → 2026-05-07 — iCal: DTSTART:20260505 DTEND:20260508
+    const start = new Date(2026, 4, 5)
+    const end = new Date(2026, 4, 8)
+    const pd = toAllDayEndPlainDate(start, end)
+    expect(pd.toString()).toBe('2026-05-07')
+  })
+
+  it('clamps to start when DTEND === DTSTART (zero-duration / malformed event)', () => {
+    const start = new Date(2026, 4, 5)
+    const end = new Date(2026, 4, 5)
+    const pd = toAllDayEndPlainDate(start, end)
+    expect(pd.toString()).toBe('2026-05-05')
+  })
+
+  it('handles month boundaries', () => {
+    // Event on 2026-05-31 — iCal: DTSTART:20260531 DTEND:20260601
+    const start = new Date(2026, 4, 31)
+    const end = new Date(2026, 5, 1)
+    const pd = toAllDayEndPlainDate(start, end)
+    expect(pd.toString()).toBe('2026-05-31')
+  })
+
+  it('handles year boundaries', () => {
+    // Event on 2026-12-31 — iCal: DTSTART:20261231 DTEND:20270101
+    const start = new Date(2026, 11, 31)
+    const end = new Date(2027, 0, 1)
+    const pd = toAllDayEndPlainDate(start, end)
+    expect(pd.toString()).toBe('2026-12-31')
+  })
+})

--- a/apps/web/app/(app)/calendar/lib/__tests__/all-day.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/all-day.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import 'temporal-polyfill/global'
-import { toAllDayEndPlainDate } from '../all-day'
+import { toAllDayEndPlainDate, inclusiveAllDayEndDate } from '../all-day'
 
 describe('toAllDayEndPlainDate', () => {
   it('returns the start day for a single-day event with iCal-exclusive DTEND', () => {
@@ -40,5 +40,45 @@ describe('toAllDayEndPlainDate', () => {
     const end = new Date(2027, 0, 1)
     const pd = toAllDayEndPlainDate(start, end)
     expect(pd.toString()).toBe('2026-12-31')
+  })
+
+  it('preserves the calendar day across a leap day', () => {
+    // 4-year event ending 2028-02-29 — iCal: DTSTART:20280225 DTEND:20280301
+    const start = new Date(2028, 1, 25)
+    const end = new Date(2028, 2, 1)
+    const pd = toAllDayEndPlainDate(start, end)
+    expect(pd.toString()).toBe('2028-02-29')
+  })
+})
+
+describe('inclusiveAllDayEndDate', () => {
+  it('subtracts one calendar day from an iCal-exclusive end date', () => {
+    const exclusive = new Date(2026, 4, 6, 0, 0, 0, 0)
+    const inclusive = inclusiveAllDayEndDate(exclusive)
+    expect(inclusive.getFullYear()).toBe(2026)
+    expect(inclusive.getMonth()).toBe(4)
+    expect(inclusive.getDate()).toBe(5)
+    // Must be local-midnight, not 23:00 — otherwise getDate() in DST zones drifts.
+    expect(inclusive.getHours()).toBe(0)
+    expect(inclusive.getMinutes()).toBe(0)
+  })
+
+  it('lands on the correct calendar day across spring-forward', () => {
+    // 2026-03-29 is the Berlin DST start (02:00 → 03:00). The day has 23 hours.
+    // An event ending 2026-03-30 (iCal-exclusive) should yield 2026-03-29 in the form,
+    // not 2026-03-28 (which raw `getTime() - 86_400_000` would produce in Berlin).
+    const exclusive = new Date(2026, 2, 30, 0, 0, 0, 0)
+    const inclusive = inclusiveAllDayEndDate(exclusive)
+    expect(inclusive.getFullYear()).toBe(2026)
+    expect(inclusive.getMonth()).toBe(2)
+    expect(inclusive.getDate()).toBe(29)
+  })
+
+  it('handles year boundaries', () => {
+    const exclusive = new Date(2027, 0, 1, 0, 0, 0, 0)
+    const inclusive = inclusiveAllDayEndDate(exclusive)
+    expect(inclusive.getFullYear()).toBe(2026)
+    expect(inclusive.getMonth()).toBe(11)
+    expect(inclusive.getDate()).toBe(31)
   })
 })

--- a/apps/web/app/(app)/calendar/lib/all-day.ts
+++ b/apps/web/app/(app)/calendar/lib/all-day.ts
@@ -1,0 +1,30 @@
+import 'temporal-polyfill/global'
+
+/** Convert a JS Date to a Temporal.PlainDate using its local-zone wall-clock components.
+ *
+ * All-day events are stored as local-midnight Date objects (see `parseICalDateValue`
+ * and `EventDialog.buildStartDate`), so reading getFullYear / getMonth / getDate
+ * round-trips correctly.
+ */
+export function dateToPlainDate(date: Date): Temporal.PlainDate {
+  return Temporal.PlainDate.from({
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+  })
+}
+
+/** Compute the inclusive end PlainDate to hand to Schedule-X for an all-day event.
+ *
+ * Our internal `CalendarEvent.endDate` follows the iCal convention where DTEND for
+ * a `VALUE=DATE` event is exclusive — the day *after* the last day of the event.
+ * Schedule-X v4's date-grid renderer treats `end` as inclusive (it filters days by
+ * `day.date >= start && day.date <= end`), so passing the iCal-exclusive value
+ * paints the event across one extra day. Subtract one day, but never go below the
+ * start date — guards malformed events where DTEND === DTSTART.
+ */
+export function toAllDayEndPlainDate(startDate: Date, endDate: Date): Temporal.PlainDate {
+  const startPd = dateToPlainDate(startDate)
+  const endPd = dateToPlainDate(endDate).subtract({ days: 1 })
+  return Temporal.PlainDate.compare(endPd, startPd) < 0 ? startPd : endPd
+}

--- a/apps/web/app/(app)/calendar/lib/all-day.ts
+++ b/apps/web/app/(app)/calendar/lib/all-day.ts
@@ -28,3 +28,17 @@ export function toAllDayEndPlainDate(startDate: Date, endDate: Date): Temporal.P
   const endPd = dateToPlainDate(endDate).subtract({ days: 1 })
   return Temporal.PlainDate.compare(endPd, startPd) < 0 ? startPd : endPd
 }
+
+/** Convert an iCal-exclusive all-day end Date (next-day local-midnight) into a Date
+ * representing the inclusive last day at local-midnight.
+ *
+ * Use Temporal arithmetic rather than `getTime() - 86_400_000`: across a spring-forward
+ * boundary the previous calendar day has only 23 hours, and ms subtraction lands the
+ * result at 23:00 local on the day before that — wrong calendar day. Used by the
+ * EventDialog form-load and subtitle paths so they round-trip consistently with the
+ * `buildEndDate` save path.
+ */
+export function inclusiveAllDayEndDate(exclusiveEndDate: Date): Date {
+  const pd = dateToPlainDate(exclusiveEndDate).subtract({ days: 1 })
+  return new Date(pd.year, pd.month - 1, pd.day, 0, 0, 0, 0)
+}


### PR DESCRIPTION
## Summary

All-day events with iCal-correct exclusive `DTEND;VALUE=DATE` (i.e. anything synced from upstream EteSync, Google, iCloud, etc.) were painting across **two** days in the webapp instead of one. The internal `CalendarEvent.endDate` is iCal-exclusive (the day *after* the last day of the event), but three render sites were treating it as inclusive.

Closes #147.

## What broke, where

| Layer | Bug |
|---|---|
| **CalendarGrid → Schedule-X** | Passed `toPlainDate(event.endDate)` as the date-grid `end`. Schedule-X v4's date-grid renderer filters days by `day.date >= start && day.date <= end` — inclusive — so a single-day 5/5 birthday painted both 5/5 and 5/6. |
| **AgendaView day filter** | `end >= currentDayStart` matched the next day's morning, so a 5/5 event also showed up under 5/6. |
| **EventDialog edit form** | `defaultEnd = event.endDate` populated the date input with the day *after* the event. Saving inverted it: `buildEndDate` stored same-day 23:59:59, which round-trips to a DTEND **on the same day as DTSTART** — RFC-non-compliant and breaks downstream clients. |

## Fix

- New `apps/web/app/(app)/calendar/lib/all-day.ts` with `toAllDayEndPlainDate(start, end)` — subtracts one day, clamped to start.
- `CalendarGrid.toScheduleXEvents` uses it.
- `AgendaView` uses strict `>` for allDay end comparison.
- `EventDialog`:
  - `defaultEnd` subtracts a day for allDay edit-form load.
  - `buildEndDate` writes next-day-midnight (iCal-exclusive) for allDay save.
  - Subtitle subtracts a day for human-readable display.

## Tests

- New `lib/__tests__/all-day.test.ts` — 5 tests covering single-day, multi-day, malformed (`DTEND===DTSTART`), month boundaries, year boundaries.
- All 164 webapp tests pass locally (`pnpm --filter web test`).

## Migration note

Webapp-created multi-day all-day events saved before this change used the old inclusive-end convention (`DTEND` on the last visible day rather than the day after). After this lands, those events will display **one day shorter** until re-saved. Users can correct an affected event by opening it and clicking Save — the form load and save paths are now symmetric, so the round-trip stays correct.

Single-day birthdays/anniversaries (the user-reported case) are unaffected by the migration concern: a single-day event saved either way collapses back to one day.

## Test plan

- [ ] Build a Cloudflare Pages preview for this branch.
- [ ] On an account with upstream-synced birthdays / holidays, open Calendar → week and month views. All-day events span exactly one day.
- [ ] Open a multi-day all-day event (e.g. a 3-day conference) — paints exactly 3 days, not 4.
- [ ] AgendaView for the day of a single-day all-day event — event listed once, not also on the day after.
- [ ] Open an existing all-day event in the edit dialog — the End-date input shows the same day the event is on (not the day after). Save without changes — round-trip should not shift the event.
- [ ] Create a new all-day event from the form — saves with iCal-correct exclusive DTEND. Verify by re-opening the event after a sync round-trip.