### PR TITLE
fix(web): make data export robust at scale, surface errors honestly (#146)

### DIFF
--- a/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { toVEvent } from '@silentsuite/core'
+import { showErrorToast, showWarningToast } from '@/app/stores/use-toast-store'
 import ExportPage from '../page'
+
+vi.mock('@/app/stores/use-toast-store', () => ({
+  showErrorToast: vi.fn(),
+  showWarningToast: vi.fn(),
+}))
 
 // Mock stores
 vi.mock('@/app/stores/use-task-store', () => ({
@@ -225,5 +232,47 @@ describe('ExportPage', () => {
     const blobCall = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as Blob
     expect(blobCall.type).toBe('text/vcard')
+  })
+
+  it('skips events that fail to serialize and shows a warning toast', () => {
+    vi.mocked(toVEvent).mockImplementationOnce(() => {
+      throw new Error('boom — malformed event')
+    })
+
+    render(<ExportPage />)
+    fireEvent.click(screen.getByText(/Export Calendar/))
+
+    expect(URL.createObjectURL).toHaveBeenCalled()
+    expect(clickedLink).not.toBeNull()
+    expect(clickedLink!.download).toBe('silentsuite-calendar.ics')
+    expect(showWarningToast).toHaveBeenCalledWith(
+      expect.stringContaining('1 event'),
+    )
+  })
+
+  it('shows an error toast (with detail) when serialization itself fails fatally', () => {
+    // Force `serializeAll` to throw at a level we can't recover from — by
+    // making the mocked serializer throw a non-Error object that the loop
+    // handles gracefully isn't enough; instead, throw from inside the test
+    // by stubbing `toVEvent` to throw on the first call AND rejecting
+    // recovery by making the DOM blob construction fail.
+    const originalCreateObjectURL = URL.createObjectURL
+    ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => {
+        throw new Error('blob URL creation blocked')
+      },
+    )
+
+    render(<ExportPage />)
+    fireEvent.click(screen.getByText(/Export Calendar/))
+
+    expect(showErrorToast).toHaveBeenCalledWith(
+      expect.stringContaining('Calendar export failed'),
+    )
+
+    // restore the spy for downstream tests in this describe block
+    ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementation(
+      originalCreateObjectURL as () => string,
+    )
   })
 })

--- a/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
@@ -250,12 +250,10 @@ describe('ExportPage', () => {
     )
   })
 
-  it('shows an error toast (with detail) when serialization itself fails fatally', () => {
-    // Force `serializeAll` to throw at a level we can't recover from — by
-    // making the mocked serializer throw a non-Error object that the loop
-    // handles gracefully isn't enough; instead, throw from inside the test
-    // by stubbing `toVEvent` to throw on the first call AND rejecting
-    // recovery by making the DOM blob construction fail.
+  it('shows an error toast (with detail) when the download path fails', () => {
+    // Simulate a real-world failure mode: blob URL creation blocked by a
+    // privacy-hardened browser context. Fires after `serializeAll` succeeds,
+    // exercising the outer try/catch in `exportCalendar`.
     const originalCreateObjectURL = URL.createObjectURL
     ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementationOnce(
       () => {

--- a/apps/web/app/(app)/settings/export/page.tsx
+++ b/apps/web/app/(app)/settings/export/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { Button } from '@silentsuite/ui'
-import { toVEvent, toVTodo, toVCard } from '@silentsuite/core'
+import { toVEvent, toVTodo, toVCard, type CalendarEvent, type Task, type Contact } from '@silentsuite/core'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
@@ -15,14 +15,15 @@ import JSZip from 'jszip'
 
 /**
  * Above this combined item count we surface a "this may take a minute" warning
- * before kicking off the ZIP export. The previous in-memory implementation was
- * known to silently fail at ~2000 events; 1000 is a conservative early warning.
+ * before kicking off the ZIP export.
  */
 const LARGE_EXPORT_THRESHOLD = 1000
 
-function downloadFile(content: string | Blob, filename: string, mimeType: string) {
+function downloadFile(content: string | Blob | Uint8Array, filename: string, mimeType: string) {
   const blob =
-    content instanceof Blob ? content : new Blob([content], { type: mimeType })
+    content instanceof Blob
+      ? content
+      : new Blob([content as BlobPart], { type: mimeType })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
@@ -41,6 +42,51 @@ function buildCalendarIcs(vcomponents: string[]): string {
   ].join('\r\n')
 }
 
+/** Serialize each item independently and skip the ones that throw, so a single
+ * malformed event doesn't take the whole export down silently. Returns the
+ * successfully-serialized payload plus a count of skipped items, which we
+ * surface in a warning toast.
+ */
+function serializeAll<T>(items: T[], serialize: (item: T) => string): { vcomponents: string[]; skipped: number } {
+  const vcomponents: string[] = []
+  let skipped = 0
+  for (const item of items) {
+    try {
+      vcomponents.push(serialize(item))
+    } catch (err) {
+      skipped++
+      console.warn('[export] Skipped item that failed to serialize:', err, item)
+    }
+  }
+  return { vcomponents, skipped }
+}
+
+function serializeEvents(events: CalendarEvent[]) {
+  return serializeAll(events, toVEvent)
+}
+
+function serializeTasks(tasks: Task[]) {
+  return serializeAll(tasks, toVTodo)
+}
+
+function serializeContacts(contacts: Contact[]) {
+  return serializeAll(contacts, toVCard)
+}
+
+function reportSkipped(label: string, skipped: number) {
+  if (skipped > 0) {
+    showWarningToast(
+      `${skipped} ${label}${skipped === 1 ? '' : 's'} were skipped because they couldn't be serialized — see browser console for details.`,
+    )
+  }
+}
+
+function reportError(label: string, err: unknown) {
+  console.error(`[export] ${label} failed:`, err)
+  const detail = err instanceof Error ? `: ${err.message}` : ''
+  showErrorToast(`${label} failed${detail}. See browser console for details.`)
+}
+
 export default function ExportPage() {
   const tasks = useTaskStore((s) => s.tasks)
   const contacts = useContactStore((s) => s.contacts)
@@ -50,21 +96,36 @@ export default function ExportPage() {
   const [exportProgress, setExportProgress] = useState(0)
 
   function exportCalendar() {
-    const vevents = events.map((e) => toVEvent(e))
-    const ics = buildCalendarIcs(vevents)
-    downloadFile(ics, 'silentsuite-calendar.ics', 'text/calendar')
+    try {
+      const { vcomponents, skipped } = serializeEvents(events)
+      const ics = buildCalendarIcs(vcomponents)
+      downloadFile(ics, 'silentsuite-calendar.ics', 'text/calendar')
+      reportSkipped('event', skipped)
+    } catch (err) {
+      reportError('Calendar export', err)
+    }
   }
 
   function exportTasks() {
-    const vtodos = tasks.map((t) => toVTodo(t))
-    const ics = buildCalendarIcs(vtodos)
-    downloadFile(ics, 'silentsuite-tasks.ics', 'text/calendar')
+    try {
+      const { vcomponents, skipped } = serializeTasks(tasks)
+      const ics = buildCalendarIcs(vcomponents)
+      downloadFile(ics, 'silentsuite-tasks.ics', 'text/calendar')
+      reportSkipped('task', skipped)
+    } catch (err) {
+      reportError('Tasks export', err)
+    }
   }
 
   function exportContacts() {
-    const vcards = contacts.map((c) => toVCard(c))
-    const vcf = vcards.join('\n')
-    downloadFile(vcf, 'silentsuite-contacts.vcf', 'text/vcard')
+    try {
+      const { vcomponents, skipped } = serializeContacts(contacts)
+      const vcf = vcomponents.join('\n')
+      downloadFile(vcf, 'silentsuite-contacts.vcf', 'text/vcard')
+      reportSkipped('contact', skipped)
+    } catch (err) {
+      reportError('Contacts export', err)
+    }
   }
 
   async function exportAll() {
@@ -83,23 +144,30 @@ export default function ExportPage() {
 
     try {
       const zip = new JSZip()
+      const enc = new TextEncoder()
 
-      const vevents = events.map((e) => toVEvent(e))
-      zip.file('silentsuite-calendar.ics', buildCalendarIcs(vevents))
+      const eventsResult = serializeEvents(events)
+      const tasksResult = serializeTasks(tasks)
+      const contactsResult = serializeContacts(contacts)
 
-      const vtodos = tasks.map((t) => toVTodo(t))
-      zip.file('silentsuite-tasks.ics', buildCalendarIcs(vtodos))
-
-      const vcards = contacts.map((c) => toVCard(c))
-      zip.file('silentsuite-contacts.vcf', vcards.join('\n'))
+      // Pre-encode payloads as UTF-8 byte arrays before handing to JSZip. JSZip's
+      // string path runs the entire file through DEFLATE in a synchronous loop
+      // before the async pump kicks in — for multi-megabyte ICS strings this
+      // can blow the call stack ("RangeError: Maximum call stack size exceeded")
+      // or stall the main thread for tens of seconds. Uint8Array input bypasses
+      // the string-tokenization step. Combined with `compression: 'STORE'` (no
+      // DEFLATE — text payloads are already small and the ZIP framing is the
+      // value here, not the savings), this makes the build robust at scale.
+      zip.file('silentsuite-calendar.ics', enc.encode(buildCalendarIcs(eventsResult.vcomponents)))
+      zip.file('silentsuite-tasks.ics', enc.encode(buildCalendarIcs(tasksResult.vcomponents)))
+      zip.file('silentsuite-contacts.vcf', enc.encode(contactsResult.vcomponents.join('\n')))
 
       // Throttle progress updates: only re-render when the integer percent
-      // changes. JSZip can fire onUpdate hundreds of times per second on
-      // large archives, which would otherwise spam React renders.
+      // changes. JSZip can fire onUpdate hundreds of times per second.
       let lastReportedPercent = -1
 
       const blob = await zip.generateAsync(
-        { type: 'blob', streamFiles: true },
+        { type: 'blob', compression: 'STORE', streamFiles: true },
         (metadata) => {
           const percent = Math.floor(metadata.percent)
           if (percent !== lastReportedPercent) {
@@ -110,13 +178,15 @@ export default function ExportPage() {
       )
 
       downloadFile(blob, 'silentsuite-export.zip', 'application/zip')
+
+      const totalSkipped = eventsResult.skipped + tasksResult.skipped + contactsResult.skipped
+      if (totalSkipped > 0) {
+        showWarningToast(
+          `${totalSkipped} item${totalSkipped === 1 ? '' : 's'} were skipped because they couldn't be serialized — see browser console for details.`,
+        )
+      }
     } catch (err) {
-      // Log enough detail for a useful bug report. The original bug was that
-      // generateAsync rejected silently with no console output at all.
-      console.error('[export] Failed to build ZIP archive:', err)
-      showErrorToast(
-        'Failed to build ZIP. Try exporting calendar, tasks, and contacts separately.',
-      )
+      reportError('ZIP build', err)
     } finally {
       setIsExportingAll(false)
       setExportProgress(0)

--- a/apps/web/app/(app)/settings/export/page.tsx
+++ b/apps/web/app/(app)/settings/export/page.tsx
@@ -178,13 +178,7 @@ export default function ExportPage() {
       )
 
       downloadFile(blob, 'silentsuite-export.zip', 'application/zip')
-
-      const totalSkipped = eventsResult.skipped + tasksResult.skipped + contactsResult.skipped
-      if (totalSkipped > 0) {
-        showWarningToast(
-          `${totalSkipped} item${totalSkipped === 1 ? '' : 's'} were skipped because they couldn't be serialized — see browser console for details.`,
-        )
-      }
+      reportSkipped('item', eventsResult.skipped + tasksResult.skipped + contactsResult.skipped)
     } catch (err) {
       reportError('ZIP build', err)
     } finally {


### PR DESCRIPTION
## Summary

Fixes two distinct user-facing failures from the v0.1.1 soak:

- **Single-collection export buttons silently failed.** The user reported that clicking "Export Calendar" with 2,473 events did nothing — no download, no error toast, no spinner. Cause: those handlers had no `try/catch`, so any throw from `toVEvent` (or the equivalent for tasks/contacts) bubbled up and disappeared into the React event-dispatcher.
- **ZIP build threw on large libraries.** The same user got "Failed to build ZIP. Try exporting calendar, tasks, and contacts separately." JSZip's string path runs a synchronous tokenize-and-DEFLATE loop over the whole file before yielding to the event loop — for multi-MB ICS payloads this can stall the main thread for tens of seconds and (more pointedly) blow the call stack.

Closes #146.

## Fix

1. **Per-item resilience** (`serializeAll(items, fn)`): runs the serializer in a try/catch per item, collecting successes and counting skips. One malformed event no longer takes the whole export down — instead a warning toast surfaces the count, and details land in the browser console for triage.

2. **Robust ZIP build for large libraries:**
   - Pre-encode each ICS / VCF payload to a `Uint8Array` via `TextEncoder` before handing to JSZip — bypasses the string-tokenization path that gets pathological at scale.
   - `compression: 'STORE'` (no DEFLATE). Text payloads compress poorly; the value of the ZIP here is framing, not savings.

3. **Error surface:** every export entry point now wraps in `try/catch` and routes failures through a single `reportError(label, err)` that logs to console *and* shows an error toast including the underlying message. Next time something breaks, the report will say what.

## What changes

| File | Change |
|---|---|
| `apps/web/app/(app)/settings/export/page.tsx` | New `serializeAll`, per-item skipping, `reportSkipped` / `reportError` helpers. Pre-encode ZIP payloads, switch to STORE compression. Try/catch on all four export handlers. |
| `apps/web/app/(app)/settings/export/__tests__/page.test.tsx` | New tests: skipping a serializer-throwing event, and the error-toast path when a fatal failure (e.g. blob URL creation blocked) prevents the download. |

## Tests

- All 12 export-page tests pass (10 existing + 2 new).
- `pnpm --filter web exec vitest run "app/(app)/settings/export/__tests__/page.test.tsx"` is the direct invocation; the regular `pnpm test` doesn't pick up files under `(app)` due to a glob quirk in the default `include` pattern (pre-existing, not related to this PR).

## Test plan

- [ ] Cloudflare Pages preview build for this branch.
- [ ] On an account with ≥ 2,000 calendar events, click **Export Calendar** — should produce a working `.ics` and the file downloads. If anything inside `toVEvent` throws on a specific event, a warning toast names the count of skipped items and details land in the browser console.
- [ ] Same account, **Export All Data (.zip)** — should produce a working zip containing all three files. The progress indicator advances, and the build completes without "Failed to build ZIP".
- [ ] Worst-case: simulate a malformed event (e.g. via devtools store mutation that nulls `created`) — verify the export still completes, with the warning toast surfacing the skip.

## Notes / follow-ups

- The pre-existing `qrcode.react` type error in `apps/web/app/(app)/settings/mobile/page.tsx` is on `dev` already and not affected by this PR.
- We can't reproduce the exact scenario on a stock dev account here (the user has the 2,473-event library); the fix is defensive rather than targeting one identified bug, since the silent-failure code path masked the actual cause. With this PR the next failure will name itself in the toast.