### PR TITLE
chore(self-host): pin v0.1.2 server image digest

### DIFF
--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     # which fetches the latest compose (will become release-tag-pinned once
     # the installer's --version flag lands). Editing this digest by hand
     # decouples the compose from the rest of the release matrix.
-    image: ghcr.io/silent-suite/silentsuite-server@sha256:6689b5d873cfe5844ca38de74e458fd382ce106916bb5dfa1027786eb6bc4ac8
+    image: ghcr.io/silent-suite/silentsuite-server@sha256:6d45c6750c5913bf0ab43eec8b85be2213c133eb8bd7c50e9aeb3fee80194509
     container_name: silentsuite-server
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- Updates the self-host compose pin to the server image built from the v0.1.2 release merge commit.
- Ensures versioned self-host installs include the Django admin static-assets fix from #153.

## Validation
- Server image built and deployed successfully from `d77b6a2df852dfc7b067af9b99d4dc1747cb3ed7`.
- GHCR digest resolved from the `d77b6a2df852dfc7b067af9b99d4dc1747cb3ed7` / `latest` package version.

## Notes
- This is release plumbing only; no runtime code changes.