### PR TITLE
Prepare Android package for store release

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,4 +1,4 @@
-name: Build Android APK
+name: Build Android APK and AAB
 
 on:
   push:
@@ -54,12 +54,12 @@ jobs:
           echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/keystore/silentsuite-release.jks"
           echo "KEYSTORE_PATH=$RUNNER_TEMP/keystore/silentsuite-release.jks" >> "$GITHUB_ENV"
 
-      - name: Build signed release APK
+      - name: Build signed release APK and AAB
         env:
           KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
-          ./gradlew assembleRelease --no-daemon \
+          ./gradlew assembleRelease bundleRelease --no-daemon \
             -PsigningStoreLocation="$KEYSTORE_PATH" \
             -PsigningKeyAlias="$KEY_ALIAS"
 
@@ -68,23 +68,33 @@ jobs:
           BUILD_TOOLS=$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -1)
           "$BUILD_TOOLS/apksigner" verify --print-certs app/build/outputs/apk/release/*.apk
 
-      - name: Upload signed release APK
+      - name: Verify AAB signature
+        run: jarsigner -verify -certs -verbose app/build/outputs/bundle/release/*.aab
+
+      - name: Upload signed release APK and AAB
         uses: actions/upload-artifact@v4
         with:
           name: silentsuite-release-${{ github.sha }}
-          path: android/app/build/outputs/apk/release/*.apk
+          path: |
+            android/app/build/outputs/apk/release/*.apk
+            android/app/build/outputs/bundle/release/*.aab
           retention-days: 30
 
-      - name: Rename APK for release (tag push only)
+      - name: Rename Android artifacts for release (tag push only)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           mv app/build/outputs/apk/release/app-release.apk \
              "app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk"
+          mv app/build/outputs/bundle/release/app-release.aab \
+             "app/build/outputs/bundle/release/silentsuite-android-${{ github.ref_name }}.aab"
           cd app/build/outputs/apk/release
           sha256sum "silentsuite-android-${{ github.ref_name }}.apk" \
             > "silentsuite-android-${{ github.ref_name }}.apk.sha256"
+          cd ../../bundle/release
+          sha256sum "silentsuite-android-${{ github.ref_name }}.aab" \
+            > "silentsuite-android-${{ github.ref_name }}.aab.sha256"
 
-      - name: Attach APK + checksum to umbrella GitHub Release (tag push only)
+      - name: Attach Android artifacts to umbrella GitHub Release (tag push only)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
@@ -95,6 +105,8 @@ jobs:
           files: |
             android/app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk
             android/app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk.sha256
+            android/app/build/outputs/bundle/release/silentsuite-android-${{ github.ref_name }}.aab
+            android/app/build/outputs/bundle/release/silentsuite-android-${{ github.ref_name }}.aab.sha256
 
       - name: Cleanup keystore
         if: always()

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -15,13 +15,13 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        applicationId "io.silentsuite.sync"
+        applicationId "io.silentsuite.android"
 
         minSdkVersion 21
         targetSdkVersion 34
 
-        versionCode 1
-        versionName "1.0.0-beta.1"
+        versionCode 2
+        versionName "0.1.2-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -65,7 +65,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.PACKAGE_REPLACED" />
-                <data android:scheme="package" android:path="io.silentsuite.sync" />
+                <data android:scheme="package" android:path="io.silentsuite.android" />
             </intent-filter>
         </receiver>
 
@@ -74,7 +74,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.PACKAGE_REPLACED" />
-                <data android:scheme="package" android:path="io.silentsuite.sync" />
+                <data android:scheme="package" android:path="io.silentsuite.android" />
             </intent-filter>
         </receiver>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -11,10 +11,10 @@
 
     <!-- common strings -->
     <string name="app_name">SilentSuite</string>
-    <string name="account_type" translatable="false">io.silentsuite.sync</string>
-    <string name="account_type_address_book" translatable="false">io.silentsuite.sync.address_book</string>
+    <string name="account_type" translatable="false">io.silentsuite.android</string>
+    <string name="account_type_address_book" translatable="false">io.silentsuite.android.address_book</string>
     <string name="account_title_address_book">SilentSuite Address book</string>
-    <string name="address_books_authority" translatable="false">io.silentsuite.sync.addressbooks</string>
+    <string name="address_books_authority" translatable="false">io.silentsuite.android.addressbooks</string>
     <string name="address_books_authority_title">Address books</string>
     <string name="help">Help</string>
     <string name="manage_accounts">Manage accounts</string>
@@ -394,7 +394,7 @@
     <string name="exception_show_details">Show details</string>
 
     <!-- sync errors and DebugInfoActivity -->
-    <string name="authority_log_provider" translatable="false">io.silentsuite.sync.log</string>
+    <string name="authority_log_provider" translatable="false">io.silentsuite.android.log</string>
     <string name="debug_info_title">Debug info</string>
     <string name="debug_info_more_data_shared">Clicking share will send developers the data below, as well as some additional debug information, attached. Please note that it may contain some private information.</string>
     <string name="sync_error_permissions">SilentSuite permissions</string>

--- a/android/app/src/main/res/xml/settings_app.xml
+++ b/android/app/src/main/res/xml/settings_app.xml
@@ -131,7 +131,7 @@
             android:title="@string/app_settings_show_debug_info"
             android:summary="@string/app_settings_show_debug_info_details">
             <intent
-                android:targetPackage="io.silentsuite.sync"
+                android:targetPackage="io.silentsuite.android"
                 android:targetClass="io.silentsuite.sync.ui.DebugInfoActivity"/>
         </Preference>
 

--- a/android/app/src/main/res/xml/sync_calendars.xml
+++ b/android/app/src/main/res/xml/sync_calendars.xml
@@ -7,7 +7,7 @@
   -->
 
 <sync-adapter xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accountType="io.silentsuite.sync"
+    android:accountType="@string/account_type"
     android:contentAuthority="com.android.calendar"
     android:allowParallelSyncs="true"
     android:supportsUploading="true"

--- a/android/app/src/main/res/xml/sync_prefs.xml
+++ b/android/app/src/main/res/xml/sync_prefs.xml
@@ -11,7 +11,7 @@
     
     <PreferenceScreen android:title="@string/manage_accounts">
         <intent
-            android:targetPackage="io.silentsuite.sync"
+            android:targetPackage="io.silentsuite.android"
             android:targetClass="io.silentsuite.sync.ui.AccountsActivity"
             android:action="ACTION_VIEW" />
     </PreferenceScreen>

--- a/android/fastlane/metadata/android/en-US/changelogs/2.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/2.txt
@@ -1,0 +1,1 @@
+Renames the Android package to io.silentsuite.android and aligns the Android version with v0.1.2-beta. If you installed a previous beta APK, re-add your SilentSuite account after installing this build.


### PR DESCRIPTION
## Summary
- Rename the Android install package identity to `io.silentsuite.android` while keeping source namespace/class references intact.
- Align Android release metadata to `versionCode 2` / `versionName 0.1.2-beta` and add the matching Fastlane changelog.
- Extend Android CI to build, verify, upload, and release both APK and AAB artifacts.

## Verification
- `git diff --check`
- code-reviewer pass: green with versionName re-baselining acknowledged
- Local Android build not run: this machine has no Java/JDK configured.

Refs #162