### PR TITLE
Improve import collection cleanup UX

### DIFF
--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useState } from 'react'
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
+import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { PullToRefresh } from '@/app/components/PullToRefresh'
 import { CalendarViewSwitcher } from './components/CalendarViewSwitcher'
@@ -96,6 +97,7 @@ export default function CalendarPage() {
   const navigateToday = useCalendarStore((s) => s.navigateToday)
   const selectedEventId = useCalendarStore((s) => s.selectedEventId)
   const setSelectedEvent = useCalendarStore((s) => s.setSelectedEvent)
+  const calendars = useCalendarListStore((s) => s.calendars)
 
   const [createDialog, setCreateDialog] = useState<CreateDialogState | null>(null)
   const [eventInstanceDate, setEventInstanceDate] = useState<Date | undefined>(undefined)
@@ -103,6 +105,19 @@ export default function CalendarPage() {
   const dateLabel = useMemo(
     () => formatDateRange(currentDate, currentView),
     [currentDate, currentView],
+  )
+
+  const visibleCalendarIds = useMemo(
+    () => {
+      const visibleIds = calendars.filter((calendar) => calendar.visible).map((calendar) => calendar.id)
+      return new Set(calendars.length === 0 ? ['default', ...visibleIds] : visibleIds)
+    },
+    [calendars],
+  )
+
+  const visibleEvents = useMemo(
+    () => events.filter((event) => visibleCalendarIds.has(event.calendarId ?? 'default')),
+    [events, visibleCalendarIds],
   )
 
   const handleSlotClick = useCallback((slot: SlotClickEvent) => {
@@ -219,14 +234,14 @@ export default function CalendarPage() {
         <>
           {/* Desktop: schedule-x grid */}
           <div className="hidden md:flex md:flex-1 md:min-h-0">
-            <CalendarGrid events={events} onSlotClick={handleSlotClick} onEventClick={handleEventClick} />
+            <CalendarGrid events={visibleEvents} onSlotClick={handleSlotClick} onEventClick={handleEventClick} />
           </div>
 
           {/* Mobile: agenda list view */}
           <div className="flex flex-col flex-1 md:hidden">
             <PullToRefresh>
               <AgendaView
-                events={events}
+                events={visibleEvents}
                 currentDate={currentDate}
                 onEventClick={(id) => {
                   setSelectedEvent(id)

--- a/apps/web/app/(app)/settings/import/page.tsx
+++ b/apps/web/app/(app)/settings/import/page.tsx
@@ -1,14 +1,181 @@
 'use client'
 
 import { useState, useCallback } from 'react'
-import { Calendar, CheckSquare, Users } from 'lucide-react'
+import { Calendar, CheckSquare, Trash2, Users } from 'lucide-react'
 import CalendarImport from '@/app/components/import/CalendarImport'
 import TaskImport from '@/app/components/import/TaskImport'
 import ContactImport from '@/app/components/import/ContactImport'
+import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
+import { useCalendarStore } from '@/app/stores/use-calendar-store'
+import { useTaskListStore } from '@/app/stores/use-task-list-store'
+import { useTaskStore } from '@/app/stores/use-task-store'
+import { useContactListStore } from '@/app/stores/use-contact-list-store'
+import { useContactStore } from '@/app/stores/use-contact-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 
 interface Toast {
   id: number
   message: string
+}
+
+type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts'
+
+interface DataCollectionRow {
+  id: string
+  name: string
+  color: string
+  count: number
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return count === 1 ? singular : plural
+}
+
+function ManageImportedDataSection({ showToast }: { showToast: (message: string) => void }) {
+  const calendars = useCalendarListStore((s) => s.calendars)
+  const events = useCalendarStore((s) => s.events)
+  const taskLists = useTaskListStore((s) => s.lists)
+  const tasks = useTaskStore((s) => s.tasks)
+  const contactLists = useContactListStore((s) => s.lists)
+  const contacts = useContactStore((s) => s.contacts)
+  const deleteCollection = useEtebaseStore((s) => s.deleteCollection)
+  const deleteItemsInCollection = useEtebaseStore((s) => s.deleteItemsInCollection)
+
+  const calendarRows: DataCollectionRow[] = calendars.map((calendar) => ({
+    id: calendar.id,
+    name: calendar.name,
+    color: calendar.color,
+    count: events.filter((event) => (event.calendarId ?? 'default') === calendar.id).length,
+  }))
+  const taskRows: DataCollectionRow[] = taskLists.map((list) => ({
+    id: list.id,
+    name: list.name,
+    color: list.color,
+    count: tasks.filter((task) => (task.listId ?? 'default') === list.id).length,
+  }))
+  const contactRows: DataCollectionRow[] = contactLists.map((list) => ({
+    id: list.id,
+    name: list.name,
+    color: list.color,
+    count: contacts.filter((contact) => (contact.listId ?? 'default') === list.id).length,
+  }))
+
+  const handleClear = useCallback(async (
+    type: CollectionTypeKey,
+    row: DataCollectionRow,
+    itemSingular: string,
+    itemPlural: string,
+  ) => {
+    if (row.count === 0) return
+    const itemLabel = pluralize(row.count, itemSingular, itemPlural)
+    if (!window.confirm(`Delete all ${row.count} ${itemLabel} from "${row.name}"? This syncs to all devices and cannot be undone.`)) return
+    const deleted = await deleteItemsInCollection(type, row.id)
+    if (deleted > 0) {
+      showToast(`Deleted ${deleted} ${pluralize(deleted, itemSingular, itemPlural)} from ${row.name}`)
+    }
+  }, [deleteItemsInCollection, showToast])
+
+  const handleDelete = useCallback(async (
+    type: CollectionTypeKey,
+    row: DataCollectionRow,
+    collectionLabel: string,
+    itemSingular: string,
+    itemPlural: string,
+  ) => {
+    const itemLabel = pluralize(row.count, itemSingular, itemPlural)
+    if (!window.confirm(`Delete ${collectionLabel} "${row.name}" and all ${row.count} ${itemLabel} in it? This syncs to all devices and cannot be undone.`)) return
+    const deleted = await deleteCollection(type, row.id)
+    if (deleted) {
+      showToast(`Deleted ${collectionLabel} ${row.name}`)
+    }
+  }, [deleteCollection, showToast])
+
+  const sections = [
+    {
+      type: 'calendar' as const,
+      title: 'Calendars',
+      collectionLabel: 'calendar',
+      itemSingular: 'event',
+      itemPlural: 'events',
+      rows: calendarRows,
+    },
+    {
+      type: 'tasks' as const,
+      title: 'Task lists',
+      collectionLabel: 'task list',
+      itemSingular: 'task',
+      itemPlural: 'tasks',
+      rows: taskRows,
+    },
+    {
+      type: 'contacts' as const,
+      title: 'Address books',
+      collectionLabel: 'address book',
+      itemSingular: 'contact',
+      itemPlural: 'contacts',
+      rows: contactRows,
+    },
+  ]
+
+  return (
+    <section className="space-y-3 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))]/40 p-4">
+      <div>
+        <h3 className="text-sm font-medium text-[rgb(var(--foreground))]">Manage imported data</h3>
+        <p className="mt-1 text-xs text-[rgb(var(--muted))]">
+          Clear the contents of a calendar/list/address book, or delete extra collections and everything inside them.
+        </p>
+      </div>
+
+      <div className="space-y-4">
+        {sections.map((section) => (
+          <div key={section.type} className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">
+              {section.title}
+            </p>
+            <div className="space-y-1">
+              {section.rows.map((row) => {
+                const itemLabel = pluralize(row.count, section.itemSingular, section.itemPlural)
+                const canDeleteCollection = section.rows.length > 1
+                return (
+                  <div key={row.id} className="flex flex-col gap-2 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 sm:flex-row sm:items-center">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <span className="h-3 w-3 shrink-0 rounded-sm" style={{ backgroundColor: row.color }} />
+                        <span className="truncate text-sm font-medium text-[rgb(var(--foreground))]">{row.name}</span>
+                      </div>
+                      <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">
+                        {row.count} {itemLabel}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleClear(section.type, row, section.itemSingular, section.itemPlural)}
+                        disabled={row.count === 0}
+                        className="rounded-md border border-[rgb(var(--border))] px-3 py-1.5 text-xs font-medium text-[rgb(var(--foreground))] transition-colors hover:bg-[rgb(var(--surface))] disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Clear {section.itemPlural}
+                      </button>
+                      {canDeleteCollection && (
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(section.type, row, section.collectionLabel, section.itemSingular, section.itemPlural)}
+                          className="inline-flex items-center gap-1 rounded-md border border-red-500/40 px-3 py-1.5 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/10"
+                        >
+                          <Trash2 className="h-3 w-3" />
+                          Delete {section.collectionLabel}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
 }
 
 export default function ImportPage() {
@@ -31,6 +198,8 @@ export default function ImportPage() {
           All parsing happens locally in your browser — no data leaves your device.
         </p>
       </div>
+
+      <ManageImportedDataSection showToast={showToast} />
 
       {/* Calendar Import */}
       <section className="space-y-3">

--- a/apps/web/app/components/import/CalendarImport.tsx
+++ b/apps/web/app/components/import/CalendarImport.tsx
@@ -1,16 +1,14 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { CheckCircle2, ChevronDown, ExternalLink, Loader2 } from 'lucide-react'
 import { parseVCalendar, parseICalDateValue } from '@silentsuite/core'
-import { ExternalLink } from 'lucide-react'
 import type { VEvent } from '@silentsuite/core/utils/ical-parser'
 import FileDropZone from './FileDropZone'
-import ImportPreview from './ImportPreview'
 import ImportListSelector from './ImportListSelector'
 import { vEventToImportEvent } from './import-mappers'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
-import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
+import { DEFAULT_CALENDAR_COLORS, useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 
 interface CalendarImportProps {
@@ -18,20 +16,30 @@ interface CalendarImportProps {
   heading?: string
 }
 
+interface CalendarImportGroup {
+  id: string
+  fileName: string
+  name: string
+  color: string
+  events: VEvent[]
+}
+
+type ImportMode = 'single' | 'separate'
+
 const PLATFORM_INSTRUCTIONS = [
   {
     name: 'Google Calendar',
-    steps: 'Go to Settings → Import & Export → Export',
+    steps: 'Go to Settings -> Import & Export -> Export',
     link: 'https://calendar.google.com/calendar/u/0/r/settings/export?pli=1',
   },
   {
     name: 'Apple Calendar',
-    steps: 'Open Calendar app → File → Export',
+    steps: 'Open Calendar app -> File -> Export',
     link: undefined,
   },
   {
     name: 'Outlook',
-    steps: 'Open Outlook → Calendar → Share → Export to .ics',
+    steps: 'Open Outlook -> Calendar -> Share -> Export to .ics',
     link: undefined,
   },
   {
@@ -65,9 +73,29 @@ function formatEventPreviewDate(dtstart: string, tzid?: string): string {
   }
 }
 
+function stripIcsExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, '').replace(/[-_]+/g, ' ').trim() || 'Imported Calendar'
+}
+
+function unescapeICalText(value: string): string {
+  return value
+    .replace(/\\n/gi, ' ')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\')
+    .trim()
+}
+
+function inferCalendarName(fileName: string, text: string): string {
+  const unfolded = text.replace(/\r?\n[ \t]/g, '')
+  const match = unfolded.match(/^X-WR-CALNAME(?:;[^:]*)?:(.+)$/im)
+  const name = match?.[1] ? unescapeICalText(match[1]) : stripIcsExtension(fileName)
+  return name || stripIcsExtension(fileName)
+}
 
 export default function CalendarImport({ onImportComplete, heading }: CalendarImportProps) {
-  const [events, setEvents] = useState<VEvent[]>([])
+  const [groups, setGroups] = useState<CalendarImportGroup[]>([])
+  const [importMode, setImportMode] = useState<ImportMode>('single')
   const [error, setError] = useState<string | null>(null)
   const [todoWarning, setTodoWarning] = useState<string | null>(null)
   const [isImporting, setIsImporting] = useState(false)
@@ -78,6 +106,15 @@ export default function CalendarImport({ onImportComplete, heading }: CalendarIm
   const defaultCalendarId = useCalendarListStore((s) => s.defaultCalendarId)
   const [selectedCalendarId, setSelectedCalendarId] = useState(defaultCalendarId)
   const createCollection = useEtebaseStore((s) => s.createCollection)
+
+  const totalEvents = useMemo(
+    () => groups.reduce((sum, group) => sum + group.events.length, 0),
+    [groups],
+  )
+  const previewEvents = useMemo(
+    () => groups.flatMap((group) => group.events.map((event) => ({ event, group }))),
+    [groups],
+  )
 
   useEffect(() => {
     if (calendars.length === 0) return
@@ -91,46 +128,76 @@ export default function CalendarImport({ onImportComplete, heading }: CalendarIm
 
   const handleFiles = useCallback(async (files: File[]) => {
     setError(null)
-    setEvents([])
+    setGroups([])
     setImportedCount(null)
     setTodoWarning(null)
 
     try {
-      const allEvents: VEvent[] = []
+      const parsedGroups: CalendarImportGroup[] = []
+      const usedColors = new Set(calendars.map((calendar) => calendar.color))
       let todoCount = 0
-      for (const file of files) {
+
+      for (const [index, file] of files.entries()) {
         if (file.size > 10 * 1024 * 1024) {
           setError('File is too large. Maximum size is 10 MB.')
           return
         }
         const text = await file.text()
         const parsed = parseVCalendar(text)
-        allEvents.push(...parsed)
-        // Count VTODO components
         const todoMatches = text.match(/BEGIN:VTODO/gi)
         if (todoMatches) todoCount += todoMatches.length
+        if (parsed.length === 0) continue
+
+        const color = DEFAULT_CALENDAR_COLORS.find((candidate) => !usedColors.has(candidate))
+          ?? DEFAULT_CALENDAR_COLORS[(calendars.length + index) % DEFAULT_CALENDAR_COLORS.length]
+          ?? '#10b981'
+        usedColors.add(color)
+        parsedGroups.push({
+          id: `${file.name}-${file.lastModified}-${index}`,
+          fileName: file.name,
+          name: inferCalendarName(file.name, text),
+          color,
+          events: parsed,
+        })
       }
+
       if (todoCount > 0) {
         setTodoWarning(
           `This file contains ${todoCount} task${todoCount !== 1 ? 's' : ''} (VTODO). ` +
-          `Use the Tasks import step to import them.`
+          `Use the Tasks import step to import them.`,
         )
       }
-      if (allEvents.length === 0 && todoCount === 0) {
+      if (parsedGroups.length === 0 && todoCount === 0) {
         setError('No calendar events found in the selected file(s).')
         return
       }
-      setEvents(allEvents)
+      setImportMode(parsedGroups.length > 1 ? 'separate' : 'single')
+      setGroups(parsedGroups)
     } catch {
       setError('Failed to parse the file. Please make sure it is a valid .ics file.')
     }
+  }, [calendars])
+
+  const updateGroup = useCallback((id: string, updates: Partial<Pick<CalendarImportGroup, 'name' | 'color'>>) => {
+    setGroups((current) => current.map((group) => group.id === id ? { ...group, ...updates } : group))
   }, [])
 
   const handleImport = useCallback(async () => {
+    if (totalEvents === 0) return
     setIsImporting(true)
     try {
-      const newEvents = events.map((event) => vEventToImportEvent(event, selectedCalendarId))
-      const count = await importEvents(newEvents)
+      let count = 0
+      if (importMode === 'separate' && groups.length > 1) {
+        for (const group of groups) {
+          const calendarName = group.name.trim() || stripIcsExtension(group.fileName)
+          const calendarId = await createCollection('calendar', calendarName, group.color)
+          if (!calendarId) throw new Error('Failed to create calendar')
+          count += await importEvents(group.events.map((event) => vEventToImportEvent(event, calendarId)))
+        }
+      } else {
+        const allEvents = groups.flatMap((group) => group.events)
+        count = await importEvents(allEvents.map((event) => vEventToImportEvent(event, selectedCalendarId)))
+      }
       setImportedCount(count)
       onImportComplete(count)
     } catch {
@@ -138,7 +205,7 @@ export default function CalendarImport({ onImportComplete, heading }: CalendarIm
     } finally {
       setIsImporting(false)
     }
-  }, [events, importEvents, onImportComplete, selectedCalendarId])
+  }, [createCollection, groups, importEvents, importMode, onImportComplete, selectedCalendarId, totalEvents])
 
   const handleCreateCalendar = useCallback(async (name: string, color: string) => {
     const uid = await createCollection('calendar', name, color)
@@ -146,7 +213,7 @@ export default function CalendarImport({ onImportComplete, heading }: CalendarIm
   }, [createCollection])
 
   const handleCancel = useCallback(() => {
-    setEvents([])
+    setGroups([])
     setError(null)
     setImportedCount(null)
   }, [])
@@ -196,13 +263,15 @@ export default function CalendarImport({ onImportComplete, heading }: CalendarIm
         ))}
       </div>
 
-      <ImportListSelector
-        lists={calendars}
-        selectedId={selectedCalendarId}
-        onSelect={setSelectedCalendarId}
-        onCreateNew={handleCreateCalendar}
-        label="calendar"
-      />
+      {(groups.length <= 1 || importMode === 'single') && (
+        <ImportListSelector
+          lists={calendars}
+          selectedId={selectedCalendarId}
+          onSelect={setSelectedCalendarId}
+          onCreateNew={handleCreateCalendar}
+          label="calendar"
+        />
+      )}
 
       <FileDropZone accept=".ics" onFiles={handleFiles} />
 
@@ -214,29 +283,128 @@ export default function CalendarImport({ onImportComplete, heading }: CalendarIm
         <p className="rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-400">{todoWarning}</p>
       )}
 
-      {events.length > 0 && (
-        <ImportPreview
-          items={events.map((e) => ({
-            title: e.summary || 'Untitled Event',
-            subtitle: formatEventPreviewDate(e.dtstart, e.dtstartParams?.['TZID']),
-          }))}
-          type="events"
-          onImport={handleImport}
-          onCancel={handleCancel}
-          isImporting={isImporting}
-          importedCount={importedCount}
-        />
+      {importedCount !== null && (
+        <div className="flex flex-col items-center gap-3 rounded-lg bg-[rgb(var(--primary))]/10 p-6">
+          <CheckCircle2 className="h-10 w-10 text-[rgb(var(--primary))]" />
+          <p className="text-sm font-medium text-[rgb(var(--primary))]">
+            {importedCount} events imported
+          </p>
+        </div>
       )}
 
-      {events.length === 0 && importedCount !== null && (
-        <ImportPreview
-          items={[]}
-          type="events"
-          onImport={handleImport}
-          onCancel={handleCancel}
-          isImporting={false}
-          importedCount={importedCount}
-        />
+      {totalEvents > 0 && importedCount === null && (
+        <div className="space-y-4">
+          <div className="space-y-3 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))]/50 p-3">
+            <div>
+              <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+                {totalEvents} events found in {groups.length} file{groups.length !== 1 ? 's' : ''}
+              </p>
+              <p className="mt-1 text-xs text-[rgb(var(--muted))]">
+                Review the destination before importing. You can delete or clear calendars later from this page.
+              </p>
+            </div>
+
+            {groups.length > 1 && (
+              <div className="grid gap-2 sm:grid-cols-2">
+                <button
+                  type="button"
+                  onClick={() => setImportMode('separate')}
+                  className={`rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                    importMode === 'separate'
+                      ? 'border-emerald-500 bg-emerald-600/10 text-[rgb(var(--foreground))]'
+                      : 'border-[rgb(var(--border))] text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
+                  }`}
+                >
+                  <span className="block font-medium">Create one calendar per file</span>
+                  <span className="mt-0.5 block text-xs opacity-80">Best when exports came from separate calendars.</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setImportMode('single')}
+                  className={`rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                    importMode === 'single'
+                      ? 'border-emerald-500 bg-emerald-600/10 text-[rgb(var(--foreground))]'
+                      : 'border-[rgb(var(--border))] text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
+                  }`}
+                >
+                  <span className="block font-medium">Import all into one calendar</span>
+                  <span className="mt-0.5 block text-xs opacity-80">Use this for split files from the same calendar.</span>
+                </button>
+              </div>
+            )}
+
+            {importMode === 'separate' && groups.length > 1 ? (
+              <div className="space-y-2">
+                {groups.map((group) => (
+                  <div key={group.id} className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3">
+                    <div className="flex items-start gap-3">
+                      <input
+                        type="color"
+                        value={group.color}
+                        onChange={(event) => updateGroup(group.id, { color: event.target.value })}
+                        aria-label={`Color for ${group.name}`}
+                        className="mt-1 h-8 w-8 shrink-0 rounded border border-[rgb(var(--border))] bg-transparent p-0"
+                      />
+                      <div className="min-w-0 flex-1 space-y-1">
+                        <input
+                          type="text"
+                          value={group.name}
+                          onChange={(event) => updateGroup(group.id, { name: event.target.value })}
+                          aria-label={`Calendar name for ${group.fileName}`}
+                          className="w-full rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-1.5 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                        />
+                        <p className="truncate text-xs text-[rgb(var(--muted))]">
+                          {group.fileName} {'->'} {group.events.length} event{group.events.length !== 1 ? 's' : ''}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="max-h-60 space-y-1 overflow-y-auto rounded-lg bg-[rgb(var(--background))]/70 p-2">
+                {previewEvents.slice(0, 10).map(({ event, group }, i) => (
+                  <div key={`${group.id}-${i}`} className="rounded-md px-3 py-2 text-sm hover:bg-[rgb(var(--surface))]">
+                    <p className="text-[rgb(var(--foreground))]">{event.summary || 'Untitled Event'}</p>
+                    <p className="text-xs text-[rgb(var(--muted))]">
+                      {formatEventPreviewDate(event.dtstart, event.dtstartParams?.['TZID'])}
+                      {groups.length > 1 ? ` - ${group.fileName}` : ''}
+                    </p>
+                  </div>
+                ))}
+                {totalEvents > 10 && (
+                  <p className="px-3 py-2 text-xs text-[rgb(var(--muted))]">
+                    ...and {totalEvents - 10} more
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleImport}
+              disabled={isImporting}
+              className="inline-flex items-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[rgb(var(--primary-hover))] disabled:opacity-50"
+            >
+              {isImporting && <Loader2 className="h-4 w-4 animate-spin" />}
+              {isImporting
+                ? 'Importing...'
+                : importMode === 'separate' && groups.length > 1
+                  ? `Import into ${groups.length} calendars`
+                  : `Import ${totalEvents} events`}
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={isImporting}
+              className="text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/apps/web/app/stores/__tests__/use-calendar-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-calendar-store.test.ts
@@ -7,6 +7,7 @@ const etebaseMock = vi.hoisted(() => ({
   state: {
     account: null as unknown,
     createItem: vi.fn(),
+    createItemsBatch: vi.fn(),
     updateItem: vi.fn(),
     itemCache: new Map<string, unknown>(),
   },
@@ -31,6 +32,7 @@ vi.mock('@/app/stores/use-toast-store', () => ({
 function resetStore() {
   etebaseMock.state.account = null
   etebaseMock.state.createItem.mockReset()
+  etebaseMock.state.createItemsBatch.mockReset()
   etebaseMock.state.updateItem.mockReset()
   etebaseMock.state.itemCache = new Map()
   useCalendarStore.setState({
@@ -136,6 +138,32 @@ describe('useCalendarStore.importEvents', () => {
     const ical = serializeCalendarEvent(events[0]!)
     expect(ical).not.toMatch(/DTSTART;TZID=/)
     expect(ical).toContain('DTSTART;VALUE=DATE:')
+  })
+
+  it('routes mixed-calendar imports to each target collection', async () => {
+    etebaseMock.state.account = {}
+    etebaseMock.state.createItemsBatch.mockImplementation(async (_type: unknown, contents: unknown[]) => (
+      contents.map((_, index) => `remote-${index}-${String(index)}`)
+    ))
+
+    await useCalendarStore.getState().importEvents([
+      {
+        title: 'Work event',
+        startDate: new Date('2026-06-01T09:00:00Z'),
+        endDate: new Date('2026-06-01T10:00:00Z'),
+        calendarId: 'work-cal',
+      },
+      {
+        title: 'Family event',
+        startDate: new Date('2026-06-02T09:00:00Z'),
+        endDate: new Date('2026-06-02T10:00:00Z'),
+        calendarId: 'family-cal',
+      },
+    ])
+
+    expect(etebaseMock.state.createItemsBatch).toHaveBeenCalledTimes(2)
+    expect(etebaseMock.state.createItemsBatch.mock.calls[0]![2]).toBe('work-cal')
+    expect(etebaseMock.state.createItemsBatch.mock.calls[1]![2]).toBe('family-cal')
   })
 })
 

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useEtebaseStore } from '../use-etebase-store'
+import { useCalendarStore } from '../use-calendar-store'
+
+const offlineQueueMock = vi.hoisted(() => ({
+  enqueue: vi.fn(async () => {}),
+  getAll: vi.fn(async () => []),
+  remove: vi.fn(async () => {}),
+  isOfflineError: vi.fn(() => false),
+}))
 
 // Stub the offline queue so isOfflineError + enqueue don't try to open IndexedDB.
-vi.mock('@/app/lib/offline-queue', () => ({
-  enqueue: vi.fn(async () => {}),
-  isOfflineError: () => false,
-}))
+vi.mock('@/app/lib/offline-queue', () => offlineQueueMock)
 
 vi.mock('@/app/lib/secure-storage', () => ({
   secureGet: vi.fn(async () => null),
@@ -75,6 +80,18 @@ function setupStoreWithCollections(itemManagerByUid: Record<string, MockItemMana
 
 describe('useEtebaseStore.createItemsBatch', () => {
   beforeEach(() => {
+    offlineQueueMock.enqueue.mockClear()
+    offlineQueueMock.getAll.mockReset().mockResolvedValue([])
+    offlineQueueMock.remove.mockClear()
+    offlineQueueMock.isOfflineError.mockReset().mockReturnValue(false)
+    useCalendarStore.setState({
+      events: [],
+      isLoading: false,
+      syncStatus: 'synced',
+      currentView: 'week',
+      currentDate: new Date('2026-01-01T00:00:00Z'),
+      selectedEventId: null,
+    })
     useEtebaseStore.setState({
       account: null,
       collections: { calendar: [], tasks: [], contacts: [] },
@@ -241,6 +258,153 @@ describe('useEtebaseStore.createItemsBatch', () => {
     expect(itemManager.batch).toHaveBeenCalledTimes(1 + 3)
     expect(uids.slice(0, 20).every((u) => typeof u === 'string')).toBe(true)
     expect(uids.slice(20).every((u) => u === null)).toBe(true)
+  })
+})
+
+describe('useEtebaseStore.deleteItemsInCollection', () => {
+  beforeEach(() => {
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: [], tasks: [], contacts: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('deletes only items in the requested collection and clears local maps', async () => {
+    const deleteItemOne = { uid: 'item-1', delete: vi.fn() }
+    const deleteItemTwo = { uid: 'item-2', delete: vi.fn() }
+    const keepItem = { uid: 'item-3', delete: vi.fn() }
+    const itemManager = { batch: vi.fn(async () => {}) }
+    const account = {
+      getCollectionManager: () => ({
+        getItemManager: () => itemManager,
+      }),
+    }
+
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [{ uid: 'col-1' }, { uid: 'col-2' }] as any[], tasks: [], contacts: [] },
+      itemCache: new Map([
+        ['item-1', deleteItemOne],
+        ['item-2', deleteItemTwo],
+        ['item-3', keepItem],
+      ]),
+      itemTypeMap: new Map([
+        ['item-1', 'calendar'],
+        ['item-2', 'calendar'],
+        ['item-3', 'calendar'],
+      ]),
+      itemCollectionMap: new Map([
+        ['item-1', 'col-1'],
+        ['item-2', 'col-1'],
+        ['item-3', 'col-2'],
+      ]),
+      isInitialized: true,
+      syncEngine: null,
+    })
+
+    const deleted = await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
+    const state = useEtebaseStore.getState()
+
+    expect(deleted).toBe(2)
+    expect(deleteItemOne.delete).toHaveBeenCalledTimes(1)
+    expect(deleteItemTwo.delete).toHaveBeenCalledTimes(1)
+    expect(keepItem.delete).not.toHaveBeenCalled()
+    expect(itemManager.batch).toHaveBeenCalledWith([deleteItemOne, deleteItemTwo])
+    expect(state.itemCache.has('item-1')).toBe(false)
+    expect(state.itemCache.has('item-2')).toBe(false)
+    expect(state.itemCache.get('item-3')).toBe(keepItem)
+    expect(state.itemCollectionMap.get('item-3')).toBe('col-2')
+  })
+
+  it('clears local-only queued items for the requested collection', async () => {
+    const account = {
+      getCollectionManager: () => ({
+        getItemManager: () => ({ batch: vi.fn() }),
+      }),
+    }
+
+    offlineQueueMock.getAll.mockResolvedValueOnce([
+      {
+        id: 'queue-1',
+        type: 'create',
+        collectionType: 'calendar',
+        collectionUid: 'col-1',
+        tempId: 'temp-1',
+        createdAt: 1,
+        retryCount: 0,
+        status: 'pending',
+      },
+    ])
+
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: true,
+      syncEngine: null,
+    })
+    useCalendarStore.setState({
+      events: [{ id: 'temp-1', calendarId: 'col-1', title: 'Queued event' } as any],
+      selectedEventId: 'temp-1',
+    })
+
+    const deleted = await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
+
+    expect(deleted).toBe(1)
+    expect(offlineQueueMock.remove).toHaveBeenCalledWith('queue-1')
+    expect(useCalendarStore.getState().events).toHaveLength(0)
+    expect(useCalendarStore.getState().selectedEventId).toBeNull()
+  })
+
+  it('removes locally confirmed deletes when a later clear batch fails', async () => {
+    const items = Array.from({ length: 21 }, (_, index) => ({ uid: `item-${index}`, delete: vi.fn() }))
+    let batchCalls = 0
+    const itemManager = {
+      batch: vi.fn(async () => {
+        batchCalls++
+        if (batchCalls === 2) throw new Error('server error')
+      }),
+    }
+    const account = {
+      getCollectionManager: () => ({
+        getItemManager: () => itemManager,
+      }),
+    }
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [] },
+      itemCache: new Map(items.map((item) => [item.uid, item])),
+      itemTypeMap: new Map(items.map((item) => [item.uid, 'calendar' as const])),
+      itemCollectionMap: new Map(items.map((item) => [item.uid, 'col-1'])),
+      isInitialized: true,
+      syncEngine: null,
+    })
+    useCalendarStore.setState({
+      events: [
+        { id: 'item-0', calendarId: 'col-1', title: 'Deleted remotely' } as any,
+        { id: 'item-20', calendarId: 'col-1', title: 'Still pending' } as any,
+      ],
+    })
+
+    const deleted = await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
+    const state = useEtebaseStore.getState()
+
+    expect(deleted).toBe(0)
+    expect(itemManager.batch).toHaveBeenCalledTimes(2)
+    expect(state.itemCache.has('item-0')).toBe(false)
+    expect(state.itemCache.has('item-19')).toBe(false)
+    expect(state.itemCache.has('item-20')).toBe(true)
+    expect(useCalendarStore.getState().events.map((event) => event.id)).toEqual(['item-20'])
+    errorSpy.mockRestore()
   })
 })
 

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -474,22 +474,29 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
     if (etebase.account) {
       try {
         const { serializeCalendarEvent } = await import('@silentsuite/core')
-        const contents = events.map((e) => ({
-          content: serializeCalendarEvent(e),
-          tempId: e.id,
-        }))
-        const targetCollectionUid = events[0]?.calendarId
-        const uids = await etebase.createItemsBatch('calendar', contents, targetCollectionUid)
-        // Replace temp IDs with real UIDs
-        set((state) => ({
-          events: state.events.map((e) => {
-            const idx = events.findIndex((ev) => ev.id === e.id)
-            if (idx !== -1 && uids[idx]) {
-              return { ...e, id: uids[idx]! }
-            }
-            return e
-          }),
-        }))
+        const groups = new Map<string | undefined, CalendarEvent[]>()
+        for (const event of events) {
+          const key = event.calendarId
+          groups.set(key, [...(groups.get(key) ?? []), event])
+        }
+
+        for (const [targetCollectionUid, groupEvents] of groups) {
+          const contents = groupEvents.map((e) => ({
+            content: serializeCalendarEvent(e),
+            tempId: e.id,
+          }))
+          const uids = await etebase.createItemsBatch('calendar', contents, targetCollectionUid)
+          // Replace temp IDs with real item UIDs for this concrete collection.
+          set((state) => ({
+            events: state.events.map((e) => {
+              const idx = groupEvents.findIndex((ev) => ev.id === e.id)
+              if (idx !== -1 && uids[idx]) {
+                return { ...e, id: uids[idx]! }
+              }
+              return e
+            }),
+          }))
+        }
       } catch (err) {
         console.error('[calendar-store] Failed to batch import events:', err)
       }

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -201,21 +201,28 @@ export const useContactStore = create<ContactState & ContactActions>()(
         if (etebase.account) {
           try {
             const { serializeContact } = await import('@silentsuite/core')
-            const contents = contacts.map((c) => ({
-              content: serializeContact(c),
-              tempId: c.id,
-            }))
-            const targetCollectionUid = contacts[0]?.listId
-            const uids = await etebase.createItemsBatch('contacts', contents, targetCollectionUid)
-            set((state) => ({
-              contacts: state.contacts.map((c) => {
-                const idx = contacts.findIndex((contact) => contact.id === c.id)
-                if (idx !== -1 && uids[idx]) {
-                  return { ...c, id: uids[idx]! }
-                }
-                return c
-              }),
-            }))
+            const groups = new Map<string | undefined, Contact[]>()
+            for (const contact of contacts) {
+              const key = contact.listId
+              groups.set(key, [...(groups.get(key) ?? []), contact])
+            }
+
+            for (const [targetCollectionUid, groupContacts] of groups) {
+              const contents = groupContacts.map((c) => ({
+                content: serializeContact(c),
+                tempId: c.id,
+              }))
+              const uids = await etebase.createItemsBatch('contacts', contents, targetCollectionUid)
+              set((state) => ({
+                contacts: state.contacts.map((c) => {
+                  const idx = groupContacts.findIndex((contact) => contact.id === c.id)
+                  if (idx !== -1 && uids[idx]) {
+                    return { ...c, id: uids[idx]! }
+                  }
+                  return c
+                }),
+              }))
+            }
           } catch (err) {
             console.error('[contact-store] Failed to batch import contacts:', err)
           }

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -6,7 +6,12 @@ import type {
   CollectionType,
   SyncChangeEvent,
 } from '@silentsuite/core'
-import { enqueue, isOfflineError } from '@/app/lib/offline-queue'
+import {
+  enqueue,
+  getAll as getQueuedMutations,
+  isOfflineError,
+  remove as removeQueuedMutation,
+} from '@/app/lib/offline-queue'
 import { secureGet } from '@/app/lib/secure-storage'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
@@ -170,6 +175,81 @@ async function hydrateListStores(collections: Record<CollectionTypeKey, any[]>):
   )
 }
 
+async function removeItemsFromDomainStore(type: CollectionTypeKey, collectionUid: string, itemUids?: string[]): Promise<number> {
+  const itemUidSet = itemUids ? new Set(itemUids) : null
+
+  if (type === 'calendar') {
+    const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
+    let removed = 0
+    useCalendarStore.setState((state) => {
+      const events = state.events.filter((event) => {
+        const shouldRemove = itemUidSet
+          ? itemUidSet.has(event.id)
+          : (event.calendarId ?? 'default') === collectionUid
+        if (shouldRemove) removed++
+        return !shouldRemove
+      })
+      const selectedEventId = state.selectedEventId && (itemUidSet
+        ? itemUidSet.has(state.selectedEventId)
+        : state.events.some((event) => event.id === state.selectedEventId && (event.calendarId ?? 'default') === collectionUid))
+        ? null
+        : state.selectedEventId
+      return { events, selectedEventId }
+    })
+    return removed
+  }
+  if (type === 'tasks') {
+    const { useTaskStore } = await import('@/app/stores/use-task-store')
+    let removed = 0
+    useTaskStore.setState((state) => ({
+      tasks: state.tasks.filter((task) => {
+        const shouldRemove = itemUidSet
+          ? itemUidSet.has(task.id)
+          : (task.listId ?? 'default') === collectionUid
+        if (shouldRemove) removed++
+        return !shouldRemove
+      }),
+    }))
+    return removed
+  }
+  const { useContactStore } = await import('@/app/stores/use-contact-store')
+  let removed = 0
+  useContactStore.setState((state) => ({
+    contacts: state.contacts.filter((contact) => {
+      const shouldRemove = itemUidSet
+        ? itemUidSet.has(contact.id)
+        : (contact.listId ?? 'default') === collectionUid
+      if (shouldRemove) removed++
+      return !shouldRemove
+    }),
+  }))
+  return removed
+}
+
+async function removeQueuedMutationsForCollection(type: CollectionTypeKey, collectionUid: string, includeDeletes: boolean): Promise<number> {
+  try {
+    const entries = await getQueuedMutations()
+    const matching = entries.filter((entry) => (
+      entry.collectionType === type
+      && entry.collectionUid === collectionUid
+      && (includeDeletes || entry.type !== 'delete')
+    ))
+    for (const entry of matching) {
+      await removeQueuedMutation(entry.id)
+    }
+    return matching.length
+  } catch (err) {
+    logger.warn(`[etebase-store] Failed to prune queued mutations for ${type}/${collectionUid}`, err)
+    return 0
+  }
+}
+
+function collectionItemNoun(type: CollectionTypeKey): string {
+  if (type === 'calendar') return 'events'
+  if (type === 'tasks') return 'tasks'
+  return 'contacts'
+}
+
 interface EtebaseState {
   // The live Account object (null until session restored)
   account: any | null
@@ -209,7 +289,12 @@ interface EtebaseActions {
   /**
    * Delete an Etebase collection and remove its cached items locally.
    */
-  deleteCollection: (type: CollectionTypeKey, collectionUid: string) => Promise<void>
+  deleteCollection: (type: CollectionTypeKey, collectionUid: string) => Promise<boolean>
+
+  /**
+   * Delete every item inside a collection while keeping the collection itself.
+   */
+  deleteItemsInCollection: (type: CollectionTypeKey, collectionUid: string) => Promise<number>
 
   /**
    * Create multiple items in a single batch upload.
@@ -438,11 +523,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot delete ${type} collection ${collectionUid}: missing account or collection`)
-      return
+      return false
     }
     if (collections[type].length <= 1) {
       showErrorToast(`Create another ${type === 'calendar' ? 'calendar' : type === 'tasks' ? 'task list' : 'address book'} before deleting this one.`)
-      return
+      return false
     }
 
     try {
@@ -474,10 +559,104 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (isLocalCacheEnabled()) {
         void cacheReplaceItemsForCollection(collection.uid, [])
       }
+      await removeQueuedMutationsForCollection(type, collection.uid, true)
+      await removeItemsFromDomainStore(type, collection.uid)
       await hydrateListStores(newCollections)
+      return true
     } catch (err) {
       console.error(`[etebase-store] Failed to delete ${type} collection ${collectionUid}:`, err)
       showErrorToast(`Failed to delete ${type === 'calendar' ? 'calendar' : type === 'tasks' ? 'task list' : 'address book'}. Please try again.`)
+      return false
+    }
+  },
+
+  deleteItemsInCollection: async (type: CollectionTypeKey, collectionUid: string) => {
+    const { account, collections, itemCache, itemCollectionMap } = get()
+    const collection = resolveCollection(collections, type, collectionUid)
+    if (!account || !collection) {
+      logger.warn(`[etebase-store] Cannot clear ${type} collection ${collectionUid}: missing account or collection`)
+      return 0
+    }
+
+    const removeCachedItems = (uids: string[]) => {
+      if (uids.length === 0) return
+      const uidSet = new Set(uids)
+      const newItemCache = new Map(get().itemCache)
+      const newItemTypeMap = new Map(get().itemTypeMap)
+      const newItemCollectionMap = new Map(get().itemCollectionMap)
+      for (const uid of uidSet) {
+        newItemCache.delete(uid)
+        newItemTypeMap.delete(uid)
+        newItemCollectionMap.delete(uid)
+        if (isLocalCacheEnabled()) {
+          void cacheDeleteItem(uid)
+        }
+      }
+      set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, itemCollectionMap: newItemCollectionMap })
+    }
+
+    const itemEntries = Array.from(itemCollectionMap.entries())
+      .filter(([, mappedCollectionUid]) => mappedCollectionUid === collection.uid)
+      .map(([uid]) => ({ uid, item: itemCache.get(uid) }))
+      .filter((entry): entry is { uid: string; item: any } => Boolean(entry.item))
+
+    if (itemEntries.length === 0) {
+      await removeQueuedMutationsForCollection(type, collection.uid, true)
+      return await removeItemsFromDomainStore(type, collection.uid)
+    }
+
+    const successfulUids: string[] = []
+
+    try {
+      const collectionManager = account.getCollectionManager()
+      const itemManager = collectionManager.getItemManager(collection)
+      const BATCH_SIZE = 20
+
+      for (let i = 0; i < itemEntries.length; i += BATCH_SIZE) {
+        const batchEntries = itemEntries.slice(i, i + BATCH_SIZE)
+        const batchItems = batchEntries.map(({ item }) => item)
+        for (const item of batchItems) item.delete()
+        await itemManager.batch(batchItems)
+        successfulUids.push(...batchEntries.map(({ uid }) => uid))
+      }
+
+      removeCachedItems(successfulUids)
+      if (isLocalCacheEnabled()) {
+        void cacheReplaceItemsForCollection(collection.uid, [])
+      }
+      await removeQueuedMutationsForCollection(type, collection.uid, true)
+      const removedLocal = await removeItemsFromDomainStore(type, collection.uid)
+      return Math.max(successfulUids.length, removedLocal)
+    } catch (err) {
+      if (isOfflineError(err)) {
+        logger.warn(`[etebase-store] Offline — queuing clear for ${type}/${collection.uid}`)
+        await removeQueuedMutationsForCollection(type, collection.uid, false)
+        const alreadyDeleted = new Set(successfulUids)
+        for (const { uid } of itemEntries) {
+          if (alreadyDeleted.has(uid)) continue
+          try {
+            await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid })
+          } catch (queueErr) {
+            console.error(`[etebase-store] Failed to enqueue collection item delete:`, queueErr)
+          }
+        }
+        removeCachedItems(itemEntries.map(({ uid }) => uid))
+        if (isLocalCacheEnabled()) {
+          void cacheReplaceItemsForCollection(collection.uid, [])
+        }
+        const removedLocal = await removeItemsFromDomainStore(type, collection.uid)
+        return Math.max(itemEntries.length, removedLocal)
+      }
+
+      console.error(`[etebase-store] Failed to clear ${type} collection ${collectionUid}:`, err)
+      if (successfulUids.length > 0) {
+        removeCachedItems(successfulUids)
+        await removeItemsFromDomainStore(type, collection.uid, successfulUids)
+        showErrorToast(`Deleted ${successfulUids.length} of ${itemEntries.length} ${collectionItemNoun(type)}. Please try again to delete the rest.`)
+      } else {
+        showErrorToast(`Failed to delete ${collectionItemNoun(type)}. Please try again.`)
+      }
+      return 0
     }
   },
 

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -207,21 +207,28 @@ export const useTaskStore = create<TaskState & TaskActions>()(
         if (etebase.account) {
           try {
             const { serializeTask } = await import('@silentsuite/core')
-            const contents = tasks.map((t) => ({
-              content: serializeTask(t),
-              tempId: t.id,
-            }))
-            const targetCollectionUid = tasks[0]?.listId
-            const uids = await etebase.createItemsBatch('tasks', contents, targetCollectionUid)
-            set((state) => ({
-              tasks: state.tasks.map((t) => {
-                const idx = tasks.findIndex((task) => task.id === t.id)
-                if (idx !== -1 && uids[idx]) {
-                  return { ...t, id: uids[idx]! }
-                }
-                return t
-              }),
-            }))
+            const groups = new Map<string | undefined, Task[]>()
+            for (const task of tasks) {
+              const key = task.listId
+              groups.set(key, [...(groups.get(key) ?? []), task])
+            }
+
+            for (const [targetCollectionUid, groupTasks] of groups) {
+              const contents = groupTasks.map((t) => ({
+                content: serializeTask(t),
+                tempId: t.id,
+              }))
+              const uids = await etebase.createItemsBatch('tasks', contents, targetCollectionUid)
+              set((state) => ({
+                tasks: state.tasks.map((t) => {
+                  const idx = groupTasks.findIndex((task) => task.id === t.id)
+                  if (idx !== -1 && uids[idx]) {
+                    return { ...t, id: uids[idx]! }
+                  }
+                  return t
+                }),
+              }))
+            }
           } catch (err) {
             console.error('[task-store] Failed to batch import tasks:', err)
           }

--- a/docs/user-guide/calendar.md
+++ b/docs/user-guide/calendar.md
@@ -48,6 +48,10 @@ Timezones are stored as `TZID` references on each event, not converted to UTC on
 
 **Settings → Import** accepts `.ics` files. Parsing happens entirely in your browser — the file's contents never reach the server in plaintext. Imported events keep their original `TZID`s and `VALARM`s.
 
+When you select multiple `.ics` files at once, SilentSuite asks whether to create one calendar per file or import every file into a single calendar. Calendar names are suggested from the file metadata or filename before anything is imported.
+
+If you imported into the wrong place, use **Settings → Import → Manage imported data** to clear a calendar's events or delete an extra calendar and everything inside it.
+
 ## Export
 
 **Settings → Export** gives you:

--- a/docs/user-guide/contacts.md
+++ b/docs/user-guide/contacts.md
@@ -20,6 +20,8 @@ The search box at the top of the contacts list filters by name, email, phone, or
 
 **Settings → Import** accepts `.vcf` files (vCard 3.0 and 4.0). Parsing is local-only — the file content never leaves your browser unencrypted. Multi-contact files are supported (one big `.vcf` with many `BEGIN:VCARD` blocks).
 
+Use **Settings → Import → Manage imported data** to clear an address book's contacts or delete an extra address book and everything inside it.
+
 ## Export
 
 **Settings → Export** gives you:

--- a/docs/user-guide/tasks.md
+++ b/docs/user-guide/tasks.md
@@ -28,6 +28,8 @@ The list can be filtered by completion state and sorted by due date or priority.
 
 **Settings → Import** accepts `.ics` files containing `VTODO` entries. Parsing is local-only.
 
+Use **Settings → Import → Manage imported data** to clear a task list's tasks or delete an extra task list and everything inside it.
+
 ## Export
 
 **Settings → Export** gives you:


### PR DESCRIPTION
## Summary
- add grouped multi-file calendar import with one-calendar-per-file defaults
- add Settings -> Import management for clearing/deleting imported collections
- clean local/cache/offline queue state when collection contents are cleared or collections are deleted

## Review
- code-reviewer subagent: green light to merge after fixes

## Verification
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web test -- app/stores/__tests__/use-etebase-store.test.ts app/stores/__tests__/use-calendar-store.test.ts
- git diff --check HEAD~1..HEAD