### PR TITLE
Release beta signup analytics

### DIFF
--- a/apps/web/app/(auth)/signup/layout.tsx
+++ b/apps/web/app/(auth)/signup/layout.tsx
@@ -1,0 +1,22 @@
+import Script from 'next/script'
+import type { ReactNode } from 'react'
+
+export default function SignupLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <>
+      {/* Privacy-friendly, cookieless analytics for the unauthenticated signup funnel only. */}
+      <Script
+        src="https://plausible.silentsuite.io/js/pa-ZqdDjldOcs8obwiOHgHSR.js"
+        strategy="afterInteractive"
+      />
+      <Script id="plausible-init" strategy="afterInteractive">
+        {`window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()`}
+      </Script>
+      {children}
+    </>
+  )
+}

--- a/apps/web/app/(auth)/signup/layout.tsx
+++ b/apps/web/app/(auth)/signup/layout.tsx
@@ -1,5 +1,5 @@
-import Script from 'next/script'
 import type { ReactNode } from 'react'
+import { SignupAnalytics } from './signup-analytics'
 
 export default function SignupLayout({
   children,
@@ -8,14 +8,7 @@ export default function SignupLayout({
 }) {
   return (
     <>
-      {/* Privacy-friendly, cookieless analytics for the unauthenticated signup funnel only. */}
-      <Script
-        src="https://plausible.silentsuite.io/js/pa-ZqdDjldOcs8obwiOHgHSR.js"
-        strategy="afterInteractive"
-      />
-      <Script id="plausible-init" strategy="afterInteractive">
-        {`window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()`}
-      </Script>
+      <SignupAnalytics />
       {children}
     </>
   )

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -400,7 +400,7 @@ function StepChoosePlan({
   interval: BillingInterval
   onIntervalChange: (interval: BillingInterval) => void
   onSelectFree: () => void
-  onSelectPaid: () => void
+  onSelectPaid: (promoCode?: string) => void
   planView: PlanView
   onBack: () => void
   clientSecret: string | null
@@ -412,14 +412,15 @@ function StepChoosePlan({
 }) {
   const contentRef = useRef<HTMLDivElement>(null)
   const [selectedTrial, setSelectedTrial] = useState<TrialPath>('30day')
+  const [promoCode, setPromoCode] = useState('')
 
   const handleContinue = useCallback(() => {
     if (selectedTrial === '7day') {
       onSelectFree()
     } else {
-      onSelectPaid()
+      onSelectPaid(promoCode)
     }
-  }, [selectedTrial, onSelectFree, onSelectPaid])
+  }, [selectedTrial, onSelectFree, onSelectPaid, promoCode])
 
   useEffect(() => {
     // Scroll to top of page on step transitions, not just the element
@@ -598,6 +599,30 @@ function StepChoosePlan({
           </div>
         </button>
       </div>
+
+      {selectedTrial === '30day' && (
+        <div className="space-y-2">
+          <label
+            htmlFor="beta-promo-code"
+            className="block text-sm font-medium text-[rgb(var(--foreground))]/80"
+          >
+            Beta promo code <span className="text-[rgb(var(--muted))]">(optional)</span>
+          </label>
+          <Input
+            id="beta-promo-code"
+            value={promoCode}
+            onChange={(event) => setPromoCode(event.target.value)}
+            placeholder="Enter code if you have one"
+            autoCapitalize="characters"
+            autoComplete="off"
+            disabled={provisioning}
+            className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
+          />
+          <p className="text-xs text-[rgb(var(--muted))]">
+            Applied securely by Stripe before your trial starts.
+          </p>
+        </div>
+      )}
 
       {/* Continue button */}
       <Button
@@ -991,13 +1016,13 @@ export default function SignupPage() {
     }
   }, [signup, selectedInterval])
 
-  const handleSelectPaid = useCallback(async () => {
+  const handleSelectPaid = useCallback(async (promoCode?: string) => {
     setProvisionError(null)
     setProvisioning(true)
     setPlanView('payment')
     try {
       const planId: PlanId = selectedInterval === 'monthly' ? 'early_monthly' : 'early_annual'
-      const secret = await signup(planId, '30day')
+      const secret = await signup(planId, '30day', promoCode)
       if (secret) {
         setClientSecret(secret)
       }

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -611,8 +611,9 @@ function StepChoosePlan({
           <Input
             id="beta-promo-code"
             value={promoCode}
-            onChange={(event) => setPromoCode(event.target.value)}
+            onChange={(event) => setPromoCode(event.target.value.toUpperCase().replace(/\s/g, '').slice(0, 64))}
             placeholder="Enter code if you have one"
+            maxLength={64}
             autoCapitalize="characters"
             autoComplete="off"
             disabled={provisioning}

--- a/apps/web/app/(auth)/signup/signup-analytics.tsx
+++ b/apps/web/app/(auth)/signup/signup-analytics.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+const PLAUSIBLE_EVENT_ENDPOINT = 'https://plausible.silentsuite.io/api/event'
+const PLAUSIBLE_DOMAIN = 'app.silentsuite.io'
+
+export function SignupAnalytics() {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (!pathname?.startsWith('/signup')) return
+
+    const payload = JSON.stringify({
+      domain: PLAUSIBLE_DOMAIN,
+      name: 'pageview',
+      url: window.location.href,
+      referrer: document.referrer || undefined,
+    })
+
+    if (navigator.sendBeacon) {
+      const blob = new Blob([payload], { type: 'application/json' })
+      navigator.sendBeacon(PLAUSIBLE_EVENT_ENDPOINT, blob)
+      return
+    }
+
+    void fetch(PLAUSIBLE_EVENT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+      keepalive: true,
+    })
+  }, [pathname])
+
+  return null
+}

--- a/apps/web/app/(auth)/signup/signup-analytics.tsx
+++ b/apps/web/app/(auth)/signup/signup-analytics.tsx
@@ -5,6 +5,32 @@ import { usePathname } from 'next/navigation'
 
 const PLAUSIBLE_EVENT_ENDPOINT = 'https://plausible.silentsuite.io/api/event'
 const PLAUSIBLE_DOMAIN = 'app.silentsuite.io'
+const MARKETING_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']
+
+function signupAnalyticsUrl() {
+  const current = new URL(window.location.href)
+  const sanitized = new URL(`${current.origin}${current.pathname}`)
+
+  if (current.pathname === '/signup') {
+    for (const param of MARKETING_PARAMS) {
+      const value = current.searchParams.get(param)
+      if (value) sanitized.searchParams.set(param, value)
+    }
+  }
+
+  return sanitized.toString()
+}
+
+function sanitizedReferrer() {
+  if (!document.referrer) return undefined
+
+  try {
+    const referrer = new URL(document.referrer)
+    return `${referrer.origin}${referrer.pathname}`
+  } catch {
+    return undefined
+  }
+}
 
 export function SignupAnalytics() {
   const pathname = usePathname()
@@ -15,8 +41,8 @@ export function SignupAnalytics() {
     const payload = JSON.stringify({
       domain: PLAUSIBLE_DOMAIN,
       name: 'pageview',
-      url: window.location.href,
-      referrer: document.referrer || undefined,
+      url: signupAnalyticsUrl(),
+      referrer: sanitizedReferrer(),
     })
 
     if (navigator.sendBeacon) {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -33,12 +33,6 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={inter.variable} suppressHydrationWarning>
-      <head>
-        {/* Privacy-friendly analytics by Plausible */}
-        <script async src="https://plausible.silentsuite.io/js/pa-ZqdDjldOcs8obwiOHgHSR.js"></script>
-        <script dangerouslySetInnerHTML={{ __html: `window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()` }} />
-      </head>
-
       <body className="font-sans">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <AuthProvider>

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -84,6 +84,60 @@ describe('useAuthStore', () => {
     expect(state.isLoading).toBe(false)
   })
 
+  it('signup sends a trimmed promo code when provided', async () => {
+    useAuthStore.setState({
+      pendingSignup: {
+        email: 'promo@example.com',
+        etebaseAuthToken: 'etebase-token',
+        wantsProductUpdates: true,
+      },
+    })
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'user-1', isAdmin: false, clientSecret: 'cs_test' }),
+    } as Response)
+
+    await useAuthStore.getState().signup('early_monthly', '30day', '  beta196  ')
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/provision'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          etebaseSessionToken: 'etebase-token',
+          planId: 'early_monthly',
+          trialPath: '30day',
+          promoCode: 'beta196',
+          wantsProductUpdates: true,
+        }),
+      }),
+    )
+  })
+
+  it('signup omits an empty promo code', async () => {
+    useAuthStore.setState({
+      pendingSignup: {
+        email: 'promo@example.com',
+        etebaseAuthToken: 'etebase-token',
+      },
+    })
+
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'user-1', isAdmin: false, clientSecret: 'cs_test' }),
+    } as Response)
+
+    await useAuthStore.getState().signup('early_monthly', '30day', '   ')
+
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    expect(JSON.parse(init?.body as string)).toEqual({
+      etebaseSessionToken: 'etebase-token',
+      planId: 'early_monthly',
+      trialPath: '30day',
+    })
+  })
+
   // --- onboardedAt hydration (issue #113) ---
 
   describe('onboardedAt hydration', () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -56,7 +56,7 @@ interface AuthState {
   isReadOnly: () => boolean
   canWrite: () => boolean
   createEtebaseAccount: (email: string, password: string, serverUrl?: string) => Promise<void>
-  signup: (planId: string, trialPath: string) => Promise<string | null>
+  signup: (planId: string, trialPath: string, promoCode?: string) => Promise<string | null>
   /** Call after the entire signup flow (including payment + vault) to finalize authentication. */
   completeSignup: () => void
   login: (email: string, password: string, serverUrl?: string) => Promise<void>
@@ -178,7 +178,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   },
 
-  signup: async (planId: string, trialPath: string) => {
+  signup: async (planId: string, trialPath: string, promoCode?: string) => {
     if (isSelfHosted || planId === 'self-hosted') {
       const pending = get().pendingSignup
       if (!pending) throw new Error('No pending signup')
@@ -224,6 +224,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           etebaseSessionToken: pending.etebaseAuthToken,
           planId,
           trialPath,
+          ...(promoCode?.trim() ? { promoCode: promoCode.trim() } : {}),
           wantsProductUpdates: pending.wantsProductUpdates,
         }),
         credentials: 'include',


### PR DESCRIPTION
## Summary
- Deploy signup-scoped Plausible analytics while keeping analytics out of authenticated app routes.
- Add optional beta promo-code capture on hosted signup and pass it through billing provisioning.

## Validation
- Previously validated on dev in PR #158.
- Web lint passed with pre-existing warnings.
- Auth store tests passed.
- Web type-check still has the pre-existing unrelated qrcode.react resolution issue.