### PR TITLE
Fix Android F-Droid source build

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,11 +31,17 @@ buildscript {
 allprojects {
     repositories {
         mavenCentral()
-        maven() {
+        maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots'
         }
         maven { url 'https://jitpack.io' }
         google()
+    }
+}
+
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions.jvmTarget = '17'
     }
 }
 

--- a/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,20 +1,21 @@
-Secure, end-to-end encrypted, and privacy respecting sync for your contacts, calendars, and tasks (using Tasks.org and OpenTasks).
+SilentSuite is a zero-knowledge sync app for Android calendars, contacts, and tasks. It keeps your productivity data encrypted before it reaches the server, so SilentSuite cannot read your calendar events, address book, or task lists.
 
-In order to use this application you need to have an account with SilentSuite (paid hosting), or run your own instance (free and open source). Check out https://www.silentsuite.io/ for more information.
+Use Your Existing Apps
+======================
+SilentSuite works as an Android sync adapter. After you sign in, your encrypted SilentSuite collections appear in compatible calendar, contacts, and task apps on your phone. Use the Android apps you already like while keeping sync private.
 
-Easy to Use
-===========
-SilentSuite is very easy to use. It seamlessly integrates with Android so you won't even notice you are using it. Security doesn't always have to come at a cost.
+Private By Design
+=================
+Your plaintext data stays on your devices. Sync data is stored on the server as encrypted blobs, and your encryption keys do not leave your device. The server needs limited metadata, such as sync tokens and timestamps, so sync can work, but it cannot decrypt the contents of your calendars, contacts, or tasks.
 
-Secure & Open
-============
-Thanks to zero-knowledge end-to-end encryption, not even we can see your data. Don't believe us? You shouldn't, just verify yourself, both the client and server are open source.
+Hosted Or Self-Hosted
+=====================
+You can use SilentSuite with a hosted SilentSuite account, or point the app at your own self-hosted SilentSuite server. The server and client code are open source, so privacy claims can be inspected instead of merely trusted.
 
-Full History
+What You Need
+=============
+To use this app, you need a SilentSuite account or a compatible self-hosted server. Learn more at https://silentsuite.io/.
+
+Beta Note
 =========
-A full history of your data is saved in an encrypted tamper-proof journal which means you can review, replay and revert any changes you have made at any point in time.
-
-
-How does it work?
-===============
-SilentSuite integrates seamlessly with your existing apps. All you need to do is sign up (or run your own instance), install the app, and enter your password. After that, you will be able to save your contacts, calendar events and tasks to SilentSuite using your existing Android apps, and SilentSuite will transparently encrypt your data and update the change journal in the background. More security, same work-flow.
+SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta; please report issues so we can make the Android experience better.

--- a/android/fastlane/metadata/android/en-US/short_description.txt
+++ b/android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Secure, private and end-to-end encrypted calendar, contacts and tasks sync
+Zero-knowledge calendar, contacts, and tasks sync for Android


### PR DESCRIPTION
## Summary
- Move the F-Droid Gradle source-build fixes into upstream Android build configuration.
- Refresh Android Fastlane description metadata so the F-Droid submission can point at current upstream store copy.

## Validation
- Code-review subagent: green to proceed.
- Local Gradle validation blocked: JAVA_HOME/java is not installed on this machine.

## F-Droid context
Addresses reviewer comments on fdroid/fdroiddata!38073 asking to update source code directly instead of patching Gradle from fdroiddata metadata.