### PR TITLE
Support multiple collections

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -673,12 +673,8 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             }
 
             synchronized(etebaseLocalCache) {
-                // Surface at most one collection per type — multi-collection support was
-                // dropped in the 2026-04-12 triage. The sync adapter still caches every
-                // collection locally so nothing is lost for users with prior extras.
                 return etebaseLocalCache.collectionList(colMgr)
                     .filter { it.collectionType == strType }
-                    .take(1)
                     .map {
                         val meta = it.meta
                         val accessLevel = it.col.accessLevel

--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -21,6 +21,8 @@ The bridge handles encryption/decryption locally. Your data is still end-to-end 
 - Tasks (CalDAV / VTODO)
 - Contacts (CardDAV / VCARD)
 
+The bridge exposes every SilentSuite calendar, task list, and address book as its own DAV collection, so compatible clients can select the destination collection for new events, tasks, and contacts.
+
 ## Install
 
 ### One-Line Installer (Recommended)

--- a/apps/docs/user-guide/calendar.md
+++ b/apps/docs/user-guide/calendar.md
@@ -6,6 +6,8 @@ Your calendar events are end-to-end encrypted. Only your devices can read them.
 
 The web app at [app.silentsuite.io](https://app.silentsuite.io) provides day, week, and month views. The sidebar includes a mini calendar for quick navigation and a calendar list where you can toggle visibility of individual calendars.
 
+You can create multiple calendars. Each calendar is a separate encrypted collection with its own name, color, items, and DAV collection URL.
+
 ## Create an Event
 
 1. Open the Calendar view.

--- a/apps/docs/user-guide/contacts.md
+++ b/apps/docs/user-guide/contacts.md
@@ -2,6 +2,8 @@
 
 Your contacts are end-to-end encrypted. Only your devices can read them.
 
+Contacts can be organized into multiple address books. Each address book is a separate encrypted collection that syncs across your devices and compatible CardDAV clients.
+
 ## Add a Contact
 
 1. Open the Contacts view.

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -195,6 +195,16 @@ export function EventDialog({
     isEdit ? (event.calendarId ?? defaultCalendarId) : defaultCalendarId,
   )
 
+  useEffect(() => {
+    if (isEdit || calendarLists.length === 0) return
+    if (calendarLists.some((calendar) => calendar.id === selectedCalendarId)) return
+    setSelectedCalendarId(
+      calendarLists.some((calendar) => calendar.id === defaultCalendarId)
+        ? defaultCalendarId
+        : calendarLists[0]!.id,
+    )
+  }, [calendarLists, defaultCalendarId, isEdit, selectedCalendarId])
+
   // Saving state to prevent double-submission
   const [saving, setSaving] = useState(false)
 

--- a/apps/web/app/components/CalendarListPanel.tsx
+++ b/apps/web/app/components/CalendarListPanel.tsx
@@ -1,21 +1,36 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { Plus, Trash2, Star } from 'lucide-react'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 
 export function CalendarListPanel() {
-  const { calendars, defaultCalendarId, addCalendar, removeCalendar, toggleVisibility, setDefaultCalendar, getNextColor } = useCalendarListStore()
+  const { calendars, defaultCalendarId, toggleVisibility, setDefaultCalendar, getNextColor } = useCalendarListStore()
+  const createCollection = useEtebaseStore((s) => s.createCollection)
+  const deleteCollection = useEtebaseStore((s) => s.deleteCollection)
   const [isAdding, setIsAdding] = useState(false)
   const [newName, setNewName] = useState('')
+  const isCreatingRef = useRef(false)
 
-  const handleAdd = useCallback(() => {
-    if (newName.trim()) {
-      addCalendar(newName.trim())
+  const handleAdd = useCallback(async () => {
+    if (isCreatingRef.current) return
+    const name = newName.trim()
+    if (name) {
+      isCreatingRef.current = true
       setNewName('')
-      setIsAdding(false)
+      const uid = await createCollection('calendar', name, getNextColor())
+      if (uid) setIsAdding(false)
+      else setNewName(name)
+      isCreatingRef.current = false
     }
-  }, [newName, addCalendar])
+  }, [createCollection, getNextColor, newName])
+
+  const handleDelete = useCallback(async (id: string, name: string) => {
+    if (calendars.length <= 1) return
+    if (!window.confirm(`Delete calendar "${name}" and all events in it? This cannot be undone.`)) return
+    await deleteCollection('calendar', id)
+  }, [calendars.length, deleteCollection])
 
   return (
     <div className="px-3 py-2">
@@ -69,9 +84,9 @@ export function CalendarListPanel() {
               >
                 <Star className={`h-3 w-3 ${cal.id === defaultCalendarId ? 'fill-current' : ''}`} />
               </button>
-              {cal.id !== 'default' && (
+              {calendars.length > 1 && (
                 <button
-                  onClick={() => removeCalendar(cal.id)}
+                  onClick={() => handleDelete(cal.id, cal.name)}
                   className="hidden group-hover:block rounded p-0.5 text-[rgb(var(--muted))] hover:text-red-500 transition-colors"
                   aria-label={`Remove ${cal.name}`}
                 >

--- a/apps/web/app/components/ContactListPanel.tsx
+++ b/apps/web/app/components/ContactListPanel.tsx
@@ -1,21 +1,36 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { Plus, Trash2 } from 'lucide-react'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 
 export function ContactListPanel() {
-  const { lists, addList, removeList, toggleVisibility, getNextColor } = useContactListStore()
+  const { lists, toggleVisibility, getNextColor } = useContactListStore()
+  const createCollection = useEtebaseStore((s) => s.createCollection)
+  const deleteCollection = useEtebaseStore((s) => s.deleteCollection)
   const [isAdding, setIsAdding] = useState(false)
   const [newName, setNewName] = useState('')
+  const isCreatingRef = useRef(false)
 
-  const handleAdd = useCallback(() => {
-    if (newName.trim()) {
-      addList(newName.trim())
+  const handleAdd = useCallback(async () => {
+    if (isCreatingRef.current) return
+    const name = newName.trim()
+    if (name) {
+      isCreatingRef.current = true
       setNewName('')
-      setIsAdding(false)
+      const uid = await createCollection('contacts', name, getNextColor())
+      if (uid) setIsAdding(false)
+      else setNewName(name)
+      isCreatingRef.current = false
     }
-  }, [newName, addList])
+  }, [createCollection, getNextColor, newName])
+
+  const handleDelete = useCallback(async (id: string, name: string) => {
+    if (lists.length <= 1) return
+    if (!window.confirm(`Delete address book "${name}" and all contacts in it? This cannot be undone.`)) return
+    await deleteCollection('contacts', id)
+  }, [deleteCollection, lists.length])
 
   return (
     <div className="px-3 py-2">
@@ -56,9 +71,9 @@ export function ContactListPanel() {
               </span>
             </button>
             <div className="flex items-center gap-0.5">
-              {list.id !== 'default' && (
+              {lists.length > 1 && (
                 <button
-                  onClick={() => removeList(list.id)}
+                  onClick={() => handleDelete(list.id, list.name)}
                   className="hidden group-hover:block rounded p-0.5 text-[rgb(var(--muted))] hover:text-red-500 transition-colors"
                   aria-label={`Remove ${list.name}`}
                 >

--- a/apps/web/app/components/TaskListPanel.tsx
+++ b/apps/web/app/components/TaskListPanel.tsx
@@ -1,21 +1,36 @@
 'use client'
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { Plus, Trash2 } from 'lucide-react'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 
 export function TaskListPanel() {
-  const { lists, addList, removeList, toggleVisibility, getNextColor } = useTaskListStore()
+  const { lists, toggleVisibility, getNextColor } = useTaskListStore()
+  const createCollection = useEtebaseStore((s) => s.createCollection)
+  const deleteCollection = useEtebaseStore((s) => s.deleteCollection)
   const [isAdding, setIsAdding] = useState(false)
   const [newName, setNewName] = useState('')
+  const isCreatingRef = useRef(false)
 
-  const handleAdd = useCallback(() => {
-    if (newName.trim()) {
-      addList(newName.trim())
+  const handleAdd = useCallback(async () => {
+    if (isCreatingRef.current) return
+    const name = newName.trim()
+    if (name) {
+      isCreatingRef.current = true
       setNewName('')
-      setIsAdding(false)
+      const uid = await createCollection('tasks', name, getNextColor())
+      if (uid) setIsAdding(false)
+      else setNewName(name)
+      isCreatingRef.current = false
     }
-  }, [newName, addList])
+  }, [createCollection, getNextColor, newName])
+
+  const handleDelete = useCallback(async (id: string, name: string) => {
+    if (lists.length <= 1) return
+    if (!window.confirm(`Delete task list "${name}" and all tasks in it? This cannot be undone.`)) return
+    await deleteCollection('tasks', id)
+  }, [deleteCollection, lists.length])
 
   return (
     <div className="px-3 py-2">
@@ -56,9 +71,9 @@ export function TaskListPanel() {
               </span>
             </button>
             <div className="flex items-center gap-0.5">
-              {list.id !== 'default' && (
+              {lists.length > 1 && (
                 <button
-                  onClick={() => removeList(list.id)}
+                  onClick={() => handleDelete(list.id, list.name)}
                   className="hidden group-hover:block rounded p-0.5 text-[rgb(var(--muted))] hover:text-red-500 transition-colors"
                   aria-label={`Remove ${list.name}`}
                 >

--- a/apps/web/app/components/import/CalendarImport.tsx
+++ b/apps/web/app/components/import/CalendarImport.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { parseVCalendar, parseICalDateValue } from '@silentsuite/core'
 import { ExternalLink } from 'lucide-react'
@@ -11,6 +11,7 @@ import ImportListSelector from './ImportListSelector'
 import { vEventToImportEvent } from './import-mappers'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 
 interface CalendarImportProps {
   onImportComplete: (count: number) => void
@@ -72,10 +73,21 @@ export default function CalendarImport({ onImportComplete, heading }: CalendarIm
   const [isImporting, setIsImporting] = useState(false)
   const [importedCount, setImportedCount] = useState<number | null>(null)
   const [openAccordion, setOpenAccordion] = useState<string | null>(null)
-  const [selectedCalendarId, setSelectedCalendarId] = useState('default')
   const importEvents = useCalendarStore((s) => s.importEvents)
   const calendars = useCalendarListStore((s) => s.calendars)
-  const addCalendar = useCalendarListStore((s) => s.addCalendar)
+  const defaultCalendarId = useCalendarListStore((s) => s.defaultCalendarId)
+  const [selectedCalendarId, setSelectedCalendarId] = useState(defaultCalendarId)
+  const createCollection = useEtebaseStore((s) => s.createCollection)
+
+  useEffect(() => {
+    if (calendars.length === 0) return
+    const fallbackId = calendars.some((cal) => cal.id === defaultCalendarId)
+      ? defaultCalendarId
+      : calendars[0]!.id
+    if (!calendars.some((cal) => cal.id === selectedCalendarId)) {
+      setSelectedCalendarId(fallbackId)
+    }
+  }, [calendars, defaultCalendarId, selectedCalendarId])
 
   const handleFiles = useCallback(async (files: File[]) => {
     setError(null)
@@ -128,12 +140,10 @@ export default function CalendarImport({ onImportComplete, heading }: CalendarIm
     }
   }, [events, importEvents, onImportComplete, selectedCalendarId])
 
-  const handleCreateCalendar = useCallback((name: string, color: string) => {
-    addCalendar(name, color)
-    const newCalendars = useCalendarListStore.getState().calendars
-    const created = newCalendars[newCalendars.length - 1]
-    if (created) setSelectedCalendarId(created.id)
-  }, [addCalendar])
+  const handleCreateCalendar = useCallback(async (name: string, color: string) => {
+    const uid = await createCollection('calendar', name, color)
+    if (uid) setSelectedCalendarId(uid)
+  }, [createCollection])
 
   const handleCancel = useCallback(() => {
     setEvents([])

--- a/apps/web/app/components/import/ContactImport.tsx
+++ b/apps/web/app/components/import/ContactImport.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { parseVCard } from '@silentsuite/core/utils/vcard-parser'
 import type { VCard } from '@silentsuite/core/utils/vcard-parser'
@@ -9,6 +9,7 @@ import ImportPreview from './ImportPreview'
 import ImportListSelector from './ImportListSelector'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 
 interface ContactImportProps {
   onImportComplete: (count: number) => void
@@ -64,10 +65,22 @@ export default function ContactImport({ onImportComplete, heading }: ContactImpo
   const [isImporting, setIsImporting] = useState(false)
   const [importedCount, setImportedCount] = useState<number | null>(null)
   const [openAccordion, setOpenAccordion] = useState<string | null>(null)
-  const [selectedListId, setSelectedListId] = useState('default')
   const importContacts = useContactStore((s) => s.importContacts)
   const contactLists = useContactListStore((s) => s.lists)
-  const addList = useContactListStore((s) => s.addList)
+  const activeListId = useContactListStore((s) => s.activeListId)
+  const initialListId = activeListId !== 'all' ? activeListId : 'default'
+  const [selectedListId, setSelectedListId] = useState(initialListId)
+  const createCollection = useEtebaseStore((s) => s.createCollection)
+
+  useEffect(() => {
+    if (contactLists.length === 0) return
+    const fallbackId = activeListId !== 'all' && contactLists.some((list) => list.id === activeListId)
+      ? activeListId
+      : contactLists[0]!.id
+    if (!contactLists.some((list) => list.id === selectedListId)) {
+      setSelectedListId(fallbackId)
+    }
+  }, [activeListId, contactLists, selectedListId])
 
   const handleFiles = useCallback(async (files: File[]) => {
     setError(null)
@@ -141,12 +154,10 @@ export default function ContactImport({ onImportComplete, heading }: ContactImpo
     }
   }, [contacts, importContacts, onImportComplete, selectedListId])
 
-  const handleCreateList = useCallback((name: string, color: string) => {
-    addList(name, color)
-    const newLists = useContactListStore.getState().lists
-    const created = newLists[newLists.length - 1]
-    if (created) setSelectedListId(created.id)
-  }, [addList])
+  const handleCreateList = useCallback(async (name: string, color: string) => {
+    const uid = await createCollection('contacts', name, color)
+    if (uid) setSelectedListId(uid)
+  }, [createCollection])
 
   const handleCancel = useCallback(() => {
     setContacts([])

--- a/apps/web/app/components/import/ImportListSelector.tsx
+++ b/apps/web/app/components/import/ImportListSelector.tsx
@@ -13,7 +13,7 @@ interface ImportListSelectorProps {
   lists: ListItem[]
   selectedId: string
   onSelect: (id: string) => void
-  onCreateNew: (name: string, color: string) => void
+  onCreateNew: (name: string, color: string) => void | Promise<void>
   label: string
 }
 
@@ -36,10 +36,10 @@ export default function ImportListSelector({
     return PRESET_COLORS.find((c) => !usedColors.has(c)) ?? PRESET_COLORS[0]!
   })
 
-  const handleCreate = () => {
+  const handleCreate = async () => {
     const name = newName.trim()
     if (!name) return
-    onCreateNew(name, newColor)
+    await onCreateNew(name, newColor)
     setNewName('')
     setShowCreate(false)
   }

--- a/apps/web/app/components/import/TaskImport.tsx
+++ b/apps/web/app/components/import/TaskImport.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { parseVTodo } from '@silentsuite/core/utils/ical-parser'
 import type { VTodo } from '@silentsuite/core/utils/ical-parser'
@@ -10,6 +10,7 @@ import ImportListSelector from './ImportListSelector'
 import { parseICalDate } from './import-mappers'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import type { Priority } from '@silentsuite/core'
 
 interface TaskImportProps {
@@ -166,10 +167,22 @@ export default function TaskImport({ onImportComplete, heading }: TaskImportProp
   const [isImporting, setIsImporting] = useState(false)
   const [importedCount, setImportedCount] = useState<number | null>(null)
   const [openAccordion, setOpenAccordion] = useState<string | null>(null)
-  const [selectedListId, setSelectedListId] = useState('default')
   const importTasks = useTaskStore((s) => s.importTasks)
   const taskLists = useTaskListStore((s) => s.lists)
-  const addList = useTaskListStore((s) => s.addList)
+  const activeListId = useTaskListStore((s) => s.activeListId)
+  const initialListId = activeListId !== 'all' ? activeListId : 'default'
+  const [selectedListId, setSelectedListId] = useState(initialListId)
+  const createCollection = useEtebaseStore((s) => s.createCollection)
+
+  useEffect(() => {
+    if (taskLists.length === 0) return
+    const fallbackId = activeListId !== 'all' && taskLists.some((list) => list.id === activeListId)
+      ? activeListId
+      : taskLists[0]!.id
+    if (!taskLists.some((list) => list.id === selectedListId)) {
+      setSelectedListId(fallbackId)
+    }
+  }, [activeListId, selectedListId, taskLists])
 
   const handleFiles = useCallback(async (files: File[]) => {
     setError(null)
@@ -220,12 +233,10 @@ export default function TaskImport({ onImportComplete, heading }: TaskImportProp
     }
   }, [tasks, importTasks, onImportComplete, selectedListId])
 
-  const handleCreateList = useCallback((name: string, color: string) => {
-    addList(name, color)
-    const newLists = useTaskListStore.getState().lists
-    const created = newLists[newLists.length - 1]
-    if (created) setSelectedListId(created.id)
-  }, [addList])
+  const handleCreateList = useCallback(async (name: string, color: string) => {
+    const uid = await createCollection('tasks', name, color)
+    if (uid) setSelectedListId(uid)
+  }, [createCollection])
 
   const handleCancel = useCallback(() => {
     setTasks([])

--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -6,6 +6,7 @@ import {
   putItems,
   deleteItem,
   replaceItemsForType,
+  replaceItemsForCollection,
   getCollection,
   putCollection,
   getStoken,
@@ -30,11 +31,11 @@ beforeEach(async () => {
   })
 })
 
-function makeItem(uid: string, type: 'tasks' | 'contacts' | 'calendar' = 'tasks', content = 'CONTENT'): CachedItem {
+function makeItem(uid: string, type: 'tasks' | 'contacts' | 'calendar' = 'tasks', content = 'CONTENT', collectionUid = 'col-1'): CachedItem {
   return {
     itemUid: uid,
     collectionType: type,
-    collectionUid: 'col-1',
+    collectionUid,
     content,
     lastModified: Date.now(),
   }
@@ -110,12 +111,24 @@ describe('data-cache', () => {
       expect(contacts).toHaveLength(1)
       expect(contacts[0]!.itemUid).toBe('c')
     })
+
+    it('replaceItemsForCollection only drops items in that collection', async () => {
+      await putItems([
+        makeItem('a', 'tasks', 'old-a', 'col-a'),
+        makeItem('b', 'tasks', 'old-b', 'col-b'),
+      ])
+      await replaceItemsForCollection('col-a', [makeItem('z', 'tasks', 'fresh', 'col-a')])
+
+      const tasks = await getItemsByType('tasks')
+      expect(tasks.map((item) => item.itemUid).sort()).toEqual(['b', 'z'])
+      expect(tasks.find((item) => item.itemUid === 'b')!.collectionUid).toBe('col-b')
+    })
   })
 
   describe('collections / stokens', () => {
     it('returns null for an unknown collection', async () => {
-      expect(await getCollection('tasks')).toBeNull()
-      expect(await getStoken('tasks')).toBeNull()
+      expect(await getCollection('col-tasks')).toBeNull()
+      expect(await getStoken('col-tasks')).toBeNull()
     })
 
     it('persists a collection record', async () => {
@@ -125,7 +138,7 @@ describe('data-cache', () => {
         stoken: 'stk-1',
         lastFullSyncAt: 12345,
       })
-      const col = await getCollection('tasks')
+      const col = await getCollection('col-tasks')
       expect(col).not.toBeNull()
       expect(col!.stoken).toBe('stk-1')
       expect(col!.collectionUid).toBe('col-tasks')
@@ -133,16 +146,23 @@ describe('data-cache', () => {
 
     it('setStoken creates and updates the cursor', async () => {
       await setStoken('tasks', 'col-tasks', 'stk-a')
-      expect(await getStoken('tasks')).toBe('stk-a')
+      expect(await getStoken('col-tasks')).toBe('stk-a')
       await setStoken('tasks', 'col-tasks', 'stk-b')
-      expect(await getStoken('tasks')).toBe('stk-b')
+      expect(await getStoken('col-tasks')).toBe('stk-b')
+    })
+
+    it('stokens are keyed by collectionUid, not collectionType', async () => {
+      await setStoken('tasks', 'col-a', 'stk-a')
+      await setStoken('tasks', 'col-b', 'stk-b')
+      expect(await getStoken('col-a')).toBe('stk-a')
+      expect(await getStoken('col-b')).toBe('stk-b')
     })
 
     it('clearStoken nulls the stoken but preserves the row', async () => {
       await setStoken('tasks', 'col-tasks', 'stk-a')
-      await clearStoken('tasks')
-      expect(await getStoken('tasks')).toBeNull()
-      const col = await getCollection('tasks')
+      await clearStoken('col-tasks')
+      expect(await getStoken('col-tasks')).toBeNull()
+      const col = await getCollection('col-tasks')
       expect(col).not.toBeNull()
       expect(col!.collectionUid).toBe('col-tasks')
     })
@@ -179,7 +199,7 @@ describe('data-cache', () => {
       expect(ok).toBe(false)
 
       // Cache should be wiped for the new account.
-      expect(await getStoken('tasks')).toBeNull()
+      expect(await getStoken('col-tasks')).toBeNull()
       const meta = await getMeta()
       expect(meta?.accountFingerprint).toBe('bob@example.com')
       expect(meta?.lastInvalidatedAt).not.toBeNull()
@@ -191,7 +211,7 @@ describe('data-cache', () => {
 
       const ok = await ensureFingerprint('alice@example.com')
       expect(ok).toBe(true)
-      expect(await getStoken('tasks')).toBe('stk-a')
+      expect(await getStoken('col-tasks')).toBe('stk-a')
     })
   })
 
@@ -208,7 +228,7 @@ describe('data-cache', () => {
       await clearAll()
 
       expect(await getItemsByType('tasks')).toEqual([])
-      expect(await getStoken('tasks')).toBeNull()
+      expect(await getStoken('col-tasks')).toBeNull()
       expect(await getMeta()).toBeNull()
     })
 

--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -258,6 +258,21 @@ describe('offline-queue', () => {
       expect(all).toHaveLength(2)
     })
 
+    it('does not compact entries in different collections of the same type', async () => {
+      await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: 'col-a', content: 'v1', itemUid: 'uid-1' })
+      await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: 'col-b', content: 'v2', itemUid: 'uid-1' })
+
+      const all = await getAll()
+      expect(all).toHaveLength(2)
+    })
+
+    it('persists collectionUid for replay routing', async () => {
+      await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'cal-b', content: 'ics', tempId: 'temp-1' })
+
+      const all = await getAll()
+      expect(all[0].collectionUid).toBe('cal-b')
+    })
+
     it('does not compact entries with different tempIds', async () => {
       await enqueue({ type: 'create', collectionType: 'tasks', content: 'a', tempId: 'temp-a' })
       await enqueue({ type: 'update', collectionType: 'tasks', content: 'b', tempId: 'temp-b' })

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -51,10 +51,10 @@ export interface CacheMeta {
 }
 
 /** Bumped on shape changes to the cached records. */
-export const CACHE_SCHEMA_VERSION = 1
+export const CACHE_SCHEMA_VERSION = 2
 
 const DB_NAME = 'silentsuite-data-cache'
-const DB_VERSION = 1
+const DB_VERSION = 2
 const STORE_ITEMS = 'items'
 const STORE_COLLECTIONS = 'collections'
 const STORE_META = 'meta'
@@ -71,15 +71,18 @@ function openDB(): Promise<IDBDatabase> {
       return
     }
     const request = indexedDB.open(DB_NAME, DB_VERSION)
-    request.onupgradeneeded = () => {
+    request.onupgradeneeded = (event) => {
       const db = request.result
       if (!db.objectStoreNames.contains(STORE_ITEMS)) {
         const items = db.createObjectStore(STORE_ITEMS, { keyPath: 'itemUid' })
         items.createIndex('byCollectionType', 'collectionType', { unique: false })
         items.createIndex('byCollectionUid', 'collectionUid', { unique: false })
       }
+      if (db.objectStoreNames.contains(STORE_COLLECTIONS) && event.oldVersion < 2) {
+        db.deleteObjectStore(STORE_COLLECTIONS)
+      }
       if (!db.objectStoreNames.contains(STORE_COLLECTIONS)) {
-        db.createObjectStore(STORE_COLLECTIONS, { keyPath: 'collectionType' })
+        db.createObjectStore(STORE_COLLECTIONS, { keyPath: 'collectionUid' })
       }
       if (!db.objectStoreNames.contains(STORE_META)) {
         db.createObjectStore(STORE_META)
@@ -200,11 +203,44 @@ export async function replaceItemsForType(
   }
 }
 
+/**
+ * Replace all cached items for one concrete collection. Other collections of
+ * the same type are intentionally left intact.
+ */
+export async function replaceItemsForCollection(
+  collectionUid: string,
+  items: CachedItem[],
+): Promise<void> {
+  try {
+    const db = await openDB()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_ITEMS, 'readwrite')
+      const store = tx.objectStore(STORE_ITEMS)
+      const idx = store.index('byCollectionUid')
+      const cursorReq = idx.openCursor(collectionUid)
+      cursorReq.onsuccess = () => {
+        const cursor = cursorReq.result
+        if (cursor) {
+          cursor.delete()
+          cursor.continue()
+        } else {
+          for (const item of items) store.put(item)
+        }
+      }
+      cursorReq.onerror = () => reject(cursorReq.error)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch (err) {
+    logger.warn('[data-cache] replaceItemsForCollection failed', err)
+  }
+}
+
 // ── Collections / stokens ──
 
-export async function getCollection(type: CollectionTypeKey): Promise<CachedCollection | null> {
+export async function getCollection(collectionUid: string): Promise<CachedCollection | null> {
   try {
-    const value = await withStore(STORE_COLLECTIONS, 'readonly', (store) => store.get(type))
+    const value = await withStore(STORE_COLLECTIONS, 'readonly', (store) => store.get(collectionUid))
     return (value as CachedCollection | undefined) ?? null
   } catch (err) {
     logger.warn('[data-cache] getCollection failed', err)
@@ -220,8 +256,8 @@ export async function putCollection(record: CachedCollection): Promise<void> {
   }
 }
 
-export async function getStoken(type: CollectionTypeKey): Promise<string | null> {
-  const col = await getCollection(type)
+export async function getStoken(collectionUid: string): Promise<string | null> {
+  const col = await getCollection(collectionUid)
   return col?.stoken ?? null
 }
 
@@ -230,7 +266,7 @@ export async function setStoken(
   collectionUid: string,
   stoken: string | null,
 ): Promise<void> {
-  const existing = await getCollection(type)
+  const existing = await getCollection(collectionUid)
   await putCollection({
     collectionType: type,
     collectionUid,
@@ -243,8 +279,8 @@ export async function setStoken(
  * Mark a collection's stoken as stale (server returned an unknown-stoken error).
  * Caller should fall back to a full refresh.
  */
-export async function clearStoken(type: CollectionTypeKey): Promise<void> {
-  const existing = await getCollection(type)
+export async function clearStoken(collectionUid: string): Promise<void> {
+  const existing = await getCollection(collectionUid)
   if (!existing) return
   await putCollection({ ...existing, stoken: null })
 }

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -12,6 +12,7 @@ export interface QueueEntry {
   id: string
   type: MutationType
   collectionType: CollectionTypeKey
+  collectionUid?: string
   content?: string
   itemUid?: string
   tempId?: string
@@ -97,7 +98,7 @@ async function compact(
   // Match by tempId (for items created offline that haven't synced yet)
   if (incoming.tempId) {
     const existing = pending.find(
-      (e) => e.tempId === incoming.tempId && e.collectionType === incoming.collectionType,
+      (e) => e.tempId === incoming.tempId && e.collectionType === incoming.collectionType && e.collectionUid === incoming.collectionUid,
     )
     if (existing) {
       if (existing.type === 'create' && incoming.type === 'update') {
@@ -116,7 +117,7 @@ async function compact(
   // Match by itemUid (for items that already exist on server)
   if (incoming.itemUid) {
     const existing = pending.find(
-      (e) => e.itemUid === incoming.itemUid && e.collectionType === incoming.collectionType,
+      (e) => e.itemUid === incoming.itemUid && e.collectionType === incoming.collectionType && e.collectionUid === incoming.collectionUid,
     )
     if (existing) {
       if (existing.type === 'update' && incoming.type === 'update') {

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -107,7 +107,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           try {
             const tasks = taskItems.map((it) => {
               const task = core.deserializeTask(it.content)
-              return { ...task, id: it.itemUid, uid: it.itemUid }
+              return { ...task, id: it.itemUid, uid: it.itemUid, listId: it.collectionUid }
             })
             useTaskStore.getState().syncFromRemote(tasks)
             logger.log(`[sync-provider] Hydrated ${tasks.length} tasks from cache`)
@@ -120,7 +120,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           try {
             const contacts = contactItems.map((it) => {
               const contact = core.deserializeContact(it.content)
-              return { ...contact, id: it.itemUid, uid: it.itemUid }
+              return { ...contact, id: it.itemUid, uid: it.itemUid, listId: it.collectionUid }
             })
             useContactStore.getState().syncFromRemote(contacts)
             logger.log(`[sync-provider] Hydrated ${contacts.length} contacts from cache`)
@@ -133,7 +133,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           try {
             const events = eventItems.map((it) => {
               const event = core.deserializeCalendarEvent(it.content)
-              return { ...event, id: it.itemUid, uid: it.itemUid }
+              return { ...event, id: it.itemUid, uid: it.itemUid, calendarId: it.collectionUid }
             })
             useCalendarStore.getState().syncFromRemote(events)
             logger.log(`[sync-provider] Hydrated ${events.length} events from cache`)
@@ -152,15 +152,13 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
       async function mirrorToCache(
         type: 'tasks' | 'contacts' | 'calendar',
-        items: { uid: string; content: string }[],
+        items: { uid: string; content: string; collectionUid: string }[],
       ) {
         if (!cacheEnabled || items.length === 0) return
-        const collectionUid = useEtebaseStore.getState().collections[type]?.uid
-        if (!collectionUid) return
         const records: CachedItem[] = items.map((it) => ({
           itemUid: it.uid,
           collectionType: type,
-          collectionUid,
+          collectionUid: it.collectionUid,
           content: it.content,
           lastModified: Date.now(),
         }))
@@ -180,7 +178,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             const task = deserializeTask(item.content)
             // Override the local id/uid with the Etebase item UID
             // so we can map back to the Etebase item for updates/deletes
-            return { ...task, id: item.uid, uid: item.uid }
+            return { ...task, id: item.uid, uid: item.uid, listId: item.collectionUid }
           })
           useTaskStore.getState().syncFromRemote(tasks)
           logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
@@ -198,7 +196,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           const { deserializeContact } = await import('@silentsuite/core')
           const contacts = contactItems.map((item) => {
             const contact = deserializeContact(item.content)
-            return { ...contact, id: item.uid, uid: item.uid }
+            return { ...contact, id: item.uid, uid: item.uid, listId: item.collectionUid }
           })
           useContactStore.getState().syncFromRemote(contacts)
           logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
@@ -216,7 +214,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           const { deserializeCalendarEvent } = await import('@silentsuite/core')
           const events = eventItems.map((item) => {
             const event = deserializeCalendarEvent(item.content)
-            return { ...event, id: item.uid, uid: item.uid }
+            return { ...event, id: item.uid, uid: item.uid, calendarId: item.collectionUid }
           })
           useCalendarStore.getState().syncFromRemote(events)
           logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
@@ -241,10 +239,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
         if (collectionType === 'etebase.vtodo') {
           try {
-            const taskItems = await refresher('tasks')
+            await refresher('tasks', event.collectionUid)
+            const taskItems = await useEtebaseStore.getState().fetchAllItems('tasks')
             const tasks = taskItems.map((item) => {
               const task = core.deserializeTask(item.content)
-              return { ...task, id: item.uid, uid: item.uid }
+              return { ...task, id: item.uid, uid: item.uid, listId: item.collectionUid }
             })
             useTaskStore.getState().syncFromRemote(tasks)
           } catch (err) {
@@ -253,10 +252,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           }
         } else if (collectionType === 'etebase.vcard') {
           try {
-            const contactItems = await refresher('contacts')
+            await refresher('contacts', event.collectionUid)
+            const contactItems = await useEtebaseStore.getState().fetchAllItems('contacts')
             const contacts = contactItems.map((item) => {
               const contact = core.deserializeContact(item.content)
-              return { ...contact, id: item.uid, uid: item.uid }
+              return { ...contact, id: item.uid, uid: item.uid, listId: item.collectionUid }
             })
             useContactStore.getState().syncFromRemote(contacts)
           } catch (err) {
@@ -265,10 +265,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           }
         } else if (collectionType === 'etebase.vevent') {
           try {
-            const eventItems = await refresher('calendar')
+            await refresher('calendar', event.collectionUid)
+            const eventItems = await useEtebaseStore.getState().fetchAllItems('calendar')
             const events = eventItems.map((item) => {
               const event = core.deserializeCalendarEvent(item.content)
-              return { ...event, id: item.uid, uid: item.uid }
+              return { ...event, id: item.uid, uid: item.uid, calendarId: item.collectionUid }
             })
             useCalendarStore.getState().syncFromRemote(events)
           } catch (err) {

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -29,6 +29,14 @@ interface MockSyncEngine {
   resume: ReturnType<typeof vi.fn>
 }
 
+function mockItem(uid: string, content: string, isDeleted = false) {
+  return {
+    uid,
+    isDeleted,
+    getContent: vi.fn(async () => content),
+  }
+}
+
 function setupStoreWithMocks(itemManager: MockItemManager, syncEngine: MockSyncEngine) {
   const collection = { uid: 'col-1' }
   const account = {
@@ -38,9 +46,28 @@ function setupStoreWithMocks(itemManager: MockItemManager, syncEngine: MockSyncE
   }
   useEtebaseStore.setState({
     account: account as any,
-    collections: { calendar: collection as any, tasks: null, contacts: null },
+    collections: { calendar: [collection as any], tasks: [], contacts: [] },
     itemCache: new Map(),
     itemTypeMap: new Map(),
+    itemCollectionMap: new Map(),
+    isInitialized: true,
+    syncEngine: syncEngine as any,
+  })
+}
+
+function setupStoreWithCollections(itemManagerByUid: Record<string, MockItemManager>, syncEngine: MockSyncEngine) {
+  const collections = [{ uid: 'col-1' }, { uid: 'col-2' }]
+  const account = {
+    getCollectionManager: () => ({
+      getItemManager: (collection: { uid: string }) => itemManagerByUid[collection.uid],
+    }),
+  }
+  useEtebaseStore.setState({
+    account: account as any,
+    collections: { calendar: collections as any[], tasks: [], contacts: [] },
+    itemCache: new Map(),
+    itemTypeMap: new Map(),
+    itemCollectionMap: new Map(),
     isInitialized: true,
     syncEngine: syncEngine as any,
   })
@@ -50,9 +77,10 @@ describe('useEtebaseStore.createItemsBatch', () => {
   beforeEach(() => {
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: null, tasks: null, contacts: null },
+      collections: { calendar: [], tasks: [], contacts: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
       isInitialized: false,
       syncEngine: null,
     })
@@ -95,6 +123,28 @@ describe('useEtebaseStore.createItemsBatch', () => {
 
     expect(syncEngine.pause).toHaveBeenCalledTimes(1)
     expect(syncEngine.resume).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes batch creates to the requested collection uid', async () => {
+    const firstManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: 'wrong' })),
+      batch: vi.fn(async () => {}),
+    }
+    const secondManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: 'right' })),
+      batch: vi.fn(async () => {}),
+    }
+    const syncEngine: MockSyncEngine = { pause: vi.fn(), resume: vi.fn() }
+    setupStoreWithCollections({ 'col-1': firstManager, 'col-2': secondManager }, syncEngine)
+
+    const uids = await useEtebaseStore.getState().createItemsBatch('calendar', [
+      { content: 'a', tempId: 't1' },
+    ], 'col-2')
+
+    expect(firstManager.create).not.toHaveBeenCalled()
+    expect(secondManager.create).toHaveBeenCalledTimes(1)
+    expect(uids).toEqual(['right'])
+    expect(useEtebaseStore.getState().itemCollectionMap.get('right')).toBe('col-2')
   })
 
   it('resumes the sync engine even when the import throws', async () => {
@@ -172,5 +222,100 @@ describe('useEtebaseStore.createItemsBatch', () => {
     expect(itemManager.batch).toHaveBeenCalledTimes(1 + 3)
     expect(uids.slice(0, 20).every((u) => typeof u === 'string')).toBe(true)
     expect(uids.slice(20).every((u) => u === null)).toBe(true)
+  })
+})
+
+describe('useEtebaseStore.refreshCollection', () => {
+  beforeEach(() => {
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: [], tasks: [], contacts: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('refreshes one concrete collection without removing same-type items from others', async () => {
+    const staleItem = mockItem('old-col-1', 'old calendar')
+    const survivorItem = mockItem('keep-col-2', 'other calendar')
+    const freshItem = mockItem('new-col-1', 'fresh calendar')
+    const collections = [{ uid: 'col-1' }, { uid: 'col-2' }]
+    const itemManagers = {
+      'col-1': {
+        list: vi.fn(async () => ({ data: [freshItem], stoken: null, done: true })),
+      },
+      'col-2': {
+        list: vi.fn(async () => ({ data: [], stoken: null, done: true })),
+      },
+    }
+    const account = {
+      getCollectionManager: () => ({
+        fetch: vi.fn(async (uid: string) => ({ uid })),
+        getItemManager: (collection: { uid: keyof typeof itemManagers }) => itemManagers[collection.uid],
+      }),
+    }
+
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: collections as any[], tasks: [], contacts: [] },
+      itemCache: new Map([
+        ['old-col-1', staleItem],
+        ['keep-col-2', survivorItem],
+      ]),
+      itemTypeMap: new Map([
+        ['old-col-1', 'calendar'],
+        ['keep-col-2', 'calendar'],
+      ]),
+      itemCollectionMap: new Map([
+        ['old-col-1', 'col-1'],
+        ['keep-col-2', 'col-2'],
+      ]),
+      isInitialized: true,
+      syncEngine: null,
+    })
+
+    const result = await useEtebaseStore.getState().refreshCollection('calendar', 'col-1')
+    const state = useEtebaseStore.getState()
+
+    expect(result).toEqual([{ uid: 'new-col-1', content: 'fresh calendar', collectionUid: 'col-1' }])
+    expect(state.itemCache.has('old-col-1')).toBe(false)
+    expect(state.itemCache.get('new-col-1')).toBe(freshItem)
+    expect(state.itemCollectionMap.get('new-col-1')).toBe('col-1')
+    expect(state.itemCache.get('keep-col-2')).toBe(survivorItem)
+    expect(state.itemCollectionMap.get('keep-col-2')).toBe('col-2')
+    expect(itemManagers['col-2'].list).not.toHaveBeenCalled()
+  })
+
+  it('preserves and returns existing items when a network refresh fails', async () => {
+    const existingItem = mockItem('existing', 'existing calendar')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const account = {
+      getCollectionManager: () => ({
+        fetch: vi.fn(async () => {
+          throw new Error('network down')
+        }),
+      }),
+    }
+
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [] },
+      itemCache: new Map([['existing', existingItem]]),
+      itemTypeMap: new Map([['existing', 'calendar']]),
+      itemCollectionMap: new Map([['existing', 'col-1']]),
+      isInitialized: true,
+      syncEngine: null,
+    })
+
+    const result = await useEtebaseStore.getState().refreshCollection('calendar')
+    const state = useEtebaseStore.getState()
+
+    expect(result).toEqual([{ uid: 'existing', content: 'existing calendar', collectionUid: 'col-1' }])
+    expect(state.itemCache.get('existing')).toBe(existingItem)
+    expect(state.itemCollectionMap.get('existing')).toBe('col-1')
+    errorSpy.mockRestore()
   })
 })

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -147,6 +147,25 @@ describe('useEtebaseStore.createItemsBatch', () => {
     expect(useEtebaseStore.getState().itemCollectionMap.get('right')).toBe('col-2')
   })
 
+  it('does not fall back to the first collection when the requested collection uid is missing', async () => {
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: 'wrong' })),
+      batch: vi.fn(async () => {}),
+    }
+    const syncEngine: MockSyncEngine = { pause: vi.fn(), resume: vi.fn() }
+    setupStoreWithCollections({ 'col-1': itemManager }, syncEngine)
+
+    const uids = await useEtebaseStore.getState().createItemsBatch('calendar', [
+      { content: 'a', tempId: 't1' },
+    ], 'missing-col')
+
+    expect(uids).toEqual([null])
+    expect(itemManager.create).not.toHaveBeenCalled()
+    expect(itemManager.batch).not.toHaveBeenCalled()
+    expect(syncEngine.pause).not.toHaveBeenCalled()
+    expect(syncEngine.resume).not.toHaveBeenCalled()
+  })
+
   it('resumes the sync engine even when the import throws', async () => {
     const itemManager: MockItemManager = {
       create: vi.fn(async () => {

--- a/apps/web/app/stores/use-calendar-list-store.ts
+++ b/apps/web/app/stores/use-calendar-list-store.ts
@@ -9,7 +9,7 @@ export interface CalendarList {
   visible: boolean
 }
 
-const DEFAULT_COLORS = [
+export const DEFAULT_CALENDAR_COLORS = [
   '#10b981', // emerald
   '#3b82f6', // blue
   '#f59e0b', // amber
@@ -28,6 +28,7 @@ interface CalendarListState {
   updateCalendar: (id: string, updates: Partial<CalendarList>) => void
   toggleVisibility: (id: string) => void
   setDefaultCalendar: (id: string) => void
+  replaceCalendarsFromRemote: (calendars: CalendarList[]) => void
   getNextColor: () => string
 }
 
@@ -86,10 +87,24 @@ export const useCalendarListStore = create<CalendarListState>()(
           set({ defaultCalendarId: id })
         }
       },
+      replaceCalendarsFromRemote: (calendars) => {
+        if (calendars.length === 0) return
+        const current = get()
+        const remoteIds = new Set(calendars.map((calendar) => calendar.id))
+        const currentById = new Map(current.calendars.map((calendar) => [calendar.id, calendar]))
+        const merged = calendars.map((calendar) => ({
+          ...calendar,
+          visible: currentById.get(calendar.id)?.visible ?? calendar.visible,
+        }))
+        set({
+          calendars: merged,
+          defaultCalendarId: remoteIds.has(current.defaultCalendarId) ? current.defaultCalendarId : calendars[0]!.id,
+        })
+      },
       getNextColor: () => {
         const { calendars } = get()
         const usedColors = new Set(calendars.map((c) => c.color))
-        return DEFAULT_COLORS.find((c) => !usedColors.has(c)) || DEFAULT_COLORS[calendars.length % DEFAULT_COLORS.length]
+        return DEFAULT_CALENDAR_COLORS.find((c) => !usedColors.has(c)) || DEFAULT_CALENDAR_COLORS[calendars.length % DEFAULT_CALENDAR_COLORS.length]
       },
     }),
     {

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -7,6 +7,7 @@ import type { RecurrenceScope } from '@/app/(app)/calendar/components/Recurrence
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { showErrorToast } from '@/app/stores/use-toast-store'
+import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 
 type CalendarView = 'week' | 'month'
 
@@ -95,7 +96,7 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
     const { serializeCalendarEvent } = await import('@silentsuite/core')
     const content = serializeCalendarEvent(event)
     if (mode === 'create') {
-      return await etebase.createItem('calendar', content, tempId)
+      return await etebase.createItem('calendar', content, tempId, event.calendarId)
     } else {
       // For updates of offline-created items, enqueue with tempId for compaction
       const itemInCache = etebase.itemCache.has(event.id)
@@ -104,7 +105,7 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
         return event.id
       } else {
         const { enqueue } = await import('@/app/lib/offline-queue')
-        await enqueue({ type: 'update', collectionType: 'calendar', content, tempId: event.id })
+        await enqueue({ type: 'update', collectionType: 'calendar', collectionUid: event.calendarId, content, tempId: event.id })
         return event.id
       }
     }
@@ -116,6 +117,12 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
     }
     return null
   }
+}
+
+function defaultCalendarId(): string {
+  const { calendars, defaultCalendarId } = useCalendarListStore.getState()
+  if (calendars.some((calendar) => calendar.id === defaultCalendarId)) return defaultCalendarId
+  return calendars[0]?.id ?? 'default'
 }
 
 export const useCalendarStore = create<CalendarState & CalendarActions>()((set, get) => ({
@@ -142,7 +149,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
       recurrenceRule: newEvent.recurrenceRule ?? null,
       exceptions: [],
       alarms: newEvent.alarms ?? [],
-      calendarId: newEvent.calendarId ?? 'default',
+      calendarId: newEvent.calendarId ?? defaultCalendarId(),
       timezone: newEvent.timezone,
       created: now,
       updated: now,
@@ -183,6 +190,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
 
   deleteEvent: async (id: string) => {
     if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
+    const eventToDelete = get().events.find((e) => e.id === id)
     // Optimistic update
     set((state) => ({ events: state.events.filter((e) => e.id !== id) }))
 
@@ -198,7 +206,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
           // Non-offline errors are logged and the optimistic removal stands.
           const { isOfflineError, enqueue } = await import('@/app/lib/offline-queue')
           if (isOfflineError(err)) {
-            await enqueue({ type: 'delete', collectionType: 'calendar', itemUid: id })
+            await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id })
           } else {
             showErrorToast('Failed to delete event. Please try again.')
           }
@@ -207,7 +215,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
       } else {
         // Item was created offline — enqueue delete with tempId for compaction
         const { enqueue } = await import('@/app/lib/offline-queue')
-        await enqueue({ type: 'delete', collectionType: 'calendar', tempId: id })
+        await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: eventToDelete?.calendarId, tempId: id })
       }
     }
   },
@@ -386,7 +394,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
             } catch (err) {
               const { isOfflineError, enqueue } = await import('@/app/lib/offline-queue')
               if (isOfflineError(err)) {
-                await enqueue({ type: 'delete', collectionType: 'calendar', itemUid: id })
+                await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id })
               } else {
                 showErrorToast('Failed to delete event. Please try again.')
               }
@@ -394,7 +402,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
             }
           } else {
             const { enqueue } = await import('@/app/lib/offline-queue')
-            await enqueue({ type: 'delete', collectionType: 'calendar', tempId: id })
+            await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: master.calendarId, tempId: id })
           }
         }
         break
@@ -451,7 +459,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
         recurrenceRule: ne.recurrenceRule ?? null,
         exceptions: [],
         alarms: ne.alarms ?? [],
-        calendarId: ne.calendarId ?? 'default',
+        calendarId: ne.calendarId ?? defaultCalendarId(),
         timezone: ne.timezone,
         created: now,
         updated: now,
@@ -470,7 +478,8 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
           content: serializeCalendarEvent(e),
           tempId: e.id,
         }))
-        const uids = await etebase.createItemsBatch('calendar', contents)
+        const targetCollectionUid = events[0]?.calendarId
+        const uids = await etebase.createItemsBatch('calendar', contents, targetCollectionUid)
         // Replace temp IDs with real UIDs
         set((state) => ({
           events: state.events.map((e) => {

--- a/apps/web/app/stores/use-contact-list-store.ts
+++ b/apps/web/app/stores/use-contact-list-store.ts
@@ -9,7 +9,7 @@ export interface ContactList {
   visible: boolean
 }
 
-const DEFAULT_COLORS = [
+export const DEFAULT_CONTACT_LIST_COLORS = [
   '#8b5cf6', // violet
   '#10b981', // emerald
   '#3b82f6', // blue
@@ -28,6 +28,7 @@ interface ContactListState {
   updateList: (id: string, updates: Partial<ContactList>) => void
   setActiveList: (id: string) => void
   toggleVisibility: (id: string) => void
+  replaceListsFromRemote: (lists: ContactList[]) => void
   getNextColor: () => string
 }
 
@@ -86,10 +87,25 @@ export const useContactListStore = create<ContactListState>()(
         }))
       },
 
+      replaceListsFromRemote: (lists) => {
+        if (lists.length === 0) return
+        const current = get()
+        const remoteIds = new Set(lists.map((list) => list.id))
+        const currentById = new Map(current.lists.map((list) => [list.id, list]))
+        const merged = lists.map((list) => ({
+          ...list,
+          visible: currentById.get(list.id)?.visible ?? list.visible,
+        }))
+        set({
+          lists: merged,
+          activeListId: current.activeListId === 'all' || remoteIds.has(current.activeListId) ? current.activeListId : lists[0]!.id,
+        })
+      },
+
       getNextColor: () => {
         const { lists } = get()
         const usedColors = new Set(lists.map((l) => l.color))
-        return DEFAULT_COLORS.find((c) => !usedColors.has(c)) || DEFAULT_COLORS[lists.length % DEFAULT_COLORS.length]
+        return DEFAULT_CONTACT_LIST_COLORS.find((c) => !usedColors.has(c)) || DEFAULT_CONTACT_LIST_COLORS[lists.length % DEFAULT_CONTACT_LIST_COLORS.length]
       },
     }),
     {

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -6,6 +6,7 @@ import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
 import { showErrorToast } from '@/app/stores/use-toast-store'
+import { useContactListStore } from '@/app/stores/use-contact-list-store'
 
 interface NewContact {
   displayName: string
@@ -37,6 +38,12 @@ interface ContactActions {
   syncFromRemote: (contacts: Contact[]) => void
 }
 
+function defaultContactListId(): string | undefined {
+  const { lists, activeListId } = useContactListStore.getState()
+  if (activeListId !== 'all' && lists.some((list) => list.id === activeListId)) return activeListId
+  return lists[0]?.id
+}
+
 export const useContactStore = create<ContactState & ContactActions>()(
     (set, get) => ({
       contacts: [],
@@ -66,7 +73,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
           notes: newContact.notes ?? '',
           birthday: newContact.birthday ?? null,
           photoUrl: newContact.photoUrl ?? null,
-          listId: newContact.listId,
+          listId: newContact.listId ?? defaultContactListId(),
           created_at: now,
           updated_at: now,
         }
@@ -80,7 +87,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
           try {
             const { serializeContact } = await import('@silentsuite/core')
             const content = serializeContact(contact)
-            const itemUid = await etebase.createItem('contacts', content, tempId)
+            const itemUid = await etebase.createItem('contacts', content, tempId, contact.listId)
             if (itemUid) {
               set((state) => ({
                 contacts: state.contacts.map((c) =>
@@ -125,13 +132,14 @@ export const useContactStore = create<ContactState & ContactActions>()(
           } else {
             const { serializeContact } = await import('@silentsuite/core')
             const content = serializeContact(updated)
-            await enqueue({ type: 'update', collectionType: 'contacts', content, tempId: id })
+            await enqueue({ type: 'update', collectionType: 'contacts', collectionUid: updated.listId, content, tempId: id })
           }
         }
       },
 
       deleteContact: async (id: string) => {
         if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
+        const contactToDelete = get().contacts.find((c) => c.id === id)
         set((state) => ({ contacts: state.contacts.filter((c) => c.id !== id) }))
 
         // Sync to Etebase
@@ -147,7 +155,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
             }
           } else {
             // Item was created offline and not yet synced — enqueue delete with tempId for compaction
-            await enqueue({ type: 'delete', collectionType: 'contacts', tempId: id })
+            await enqueue({ type: 'delete', collectionType: 'contacts', collectionUid: contactToDelete?.listId, tempId: id })
           }
         }
       },
@@ -179,7 +187,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
             notes: nc.notes ?? '',
             birthday: nc.birthday ?? null,
             photoUrl: nc.photoUrl ?? null,
-            listId: nc.listId,
+            listId: nc.listId ?? defaultContactListId(),
             created_at: now,
             updated_at: now,
           }
@@ -197,7 +205,8 @@ export const useContactStore = create<ContactState & ContactActions>()(
               content: serializeContact(c),
               tempId: c.id,
             }))
-            const uids = await etebase.createItemsBatch('contacts', contents)
+            const targetCollectionUid = contacts[0]?.listId
+            const uids = await etebase.createItemsBatch('contacts', contents, targetCollectionUid)
             set((state) => ({
               contacts: state.contacts.map((c) => {
                 const idx = contacts.findIndex((contact) => contact.id === c.id)

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -114,6 +114,8 @@ function resolveCollection(
   if (collectionUid && collectionUid !== 'default' && collectionUid !== 'all') {
     const match = typedCollections.find((collection) => collection.uid === collectionUid)
     if (match) return match
+    logger.warn(`[etebase-store] Unknown ${type} collection ${collectionUid}`)
+    return null
   }
   return typedCollections[0] ?? null
 }

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -17,10 +17,9 @@ import {
   putItems as cachePutItems,
   putItem as cachePutItem,
   deleteItem as cacheDeleteItem,
-  replaceItemsForType as cacheReplaceItemsForType,
+  replaceItemsForCollection as cacheReplaceItemsForCollection,
   isCacheEnabled as isLocalCacheEnabled,
   type CachedItem,
-  type CollectionTypeKey as CacheCollectionTypeKey,
 } from '@/app/lib/data-cache'
 
 /**
@@ -69,11 +68,19 @@ const COLLECTION_TYPE_CONTACTS = 'etebase.vcard'
 
 type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts'
 
+type CachedContentItem = { uid: string; content: string; collectionUid: string }
+
 function collectionTypeToKey(ct: string): CollectionTypeKey | null {
   if (ct === COLLECTION_TYPE_CALENDAR) return 'calendar'
   if (ct === COLLECTION_TYPE_TASKS) return 'tasks'
   if (ct === COLLECTION_TYPE_CONTACTS) return 'contacts'
   return null
+}
+
+function keyToCollectionType(type: CollectionTypeKey): string {
+  if (type === 'calendar') return COLLECTION_TYPE_CALENDAR
+  if (type === 'tasks') return COLLECTION_TYPE_TASKS
+  return COLLECTION_TYPE_CONTACTS
 }
 
 /**
@@ -98,15 +105,80 @@ async function writeItemToCache(
   await cachePutItem(record)
 }
 
+function resolveCollection(
+  collections: Record<CollectionTypeKey, any[]>,
+  type: CollectionTypeKey,
+  collectionUid?: string,
+): any | null {
+  const typedCollections = collections[type] ?? []
+  if (collectionUid && collectionUid !== 'default' && collectionUid !== 'all') {
+    const match = typedCollections.find((collection) => collection.uid === collectionUid)
+    if (match) return match
+  }
+  return typedCollections[0] ?? null
+}
+
+function getCollectionName(collection: any, fallback: string): string {
+  try {
+    const meta = collection?.getMeta?.()
+    return meta?.name || fallback
+  } catch {
+    return fallback
+  }
+}
+
+function getCollectionColor(collection: any): string | undefined {
+  try {
+    return collection?.getMeta?.()?.color
+  } catch {
+    return undefined
+  }
+}
+
+async function hydrateListStores(collections: Record<CollectionTypeKey, any[]>): Promise<void> {
+  const [calendarListStore, taskListStore, contactListStore] = await Promise.all([
+    import('@/app/stores/use-calendar-list-store'),
+    import('@/app/stores/use-task-list-store'),
+    import('@/app/stores/use-contact-list-store'),
+  ])
+
+  calendarListStore.useCalendarListStore.getState().replaceCalendarsFromRemote(
+    collections.calendar.map((collection, index) => ({
+      id: collection.uid,
+      name: getCollectionName(collection, index === 0 ? 'Personal' : `Calendar ${index + 1}`),
+      color: getCollectionColor(collection) || calendarListStore.DEFAULT_CALENDAR_COLORS[index % calendarListStore.DEFAULT_CALENDAR_COLORS.length],
+      visible: true,
+    })),
+  )
+  taskListStore.useTaskListStore.getState().replaceListsFromRemote(
+    collections.tasks.map((collection, index) => ({
+      id: collection.uid,
+      name: getCollectionName(collection, index === 0 ? 'My Tasks' : `Task List ${index + 1}`),
+      color: getCollectionColor(collection) || taskListStore.DEFAULT_TASK_LIST_COLORS[index % taskListStore.DEFAULT_TASK_LIST_COLORS.length],
+      visible: true,
+    })),
+  )
+  contactListStore.useContactListStore.getState().replaceListsFromRemote(
+    collections.contacts.map((collection, index) => ({
+      id: collection.uid,
+      name: getCollectionName(collection, index === 0 ? 'My Contacts' : `Contacts ${index + 1}`),
+      color: getCollectionColor(collection) || contactListStore.DEFAULT_CONTACT_LIST_COLORS[index % contactListStore.DEFAULT_CONTACT_LIST_COLORS.length],
+      visible: true,
+    })),
+  )
+}
+
 interface EtebaseState {
   // The live Account object (null until session restored)
   account: any | null
-  // Collection references keyed by type
-  collections: Record<CollectionTypeKey, any | null>
+  // Collection references keyed by type; each type may have multiple collections.
+  collections: Record<CollectionTypeKey, any[]>
   // Item cache: itemUid -> Etebase.Item (needed for update/delete which require the Item object)
   itemCache: Map<string, any>
   // Tracks which collection type each item belongs to
   itemTypeMap: Map<string, CollectionTypeKey>
+  // Tracks the concrete collection UID each item belongs to for update/delete routing
+  itemCollectionMap: Map<string, string>
   // Whether initial data load from server is complete
   isInitialized: boolean
   // SyncEngine reference
@@ -125,13 +197,23 @@ interface EtebaseActions {
    * Returns the item UID.
    * @param tempId - optional temp ID from the domain store, used for offline queue mapping
    */
-  createItem: (type: CollectionTypeKey, content: string, tempId?: string) => Promise<string | null>
+  createItem: (type: CollectionTypeKey, content: string, tempId?: string, collectionUid?: string) => Promise<string | null>
+
+  /**
+   * Create a new Etebase collection for the given type.
+   */
+  createCollection: (type: CollectionTypeKey, name: string, color?: string) => Promise<string | null>
+
+  /**
+   * Delete an Etebase collection and remove its cached items locally.
+   */
+  deleteCollection: (type: CollectionTypeKey, collectionUid: string) => Promise<void>
 
   /**
    * Create multiple items in a single batch upload.
    * Returns an array of item UIDs (null for any that failed).
    */
-  createItemsBatch: (type: CollectionTypeKey, contents: { content: string; tempId: string }[]) => Promise<(string | null)[]>
+  createItemsBatch: (type: CollectionTypeKey, contents: { content: string; tempId: string }[], collectionUid?: string) => Promise<(string | null)[]>
 
   /**
    * Update an existing item by UID.
@@ -146,14 +228,14 @@ interface EtebaseActions {
   /**
    * Fetch all items from the local cache for a collection type.
    */
-  fetchAllItems: (type: CollectionTypeKey) => Promise<{ uid: string; content: string }[]>
+  fetchAllItems: (type: CollectionTypeKey) => Promise<CachedContentItem[]>
 
   /**
    * Re-fetch all items from the Etebase server for a collection type.
    * Updates the local cache and returns fresh content.
    * This is what the sync change handler should call.
    */
-  refreshCollection: (type: CollectionTypeKey) => Promise<{ uid: string; content: string }[]>
+  refreshCollection: (type: CollectionTypeKey, collectionUid?: string) => Promise<CachedContentItem[]>
 
   /**
    * Clean up on logout -- stop sync engine, clear all state.
@@ -174,9 +256,10 @@ interface EtebaseActions {
 
 export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) => ({
   account: null,
-  collections: { calendar: null, tasks: null, contacts: null },
+  collections: { calendar: [], tasks: [], contacts: [] },
   itemCache: new Map(),
   itemTypeMap: new Map(),
+  itemCollectionMap: new Map(),
   isInitialized: false,
   syncEngine: null,
 
@@ -212,10 +295,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       }
 
       // 2. Ensure collections exist (create if first login, fetch if returning)
-      const collections: Record<CollectionTypeKey, any> = {
-        calendar: null,
-        tasks: null,
-        contacts: null,
+      const collections: Record<CollectionTypeKey, any[]> = {
+        calendar: [],
+        tasks: [],
+        contacts: [],
       }
 
       const typeMap: [CollectionTypeKey, string, string][] = [
@@ -227,41 +310,46 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       for (const [key, colType, defaultName] of typeMap) {
         const existing = await core.listCollections(account, colType)
         if (existing.length > 0) {
-          collections[key] = existing[0]
-          logger.debug(`[etebase-store] Found existing ${key} collection: ${existing[0].uid}`)
+          collections[key] = existing
+          logger.debug(`[etebase-store] Found ${existing.length} existing ${key} collection(s)`)
         } else {
-          collections[key] = await core.createCollection(account, colType, { name: defaultName })
-          logger.debug(`[etebase-store] Created ${key} collection: ${collections[key].uid}`)
+          const created = await core.createCollection(account, colType, { name: defaultName })
+          collections[key] = [created]
+          logger.debug(`[etebase-store] Created ${key} collection: ${created.uid}`)
         }
       }
 
       set({ collections })
+      await hydrateListStores(collections)
 
       // 3. Load all items from each collection into the cache
       const itemCache = new Map<string, any>()
       const itemTypeMap = new Map<string, CollectionTypeKey>()
+      const itemCollectionMap = new Map<string, string>()
 
       for (const [key] of typeMap) {
-        const collection = collections[key]
-        if (!collection) continue
+        const typedCollections = collections[key]
 
-        let stoken: string | null = null
-        let done = false
+        for (const collection of typedCollections) {
+          let stoken: string | null = null
+          let done = false
 
-        while (!done) {
-          const response = await core.listItems(account, collection, stoken)
-          for (const item of response.items) {
-            if (!item.isDeleted) {
-              itemCache.set(item.uid, item)
-              itemTypeMap.set(item.uid, key)
+          while (!done) {
+            const response = await core.listItems(account, collection, stoken)
+            for (const item of response.items) {
+              if (!item.isDeleted) {
+                itemCache.set(item.uid, item)
+                itemTypeMap.set(item.uid, key)
+                itemCollectionMap.set(item.uid, collection.uid)
+              }
             }
+            stoken = response.stoken
+            done = response.done
           }
-          stoken = response.stoken
-          done = response.done
         }
       }
 
-      set({ itemCache, itemTypeMap })
+      set({ itemCache, itemTypeMap, itemCollectionMap })
       logger.debug(`[etebase-store] Loaded ${itemCache.size} items into cache`)
 
       // 4. Start SyncEngine
@@ -272,8 +360,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
       // Track all collections
       for (const [key, colType] of typeMap) {
-        const collection = collections[key]
-        if (collection) {
+        for (const collection of collections[key]) {
           engine.trackCollection(colType as CollectionType, collection.uid)
         }
       }
@@ -282,17 +369,17 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       // pulls only deltas instead of refetching the whole vault. Wire the
       // advance handler so subsequent stoken updates are persisted too.
       if (cacheEnabled) {
-        for (const [key, colType] of typeMap) {
-          const collection = collections[key]
-          if (!collection) continue
-          try {
-            const stoken = await cacheGetStoken(key as CacheCollectionTypeKey)
-            if (stoken) {
-              engine.setStoken(collection.uid, stoken)
-              logger.debug(`[etebase-store] Seeded ${key} stoken from cache`)
+        for (const [key] of typeMap) {
+          for (const collection of collections[key]) {
+            try {
+              const stoken = await cacheGetStoken(collection.uid)
+              if (stoken) {
+                engine.setStoken(collection.uid, stoken)
+                logger.debug(`[etebase-store] Seeded ${key} stoken from cache`)
+              }
+            } catch (err) {
+              logger.warn(`[etebase-store] Failed to seed ${key} stoken`, err)
             }
-          } catch (err) {
-            logger.warn(`[etebase-store] Failed to seed ${key} stoken`, err)
           }
         }
 
@@ -318,9 +405,83 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     }
   },
 
-  createItem: async (type: CollectionTypeKey, content: string, tempId?: string) => {
+  createCollection: async (type: CollectionTypeKey, name: string, color?: string) => {
+    const { account, collections, syncEngine } = get()
+    if (!account) {
+      logger.warn('[etebase-store] Cannot create collection: no account')
+      return null
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      const colType = keyToCollectionType(type)
+      const collection = await core.createCollection(account, colType, { name, color })
+      const newCollections = {
+        ...collections,
+        [type]: [...collections[type], collection],
+      }
+      syncEngine?.trackCollection(colType as CollectionType, collection.uid)
+      set({ collections: newCollections })
+      await hydrateListStores(newCollections)
+      return collection.uid
+    } catch (err) {
+      console.error(`[etebase-store] Failed to create ${type} collection:`, err)
+      showErrorToast(`Failed to create ${type === 'calendar' ? 'calendar' : type === 'tasks' ? 'task list' : 'address book'}. Please try again.`)
+      return null
+    }
+  },
+
+  deleteCollection: async (type: CollectionTypeKey, collectionUid: string) => {
+    const { account, collections, syncEngine } = get()
+    const collection = resolveCollection(collections, type, collectionUid)
+    if (!account || !collection) {
+      logger.warn(`[etebase-store] Cannot delete ${type} collection ${collectionUid}: missing account or collection`)
+      return
+    }
+    if (collections[type].length <= 1) {
+      showErrorToast(`Create another ${type === 'calendar' ? 'calendar' : type === 'tasks' ? 'task list' : 'address book'} before deleting this one.`)
+      return
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      await core.deleteCollection(account, collection)
+
+      const newItemCache = new Map(get().itemCache)
+      const newItemTypeMap = new Map(get().itemTypeMap)
+      const newItemCollectionMap = new Map(get().itemCollectionMap)
+      for (const [uid, mappedCollectionUid] of newItemCollectionMap.entries()) {
+        if (mappedCollectionUid === collection.uid) {
+          newItemCache.delete(uid)
+          newItemTypeMap.delete(uid)
+          newItemCollectionMap.delete(uid)
+        }
+      }
+
+      const newCollections = {
+        ...get().collections,
+        [type]: get().collections[type].filter((existing) => existing.uid !== collection.uid),
+      }
+      syncEngine?.untrackCollection(collection.uid)
+      set({
+        collections: newCollections,
+        itemCache: newItemCache,
+        itemTypeMap: newItemTypeMap,
+        itemCollectionMap: newItemCollectionMap,
+      })
+      if (isLocalCacheEnabled()) {
+        void cacheReplaceItemsForCollection(collection.uid, [])
+      }
+      await hydrateListStores(newCollections)
+    } catch (err) {
+      console.error(`[etebase-store] Failed to delete ${type} collection ${collectionUid}:`, err)
+      showErrorToast(`Failed to delete ${type === 'calendar' ? 'calendar' : type === 'tasks' ? 'task list' : 'address book'}. Please try again.`)
+    }
+  },
+
+  createItem: async (type: CollectionTypeKey, content: string, tempId?: string, collectionUid?: string) => {
     const { account, collections } = get()
-    const collection = collections[type]
+    const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot create item: no account or ${type} collection`)
       return null
@@ -332,9 +493,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       // Cache the item for future update/delete
       const itemCache = new Map(get().itemCache)
       const itemTypeMap = new Map(get().itemTypeMap)
+      const itemCollectionMap = new Map(get().itemCollectionMap)
       itemCache.set(item.uid, item)
       itemTypeMap.set(item.uid, type)
-      set({ itemCache, itemTypeMap })
+      itemCollectionMap.set(item.uid, collection.uid)
+      set({ itemCache, itemTypeMap, itemCollectionMap })
       // Write through to the local persistence cache so a reload paints it.
       void writeItemToCache(type, collection.uid, item.uid, content)
       return item.uid
@@ -343,7 +506,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const queueTempId = tempId ?? `pending-${Date.now()}`
         logger.warn(`[etebase-store] Offline — queuing create for ${type} (tempId: ${queueTempId})`)
         try {
-          await enqueue({ type: 'create', collectionType: type, content, tempId: queueTempId })
+          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId })
         } catch (queueErr) {
           console.error(`[etebase-store] Failed to enqueue create:`, queueErr)
         }
@@ -355,9 +518,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     }
   },
 
-  createItemsBatch: async (type: CollectionTypeKey, contents: { content: string; tempId: string }[]) => {
+  createItemsBatch: async (type: CollectionTypeKey, contents: { content: string; tempId: string }[], collectionUid?: string) => {
     const { account, collections } = get()
-    const collection = collections[type]
+    const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot create items: no account or ${type} collection`)
       return contents.map(() => null)
@@ -432,6 +595,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       // lastSuccessfulItemIndex never got an ack, so we can't claim them.
       const itemCache = new Map(get().itemCache)
       const itemTypeMap = new Map(get().itemTypeMap)
+      const itemCollectionMap = new Map(get().itemCollectionMap)
       const uids: (string | null)[] = []
       const cachedRecords: CachedItem[] = []
       for (let i = 0; i < items.length; i++) {
@@ -439,6 +603,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           const item = items[i]
           itemCache.set(item.uid, item)
           itemTypeMap.set(item.uid, type)
+          itemCollectionMap.set(item.uid, collection.uid)
           uids.push(item.uid)
           const original = contents[i]
           if (original) {
@@ -454,7 +619,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           uids.push(null)
         }
       }
-      set({ itemCache, itemTypeMap })
+      set({ itemCache, itemTypeMap, itemCollectionMap })
       if (isLocalCacheEnabled() && cachedRecords.length > 0) {
         void cachePutItems(cachedRecords)
       }
@@ -477,7 +642,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         logger.warn(`[etebase-store] Offline — queuing ${contents.length} creates for ${type}`)
         for (const { content, tempId } of contents) {
           try {
-            await enqueue({ type: 'create', collectionType: type, content, tempId })
+            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId })
           } catch (queueErr) {
             console.error(`[etebase-store] Failed to enqueue create:`, queueErr)
           }
@@ -493,8 +658,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   updateItem: async (type: CollectionTypeKey, itemUid: string, content: string) => {
-    const { account, collections, itemCache } = get()
-    const collection = collections[type]
+    const { account, collections, itemCache, itemCollectionMap } = get()
+    const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
     if (!account || !collection || !item) {
       logger.warn(`[etebase-store] Cannot update item ${itemUid}: missing account, collection, or item`)
@@ -512,7 +677,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'update', collectionType: type, content, itemUid })
+          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid })
         } catch (queueErr) {
           console.error(`[etebase-store] Failed to enqueue update:`, queueErr)
         }
@@ -524,8 +689,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   deleteItem: async (type: CollectionTypeKey, itemUid: string) => {
-    const { account, collections, itemCache } = get()
-    const collection = collections[type]
+    const { account, collections, itemCache, itemCollectionMap } = get()
+    const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
     if (!account || !collection || !item) {
       logger.warn(`[etebase-store] Cannot delete item ${itemUid}: missing account, collection, or item`)
@@ -537,9 +702,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       await core.deleteItem(account, collection, item)
       const newCache = new Map(get().itemCache)
       const newTypeMap = new Map(get().itemTypeMap)
+      const newCollectionMap = new Map(get().itemCollectionMap)
       newCache.delete(itemUid)
       newTypeMap.delete(itemUid)
-      set({ itemCache: newCache, itemTypeMap: newTypeMap })
+      newCollectionMap.delete(itemUid)
+      set({ itemCache: newCache, itemTypeMap: newTypeMap, itemCollectionMap: newCollectionMap })
       if (isLocalCacheEnabled()) {
         void cacheDeleteItem(itemUid)
       }
@@ -547,7 +714,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing delete for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'delete', collectionType: type, itemUid })
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid })
         } catch (queueErr) {
           console.error(`[etebase-store] Failed to enqueue delete:`, queueErr)
         }
@@ -559,15 +726,16 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   fetchAllItems: async (type: CollectionTypeKey) => {
-    const { itemCache, itemTypeMap } = get()
-    const results: { uid: string; content: string }[] = []
+    const { itemCache, itemTypeMap, itemCollectionMap } = get()
+    const results: CachedContentItem[] = []
 
     for (const [uid, item] of itemCache.entries()) {
       if (itemTypeMap.get(uid) !== type) continue
       try {
         const content = await item.getContent()
         const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
-        results.push({ uid, content: contentStr })
+        const collectionUid = itemCollectionMap.get(uid)
+        if (collectionUid) results.push({ uid, content: contentStr, collectionUid })
       } catch {
         // Skip items that fail to decode
       }
@@ -576,79 +744,100 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     return results
   },
 
-  refreshCollection: async (type: CollectionTypeKey) => {
+  refreshCollection: async (type: CollectionTypeKey, collectionUid?: string) => {
     const { account, collections } = get()
-    const collection = collections[type]
-    if (!account || !collection) return []
+    const targetCollections = collectionUid
+      ? [resolveCollection(collections, type, collectionUid)].filter(Boolean)
+      : collections[type]
+    if (!account || targetCollections.length === 0) return []
 
     try {
-      const core = await import('@silentsuite/core')
-
-      // Fetch fresh collection reference from server
       const colManager = account.getCollectionManager()
-      const freshCollection = await colManager.fetch(collection.uid)
+      const refreshed: { collection: any; items: { item: any; content: string }[] }[] = []
+      const allResults: CachedContentItem[] = []
 
-      // Fetch ALL items (no stoken = full fetch)
-      const itemManager = colManager.getItemManager(freshCollection)
-      const newItemCache = new Map(get().itemCache)
-      const newItemTypeMap = new Map(get().itemTypeMap)
-      const results: { uid: string; content: string }[] = []
+      for (const collection of targetCollections) {
+        // Fetch fresh collection reference from server
+        const freshCollection = await colManager.fetch(collection.uid)
 
-      // Remove old items of this type from cache
-      const uidsToRemove: string[] = []
-      for (const [uid, itemType] of newItemTypeMap.entries()) {
-        if (itemType === type) uidsToRemove.push(uid)
-      }
-      for (const uid of uidsToRemove) {
-        newItemCache.delete(uid)
-        newItemTypeMap.delete(uid)
-      }
+        // Fetch ALL items (no stoken = full fetch)
+        const itemManager = colManager.getItemManager(freshCollection)
+        const collectionItems: { item: any; content: string }[] = []
 
-      // Paginate through all items
-      let stoken: string | undefined = undefined
-      let done = false
-      while (!done) {
-        const response: { data: any[]; stoken: string | null; done: boolean } = await itemManager.list({ stoken })
-        for (const item of response.data) {
-          if (!item.isDeleted) {
-            newItemCache.set(item.uid, item)
-            newItemTypeMap.set(item.uid, type)
-            try {
-              const content = await item.getContent()
-              const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
-              results.push({ uid: item.uid, content: contentStr })
-            } catch {
-              // Skip items that fail to decode
+        // Paginate through all items
+        let stoken: string | undefined = undefined
+        let done = false
+        while (!done) {
+          const response: { data: any[]; stoken: string | null; done: boolean } = await itemManager.list({ stoken })
+          for (const item of response.data) {
+            if (!item.isDeleted) {
+              try {
+                const content = await item.getContent()
+                const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
+                collectionItems.push({ item, content: contentStr })
+                allResults.push({ uid: item.uid, content: contentStr, collectionUid: freshCollection.uid })
+              } catch {
+                // Skip items that fail to decode
+              }
             }
           }
+          stoken = response.stoken || undefined
+          done = response.done
         }
-        stoken = response.stoken || undefined
-        done = response.done
+
+        refreshed.push({ collection: freshCollection, items: collectionItems })
       }
 
-      // Update collection reference too (in case it changed)
+      const refreshedUids = new Set(refreshed.map((entry) => entry.collection.uid))
+      const newItemCache = new Map(get().itemCache)
+      const newItemTypeMap = new Map(get().itemTypeMap)
+      const newItemCollectionMap = new Map(get().itemCollectionMap)
+
+      // Remove old items for the refreshed concrete collections only.
+      for (const [uid, mappedCollectionUid] of newItemCollectionMap.entries()) {
+        if (refreshedUids.has(mappedCollectionUid)) {
+          newItemCache.delete(uid)
+          newItemTypeMap.delete(uid)
+          newItemCollectionMap.delete(uid)
+        }
+      }
+
+      for (const { collection, items } of refreshed) {
+        for (const { item } of items) {
+          newItemCache.set(item.uid, item)
+          newItemTypeMap.set(item.uid, type)
+          newItemCollectionMap.set(item.uid, collection.uid)
+        }
+      }
+
+      // Update collection references too (in case metadata changed).
+      const refreshedByUid = new Map(refreshed.map((entry) => [entry.collection.uid, entry.collection]))
       const newCollections = { ...get().collections }
-      newCollections[type] = freshCollection
-      set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, collections: newCollections })
+      newCollections[type] = newCollections[type].map((collection) =>
+        refreshedByUid.get(collection.uid) ?? collection,
+      )
+      set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, itemCollectionMap: newItemCollectionMap, collections: newCollections })
 
-      // Mirror the refresh into the local cache. Use replace-style write so
+      // Mirror the refresh into the local cache. Use replace-style writes so
       // items deleted upstream are also dropped from disk.
-      if (isLocalCacheEnabled()) {
-        const cached: CachedItem[] = results.map((r) => ({
-          itemUid: r.uid,
-          collectionType: type,
-          collectionUid: freshCollection.uid,
-          content: r.content,
-          lastModified: Date.now(),
-        }))
-        void cacheReplaceItemsForType(type, cached)
+      for (const { collection, items } of refreshed) {
+        if (isLocalCacheEnabled()) {
+          const cached: CachedItem[] = items.map(({ item, content }) => ({
+            itemUid: item.uid,
+            collectionType: type,
+            collectionUid: collection.uid,
+            content,
+            lastModified: Date.now(),
+          }))
+          void cacheReplaceItemsForCollection(collection.uid, cached)
+        }
       }
 
-      logger.debug(`[etebase-store] Refreshed ${type}: ${results.length} items`)
-      return results
+      logger.debug(`[etebase-store] Refreshed ${type}: ${allResults.length} items`)
+      return allResults
     } catch (err) {
       console.error(`[etebase-store] Failed to refresh ${type}:`, err)
-      return []
+      return get().fetchAllItems(type)
     }
   },
 
@@ -659,9 +848,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     }
     set({
       account: null,
-      collections: { calendar: null, tasks: null, contacts: null },
+      collections: { calendar: [], tasks: [], contacts: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
       isInitialized: false,
       syncEngine: null,
     })

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -104,7 +104,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       try {
         switch (entry.type) {
           case 'create': {
-            const uid = await etebase.createItem(entry.collectionType, entry.content!)
+            const uid = await etebase.createItem(entry.collectionType, entry.content!, entry.tempId, entry.collectionUid)
             return { itemUid: uid ?? undefined }
           }
           case 'update': {
@@ -128,7 +128,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
             `[sync-store] Conflict on ${entry.type} ${entry.collectionType}/${entry.itemUid} — discarding local change (server wins)`,
           )
           // Refresh the collection to get server's version
-          await etebase.refreshCollection(entry.collectionType)
+          await etebase.refreshCollection(entry.collectionType, entry.collectionUid)
           // Return success so the entry is removed from queue
           return {}
         }
@@ -195,7 +195,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         }
       }
 
-      // Then refresh all three collections from the server
+      // Then refresh every collection of each type from the server
       const [taskItems, contactItems, eventItems] = await Promise.all([
         etebase.refreshCollection('tasks'),
         etebase.refreshCollection('contacts'),
@@ -207,29 +207,23 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       const { useContactStore } = await import('@/app/stores/use-contact-store')
       const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
 
-      if (taskItems.length > 0) {
-        const tasks = taskItems.map((item) => {
-          const task = core.deserializeTask(item.content)
-          return { ...task, id: item.uid, uid: item.uid }
-        })
-        useTaskStore.getState().syncFromRemote(tasks)
-      }
+      const tasks = taskItems.map((item) => {
+        const task = core.deserializeTask(item.content)
+        return { ...task, id: item.uid, uid: item.uid, listId: item.collectionUid }
+      })
+      useTaskStore.getState().syncFromRemote(tasks)
 
-      if (contactItems.length > 0) {
-        const contacts = contactItems.map((item) => {
-          const contact = core.deserializeContact(item.content)
-          return { ...contact, id: item.uid, uid: item.uid }
-        })
-        useContactStore.getState().syncFromRemote(contacts)
-      }
+      const contacts = contactItems.map((item) => {
+        const contact = core.deserializeContact(item.content)
+        return { ...contact, id: item.uid, uid: item.uid, listId: item.collectionUid }
+      })
+      useContactStore.getState().syncFromRemote(contacts)
 
-      if (eventItems.length > 0) {
-        const events = eventItems.map((item) => {
-          const event = core.deserializeCalendarEvent(item.content)
-          return { ...event, id: item.uid, uid: item.uid }
-        })
-        useCalendarStore.getState().syncFromRemote(events)
-      }
+      const events = eventItems.map((item) => {
+        const event = core.deserializeCalendarEvent(item.content)
+        return { ...event, id: item.uid, uid: item.uid, calendarId: item.collectionUid }
+      })
+      useCalendarStore.getState().syncFromRemote(events)
 
       // Purge stale queue entries (older than 24h) that may cause phantom indicators
       const stale = await getStaleEntries()

--- a/apps/web/app/stores/use-task-list-store.ts
+++ b/apps/web/app/stores/use-task-list-store.ts
@@ -9,7 +9,7 @@ export interface TaskList {
   visible: boolean
 }
 
-const DEFAULT_COLORS = [
+export const DEFAULT_TASK_LIST_COLORS = [
   '#3b82f6', // blue
   '#10b981', // emerald
   '#f59e0b', // amber
@@ -28,6 +28,7 @@ interface TaskListState {
   updateList: (id: string, updates: Partial<TaskList>) => void
   setActiveList: (id: string) => void
   toggleVisibility: (id: string) => void
+  replaceListsFromRemote: (lists: TaskList[]) => void
   getNextColor: () => string
 }
 
@@ -86,10 +87,25 @@ export const useTaskListStore = create<TaskListState>()(
         }))
       },
 
+      replaceListsFromRemote: (lists) => {
+        if (lists.length === 0) return
+        const current = get()
+        const remoteIds = new Set(lists.map((list) => list.id))
+        const currentById = new Map(current.lists.map((list) => [list.id, list]))
+        const merged = lists.map((list) => ({
+          ...list,
+          visible: currentById.get(list.id)?.visible ?? list.visible,
+        }))
+        set({
+          lists: merged,
+          activeListId: current.activeListId === 'all' || remoteIds.has(current.activeListId) ? current.activeListId : lists[0]!.id,
+        })
+      },
+
       getNextColor: () => {
         const { lists } = get()
         const usedColors = new Set(lists.map((l) => l.color))
-        return DEFAULT_COLORS.find((c) => !usedColors.has(c)) || DEFAULT_COLORS[lists.length % DEFAULT_COLORS.length]
+        return DEFAULT_TASK_LIST_COLORS.find((c) => !usedColors.has(c)) || DEFAULT_TASK_LIST_COLORS[lists.length % DEFAULT_TASK_LIST_COLORS.length]
       },
     }),
     {

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -6,6 +6,7 @@ import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
 import { showErrorToast } from '@/app/stores/use-toast-store'
+import { useTaskListStore } from '@/app/stores/use-task-list-store'
 
 interface NewTask {
   title: string
@@ -30,6 +31,12 @@ interface TaskActions {
   syncFromRemote: (tasks: Task[]) => void
 }
 
+function defaultTaskListId(): string | undefined {
+  const { lists, activeListId } = useTaskListStore.getState()
+  if (activeListId !== 'all' && lists.some((list) => list.id === activeListId)) return activeListId
+  return lists[0]?.id
+}
+
 export const useTaskStore = create<TaskState & TaskActions>()(
     (set, get) => ({
       tasks: [],
@@ -48,7 +55,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
           due_date: newTask.due_date ?? null,
           priority: newTask.priority ?? 'medium',
           completed: false,
-          listId: newTask.listId,
+          listId: newTask.listId ?? defaultTaskListId(),
           created_at: now,
           updated_at: now,
         }
@@ -62,7 +69,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
           try {
             const { serializeTask } = await import('@silentsuite/core')
             const content = serializeTask(task)
-            const itemUid = await etebase.createItem('tasks', content, tempId)
+            const itemUid = await etebase.createItem('tasks', content, tempId, task.listId)
             if (itemUid) {
               // Replace temp id with real Etebase item UID
               set((state) => ({
@@ -109,13 +116,14 @@ export const useTaskStore = create<TaskState & TaskActions>()(
             // Item was created offline — enqueue update with tempId so compaction merges into create
             const { serializeTask } = await import('@silentsuite/core')
             const content = serializeTask(updated)
-            await enqueue({ type: 'update', collectionType: 'tasks', content, tempId: id })
+            await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id })
           }
         }
       },
 
       deleteTask: async (id: string) => {
         if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
+        const taskToDelete = get().tasks.find((t) => t.id === id)
         set((state) => ({ tasks: state.tasks.filter((t) => t.id !== id) }))
 
         // Sync to Etebase
@@ -132,7 +140,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
             }
           } else {
             // Item was created offline and not yet synced — enqueue delete with tempId for compaction
-            await enqueue({ type: 'delete', collectionType: 'tasks', tempId: id })
+            await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: taskToDelete?.listId, tempId: id })
           }
         }
       },
@@ -165,7 +173,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
           } else {
             const { serializeTask } = await import('@silentsuite/core')
             const content = serializeTask(updated)
-            await enqueue({ type: 'update', collectionType: 'tasks', content, tempId: id })
+            await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id })
           }
         }
       },
@@ -185,7 +193,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
             due_date: nt.due_date ?? null,
             priority: nt.priority ?? 'medium',
             completed: false,
-            listId: nt.listId,
+            listId: nt.listId ?? defaultTaskListId(),
             created_at: now,
             updated_at: now,
           }
@@ -203,7 +211,8 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               content: serializeTask(t),
               tempId: t.id,
             }))
-            const uids = await etebase.createItemsBatch('tasks', contents)
+            const targetCollectionUid = tasks[0]?.listId
+            const uids = await etebase.createItemsBatch('tasks', contents, targetCollectionUid)
             set((state) => ({
               tasks: state.tasks.map((t) => {
                 const idx = tasks.findIndex((task) => task.id === t.id)

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -375,6 +375,7 @@ class Collection:
         meta.update(update_info)
         self.col.meta = meta
         self.cache_col.eb_col = self.col_mgr.cache_save(self.col)
+        self.cache_col.dirty = True
         self.cache_col.save()
 
     def create(self, vobject_item):

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -538,16 +538,9 @@ class Storage(BaseStorage):
             if self.user:
                 yield Collection(self, posixpath.join(path, self.user))
         elif len(attributes) == 1:
-            # Expose at most one collection per type. Multi-collection support was
-            # dropped 2026-04-12 — CalDAV/CardDAV clients see a single calendar,
-            # address book, and task list each.
-            seen_types: set = set()
             for journal in self.etesync.list():
                 if journal.col_type not in config.COL_TYPES:
                     continue
-                if journal.col_type in seen_types:
-                    continue
-                seen_types.add(journal.col_type)
                 yield Collection(
                     self, posixpath.join(path, journal.uid)
                 )

--- a/bridge/tests/test_local_cache.py
+++ b/bridge/tests/test_local_cache.py
@@ -199,6 +199,23 @@ class TestCollectionWrapper:
         assert col.cache_col.deleted is True
         assert col.cache_col.dirty is True
 
+    def test_update_meta_marks_dirty(self, mem_db, user):
+        mock_col = _make_mock_collection(
+            "col-1", "etebase.vevent", meta={"name": "Old", "color": "#000000"}
+        )
+        mgr = self._simple_col_mgr(mock_col)
+        cache_col = CollectionEntity.create(
+            local_user=user, uid="col-1", eb_col=b"\x00" * 8
+        )
+        col = Collection(mgr, cache_col)
+
+        col.update_meta({"name": "New", "color": "#00FF00"})
+
+        refreshed = CollectionEntity.get_by_id(cache_col.id)
+        assert mock_col.meta == {"name": "New", "color": "#00FF00"}
+        assert refreshed.eb_col == b"saved"
+        assert refreshed.dirty is True
+
     def test_list_items(self, mem_db, user, mock_item_mgr):
         mock_col = _make_mock_collection("col-1", "etebase.vevent")
         mgr = MagicMock()

--- a/bridge/tests/test_storage.py
+++ b/bridge/tests/test_storage.py
@@ -246,6 +246,46 @@ class TestDiscover:
         # Should yield root collection + user collection
         assert len(results) == 2
 
+    @patch("silentsuite_bridge.radicale.storage.etesync_for_user")
+    @patch("silentsuite_bridge.radicale.storage.start_sync_thread")
+    def test_discover_user_yields_all_supported_collections(self, mock_start, mock_etesync_ctx):
+        mock_thread = MagicMock()
+        mock_thread.wait_for_sync.return_value = True
+        mock_start.return_value = mock_thread
+
+        journals = [
+            MagicMock(uid="cal-work", col_type="etebase.vevent"),
+            MagicMock(uid="cal-home", col_type="etebase.vevent"),
+            MagicMock(uid="tasks", col_type="etebase.vtodo"),
+            MagicMock(uid="contacts", col_type="etebase.vcard"),
+            MagicMock(uid="ignored", col_type="etebase.notes"),
+        ]
+        collections = {journal.uid: journal for journal in journals}
+
+        mock_etesync = MagicMock()
+        mock_etesync.list.return_value = journals
+        mock_etesync.get.side_effect = lambda uid: collections[uid]
+        mock_etesync_ctx.return_value.__enter__ = MagicMock(
+            return_value=(mock_etesync, False)
+        )
+        mock_etesync_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        from radicale.config import Configuration, DEFAULT_CONFIG_SCHEMA
+
+        configuration = Configuration(DEFAULT_CONFIG_SCHEMA)
+        storage = Storage(configuration)
+
+        with storage.acquire_lock("r", user="test@example.com"):
+            results = list(storage.discover("/test@example.com", depth="1"))
+
+        assert [result.path for result in results] == [
+            "test@example.com",
+            "test@example.com/cal-work",
+            "test@example.com/cal-home",
+            "test@example.com/tasks",
+            "test@example.com/contacts",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Collection — create_collection

--- a/docs/user-guide/calendar.md
+++ b/docs/user-guide/calendar.md
@@ -65,7 +65,8 @@ Shared calendars between accounts are not supported in v0.1.0-beta. Your calenda
 
 If you've installed the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge), your CalDAV client (Thunderbird, Apple Calendar, etc.) can read and write the same calendar through `localhost:37358`. Edits there sync the same way as edits in the web app.
 
+Multiple calendars are supported. Each calendar is a separate encrypted collection with its own name, color, items, and DAV collection URL.
+
 ## Limits in this beta
 
-- A single default calendar collection per account. Managing multiple calendars is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
 - No invitations / RSVP / scheduling — SilentSuite is single-user, by design.

--- a/docs/user-guide/contacts.md
+++ b/docs/user-guide/contacts.md
@@ -33,11 +33,12 @@ Both are built from your locally decrypted data.
 
 With the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge) installed, any CardDAV client (Thunderbird, Apple Contacts, GNOME Contacts, Evolution) can read and write the same contacts through `localhost:37358`.
 
+Multiple address books are supported. Each address book is a separate encrypted collection and appears as its own CardDAV collection in compatible clients.
+
 ## Sharing
 
 Shared address books between accounts are not supported in v0.1.0-beta. Your contacts are visible only to you, across your own devices.
 
 ## Limits in this beta
 
-- A single default contacts collection per account. Managing multiple address books is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
 - No OAuth-based one-click import from Google or iCloud yet — file-based `.vcf` import only. (On the roadmap.)

--- a/docs/user-guide/tasks.md
+++ b/docs/user-guide/tasks.md
@@ -39,8 +39,9 @@ The list can be filtered by completion state and sorted by due date or priority.
 
 With the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-bridge) installed, any CalDAV client that speaks `VTODO` can read and write the same tasks through `localhost:37358`.
 
+Multiple task lists are supported. Each list is a separate encrypted collection and appears as its own task collection in compatible DAV clients.
+
 ## Limits in this beta
 
-- A single default tasks collection per account. Managing multiple task lists is on the roadmap (see [issue #88](https://github.com/silent-suite/silentsuite/issues/88)).
 - Date-only `DUE` values round-trip cleanly. Full timezone (`TZID`) preservation on date-time `DUE` values is being tightened up — see [issue #66](https://github.com/silent-suite/silentsuite/issues/66).
 - No subtasks or dependencies — a flat task list per collection.

--- a/packages/core/src/etebase/collections.ts
+++ b/packages/core/src/etebase/collections.ts
@@ -58,6 +58,45 @@ export async function getCollection(
 }
 
 /**
+ * Update collection metadata and upload the collection.
+ */
+export async function updateCollectionMeta(
+  account: Etebase.Account,
+  collection: Etebase.Collection,
+  meta: CollectionMeta,
+): Promise<Etebase.Collection> {
+  const collectionManager = account.getCollectionManager();
+  const currentMeta = (collection as any).getMeta?.() ?? {};
+  const nextMeta = {
+    ...currentMeta,
+    name: meta.name,
+    description: meta.description,
+    color: meta.color,
+  };
+
+  if (typeof (collection as any).setMeta === 'function') {
+    await (collection as any).setMeta(nextMeta);
+  } else {
+    (collection as any).meta = nextMeta;
+  }
+
+  await collectionManager.upload(collection);
+  return collection;
+}
+
+/**
+ * Mark a collection deleted and upload the tombstone.
+ */
+export async function deleteCollection(
+  account: Etebase.Account,
+  collection: Etebase.Collection,
+): Promise<void> {
+  const collectionManager = account.getCollectionManager();
+  (collection as any).delete();
+  await collectionManager.upload(collection);
+}
+
+/**
  * Create a new item in a collection.
  */
 export async function createItem(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,8 @@ export {
   createCollection,
   listCollections,
   getCollection,
+  updateCollectionMeta,
+  deleteCollection,
   createItem,
   listItems,
   updateItem,


### PR DESCRIPTION
## Summary
- add multi-collection routing for calendar, tasks, and contacts in the web app
- expose all supported DAV collections through the bridge and remove the Android UI cap
- key local cache/stokens/offline queue entries by concrete collection UID
- update user docs for multiple calendars, task lists, and address books

## Validation
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/core type-check
- pnpm --filter @silentsuite/core test
- pnpm --filter @silentsuite/web test -- data-cache offline-queue use-etebase-store
- python3 -m py_compile bridge/src/silentsuite_bridge/radicale/storage.py bridge/src/silentsuite_bridge/local_cache/__init__.py bridge/tests/test_storage.py bridge/tests/test_local_cache.py
- git diff --check

Closes #88