### PR TITLE
Improve tasks.org completion sync

### DIFF
--- a/packages/core/src/models/task.test.ts
+++ b/packages/core/src/models/task.test.ts
@@ -109,6 +109,7 @@ describe('completed vs incomplete tasks', () => {
 
     expect(vtodo).toContain('STATUS:COMPLETED');
     expect(vtodo).toContain('COMPLETED:');
+    expect(vtodo).toContain('PERCENT-COMPLETE:100');
   });
 
   it('serializes an incomplete task with STATUS:NEEDS-ACTION', () => {
@@ -117,6 +118,7 @@ describe('completed vs incomplete tasks', () => {
 
     expect(vtodo).toContain('STATUS:NEEDS-ACTION');
     expect(vtodo).not.toContain('COMPLETED:');
+    expect(vtodo).toContain('PERCENT-COMPLETE:0');
   });
 
   it('roundtrips a completed task', () => {
@@ -133,6 +135,74 @@ describe('completed vs incomplete tasks', () => {
     const restored = fromVTodo(vtodo);
 
     expect(restored.completed).toBe(false);
+  });
+
+  it('treats PERCENT-COMPLETE:100 as completed for tasks.org compatibility', () => {
+    const task = fromVTodo([
+      'BEGIN:VTODO',
+      'UID:percent-complete-task',
+      'SUMMARY:Done elsewhere',
+      'STATUS:NEEDS-ACTION',
+      'PERCENT-COMPLETE:100',
+      'END:VTODO',
+    ].join('\r\n'));
+
+    expect(task.completed).toBe(true);
+  });
+
+  it('does not treat partial PERCENT-COMPLETE values as completed', () => {
+    const task = fromVTodo([
+      'BEGIN:VTODO',
+      'UID:partial-progress-task',
+      'SUMMARY:In progress',
+      'PERCENT-COMPLETE:50',
+      'END:VTODO',
+    ].join('\r\n'));
+
+    expect(task.completed).toBe(false);
+  });
+
+  it('treats a COMPLETED timestamp as completed for client compatibility', () => {
+    const task = fromVTodo([
+      'BEGIN:VTODO',
+      'UID:completed-date-task',
+      'SUMMARY:Done elsewhere',
+      'COMPLETED:20260310T120000',
+      'END:VTODO',
+    ].join('\r\n'));
+
+    expect(task.completed).toBe(true);
+  });
+
+  it('does not let a COMPLETED timestamp override an explicit incomplete status', () => {
+    const task = fromVTodo([
+      'BEGIN:VTODO',
+      'UID:stale-completed-date-task',
+      'SUMMARY:Marked incomplete elsewhere',
+      'STATUS:NEEDS-ACTION',
+      'COMPLETED:20260310T120000',
+      'END:VTODO',
+    ].join('\r\n'));
+
+    expect(task.completed).toBe(false);
+  });
+
+  it('normalizes tasks.org-style completion on re-serialize', () => {
+    const task = fromVTodo([
+      'BEGIN:VTODO',
+      'UID:tasks-org-completed-task',
+      'SUMMARY:Done in tasks.org',
+      'STATUS:NEEDS-ACTION',
+      'PERCENT-COMPLETE:100',
+      'END:VTODO',
+    ].join('\r\n'));
+
+    const vtodo = toVTodo(task);
+
+    expect(task.completed).toBe(true);
+    expect(vtodo).toContain('STATUS:COMPLETED');
+    expect(vtodo).toContain('COMPLETED:');
+    expect(vtodo).toContain('PERCENT-COMPLETE:100');
   });
 });
 

--- a/packages/core/src/models/task.ts
+++ b/packages/core/src/models/task.ts
@@ -89,6 +89,7 @@ export function toVTodo(task: Task): string {
     description: task.description || undefined,
     priority: PRIORITY_TO_ICAL[task.priority],
     status: task.completed ? 'COMPLETED' : 'NEEDS-ACTION',
+    percentComplete: task.completed ? 100 : 0,
     created: formatICalDateTime(task.created_at),
     lastModified: formatICalDateTime(task.updated_at),
   };
@@ -118,7 +119,9 @@ export function fromVTodo(vtodoStr: string): Task {
   const now = new Date();
 
   const due_date = vtodo.due ? parseICalDateValue(vtodo.due) : null;
-  const completed = vtodo.status?.toUpperCase() === 'COMPLETED';
+  const completed = vtodo.status?.toUpperCase() === 'COMPLETED'
+    || vtodo.percentComplete === 100
+    || (vtodo.status === undefined && vtodo.completed !== undefined);
 
   return {
     id: vtodo.uid,


### PR DESCRIPTION
## Summary
- Add VTODO PERCENT-COMPLETE serialization so tasks.org recognizes SilentSuite completed tasks.
- Treat PERCENT-COMPLETE:100 and status-less COMPLETED timestamps as completed during task import/sync.
- Cover tasks.org-style completion, partial progress, stale COMPLETED timestamps, and re-serialization normalization in core tests.

## Verification
- pnpm --filter @silentsuite/core test -- src/models/task.test.ts
- pnpm --filter @silentsuite/core type-check