### PR TITLE
Scope beta signup analytics and promo entry

### DIFF
--- a/apps/web/app/(auth)/signup/layout.tsx
+++ b/apps/web/app/(auth)/signup/layout.tsx
@@ -1,0 +1,22 @@
+import Script from 'next/script'
+import type { ReactNode } from 'react'
+
+export default function SignupLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <>
+      {/* Privacy-friendly, cookieless analytics for the unauthenticated signup funnel only. */}
+      <Script
+        src="https://plausible.silentsuite.io/js/pa-ZqdDjldOcs8obwiOHgHSR.js"
+        strategy="afterInteractive"
+      />
+      <Script id="plausible-init" strategy="afterInteractive">
+        {`window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()`}
+      </Script>
+      {children}
+    </>
+  )
+}

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -400,7 +400,7 @@ function StepChoosePlan({
   interval: BillingInterval
   onIntervalChange: (interval: BillingInterval) => void
   onSelectFree: () => void
-  onSelectPaid: () => void
+  onSelectPaid: (promoCode?: string) => void
   planView: PlanView
   onBack: () => void
   clientSecret: string | null
@@ -412,14 +412,15 @@ function StepChoosePlan({
 }) {
   const contentRef = useRef<HTMLDivElement>(null)
   const [selectedTrial, setSelectedTrial] = useState<TrialPath>('30day')
+  const [promoCode, setPromoCode] = useState('')
 
   const handleContinue = useCallback(() => {
     if (selectedTrial === '7day') {
       onSelectFree()
     } else {
-      onSelectPaid()
+      onSelectPaid(promoCode)
     }
-  }, [selectedTrial, onSelectFree, onSelectPaid])
+  }, [selectedTrial, onSelectFree, onSelectPaid, promoCode])
 
   useEffect(() => {
     // Scroll to top of page on step transitions, not just the element
@@ -598,6 +599,30 @@ function StepChoosePlan({
           </div>
         </button>
       </div>
+
+      {selectedTrial === '30day' && (
+        <div className="space-y-2">
+          <label
+            htmlFor="beta-promo-code"
+            className="block text-sm font-medium text-[rgb(var(--foreground))]/80"
+          >
+            Beta promo code <span className="text-[rgb(var(--muted))]">(optional)</span>
+          </label>
+          <Input
+            id="beta-promo-code"
+            value={promoCode}
+            onChange={(event) => setPromoCode(event.target.value)}
+            placeholder="Enter code if you have one"
+            autoCapitalize="characters"
+            autoComplete="off"
+            disabled={provisioning}
+            className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
+          />
+          <p className="text-xs text-[rgb(var(--muted))]">
+            Applied securely by Stripe before your trial starts.
+          </p>
+        </div>
+      )}
 
       {/* Continue button */}
       <Button
@@ -991,13 +1016,13 @@ export default function SignupPage() {
     }
   }, [signup, selectedInterval])
 
-  const handleSelectPaid = useCallback(async () => {
+  const handleSelectPaid = useCallback(async (promoCode?: string) => {
     setProvisionError(null)
     setProvisioning(true)
     setPlanView('payment')
     try {
       const planId: PlanId = selectedInterval === 'monthly' ? 'early_monthly' : 'early_annual'
-      const secret = await signup(planId, '30day')
+      const secret = await signup(planId, '30day', promoCode)
       if (secret) {
         setClientSecret(secret)
       }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -33,12 +33,6 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={inter.variable} suppressHydrationWarning>
-      <head>
-        {/* Privacy-friendly analytics by Plausible */}
-        <script async src="https://plausible.silentsuite.io/js/pa-ZqdDjldOcs8obwiOHgHSR.js"></script>
-        <script dangerouslySetInnerHTML={{ __html: `window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()` }} />
-      </head>
-
       <body className="font-sans">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <AuthProvider>

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -56,7 +56,7 @@ interface AuthState {
   isReadOnly: () => boolean
   canWrite: () => boolean
   createEtebaseAccount: (email: string, password: string, serverUrl?: string) => Promise<void>
-  signup: (planId: string, trialPath: string) => Promise<string | null>
+  signup: (planId: string, trialPath: string, promoCode?: string) => Promise<string | null>
   /** Call after the entire signup flow (including payment + vault) to finalize authentication. */
   completeSignup: () => void
   login: (email: string, password: string, serverUrl?: string) => Promise<void>
@@ -178,7 +178,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
-  signup: async (planId: string, trialPath: string) => {
+  signup: async (planId: string, trialPath: string, promoCode?: string) => {
     if (isSelfHosted || planId === 'self-hosted') {
       const pending = get().pendingSignup
       if (!pending) throw new Error('No pending signup')
@@ -224,6 +224,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           etebaseSessionToken: pending.etebaseAuthToken,
           planId,
           trialPath,
+          ...(promoCode?.trim() ? { promoCode: promoCode.trim() } : {}),
           wantsProductUpdates: pending.wantsProductUpdates,
         }),
         credentials: 'include',


### PR DESCRIPTION
## Summary
- Scope Plausible to the unauthenticated signup subtree instead of the global web app layout.
- Add optional beta promo-code entry to the hosted 30-day signup path.
- Pass promo codes to billing provisioning without persisting attribution locally.

## Review
- code-reviewer subagent returned empty output twice; completed read-only manual review of touched files.

## Verification
- `pnpm lint` (passes with pre-existing warnings)
- `pnpm test app/stores/__tests__/use-auth-store.test.ts`
- `pnpm type-check` not fully green because of pre-existing `qrcode.react` module/type resolution error in `app/(app)/settings/mobile/page.tsx`

Closes #156
Closes #157