### PR TITLE
Polish mobile onboarding affordances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 **/public/sw.js.map
 **/public/workbox-*.js
 **/public/workbox-*.js.map
+**/public/fallback-*.js.map
 **/public/swe-worker-*.js
 
 # Misc

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -53,10 +53,10 @@ class LoginCredentialsFragment : Fragment() {
             editUrlPassword.editText?.setText(initialPassword ?: "")
         }
 
-        val createAccount = v.findViewById<View>(R.id.create_account) as Button
+        val createAccount = v.findViewById<View>(R.id.create_account) as TextView
         createAccount.setOnClickListener {
             // Open web app for account creation — SilentSuite registration happens at app.silentsuite.io
-            startActivity(Intent(Intent.ACTION_VIEW, Constants.webAppUri))
+            startActivity(Intent(Intent.ACTION_VIEW, Constants.webAppUri.buildUpon().appendEncodedPath("signup").build()))
         }
 
         val login = v.findViewById<View>(R.id.login) as Button

--- a/android/app/src/main/res/layout/login_credentials_fragment.xml
+++ b/android/app/src/main/res/layout/login_credentials_fragment.xml
@@ -75,6 +75,16 @@
                 android:text="@string/login_forgot_password"
                 android:textColor="?attr/colorSecondary"/>
 
+            <TextView
+                android:id="@+id/create_account"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="14dp"
+                android:gravity="center"
+                android:minHeight="48dp"
+                android:text="@string/login_signup_prompt"
+                android:textColor="?attr/colorSecondary"/>
+
             <CheckedTextView
                 android:id="@+id/show_advanced"
                 android:layout_width="match_parent"
@@ -117,21 +127,8 @@
         style="@style/stepper_nav_bar">
 
         <Button
-            android:id="@+id/create_account"
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            android:text="@string/login_signup"
-            style="@style/stepper_nav_button"/>
-
-        <Space
-            android:layout_width="0dp"
-            android:layout_weight="1"
-            style="@style/stepper_nav_button"/>
-
-        <Button
             android:id="@+id/login"
-            android:layout_width="0dp"
-            android:layout_weight="1"
+            android:layout_width="match_parent"
             android:text="@string/login_login"
             style="@style/stepper_nav_button"/>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -270,6 +270,7 @@
     <string name="login_password_required">Password required</string>
     <string name="login_login">Log In</string>
     <string name="login_signup">Sign Up</string>
+    <string name="login_signup_prompt">Don\'t have an account? Sign up</string>
     <string name="login_finish">Finish</string>
     <string name="login_back">Back</string>
     <string name="login_enter_service_details">Sign in to SilentSuite</string>

--- a/apps/web/app/components/OnboardingModal.tsx
+++ b/apps/web/app/components/OnboardingModal.tsx
@@ -326,9 +326,9 @@ export function OnboardingModal() {
         <div className={`onb-transition-slide ${slideClass}`}>
           {step === 0 && <WelcomeSlide onGetStarted={next} />}
           {step === 1 && <ThemeChoiceSlide onNext={next} />}
-          {step === 2 && <CalendarImport onImportComplete={handleCalendarImport} />}
-          {step === 3 && <TaskImport onImportComplete={handleTaskImport} />}
-          {step === 4 && <ContactImport onImportComplete={handleContactImport} />}
+          {step === 2 && <CalendarImport heading="Sync your calendars" onImportComplete={handleCalendarImport} />}
+          {step === 3 && <TaskImport heading="Sync your tasks" onImportComplete={handleTaskImport} />}
+          {step === 4 && <ContactImport heading="Sync your contacts" onImportComplete={handleContactImport} />}
           {step === 5 && <CompletionSlide counts={counts} onFinish={finish} />}
         </div>
 

--- a/apps/web/app/components/header.tsx
+++ b/apps/web/app/components/header.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import Link from 'next/link'
-import { LogOut, ChevronDown, Shield, Settings, Lock } from 'lucide-react'
+import { LogOut, Menu, Shield, Settings, Lock } from 'lucide-react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { ThemeToggle } from '@/app/components/theme-toggle'
 import { SyncIndicator } from '@/app/components/SyncIndicator'
@@ -105,7 +105,7 @@ export function Header() {
             <span className="hidden max-w-[140px] truncate text-xs text-[rgb(var(--muted))] sm:inline">
               {user?.email}
             </span>
-            <ChevronDown className={`h-4 w-4 text-[rgb(var(--muted))] transition-transform ${menuOpen ? 'rotate-180' : ''}`} />
+            <Menu className="h-4 w-4 text-[rgb(var(--muted))]" />
           </button>
 
           {menuOpen && (

--- a/apps/web/app/components/import/CalendarImport.tsx
+++ b/apps/web/app/components/import/CalendarImport.tsx
@@ -14,6 +14,7 @@ import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 
 interface CalendarImportProps {
   onImportComplete: (count: number) => void
+  heading?: string
 }
 
 const PLATFORM_INSTRUCTIONS = [
@@ -64,7 +65,7 @@ function formatEventPreviewDate(dtstart: string, tzid?: string): string {
 }
 
 
-export default function CalendarImport({ onImportComplete }: CalendarImportProps) {
+export default function CalendarImport({ onImportComplete, heading }: CalendarImportProps) {
   const [events, setEvents] = useState<VEvent[]>([])
   const [error, setError] = useState<string | null>(null)
   const [todoWarning, setTodoWarning] = useState<string | null>(null)
@@ -142,6 +143,11 @@ export default function CalendarImport({ onImportComplete }: CalendarImportProps
 
   return (
     <div className="space-y-4">
+      {heading && (
+        <h2 className="text-lg font-semibold leading-tight text-[rgb(var(--foreground))]">
+          {heading}
+        </h2>
+      )}
       {/* Platform instructions */}
       <div className="space-y-1 rounded-lg bg-[rgb(var(--surface))]/50 p-1">
         {PLATFORM_INSTRUCTIONS.map((platform) => (

--- a/apps/web/app/components/import/ContactImport.tsx
+++ b/apps/web/app/components/import/ContactImport.tsx
@@ -12,6 +12,7 @@ import { useContactListStore } from '@/app/stores/use-contact-list-store'
 
 interface ContactImportProps {
   onImportComplete: (count: number) => void
+  heading?: string
 }
 
 const PLATFORM_INSTRUCTIONS = [
@@ -57,7 +58,7 @@ function splitVCards(text: string): string[] {
   return cards
 }
 
-export default function ContactImport({ onImportComplete }: ContactImportProps) {
+export default function ContactImport({ onImportComplete, heading }: ContactImportProps) {
   const [contacts, setContacts] = useState<VCard[]>([])
   const [error, setError] = useState<string | null>(null)
   const [isImporting, setIsImporting] = useState(false)
@@ -155,6 +156,11 @@ export default function ContactImport({ onImportComplete }: ContactImportProps) 
 
   return (
     <div className="space-y-4">
+      {heading && (
+        <h2 className="text-lg font-semibold leading-tight text-[rgb(var(--foreground))]">
+          {heading}
+        </h2>
+      )}
       <div className="space-y-1 rounded-lg bg-[rgb(var(--surface))]/50 p-1">
         {PLATFORM_INSTRUCTIONS.map((platform) => (
           <div key={platform.name}>

--- a/apps/web/app/components/import/FileDropZone.tsx
+++ b/apps/web/app/components/import/FileDropZone.tsx
@@ -59,7 +59,7 @@ export default function FileDropZone({ accept, onFiles, multiple = true }: FileD
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
-        className={`flex w-full cursor-pointer flex-col items-center gap-3 rounded-lg border-2 border-dashed p-8 transition-colors ${
+        className={`flex w-full cursor-pointer flex-col items-center gap-3 rounded-lg border-2 border-dashed p-5 transition-colors sm:p-8 ${
           isDragOver
             ? 'border-[rgb(var(--primary))] bg-[rgb(var(--primary))]/10'
             : 'border-[rgb(var(--border))] bg-[rgb(var(--surface))]/50 hover:border-[rgb(var(--muted))]/50 hover:bg-[rgb(var(--surface))]'

--- a/apps/web/app/components/import/TaskImport.tsx
+++ b/apps/web/app/components/import/TaskImport.tsx
@@ -14,6 +14,7 @@ import type { Priority } from '@silentsuite/core'
 
 interface TaskImportProps {
   onImportComplete: (count: number) => void
+  heading?: string
 }
 
 const PLATFORM_INSTRUCTIONS = [
@@ -159,7 +160,7 @@ function mapPriorityToStore(icalPriority?: number): Priority {
   return 'low'
 }
 
-export default function TaskImport({ onImportComplete }: TaskImportProps) {
+export default function TaskImport({ onImportComplete, heading }: TaskImportProps) {
   const [tasks, setTasks] = useState<VTodo[]>([])
   const [error, setError] = useState<string | null>(null)
   const [isImporting, setIsImporting] = useState(false)
@@ -234,6 +235,11 @@ export default function TaskImport({ onImportComplete }: TaskImportProps) {
 
   return (
     <div className="space-y-4">
+      {heading && (
+        <h2 className="text-lg font-semibold leading-tight text-[rgb(var(--foreground))]">
+          {heading}
+        </h2>
+      )}
       <div className="space-y-1 rounded-lg bg-[rgb(var(--surface))]/50 p-1">
         {PLATFORM_INSTRUCTIONS.map((platform) => (
           <div key={platform.name}>

--- a/apps/web/app/components/theme-toggle.tsx
+++ b/apps/web/app/components/theme-toggle.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useTheme } from 'next-themes'
-import { Sun, Moon, Monitor, Check } from 'lucide-react'
+import { Sun, Moon, Monitor, Check, SunMoon } from 'lucide-react'
 
 const options = [
   { value: 'light', label: 'Light', icon: Sun },
@@ -60,12 +60,10 @@ export function ThemeToggle() {
   if (!mounted) {
     return (
       <button className="rounded-md p-2" aria-label="Toggle theme">
-        <Monitor className="h-5 w-5 text-[rgb(var(--muted))]" />
+        <SunMoon className="h-5 w-5 text-[rgb(var(--muted))]" />
       </button>
     )
   }
-
-  const ActiveIcon = options.find((o) => o.value === theme)?.icon ?? Monitor
 
   return (
     <div ref={ref} className="relative">
@@ -76,7 +74,7 @@ export function ThemeToggle() {
         aria-haspopup="true"
         aria-expanded={open}
       >
-        <ActiveIcon className="h-4 w-4 text-[rgb(var(--foreground))]" />
+        <SunMoon className="h-4 w-4 text-[rgb(var(--foreground))]" />
       </button>
 
       {open && (


### PR DESCRIPTION
## Summary
- Replace ambiguous web theme/menu controls with recognizable sun/moon and hamburger icons.
- Add visible onboarding import headings for calendars, tasks, and contacts, with tighter mobile upload spacing.
- Make Android signup a secondary text link that opens `/signup`, leaving login as the only primary action.

## Verification
- `pnpm --filter @silentsuite/web test` passed in the source checkout before isolating this branch.
- `git diff --check` passed on this branch.
- Android build not run locally by convention; Android builds should run in GitHub Actions.

Closes #170
Closes #172
Closes #173
