### PR TITLE
Use HTML in Android Fastlane description

### DIFF
--- a/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,21 +1,11 @@
 SilentSuite is a zero-knowledge sync app for Android calendars, contacts, and tasks. It keeps your productivity data encrypted before it reaches the server, so SilentSuite cannot read your calendar events, address book, or task lists.
 
-Use Your Existing Apps
-======================
-SilentSuite works as an Android sync adapter. After you sign in, your encrypted SilentSuite collections appear in compatible calendar, contacts, and task apps on your phone. Use the Android apps you already like while keeping sync private.
+<b>Use Your Existing Apps</b><br />SilentSuite works as an Android sync adapter. After you sign in, your encrypted SilentSuite collections appear in compatible calendar, contacts, and task apps on your phone. Use the Android apps you already like while keeping sync private.
 
-Private By Design
-=================
-Your plaintext data stays on your devices. Sync data is stored on the server as encrypted blobs, and your encryption keys do not leave your device. The server needs limited metadata, such as sync tokens and timestamps, so sync can work, but it cannot decrypt the contents of your calendars, contacts, or tasks.
+<b>Private By Design</b><br />Your plaintext data stays on your devices. Sync data is stored on the server as encrypted blobs, and your encryption keys do not leave your device. The server needs limited metadata, such as sync tokens and timestamps, so sync can work, but it cannot decrypt the contents of your calendars, contacts, or tasks.
 
-Hosted Or Self-Hosted
-=====================
-You can use SilentSuite with a hosted SilentSuite account, or point the app at your own self-hosted SilentSuite server. The server and client code are open source, so privacy claims can be inspected instead of merely trusted.
+<b>Hosted Or Self-Hosted</b><br />You can use SilentSuite with a hosted SilentSuite account, or point the app at your own self-hosted SilentSuite server. The server and client code are open source, so privacy claims can be inspected instead of merely trusted.
 
-What You Need
-=============
-To use this app, you need a SilentSuite account or a compatible self-hosted server. Learn more at https://silentsuite.io/.
+<b>What You Need</b><br />To use this app, you need a SilentSuite account or a compatible self-hosted server. Learn more at https://silentsuite.io/.
 
-Beta Note
-=========
-SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta; please report issues so we can make the Android experience better.
+<b>Beta Note</b><br />SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta; please report issues so we can make the Android experience better.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,21 +1,11 @@
 SilentSuite is a zero-knowledge sync app for Android calendars, contacts, and tasks. It keeps your productivity data encrypted before it reaches the server, so SilentSuite cannot read your calendar events, address book, or task lists.
 
-Use Your Existing Apps
-======================
-SilentSuite works as an Android sync adapter. After you sign in, your encrypted SilentSuite collections appear in compatible calendar, contacts, and task apps on your phone. Use the Android apps you already like while keeping sync private.
+<b>Use Your Existing Apps</b><br />SilentSuite works as an Android sync adapter. After you sign in, your encrypted SilentSuite collections appear in compatible calendar, contacts, and task apps on your phone. Use the Android apps you already like while keeping sync private.
 
-Private By Design
-=================
-Your plaintext data stays on your devices. Sync data is stored on the server as encrypted blobs, and your encryption keys do not leave your device. The server needs limited metadata, such as sync tokens and timestamps, so sync can work, but it cannot decrypt the contents of your calendars, contacts, or tasks.
+<b>Private By Design</b><br />Your plaintext data stays on your devices. Sync data is stored on the server as encrypted blobs, and your encryption keys do not leave your device. The server needs limited metadata, such as sync tokens and timestamps, so sync can work, but it cannot decrypt the contents of your calendars, contacts, or tasks.
 
-Hosted Or Self-Hosted
-=====================
-You can use SilentSuite with a hosted SilentSuite account, or point the app at your own self-hosted SilentSuite server. The server and client code are open source, so privacy claims can be inspected instead of merely trusted.
+<b>Hosted Or Self-Hosted</b><br />You can use SilentSuite with a hosted SilentSuite account, or point the app at your own self-hosted SilentSuite server. The server and client code are open source, so privacy claims can be inspected instead of merely trusted.
 
-What You Need
-=============
-To use this app, you need a SilentSuite account or a compatible self-hosted server. Learn more at https://silentsuite.io/.
+<b>What You Need</b><br />To use this app, you need a SilentSuite account or a compatible self-hosted server. Learn more at https://silentsuite.io/.
 
-Beta Note
-=========
-SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta; please report issues so we can make the Android experience better.
+<b>Beta Note</b><br />SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta; please report issues so we can make the Android experience better.


### PR DESCRIPTION
## Summary
- Convert Android Fastlane full descriptions from Markdown-style headings to supported HTML tags.
- Keep the root and android-local Fastlane metadata copies in sync.

## Validation
- Code-review subagent: green, no blocking findings.

## F-Droid context
Addresses reviewer comment on fdroid/fdroiddata!38073: "Use HTML instead of Markdown in Fastlane. Then update the commit to cover the change."