### PR TITLE
Fix Android release APK for F-Droid

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 34
 
-        versionCode 2
-        versionName "0.1.3-beta"
+        versionCode 3
+        versionName "0.1.4-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }
@@ -67,6 +67,11 @@ android {
         jniLibs {
             useLegacyPackaging = false
         }
+    }
+
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
     }
 
 

--- a/android/fastlane/metadata/android/en-US/changelogs/1.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/1.txt
@@ -1,0 +1,3 @@
+First F-Droid build of SilentSuite.
+
+End-to-end encrypted sync for calendar, contacts, and tasks via the Etebase protocol. Pair with a managed account at app.silentsuite.io or self-host the server.

--- a/android/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -1,0 +1,1 @@
+Removes Android Gradle dependency metadata from release APK signing blocks for F-Droid compatibility.

--- a/android/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -1,1 +1,1 @@
-Removes Android Gradle dependency metadata from release APK signing blocks for F-Droid compatibility.
+Maintenance update for F-Droid compatibility.


### PR DESCRIPTION
## Summary
- Bump Android beta to 0.1.4-beta / versionCode 3 for a clean F-Droid-compatible release artifact.
- Disable Android Gradle dependency metadata in APK/AAB outputs so F-Droid's APK scanner does not reject the binary.
- Add F-Droid changelog entries for versionCodes 1 and 3.

## Testing
- git diff --check
- fdroid lint io.silentsuite.android (metadata parses; local fdroid warns on CI-required Binaries trailing space)
- Not run: local Gradle build, because this environment has no Java/JAVA_HOME.