### PR TITLE
Improve Android/web onboarding return flow

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -242,6 +242,18 @@
         </activity>
 
         <activity
+            android:name=".ui.setup.SignupReturnActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Transparent">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="silentsuite" android:host="signup-complete" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".ui.etebase.CollectionActivity"
             android:exported="false"
             />

--- a/android/app/src/main/java/io/silentsuite/sync/Constants.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/Constants.kt
@@ -24,6 +24,7 @@ object Constants {
 
     val webUri: Uri = Uri.parse("https://silentsuite.io/")
     val webAppUri: Uri = Uri.parse("https://app.silentsuite.io/")
+    val signupCompleteReturnUri: Uri = Uri.parse("silentsuite://signup-complete")
     val docsUri: Uri = Uri.parse("https://docs.silentsuite.io/")
     val etebaseDashboardPrefix: Uri = Uri.parse("https://dashboard.silentsuite.io/user/partner/")
     val contactUri: Uri = webUri.buildUpon().appendEncodedPath("about/#contact").build()

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -380,9 +380,18 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         return false
     }
 
+    private fun scrollToSection(sectionId: Int) {
+        val scrollView = findViewById<ScrollView>(R.id.parent) ?: return
+        val section = findViewById<View>(sectionId) ?: return
+        scrollView.post { scrollView.smoothScrollTo(0, section.top) }
+    }
+
     // NavigationView drawer item handling (moved from AccountsActivity)
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
+            R.id.nav_calendar -> scrollToSection(R.id.caldav)
+            R.id.nav_tasks -> scrollToSection(R.id.taskdav)
+            R.id.nav_contacts -> scrollToSection(R.id.carddav)
             R.id.nav_about -> startActivity(Intent(this, AboutActivity::class.java))
             R.id.nav_app_settings -> startActivity(Intent(this, AppSettingsActivity::class.java))
             R.id.nav_invitations -> startActivity(InvitationsActivity.newIntent(this, account))

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -55,8 +55,11 @@ class LoginCredentialsFragment : Fragment() {
 
         val createAccount = v.findViewById<View>(R.id.create_account) as TextView
         createAccount.setOnClickListener {
-            // Open web app for account creation — SilentSuite registration happens at app.silentsuite.io
-            startActivity(Intent(Intent.ACTION_VIEW, Constants.webAppUri.buildUpon().appendEncodedPath("signup").build()))
+            val signupUri = Constants.webAppUri.buildUpon()
+                .appendEncodedPath("signup")
+                .appendQueryParameter("return_to", Constants.signupCompleteReturnUri.toString())
+                .build()
+            startActivity(Intent(Intent.ACTION_VIEW, signupUri))
         }
 
         val login = v.findViewById<View>(R.id.login) as Button

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupReturnActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupReturnActivity.kt
@@ -1,0 +1,16 @@
+package io.silentsuite.sync.ui.setup
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import io.silentsuite.sync.R
+
+class SignupReturnActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Toast.makeText(this, R.string.signup_returned_from_web, Toast.LENGTH_LONG).show()
+        startActivity(Intent(this, LoginActivity::class.java))
+        finish()
+    }
+}

--- a/android/app/src/main/res/menu/activity_accounts_drawer.xml
+++ b/android/app/src/main/res/menu/activity_accounts_drawer.xml
@@ -25,7 +25,7 @@
             android:title="@string/navigation_drawer_tasks"/>
         <item
             android:id="@+id/nav_contacts"
-            android:icon="@drawable/ic_people_light"
+            android:icon="@drawable/ic_account_dark"
             android:title="@string/navigation_drawer_contacts"/>
         <item
             android:id="@+id/nav_app_settings"

--- a/android/app/src/main/res/menu/activity_accounts_drawer.xml
+++ b/android/app/src/main/res/menu/activity_accounts_drawer.xml
@@ -16,6 +16,18 @@
 
     <group android:id="@+id/nav_main_group" android:checkableBehavior="none">
         <item
+            android:id="@+id/nav_calendar"
+            android:icon="@drawable/ic_event_light"
+            android:title="@string/navigation_drawer_calendar"/>
+        <item
+            android:id="@+id/nav_tasks"
+            android:icon="@drawable/ic_task_light"
+            android:title="@string/navigation_drawer_tasks"/>
+        <item
+            android:id="@+id/nav_contacts"
+            android:icon="@drawable/ic_people_light"
+            android:title="@string/navigation_drawer_contacts"/>
+        <item
             android:id="@+id/nav_app_settings"
             android:icon="@drawable/ic_settings_dark"
             android:title="@string/navigation_drawer_settings"/>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -85,6 +85,10 @@
     <string name="navigation_drawer_faq">FAQ</string>
     <string name="navigation_drawer_report_issue">Report issue</string>
     <string name="navigation_drawer_contact">Contact</string>
+    <string name="navigation_drawer_calendar">Calendar</string>
+    <string name="navigation_drawer_tasks">Tasks</string>
+    <string name="navigation_drawer_contacts">Contacts</string>
+    <string name="signup_returned_from_web">Account created. Log in to finish connecting Android sync.</string>
 
     <string name="account_list_empty">Welcome to SilentSuite!</string>
     <string name="accounts_global_sync_disabled">System-wide automatic synchronization is disabled</string>

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -1008,6 +1008,7 @@ export default function SignupPage() {
   const [planView, setPlanView] = useState<PlanView>('cards')
   const [wantsProductUpdates, setWantsProductUpdates] = useState(false)
   const [returnTo, setReturnTo] = useState<string | null>(null)
+  const [showReturnFallback, setShowReturnFallback] = useState(false)
   const formDataRef = useRef<SignupFormData | null>(null)
 
   useEffect(() => {
@@ -1141,7 +1142,11 @@ export default function SignupPage() {
     // Finalize authentication — only NOW does the user become authenticated.
     completeSignup()
     if (returnTo) {
+      setShowReturnFallback(false)
       window.location.href = returnTo
+      window.setTimeout(() => {
+        if (document.visibilityState === 'visible') setShowReturnFallback(true)
+      }, 2000)
       return
     }
     router.push('/')
@@ -1191,7 +1196,17 @@ export default function SignupPage() {
           />
         )}
         {step === 'vault' && (
-          <StepCreateVault email={email} onComplete={handleVaultComplete} />
+          <>
+            <StepCreateVault email={email} onComplete={handleVaultComplete} />
+            {showReturnFallback && returnTo && (
+              <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-[rgb(var(--foreground))]">
+                <p className="font-medium">Browser did not reopen the Android app automatically.</p>
+                <a href={returnTo} className="mt-2 inline-flex font-medium text-[rgb(var(--primary))] underline">
+                  Tap here to return to Android
+                </a>
+              </div>
+            )}
+          </>
         )}
       </div>
       {/* Build version indicator */}

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -17,6 +17,7 @@ import { Input } from '@silentsuite/ui'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { normalizeServerUrl } from '@/app/stores/use-etebase-store'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
+import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
 import { StepCreateVault } from './components/step-create-vault'
 
@@ -1006,7 +1007,12 @@ export default function SignupPage() {
   const [usingSelfHostedServer, setUsingSelfHostedServer] = useState(false)
   const [planView, setPlanView] = useState<PlanView>('cards')
   const [wantsProductUpdates, setWantsProductUpdates] = useState(false)
+  const [returnTo, setReturnTo] = useState<string | null>(null)
   const formDataRef = useRef<SignupFormData | null>(null)
+
+  useEffect(() => {
+    setReturnTo(normalizeSignupReturnTo(new URLSearchParams(window.location.search).get('return_to')))
+  }, [])
 
   const handleAccountComplete = useCallback(async (data: SignupFormData) => {
     formDataRef.current = data
@@ -1134,8 +1140,12 @@ export default function SignupPage() {
   const handleVaultComplete = useCallback(() => {
     // Finalize authentication — only NOW does the user become authenticated.
     completeSignup()
+    if (returnTo) {
+      window.location.href = returnTo
+      return
+    }
     router.push('/')
-  }, [completeSignup, router])
+  }, [completeSignup, returnTo, router])
 
   const email = formDataRef.current?.email || ''
 

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -1116,6 +1116,11 @@ export default function SignupPage() {
       if (result.cryptoInvoiceLookupToken) {
         sessionStorage.setItem('silentsuite-pending-crypto-token', result.cryptoInvoiceLookupToken)
       }
+      if (returnTo) {
+        sessionStorage.setItem('silentsuite-pending-crypto-return-to', returnTo)
+      } else {
+        sessionStorage.removeItem('silentsuite-pending-crypto-return-to')
+      }
       window.location.href = checkoutUrl.toString()
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to start crypto checkout'
@@ -1123,7 +1128,7 @@ export default function SignupPage() {
     } finally {
       setProvisioning(false)
     }
-  }, [signup])
+  }, [returnTo, signup])
 
   const handlePlanBack = useCallback(() => {
     if (planView === 'payment') {

--- a/apps/web/app/(auth)/signup/pending-payment/page.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/page.tsx
@@ -4,24 +4,30 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { AlertTriangle, Check, Loader2 } from 'lucide-react'
 import { BILLING_API_URL } from '@/app/lib/config'
+import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 
 type PaymentState = 'pending' | 'settled' | 'expired' | 'timeout' | 'unknown'
 
 function clearPendingCryptoSignup() {
   sessionStorage.removeItem('silentsuite-pending-crypto-invoice')
   sessionStorage.removeItem('silentsuite-pending-crypto-token')
+  sessionStorage.removeItem('silentsuite-pending-crypto-return-to')
   sessionStorage.removeItem('silentsuite-signup-in-progress')
 }
 
 export default function PendingPaymentPage() {
   const [invoiceId, setInvoiceId] = useState<string | null>(null)
+  const [returnTo, setReturnTo] = useState<string | null>(null)
+  const [showReturnFallback, setShowReturnFallback] = useState(false)
   const [state, setState] = useState<PaymentState>('pending')
   const [pollNonce, setPollNonce] = useState(0)
 
   useEffect(() => {
     const id = sessionStorage.getItem('silentsuite-pending-crypto-invoice')
     const lookupToken = sessionStorage.getItem('silentsuite-pending-crypto-token')
+    const storedReturnTo = normalizeSignupReturnTo(sessionStorage.getItem('silentsuite-pending-crypto-return-to'))
     setInvoiceId(id)
+    setReturnTo(storedReturnTo)
     if (!id || !lookupToken) {
       setState('unknown')
       clearPendingCryptoSignup()
@@ -82,6 +88,18 @@ export default function PendingPaymentPage() {
     }
   }, [pollNonce])
 
+  function handleSettledContinue() {
+    if (returnTo) {
+      setShowReturnFallback(false)
+      window.location.href = returnTo
+      window.setTimeout(() => {
+        if (document.visibilityState === 'visible') setShowReturnFallback(true)
+      }, 2000)
+      return
+    }
+    window.location.href = '/'
+  }
+
   const isWaiting = state === 'pending'
   const title = state === 'settled'
     ? 'Payment settled'
@@ -126,9 +144,19 @@ export default function PendingPaymentPage() {
       )}
       <div className="space-y-3">
         {state === 'settled' ? (
-          <Link href="/" className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600">
-            Open SilentSuite
-          </Link>
+          <>
+            <button type="button" onClick={handleSettledContinue} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600">
+              {returnTo ? 'Return to Android app' : 'Open SilentSuite'}
+            </button>
+            {showReturnFallback && returnTo && (
+              <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-[rgb(var(--foreground))]">
+                <p className="font-medium">Browser did not reopen the Android app automatically.</p>
+                <a href={returnTo} className="mt-2 inline-flex font-medium text-[rgb(var(--primary))] underline">
+                  Tap here to return to Android
+                </a>
+              </div>
+            )}
+          </>
         ) : state === 'timeout' ? (
           <>
             <button type="button" onClick={() => { setState('pending'); setPollNonce((value) => value + 1) }} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600">

--- a/apps/web/app/(auth)/signup/success/page.tsx
+++ b/apps/web/app/(auth)/signup/success/page.tsx
@@ -29,6 +29,7 @@ function SignupSuccessInner() {
 
   const [state, setState] = useState<RedirectState>(isStripeRedirect ? 'loading' : 'none')
   const [restoredEmail, setRestoredEmail] = useState<string>('')
+  const [showReturnFallback, setShowReturnFallback] = useState(false)
 
   useEffect(() => {
     if (!isStripeRedirect) return
@@ -58,7 +59,11 @@ function SignupSuccessInner() {
   const handleVaultComplete = useCallback(() => {
     completeSignup()
     if (returnTo) {
+      setShowReturnFallback(false)
       window.location.href = returnTo
+      window.setTimeout(() => {
+        if (document.visibilityState === 'visible') setShowReturnFallback(true)
+      }, 2000)
       return
     }
     router.push('/')
@@ -67,7 +72,11 @@ function SignupSuccessInner() {
   const handleSuccessContinue = useCallback(() => {
     completeSignup()
     if (returnTo) {
+      setShowReturnFallback(false)
       window.location.href = returnTo
+      window.setTimeout(() => {
+        if (document.visibilityState === 'visible') setShowReturnFallback(true)
+      }, 2000)
       return
     }
     router.push('/')
@@ -100,6 +109,14 @@ function SignupSuccessInner() {
           email={restoredEmail}
           onComplete={handleVaultComplete}
         />
+        {showReturnFallback && returnTo && (
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-[rgb(var(--foreground))]">
+            <p className="font-medium">Browser did not reopen the Android app automatically.</p>
+            <a href={returnTo} className="mt-2 inline-flex font-medium text-[rgb(var(--primary))] underline">
+              Tap here to return to Android
+            </a>
+          </div>
+        )}
       </div>
     )
   }
@@ -177,6 +194,14 @@ function SignupSuccessInner() {
       <Button onClick={handleSuccessContinue} className="w-full">
         {returnTo ? 'Return to Android app' : 'Set up your workspace'}
       </Button>
+      {showReturnFallback && returnTo && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-[rgb(var(--foreground))]">
+          <p className="font-medium">Browser did not reopen the Android app automatically.</p>
+          <a href={returnTo} className="mt-2 inline-flex font-medium text-[rgb(var(--primary))] underline">
+            Tap here to return to Android
+          </a>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/app/(auth)/signup/success/page.tsx
+++ b/apps/web/app/(auth)/signup/success/page.tsx
@@ -6,6 +6,7 @@ import { CheckCircle, AlertTriangle, Lock } from 'lucide-react'
 import { MS_PER_DAY } from '@/app/lib/constants'
 import { Button } from '@silentsuite/ui'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import { StepCreateVault } from '../components/step-create-vault'
 
 // ---------------------------------------------------------------------------
@@ -23,6 +24,7 @@ function SignupSuccessInner() {
 
   const redirectStatus = searchParams.get('redirect_status')
   const setupIntent = searchParams.get('setup_intent')
+  const returnTo = normalizeSignupReturnTo(searchParams.get('return_to'))
   const isStripeRedirect = !!(setupIntent && redirectStatus)
 
   const [state, setState] = useState<RedirectState>(isStripeRedirect ? 'loading' : 'none')
@@ -55,8 +57,21 @@ function SignupSuccessInner() {
 
   const handleVaultComplete = useCallback(() => {
     completeSignup()
+    if (returnTo) {
+      window.location.href = returnTo
+      return
+    }
     router.push('/')
-  }, [completeSignup, router])
+  }, [completeSignup, returnTo, router])
+
+  const handleSuccessContinue = useCallback(() => {
+    completeSignup()
+    if (returnTo) {
+      window.location.href = returnTo
+      return
+    }
+    router.push('/')
+  }, [completeSignup, returnTo, router])
 
   // --- Stripe 3DS redirect: loading ---
   if (state === 'loading') {
@@ -159,8 +174,8 @@ function SignupSuccessInner() {
         </p>
       </div>
 
-      <Button onClick={() => router.push('/')} className="w-full">
-        Set up your workspace
+      <Button onClick={handleSuccessContinue} className="w-full">
+        {returnTo ? 'Return to Android app' : 'Set up your workspace'}
       </Button>
     </div>
   )

--- a/apps/web/app/components/stripe-payment-form.tsx
+++ b/apps/web/app/components/stripe-payment-form.tsx
@@ -7,6 +7,7 @@ import type { Stripe, Appearance } from '@stripe/stripe-js'
 import { useTheme } from 'next-themes'
 import { Button } from '@silentsuite/ui'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+import { signupSuccessUrl } from '@/app/lib/signup-return'
 
 const STRIPE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
 
@@ -75,8 +76,9 @@ function PaymentFormInner({ onSuccess, onError, submitLabel, mode, selectedInter
     // states set user.email to '', and we'd rather land on 'Customer' than ''.
     const authState = useAuthStore.getState()
     const billingName = authState.pendingSignup?.email || authState.user?.email || 'Customer'
+    const currentReturnTo = new URLSearchParams(window.location.search).get('return_to')
     const confirmParams = {
-      return_url: `${window.location.origin}/signup/success`,
+      return_url: signupSuccessUrl(window.location.origin, currentReturnTo),
       payment_method_data: { billing_details: { name: billingName } },
     }
 

--- a/apps/web/app/lib/__tests__/signup-return.test.ts
+++ b/apps/web/app/lib/__tests__/signup-return.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeSignupReturnTo, signupSuccessUrl } from '../signup-return'
+
+describe('signup return helpers', () => {
+  it('allows the Android signup completion deep link', () => {
+    expect(normalizeSignupReturnTo('silentsuite://signup-complete')).toBe('silentsuite://signup-complete')
+  })
+
+  it('rejects empty, malformed, and non-Android return URLs', () => {
+    expect(normalizeSignupReturnTo(null)).toBeNull()
+    expect(normalizeSignupReturnTo(undefined)).toBeNull()
+    expect(normalizeSignupReturnTo('')).toBeNull()
+    expect(normalizeSignupReturnTo('not a url')).toBeNull()
+    expect(normalizeSignupReturnTo('https://evil.example/')).toBeNull()
+    expect(normalizeSignupReturnTo('silentsuite://other-flow')).toBeNull()
+  })
+
+  it('builds a signup success URL without return_to when absent or invalid', () => {
+    expect(signupSuccessUrl('https://app.silentsuite.io')).toBe('https://app.silentsuite.io/signup/success')
+    expect(signupSuccessUrl('https://app.silentsuite.io', 'https://evil.example/')).toBe('https://app.silentsuite.io/signup/success')
+  })
+
+  it('preserves a valid Android return URL on the signup success URL', () => {
+    const url = new URL(signupSuccessUrl('https://app.silentsuite.io', 'silentsuite://signup-complete'))
+
+    expect(url.origin).toBe('https://app.silentsuite.io')
+    expect(url.pathname).toBe('/signup/success')
+    expect(url.searchParams.get('return_to')).toBe('silentsuite://signup-complete')
+  })
+})

--- a/apps/web/app/lib/signup-return.ts
+++ b/apps/web/app/lib/signup-return.ts
@@ -1,0 +1,26 @@
+const ANDROID_SIGNUP_RETURN_PROTOCOL = 'silentsuite:'
+const ANDROID_SIGNUP_RETURN_HOST = 'signup-complete'
+
+export function normalizeSignupReturnTo(value: string | null | undefined): string | null {
+  if (!value) return null
+
+  try {
+    const url = new URL(value)
+    if (url.protocol === ANDROID_SIGNUP_RETURN_PROTOCOL && url.host === ANDROID_SIGNUP_RETURN_HOST) {
+      return url.toString()
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+export function signupSuccessUrl(origin: string, returnTo?: string | null): string {
+  const url = new URL('/signup/success', origin)
+  const normalizedReturnTo = normalizeSignupReturnTo(returnTo)
+  if (normalizedReturnTo) {
+    url.searchParams.set('return_to', normalizedReturnTo)
+  }
+  return url.toString()
+}


### PR DESCRIPTION
## Summary
- Return Android users from web signup back into the Android app via a whitelisted deep link.
- Preserve the Android return target through Stripe 3DS and BTCPay crypto signup paths, with browser fallback UI.
- Add Android drawer shortcuts for Calendar, Tasks, and Contacts to better match the web app navigation.

## Verification
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint` (existing unrelated warnings only)
- `pnpm --filter @silentsuite/web test -- app/lib/__tests__/signup-return.test.ts`
- code-reviewer green light after follow-up fixes

Addresses #175.
Part of #176.