### PR TITLE
Fix stable VTODO UID task completion sync

### DIFF
--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -107,7 +107,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           try {
             const tasks = taskItems.map((it) => {
               const task = core.deserializeTask(it.content)
-              return { ...task, id: it.itemUid, uid: it.itemUid, listId: it.collectionUid }
+              return { ...task, id: it.itemUid, listId: it.collectionUid }
             })
             useTaskStore.getState().syncFromRemote(tasks)
             logger.log(`[sync-provider] Hydrated ${tasks.length} tasks from cache`)
@@ -120,7 +120,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           try {
             const contacts = contactItems.map((it) => {
               const contact = core.deserializeContact(it.content)
-              return { ...contact, id: it.itemUid, uid: it.itemUid, listId: it.collectionUid }
+              return { ...contact, id: it.itemUid, listId: it.collectionUid }
             })
             useContactStore.getState().syncFromRemote(contacts)
             logger.log(`[sync-provider] Hydrated ${contacts.length} contacts from cache`)
@@ -133,7 +133,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           try {
             const events = eventItems.map((it) => {
               const event = core.deserializeCalendarEvent(it.content)
-              return { ...event, id: it.itemUid, uid: it.itemUid, calendarId: it.collectionUid }
+              return { ...event, id: it.itemUid, calendarId: it.collectionUid }
             })
             useCalendarStore.getState().syncFromRemote(events)
             logger.log(`[sync-provider] Hydrated ${events.length} events from cache`)
@@ -176,9 +176,9 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           const { deserializeTask } = await import('@silentsuite/core')
           const tasks = taskItems.map((item) => {
             const task = deserializeTask(item.content)
-            // Override the local id/uid with the Etebase item UID
-            // so we can map back to the Etebase item for updates/deletes
-            return { ...task, id: item.uid, uid: item.uid, listId: item.collectionUid }
+            // Use the Etebase item UID only as the local id so updates/deletes
+            // can address the item without changing the stable iCalendar UID.
+            return { ...task, id: item.uid, listId: item.collectionUid }
           })
           useTaskStore.getState().syncFromRemote(tasks)
           logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
@@ -196,7 +196,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           const { deserializeContact } = await import('@silentsuite/core')
           const contacts = contactItems.map((item) => {
             const contact = deserializeContact(item.content)
-            return { ...contact, id: item.uid, uid: item.uid, listId: item.collectionUid }
+            return { ...contact, id: item.uid, listId: item.collectionUid }
           })
           useContactStore.getState().syncFromRemote(contacts)
           logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
@@ -214,7 +214,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           const { deserializeCalendarEvent } = await import('@silentsuite/core')
           const events = eventItems.map((item) => {
             const event = deserializeCalendarEvent(item.content)
-            return { ...event, id: item.uid, uid: item.uid, calendarId: item.collectionUid }
+            return { ...event, id: item.uid, calendarId: item.collectionUid }
           })
           useCalendarStore.getState().syncFromRemote(events)
           logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
@@ -243,7 +243,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             const taskItems = await useEtebaseStore.getState().fetchAllItems('tasks')
             const tasks = taskItems.map((item) => {
               const task = core.deserializeTask(item.content)
-              return { ...task, id: item.uid, uid: item.uid, listId: item.collectionUid }
+              return { ...task, id: item.uid, listId: item.collectionUid }
             })
             useTaskStore.getState().syncFromRemote(tasks)
           } catch (err) {
@@ -256,7 +256,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             const contactItems = await useEtebaseStore.getState().fetchAllItems('contacts')
             const contacts = contactItems.map((item) => {
               const contact = core.deserializeContact(item.content)
-              return { ...contact, id: item.uid, uid: item.uid, listId: item.collectionUid }
+              return { ...contact, id: item.uid, listId: item.collectionUid }
             })
             useContactStore.getState().syncFromRemote(contacts)
           } catch (err) {
@@ -269,7 +269,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             const eventItems = await useEtebaseStore.getState().fetchAllItems('calendar')
             const events = eventItems.map((item) => {
               const event = core.deserializeCalendarEvent(item.content)
-              return { ...event, id: item.uid, uid: item.uid, calendarId: item.collectionUid }
+              return { ...event, id: item.uid, calendarId: item.collectionUid }
             })
             useCalendarStore.getState().syncFromRemote(events)
           } catch (err) {

--- a/apps/web/app/stores/__tests__/use-calendar-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-calendar-store.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useCalendarStore } from '../use-calendar-store'
 import { serializeCalendarEvent, deserializeCalendarEvent } from '@silentsuite/core'
+import type { CalendarEvent } from '@silentsuite/core'
+
+const etebaseMock = vi.hoisted(() => ({
+  state: {
+    account: null as unknown,
+    createItem: vi.fn(),
+    updateItem: vi.fn(),
+    itemCache: new Map<string, unknown>(),
+  },
+}))
 
 vi.mock('@/app/stores/use-auth-store', () => ({
   useAuthStore: {
@@ -10,7 +20,7 @@ vi.mock('@/app/stores/use-auth-store', () => ({
 
 vi.mock('@/app/stores/use-etebase-store', () => ({
   useEtebaseStore: {
-    getState: () => ({ account: null }),
+    getState: () => etebaseMock.state,
   },
 }))
 
@@ -19,6 +29,10 @@ vi.mock('@/app/stores/use-toast-store', () => ({
 }))
 
 function resetStore() {
+  etebaseMock.state.account = null
+  etebaseMock.state.createItem.mockReset()
+  etebaseMock.state.updateItem.mockReset()
+  etebaseMock.state.itemCache = new Map()
   useCalendarStore.setState({
     events: [],
     isLoading: false,
@@ -27,6 +41,26 @@ function resetStore() {
     currentDate: new Date('2026-06-01T12:00:00Z'),
     selectedEventId: null,
   })
+}
+
+function makeRecurringEvent(overrides?: Partial<CalendarEvent>): CalendarEvent {
+  return {
+    id: 'master-item',
+    uid: 'master-vevent',
+    title: 'Daily standup',
+    description: '',
+    location: '',
+    startDate: new Date('2026-06-01T09:00:00Z'),
+    endDate: new Date('2026-06-01T09:30:00Z'),
+    allDay: false,
+    recurrenceRule: 'FREQ=DAILY',
+    exceptions: [],
+    alarms: [],
+    calendarId: 'cal-1',
+    created: new Date('2026-06-01T08:00:00Z'),
+    updated: new Date('2026-06-01T08:00:00Z'),
+    ...overrides,
+  }
 }
 
 describe('useCalendarStore.importEvents', () => {
@@ -102,5 +136,38 @@ describe('useCalendarStore.importEvents', () => {
     const ical = serializeCalendarEvent(events[0]!)
     expect(ical).not.toMatch(/DTSTART;TZID=/)
     expect(ical).toContain('DTSTART;VALUE=DATE:')
+  })
+})
+
+describe('useCalendarStore.updateRecurringEvent', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it.each([
+    ['this', 'remote-exception-item'],
+    ['this_and_future', 'remote-future-item'],
+  ] as const)('keeps the new VEVENT UID stable after %s creates a new Etebase item', async (scope, remoteItemUid) => {
+    const master = makeRecurringEvent()
+    etebaseMock.state.account = {}
+    etebaseMock.state.itemCache = new Map([[master.id, {}]])
+    etebaseMock.state.updateItem.mockResolvedValue(undefined)
+    etebaseMock.state.createItem.mockResolvedValue(remoteItemUid)
+    useCalendarStore.setState({ events: [master] })
+
+    await useCalendarStore.getState().updateRecurringEvent(
+      master.id,
+      { title: 'Adjusted occurrence' },
+      scope,
+      new Date('2026-06-03T09:00:00Z'),
+    )
+
+    const created = useCalendarStore.getState().events.find((event) => event.id === remoteItemUid)
+    expect(created).toBeDefined()
+    expect(created!.uid).not.toBe(remoteItemUid)
+
+    const uploadedContent = etebaseMock.state.createItem.mock.calls[0]![1] as string
+    expect(uploadedContent).toContain(`UID:${created!.uid}`)
+    expect(uploadedContent).not.toContain(`UID:${remoteItemUid}`)
   })
 })

--- a/apps/web/app/stores/__tests__/use-task-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-task-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useTaskStore } from '../use-task-store'
+import { useEtebaseStore } from '../use-etebase-store'
 
 // Mock the sync store to prevent side effects
 vi.mock('@/app/stores/use-sync-store', () => ({
@@ -17,6 +18,7 @@ function resetStore() {
     isLoading: false,
     syncStatus: 'synced',
   })
+  useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
 }
 
 describe('useTaskStore', () => {
@@ -84,5 +86,32 @@ describe('useTaskStore', () => {
     await useTaskStore.getState().toggleComplete(task.id)
     ;({ tasks } = useTaskStore.getState())
     expect(tasks[0]!.completed).toBe(false)
+  })
+
+  it('keeps the VTODO UID stable after replacing the local id with the Etebase item id', async () => {
+    const createItem = vi.fn(async () => 'remote-task-item')
+    const updateItem = vi.fn(async () => {})
+    useEtebaseStore.setState({
+      account: {},
+      createItem,
+      updateItem,
+    } as any)
+
+    const task = await useTaskStore.getState().createTask({ title: 'Sync me' })
+
+    expect(task.id).toBe('remote-task-item')
+    expect(task.uid).not.toBe('remote-task-item')
+    expect(createItem.mock.calls[0]![1]).toContain(`UID:${task.uid}`)
+
+    useEtebaseStore.setState({
+      itemCache: new Map([['remote-task-item', {}]]),
+    } as any)
+
+    await useTaskStore.getState().toggleComplete('remote-task-item')
+
+    const updatedContent = updateItem.mock.calls[0]![2] as string
+    expect(updatedContent).toContain(`UID:${task.uid}`)
+    expect(updatedContent).toContain('STATUS:COMPLETED')
+    expect(updatedContent).toContain('PERCENT-COMPLETE:100')
   })
 })

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -267,7 +267,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
         if (newItemUid) {
           set((state) => ({
             events: state.events.map((e) =>
-              e.id === newTempId ? { ...e, id: newItemUid, uid: newItemUid } : e,
+              e.id === newTempId ? { ...e, id: newItemUid } : e,
             ),
           }))
         }
@@ -311,7 +311,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
         if (newItemUid) {
           set((state) => ({
             events: state.events.map((e) =>
-              e.id === newTempId ? { ...e, id: newItemUid, uid: newItemUid } : e,
+              e.id === newTempId ? { ...e, id: newItemUid } : e,
             ),
           }))
         }

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -163,10 +163,10 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
     if (itemUid) {
       set((state) => ({
         events: state.events.map((e) =>
-          e.id === tempId ? { ...e, id: itemUid, uid: itemUid } : e,
+          e.id === tempId ? { ...e, id: itemUid } : e,
         ),
       }))
-      return { ...event, id: itemUid, uid: itemUid }
+      return { ...event, id: itemUid }
     }
 
     return event
@@ -485,7 +485,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
           events: state.events.map((e) => {
             const idx = events.findIndex((ev) => ev.id === e.id)
             if (idx !== -1 && uids[idx]) {
-              return { ...e, id: uids[idx]!, uid: uids[idx]! }
+              return { ...e, id: uids[idx]! }
             }
             return e
           }),

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -91,10 +91,10 @@ export const useContactStore = create<ContactState & ContactActions>()(
             if (itemUid) {
               set((state) => ({
                 contacts: state.contacts.map((c) =>
-                  c.id === tempId ? { ...c, id: itemUid, uid: itemUid } : c,
+                  c.id === tempId ? { ...c, id: itemUid } : c,
                 ),
               }))
-              return { ...contact, id: itemUid, uid: itemUid }
+              return { ...contact, id: itemUid }
             }
           } catch (err) {
             console.error('[contact-store] Failed to sync new contact to Etebase:', err)
@@ -211,7 +211,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
               contacts: state.contacts.map((c) => {
                 const idx = contacts.findIndex((contact) => contact.id === c.id)
                 if (idx !== -1 && uids[idx]) {
-                  return { ...c, id: uids[idx]!, uid: uids[idx]! }
+                  return { ...c, id: uids[idx]! }
                 }
                 return c
               }),

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -149,21 +149,21 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         const { useTaskStore } = await import('@/app/stores/use-task-store')
         useTaskStore.getState().syncFromRemote(
           useTaskStore.getState().tasks.map((t) =>
-            t.id === tempId ? { ...t, id: result.itemUid!, uid: result.itemUid! } : t,
+            t.id === tempId ? { ...t, id: result.itemUid! } : t,
           ),
         )
       } else if (collectionType === 'contacts') {
         const { useContactStore } = await import('@/app/stores/use-contact-store')
         useContactStore.getState().syncFromRemote(
           useContactStore.getState().contacts.map((c) =>
-            c.id === tempId ? { ...c, id: result.itemUid!, uid: result.itemUid! } : c,
+            c.id === tempId ? { ...c, id: result.itemUid! } : c,
           ),
         )
       } else if (collectionType === 'calendar') {
         const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
         useCalendarStore.getState().syncFromRemote(
           useCalendarStore.getState().events.map((e) =>
-            e.id === tempId ? { ...e, id: result.itemUid!, uid: result.itemUid! } : e,
+            e.id === tempId ? { ...e, id: result.itemUid! } : e,
           ),
         )
       }
@@ -209,19 +209,19 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
 
       const tasks = taskItems.map((item) => {
         const task = core.deserializeTask(item.content)
-        return { ...task, id: item.uid, uid: item.uid, listId: item.collectionUid }
+        return { ...task, id: item.uid, listId: item.collectionUid }
       })
       useTaskStore.getState().syncFromRemote(tasks)
 
       const contacts = contactItems.map((item) => {
         const contact = core.deserializeContact(item.content)
-        return { ...contact, id: item.uid, uid: item.uid, listId: item.collectionUid }
+        return { ...contact, id: item.uid, listId: item.collectionUid }
       })
       useContactStore.getState().syncFromRemote(contacts)
 
       const events = eventItems.map((item) => {
         const event = core.deserializeCalendarEvent(item.content)
-        return { ...event, id: item.uid, uid: item.uid, calendarId: item.collectionUid }
+        return { ...event, id: item.uid, calendarId: item.collectionUid }
       })
       useCalendarStore.getState().syncFromRemote(events)
 

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -74,10 +74,10 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               // Replace temp id with real Etebase item UID
               set((state) => ({
                 tasks: state.tasks.map((t) =>
-                  t.id === tempId ? { ...t, id: itemUid, uid: itemUid } : t,
+                  t.id === tempId ? { ...t, id: itemUid } : t,
                 ),
               }))
-              return { ...task, id: itemUid, uid: itemUid }
+              return { ...task, id: itemUid }
             }
           } catch (err) {
             console.error('[task-store] Failed to sync new task to Etebase:', err)
@@ -217,7 +217,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               tasks: state.tasks.map((t) => {
                 const idx = tasks.findIndex((task) => task.id === t.id)
                 if (idx !== -1 && uids[idx]) {
-                  return { ...t, id: uids[idx]!, uid: uids[idx]! }
+                  return { ...t, id: uids[idx]! }
                 }
                 return t
               }),

--- a/packages/core/src/models/task.test.ts
+++ b/packages/core/src/models/task.test.ts
@@ -112,6 +112,19 @@ describe('completed vs incomplete tasks', () => {
     expect(vtodo).toContain('PERCENT-COMPLETE:100');
   });
 
+  it('serializes completion metadata as UTC timestamps for CalDAV clients', () => {
+    const task = makeFullTask({
+      completed: true,
+      created_at: new Date(Date.UTC(2026, 0, 1, 0, 0, 0)),
+      updated_at: new Date(Date.UTC(2026, 2, 10, 12, 0, 0)),
+    });
+    const vtodo = toVTodo(task);
+
+    expect(vtodo).toContain('CREATED:20260101T000000Z');
+    expect(vtodo).toContain('LAST-MODIFIED:20260310T120000Z');
+    expect(vtodo).toContain('COMPLETED:20260310T120000Z');
+  });
+
   it('serializes an incomplete task with STATUS:NEEDS-ACTION', () => {
     const task = makeFullTask({ completed: false });
     const vtodo = toVTodo(task);

--- a/packages/core/src/models/task.ts
+++ b/packages/core/src/models/task.ts
@@ -48,6 +48,16 @@ function formatICalDateTime(date: Date): string {
   return `${y}${mo}${d}T${h}${mi}${s}`;
 }
 
+function formatICalUtcDateTime(date: Date): string {
+  const y = date.getUTCFullYear();
+  const mo = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  const h = String(date.getUTCHours()).padStart(2, '0');
+  const mi = String(date.getUTCMinutes()).padStart(2, '0');
+  const s = String(date.getUTCSeconds()).padStart(2, '0');
+  return `${y}${mo}${d}T${h}${mi}${s}Z`;
+}
+
 function formatICalDate(date: Date): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
@@ -90,8 +100,8 @@ export function toVTodo(task: Task): string {
     priority: PRIORITY_TO_ICAL[task.priority],
     status: task.completed ? 'COMPLETED' : 'NEEDS-ACTION',
     percentComplete: task.completed ? 100 : 0,
-    created: formatICalDateTime(task.created_at),
-    lastModified: formatICalDateTime(task.updated_at),
+    created: formatICalUtcDateTime(task.created_at),
+    lastModified: formatICalUtcDateTime(task.updated_at),
   };
 
   if (task.due_date) {
@@ -105,7 +115,7 @@ export function toVTodo(task: Task): string {
   }
 
   if (task.completed) {
-    vtodo.completed = formatICalDateTime(task.updated_at);
+    vtodo.completed = formatICalUtcDateTime(task.updated_at);
   }
 
   return generateVTodo(vtodo);


### PR DESCRIPTION
## Summary
- keep Etebase item UIDs as local ids without overwriting stable iCalendar/vCard UIDs
- serialize task completion metadata as UTC CalDAV timestamps
- add regression coverage for VTODO UID stability during web task completion

## Validation
- pnpm --filter @silentsuite/core test -- src/models/task.test.ts
- pnpm --filter @silentsuite/web test -- use-task-store
- pnpm --filter @silentsuite/core type-check
- pnpm --filter @silentsuite/web type-check
- git diff --check

## Notes
This targets the Tasks.org/DAV bridge completion-sync issue where a web-created task could change its VTODO UID after the web app replaced a temporary id with the Etebase item id.