### PR TITLE
Fix pending payment restore polling

### DIFF
--- a/apps/web/app/(auth)/signup/pending-payment/page.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/page.tsx
@@ -40,6 +40,8 @@ export default function PendingPaymentPage() {
   const [restartError, setRestartError] = useState<string | null>(null)
 
   useEffect(() => {
+    if (state !== 'pending') return
+
     let id = sessionStorage.getItem('silentsuite-pending-crypto-invoice')
     let invoiceLookupToken = sessionStorage.getItem('silentsuite-pending-crypto-token')
     const storedReturnTo = normalizeSignupReturnTo(sessionStorage.getItem('silentsuite-pending-crypto-return-to'))
@@ -124,7 +126,7 @@ export default function PendingPaymentPage() {
       cancelled = true
       if (timer) window.clearTimeout(timer)
     }
-  }, [pendingSignup?.email, pollNonce, restoreSignupStateFromRedirect])
+  }, [pendingSignup?.email, pollNonce, restoreSignupStateFromRedirect, state])
 
   function handleVaultComplete() {
     completeSignup()


### PR DESCRIPTION
## Summary\n- stop BTCPay pending-payment polling after terminal states such as restored account/vault state\n- prevent the restored signup state from being overwritten by a follow-up unauthenticated latest-invoice poll\n\n## Tests\n- pnpm --filter @silentsuite/web type-check