### PR TITLE
Fix calendar collection reliability

### DIFF
--- a/apps/web/app/(app)/calendar/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/calendar/__tests__/page.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, within } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import CalendarPage from '../page'
+
+const storeMock = vi.hoisted(() => ({
+  calendarState: {
+    events: [] as any[],
+    isLoading: false,
+    currentView: 'week' as const,
+    currentDate: new Date('2026-06-01T12:00:00Z'),
+    navigateForward: vi.fn(),
+    navigateBackward: vi.fn(),
+    navigateToday: vi.fn(),
+    selectedEventId: null as string | null,
+    setSelectedEvent: vi.fn(),
+  },
+  calendarListState: {
+    calendars: [] as any[],
+  },
+  authState: {
+    canWrite: vi.fn(() => true),
+  },
+}))
+
+vi.mock('@/app/stores/use-calendar-store', () => ({
+  useCalendarStore: (selector: (state: typeof storeMock.calendarState) => unknown) => selector(storeMock.calendarState),
+}))
+
+vi.mock('@/app/stores/use-calendar-list-store', () => ({
+  useCalendarListStore: (selector: (state: typeof storeMock.calendarListState) => unknown) => selector(storeMock.calendarListState),
+}))
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: (selector: (state: typeof storeMock.authState) => unknown) => selector(storeMock.authState),
+}))
+
+vi.mock('@/app/components/PullToRefresh', () => ({
+  PullToRefresh: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('../components/CalendarViewSwitcher', () => ({
+  CalendarViewSwitcher: () => null,
+}))
+
+vi.mock('../components/CalendarGrid', () => ({
+  CalendarGrid: ({ events }: { events: { title: string }[] }) => (
+    <div data-testid="desktop-grid">
+      {events.map((event) => <span key={event.title}>{event.title}</span>)}
+    </div>
+  ),
+}))
+
+vi.mock('../components/AgendaView', () => ({
+  AgendaView: ({ events }: { events: { title: string }[] }) => (
+    <div data-testid="mobile-agenda">
+      {events.map((event) => <span key={event.title}>{event.title}</span>)}
+    </div>
+  ),
+}))
+
+vi.mock('../components/EventDialog', () => ({
+  EventDialog: () => null,
+}))
+
+vi.mock('../components/FloatingAddButton', () => ({
+  FloatingAddButton: () => null,
+}))
+
+describe('CalendarPage calendar visibility', () => {
+  beforeEach(() => {
+    storeMock.calendarState.events = [
+      { id: 'visible-event', calendarId: 'visible-cal', title: 'Visible event' },
+      { id: 'hidden-event', calendarId: 'hidden-cal', title: 'Hidden event' },
+    ]
+    storeMock.calendarState.selectedEventId = null
+    storeMock.calendarListState.calendars = [
+      { id: 'visible-cal', name: 'Visible', color: '#10b981', visible: true },
+      { id: 'hidden-cal', name: 'Hidden', color: '#ef4444', visible: false },
+    ]
+  })
+
+  it('keeps hidden calendar events out of desktop grid and mobile agenda', () => {
+    render(<CalendarPage />)
+
+    const desktopGrid = within(screen.getByTestId('desktop-grid'))
+    expect(desktopGrid.getByText('Visible event')).toBeInTheDocument()
+    expect(desktopGrid.queryByText('Hidden event')).not.toBeInTheDocument()
+
+    const mobileAgenda = within(screen.getByTestId('mobile-agenda'))
+    expect(mobileAgenda.getByText('Visible event')).toBeInTheDocument()
+    expect(mobileAgenda.queryByText('Hidden event')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/app/components/CalendarListPanel.tsx
+++ b/apps/web/app/components/CalendarListPanel.tsx
@@ -9,6 +9,7 @@ export function CalendarListPanel() {
   const { calendars, defaultCalendarId, toggleVisibility, setDefaultCalendar, getNextColor } = useCalendarListStore()
   const createCollection = useEtebaseStore((s) => s.createCollection)
   const deleteCollection = useEtebaseStore((s) => s.deleteCollection)
+  const updateCollectionMeta = useEtebaseStore((s) => s.updateCollectionMeta)
   const [isAdding, setIsAdding] = useState(false)
   const [newName, setNewName] = useState('')
   const isCreatingRef = useRef(false)
@@ -31,6 +32,10 @@ export function CalendarListPanel() {
     if (!window.confirm(`Delete calendar "${name}" and all events in it? This cannot be undone.`)) return
     await deleteCollection('calendar', id)
   }, [calendars.length, deleteCollection])
+
+  const handleColorChange = useCallback((id: string, color: string) => {
+    void updateCollectionMeta('calendar', id, { color })
+  }, [updateCollectionMeta])
 
   return (
     <div className="px-3 py-2">
@@ -71,6 +76,14 @@ export function CalendarListPanel() {
               </span>
             </button>
             <div className="flex items-center gap-0.5">
+              <input
+                type="color"
+                value={cal.color}
+                onChange={(e) => handleColorChange(cal.id, e.target.value)}
+                className="h-4 w-4 cursor-pointer rounded border border-[rgb(var(--border))] bg-transparent p-0"
+                aria-label={`Change ${cal.name} color`}
+                title="Change color"
+              />
               {/* Default indicator / set as default */}
               <button
                 onClick={() => setDefaultCalendar(cal.id)}

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useEtebaseStore } from '../use-etebase-store'
 import { useCalendarStore } from '../use-calendar-store'
+import { useCalendarListStore } from '../use-calendar-list-store'
+import { useTaskListStore } from '../use-task-list-store'
+import { useContactListStore } from '../use-contact-list-store'
 
 const offlineQueueMock = vi.hoisted(() => ({
   enqueue: vi.fn(async () => {}),
@@ -9,8 +12,16 @@ const offlineQueueMock = vi.hoisted(() => ({
   isOfflineError: vi.fn(() => false),
 }))
 
+const coreMock = vi.hoisted(() => ({
+  listCollections: vi.fn(),
+  createCollection: vi.fn(),
+  updateCollectionMeta: vi.fn(),
+}))
+
 // Stub the offline queue so isOfflineError + enqueue don't try to open IndexedDB.
 vi.mock('@/app/lib/offline-queue', () => offlineQueueMock)
+
+vi.mock('@silentsuite/core', () => coreMock)
 
 vi.mock('@/app/lib/secure-storage', () => ({
   secureGet: vi.fn(async () => null),
@@ -23,6 +34,12 @@ vi.mock('@/app/lib/secure-storage', () => ({
 vi.mock('@/app/stores/use-toast-store', () => ({
   showErrorToast: vi.fn(),
 }))
+
+beforeEach(() => {
+  coreMock.listCollections.mockReset()
+  coreMock.createCollection.mockReset()
+  coreMock.updateCollectionMeta.mockReset()
+})
 
 interface MockItemManager {
   create: ReturnType<typeof vi.fn>
@@ -39,6 +56,13 @@ function mockItem(uid: string, content: string, isDeleted = false) {
     uid,
     isDeleted,
     getContent: vi.fn(async () => content),
+  }
+}
+
+function mockCollection(uid: string, meta: Record<string, string> = {}) {
+  return {
+    uid,
+    getMeta: vi.fn(() => meta),
   }
 }
 
@@ -500,5 +524,147 @@ describe('useEtebaseStore.refreshCollection', () => {
     expect(state.itemCache.get('existing')).toBe(existingItem)
     expect(state.itemCollectionMap.get('existing')).toBe('col-1')
     errorSpy.mockRestore()
+  })
+})
+
+describe('useEtebaseStore.reconcileCollections', () => {
+  beforeEach(() => {
+    offlineQueueMock.getAll.mockReset().mockResolvedValue([])
+    offlineQueueMock.remove.mockClear()
+    useCalendarStore.setState({
+      events: [],
+      selectedEventId: null,
+      isLoading: false,
+      syncStatus: 'synced',
+      currentView: 'week',
+      currentDate: new Date('2026-01-01T00:00:00Z'),
+    })
+    useCalendarListStore.setState({
+      calendars: [{ id: 'deleted-cal', name: 'Deleted', color: '#ef4444', visible: true }],
+      defaultCalendarId: 'deleted-cal',
+    })
+    useTaskListStore.setState({
+      lists: [{ id: 'tasks-1', name: 'Tasks', color: '#3b82f6', visible: true }],
+      activeListId: 'tasks-1',
+    })
+    useContactListStore.setState({
+      lists: [{ id: 'contacts-1', name: 'Contacts', color: '#8b5cf6', visible: true }],
+      activeListId: 'contacts-1',
+    })
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: [], tasks: [], contacts: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('removes a remotely deleted calendar and does not rehydrate its events', async () => {
+    const account = { id: 'account' }
+    const deletedCalendar = mockCollection('deleted-cal', { name: 'Deleted', color: '#ef4444' })
+    const replacementCalendar = mockCollection('new-default-cal', { name: 'Personal Calendar', color: '#10b981' })
+    const taskCollection = mockCollection('tasks-1', { name: 'Tasks', color: '#3b82f6' })
+    const contactCollection = mockCollection('contacts-1', { name: 'Contacts', color: '#8b5cf6' })
+    const syncEngine = {
+      pause: vi.fn(),
+      resume: vi.fn(),
+      trackCollection: vi.fn(),
+      untrackCollection: vi.fn(),
+      setStoken: vi.fn(),
+    }
+    coreMock.listCollections.mockImplementation(async (_account: unknown, collectionType: string) => {
+      if (collectionType === 'etebase.vevent') return []
+      if (collectionType === 'etebase.vtodo') return [taskCollection]
+      if (collectionType === 'etebase.vcard') return [contactCollection]
+      return []
+    })
+    coreMock.createCollection.mockResolvedValue(replacementCalendar)
+
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [deletedCalendar] as any[], tasks: [taskCollection] as any[], contacts: [contactCollection] as any[] },
+      itemCache: new Map([['event-1', mockItem('event-1', 'deleted event')]]),
+      itemTypeMap: new Map([['event-1', 'calendar']]),
+      itemCollectionMap: new Map([['event-1', 'deleted-cal']]),
+      isInitialized: true,
+      syncEngine: syncEngine as any,
+    })
+    useCalendarStore.setState({
+      events: [{ id: 'event-1', calendarId: 'deleted-cal', title: 'Deleted event' } as any],
+      selectedEventId: 'event-1',
+    })
+
+    await useEtebaseStore.getState().reconcileCollections()
+    const state = useEtebaseStore.getState()
+
+    expect(coreMock.createCollection).toHaveBeenCalledWith(account, 'etebase.vevent', { name: 'Personal Calendar' })
+    expect(state.collections.calendar.map((collection) => collection.uid)).toEqual(['new-default-cal'])
+    expect(state.itemCache.has('event-1')).toBe(false)
+    expect(state.itemTypeMap.has('event-1')).toBe(false)
+    expect(state.itemCollectionMap.has('event-1')).toBe(false)
+    expect(useCalendarStore.getState().events).toEqual([])
+    expect(useCalendarStore.getState().selectedEventId).toBeNull()
+    expect(useCalendarListStore.getState().calendars.map((calendar) => calendar.id)).toEqual(['new-default-cal'])
+    expect(syncEngine.pause).toHaveBeenCalledTimes(1)
+    expect(syncEngine.resume).toHaveBeenCalledTimes(1)
+    expect(syncEngine.untrackCollection).toHaveBeenCalledWith('deleted-cal')
+    expect(syncEngine.trackCollection).toHaveBeenCalledWith('etebase.vevent', 'new-default-cal')
+  })
+})
+
+describe('useEtebaseStore.updateCollectionMeta', () => {
+  beforeEach(() => {
+    useCalendarListStore.setState({
+      calendars: [{ id: 'cal-1', name: 'Work', color: '#111111', visible: false }],
+      defaultCalendarId: 'cal-1',
+    })
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: [], tasks: [], contacts: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('persists calendar color through collection metadata while preserving existing metadata', async () => {
+    const account = { id: 'account' }
+    const collection = mockCollection('cal-1', {
+      name: 'Work',
+      description: 'Keep this',
+      color: '#111111',
+    })
+    const updatedCollection = mockCollection('cal-1', {
+      name: 'Work',
+      description: 'Keep this',
+      color: '#ff0000',
+    })
+    coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [collection] as any[], tasks: [], contacts: [] },
+      isInitialized: true,
+    })
+
+    const result = await useEtebaseStore.getState().updateCollectionMeta('calendar', 'cal-1', { color: '#ff0000' })
+
+    expect(result).toBe(true)
+    expect(coreMock.updateCollectionMeta).toHaveBeenCalledWith(account, collection, {
+      name: 'Work',
+      description: 'Keep this',
+      color: '#ff0000',
+    })
+    expect(useEtebaseStore.getState().collections.calendar[0]).toBe(updatedCollection)
+    expect(useCalendarListStore.getState().calendars[0]).toMatchObject({
+      id: 'cal-1',
+      name: 'Work',
+      color: '#ff0000',
+      visible: false,
+    })
   })
 })

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -1,14 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useSyncStore } from '../use-sync-store'
 
+const etebaseMock = vi.hoisted(() => ({
+  state: {
+    account: null as unknown,
+    syncEngine: null as { syncNow: ReturnType<typeof vi.fn> } | null,
+    reconcileCollections: vi.fn().mockResolvedValue(undefined),
+    refreshCollection: vi.fn().mockResolvedValue([]),
+  },
+}))
+
 // Mock the heavy dependencies that simulateSyncCycle imports dynamically
 vi.mock('@/app/stores/use-etebase-store', () => ({
   useEtebaseStore: {
-    getState: () => ({
-      account: null,
-      syncEngine: null,
-      refreshCollection: vi.fn().mockResolvedValue([]),
-    }),
+    getState: () => etebaseMock.state,
   },
 }))
 
@@ -44,6 +49,10 @@ vi.mock('@/app/stores/use-toast-store', () => ({
 }))
 
 function resetStore() {
+  etebaseMock.state.account = null
+  etebaseMock.state.syncEngine = null
+  etebaseMock.state.reconcileCollections.mockReset().mockResolvedValue(undefined)
+  etebaseMock.state.refreshCollection.mockReset().mockResolvedValue([])
   useSyncStore.setState({
     syncStatus: 'synced',
     lastSyncedAt: null,
@@ -115,5 +124,25 @@ describe('useSyncStore', () => {
 
     await flushPromises()
     expect(useSyncStore.getState().syncStatus).toBe('synced')
+  })
+
+  it('reconciles collection deletion from another device before refreshing items', async () => {
+    const syncNow = vi.fn().mockResolvedValue(undefined)
+    etebaseMock.state.syncEngine = { syncNow }
+
+    useSyncStore.getState().simulateSyncCycle()
+
+    await flushPromises()
+    await flushPromises()
+    expect(etebaseMock.state.reconcileCollections).toHaveBeenCalledTimes(1)
+    expect(syncNow).toHaveBeenCalledTimes(1)
+    expect(etebaseMock.state.refreshCollection).toHaveBeenCalledTimes(3)
+    expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('tasks')
+    expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('contacts')
+    expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('calendar')
+
+    const reconcileOrder = etebaseMock.state.reconcileCollections.mock.invocationCallOrder[0]!
+    const firstRefreshOrder = etebaseMock.state.refreshCollection.mock.invocationCallOrder[0]!
+    expect(reconcileOrder).toBeLessThan(firstRefreshOrder)
   })
 })

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -72,8 +72,16 @@ const COLLECTION_TYPE_TASKS = 'etebase.vtodo'
 const COLLECTION_TYPE_CONTACTS = 'etebase.vcard'
 
 type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts'
+type CollectionMetaUpdates = { name?: string; description?: string; color?: string }
+type EtebaseCore = typeof import('@silentsuite/core')
 
 type CachedContentItem = { uid: string; content: string; collectionUid: string }
+
+const COLLECTION_DEFINITIONS: [CollectionTypeKey, string, string][] = [
+  ['calendar', COLLECTION_TYPE_CALENDAR, 'Personal Calendar'],
+  ['tasks', COLLECTION_TYPE_TASKS, 'Personal Tasks'],
+  ['contacts', COLLECTION_TYPE_CONTACTS, 'Personal Contacts'],
+]
 
 function collectionTypeToKey(ct: string): CollectionTypeKey | null {
   if (ct === COLLECTION_TYPE_CALENDAR) return 'calendar'
@@ -86,6 +94,51 @@ function keyToCollectionType(type: CollectionTypeKey): string {
   if (type === 'calendar') return COLLECTION_TYPE_CALENDAR
   if (type === 'tasks') return COLLECTION_TYPE_TASKS
   return COLLECTION_TYPE_CONTACTS
+}
+
+async function ensureCollectionsForAccount(
+  account: any,
+  core: EtebaseCore,
+): Promise<Record<CollectionTypeKey, any[]>> {
+  const collections: Record<CollectionTypeKey, any[]> = {
+    calendar: [],
+    tasks: [],
+    contacts: [],
+  }
+
+  for (const [key, colType, defaultName] of COLLECTION_DEFINITIONS) {
+    const existing = await core.listCollections(account, colType)
+    if (existing.length > 0) {
+      collections[key] = existing
+      logger.debug(`[etebase-store] Found ${existing.length} existing ${key} collection(s)`)
+    } else {
+      const created = await core.createCollection(account, colType, { name: defaultName })
+      collections[key] = [created]
+      logger.debug(`[etebase-store] Created ${key} collection: ${created.uid}`)
+    }
+  }
+
+  return collections
+}
+
+async function trackCollectionWithSyncEngine(
+  syncEngine: any | null,
+  collectionType: string,
+  type: CollectionTypeKey,
+  collectionUid: string,
+): Promise<void> {
+  if (!syncEngine) return
+  syncEngine.trackCollection(collectionType as CollectionType, collectionUid)
+  if (!isLocalCacheEnabled()) return
+  try {
+    const stoken = await cacheGetStoken(collectionUid)
+    if (stoken) {
+      syncEngine.setStoken?.(collectionUid, stoken)
+      logger.debug(`[etebase-store] Seeded ${type} stoken from cache`)
+    }
+  } catch (err) {
+    logger.warn(`[etebase-store] Failed to seed ${type} stoken`, err)
+  }
 }
 
 /**
@@ -292,6 +345,16 @@ interface EtebaseActions {
   deleteCollection: (type: CollectionTypeKey, collectionUid: string) => Promise<boolean>
 
   /**
+   * Update Etebase collection metadata and refresh local list stores.
+   */
+  updateCollectionMeta: (type: CollectionTypeKey, collectionUid: string, updates: CollectionMetaUpdates) => Promise<boolean>
+
+  /**
+   * Re-list remote collections and reconcile local state with active collections.
+   */
+  reconcileCollections: () => Promise<void>
+
+  /**
    * Delete every item inside a collection while keeping the collection itself.
    */
   deleteItemsInCollection: (type: CollectionTypeKey, collectionUid: string) => Promise<number>
@@ -382,29 +445,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       }
 
       // 2. Ensure collections exist (create if first login, fetch if returning)
-      const collections: Record<CollectionTypeKey, any[]> = {
-        calendar: [],
-        tasks: [],
-        contacts: [],
-      }
-
-      const typeMap: [CollectionTypeKey, string, string][] = [
-        ['calendar', COLLECTION_TYPE_CALENDAR, 'Personal Calendar'],
-        ['tasks', COLLECTION_TYPE_TASKS, 'Personal Tasks'],
-        ['contacts', COLLECTION_TYPE_CONTACTS, 'Personal Contacts'],
-      ]
-
-      for (const [key, colType, defaultName] of typeMap) {
-        const existing = await core.listCollections(account, colType)
-        if (existing.length > 0) {
-          collections[key] = existing
-          logger.debug(`[etebase-store] Found ${existing.length} existing ${key} collection(s)`)
-        } else {
-          const created = await core.createCollection(account, colType, { name: defaultName })
-          collections[key] = [created]
-          logger.debug(`[etebase-store] Created ${key} collection: ${created.uid}`)
-        }
-      }
+      const collections = await ensureCollectionsForAccount(account, core)
 
       set({ collections })
       await hydrateListStores(collections)
@@ -414,7 +455,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const itemTypeMap = new Map<string, CollectionTypeKey>()
       const itemCollectionMap = new Map<string, string>()
 
-      for (const [key] of typeMap) {
+      for (const [key] of COLLECTION_DEFINITIONS) {
         const typedCollections = collections[key]
 
         for (const collection of typedCollections) {
@@ -446,9 +487,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       })
 
       // Track all collections
-      for (const [key, colType] of typeMap) {
+      for (const [key, colType] of COLLECTION_DEFINITIONS) {
         for (const collection of collections[key]) {
-          engine.trackCollection(colType as CollectionType, collection.uid)
+          await trackCollectionWithSyncEngine(engine, colType, key, collection.uid)
         }
       }
 
@@ -456,20 +497,6 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       // pulls only deltas instead of refetching the whole vault. Wire the
       // advance handler so subsequent stoken updates are persisted too.
       if (cacheEnabled) {
-        for (const [key] of typeMap) {
-          for (const collection of collections[key]) {
-            try {
-              const stoken = await cacheGetStoken(collection.uid)
-              if (stoken) {
-                engine.setStoken(collection.uid, stoken)
-                logger.debug(`[etebase-store] Seeded ${key} stoken from cache`)
-              }
-            } catch (err) {
-              logger.warn(`[etebase-store] Failed to seed ${key} stoken`, err)
-            }
-          }
-        }
-
         engine.onStokenAdvance((event: { collectionType: string; collectionUid: string; stoken: string | null }) => {
           const key = collectionTypeToKey(event.collectionType)
           if (!key) return
@@ -567,6 +594,114 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       console.error(`[etebase-store] Failed to delete ${type} collection ${collectionUid}:`, err)
       showErrorToast(`Failed to delete ${type === 'calendar' ? 'calendar' : type === 'tasks' ? 'task list' : 'address book'}. Please try again.`)
       return false
+    }
+  },
+
+  updateCollectionMeta: async (type: CollectionTypeKey, collectionUid: string, updates: CollectionMetaUpdates) => {
+    const { account, collections } = get()
+    const collection = resolveCollection(collections, type, collectionUid)
+    if (!account || !collection) {
+      logger.warn(`[etebase-store] Cannot update ${type} collection ${collectionUid}: missing account or collection`)
+      return false
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      const currentMeta = collection?.getMeta?.() ?? {}
+      const updatedMeta: CollectionMetaUpdates = {}
+      if (updates.name !== undefined) updatedMeta.name = updates.name
+      else if (currentMeta.name !== undefined) updatedMeta.name = currentMeta.name
+      if (updates.description !== undefined) updatedMeta.description = updates.description
+      else if (currentMeta.description !== undefined) updatedMeta.description = currentMeta.description
+      if (updates.color !== undefined) updatedMeta.color = updates.color
+      else if (currentMeta.color !== undefined) updatedMeta.color = currentMeta.color
+      const updatedCollection = await core.updateCollectionMeta(account, collection, updatedMeta)
+      const newCollections = {
+        ...get().collections,
+        [type]: get().collections[type].map((existing) =>
+          existing.uid === collection.uid ? updatedCollection : existing,
+        ),
+      }
+      set({ collections: newCollections })
+      await hydrateListStores(newCollections)
+      return true
+    } catch (err) {
+      console.error(`[etebase-store] Failed to update ${type} collection ${collectionUid}:`, err)
+      showErrorToast(`Failed to update ${type === 'calendar' ? 'calendar' : type === 'tasks' ? 'task list' : 'address book'}. Please try again.`)
+      return false
+    }
+  },
+
+  reconcileCollections: async () => {
+    const { account, syncEngine } = get()
+    if (!account) {
+      logger.warn('[etebase-store] Cannot reconcile collections: no account')
+      return
+    }
+
+    syncEngine?.pause?.()
+    try {
+      const core = await import('@silentsuite/core')
+      const previousCollections = get().collections
+      const activeCollections = await ensureCollectionsForAccount(account, core)
+      const newItemCache = new Map(get().itemCache)
+      const newItemTypeMap = new Map(get().itemTypeMap)
+      const newItemCollectionMap = new Map(get().itemCollectionMap)
+      const cleanupPromises: Promise<unknown>[] = []
+      let removedCollectionCount = 0
+
+      for (const [type, colType] of COLLECTION_DEFINITIONS) {
+        const activeUids = new Set(activeCollections[type].map((collection) => collection.uid))
+        const previousUids = new Set(previousCollections[type].map((collection) => collection.uid))
+        const removedUids = new Set<string>()
+
+        for (const collection of previousCollections[type]) {
+          if (!activeUids.has(collection.uid)) removedUids.add(collection.uid)
+        }
+
+        for (const [itemUid, mappedCollectionUid] of newItemCollectionMap.entries()) {
+          if (newItemTypeMap.get(itemUid) === type && !activeUids.has(mappedCollectionUid)) {
+            removedUids.add(mappedCollectionUid)
+          }
+        }
+
+        for (const collectionUid of removedUids) {
+          removedCollectionCount++
+          syncEngine?.untrackCollection(collectionUid)
+          for (const [itemUid, mappedCollectionUid] of Array.from(newItemCollectionMap.entries())) {
+            if (mappedCollectionUid !== collectionUid) continue
+            newItemCache.delete(itemUid)
+            newItemTypeMap.delete(itemUid)
+            newItemCollectionMap.delete(itemUid)
+          }
+          cleanupPromises.push(removeQueuedMutationsForCollection(type, collectionUid, true))
+          cleanupPromises.push(removeItemsFromDomainStore(type, collectionUid))
+          if (isLocalCacheEnabled()) {
+            cleanupPromises.push(cacheReplaceItemsForCollection(collectionUid, []))
+          }
+        }
+
+        for (const collection of activeCollections[type]) {
+          if (!previousUids.has(collection.uid)) {
+            await trackCollectionWithSyncEngine(syncEngine, colType, type, collection.uid)
+          }
+        }
+      }
+
+      set({
+        collections: activeCollections,
+        itemCache: newItemCache,
+        itemTypeMap: newItemTypeMap,
+        itemCollectionMap: newItemCollectionMap,
+      })
+      await Promise.all(cleanupPromises)
+      await hydrateListStores(activeCollections)
+      logger.debug(`[etebase-store] Reconciled collections (${removedCollectionCount} removed)`)
+    } catch (err) {
+      console.error('[etebase-store] Failed to reconcile collections:', err)
+      throw err
+    } finally {
+      syncEngine?.resume?.()
     }
   },
 

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -187,9 +187,14 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
     ]).then(async ([{ useEtebaseStore }, core]) => {
       const etebase = useEtebaseStore.getState()
 
-      // First, run the SyncEngine poll to advance stokens
-      if (etebase.syncEngine) {
-        try { await etebase.syncEngine.syncNow() } catch (err) {
+      // First reconcile collection membership so manual sync notices calendars,
+      // task lists, or address books deleted or created on another device.
+      await etebase.reconcileCollections()
+      const reconciledEtebase = useEtebaseStore.getState()
+
+      // Then run the SyncEngine poll to advance stokens for active collections.
+      if (reconciledEtebase.syncEngine) {
+        try { await reconciledEtebase.syncEngine.syncNow() } catch (err) {
           logger.error('SyncStore', 'SyncEngine.syncNow() failed', err)
           set({ syncStatus: 'error' })
         }
@@ -197,9 +202,9 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
 
       // Then refresh every collection of each type from the server
       const [taskItems, contactItems, eventItems] = await Promise.all([
-        etebase.refreshCollection('tasks'),
-        etebase.refreshCollection('contacts'),
-        etebase.refreshCollection('calendar'),
+        reconciledEtebase.refreshCollection('tasks'),
+        reconciledEtebase.refreshCollection('contacts'),
+        reconciledEtebase.refreshCollection('calendar'),
       ])
 
       // Push fresh data into stores

--- a/packages/core/src/etebase/collections.test.ts
+++ b/packages/core/src/etebase/collections.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { listCollections, updateCollectionMeta } from './collections.js';
+
+describe('listCollections', () => {
+  it('filters deleted collection tombstones', async () => {
+    const active = { uid: 'active' };
+    const legacyActive = { uid: 'legacy-active', isDeleted: false };
+    const deleted = { uid: 'deleted', isDeleted: true };
+    const collectionManager = {
+      list: vi.fn().mockResolvedValue({ data: [active, deleted, legacyActive] }),
+    };
+    const account = {
+      getCollectionManager: vi.fn().mockReturnValue(collectionManager),
+    };
+
+    const collections = await listCollections(account as any, 'etebase.vevent');
+
+    expect(collectionManager.list).toHaveBeenCalledWith('etebase.vevent');
+    expect(collections).toEqual([active, legacyActive]);
+  });
+});
+
+describe('updateCollectionMeta', () => {
+  it('preserves existing metadata fields when updating only color', async () => {
+    const collection = {
+      uid: 'calendar-1',
+      getMeta: vi.fn().mockReturnValue({
+        name: 'Work',
+        description: 'Existing description',
+        color: '#111111',
+      }),
+      setMeta: vi.fn().mockResolvedValue(undefined),
+    };
+    const collectionManager = {
+      upload: vi.fn().mockResolvedValue(undefined),
+    };
+    const account = {
+      getCollectionManager: vi.fn().mockReturnValue(collectionManager),
+    };
+
+    const result = await updateCollectionMeta(account as any, collection as any, { color: '#ff0000' });
+
+    expect(collection.setMeta).toHaveBeenCalledWith({
+      name: 'Work',
+      description: 'Existing description',
+      color: '#ff0000',
+    });
+    expect(collectionManager.upload).toHaveBeenCalledWith(collection);
+    expect(result).toBe(collection);
+  });
+});

--- a/packages/core/src/etebase/collections.ts
+++ b/packages/core/src/etebase/collections.ts
@@ -6,6 +6,12 @@ export interface CollectionMeta {
   color?: string;
 }
 
+export interface CollectionMetaUpdate {
+  name?: string;
+  description?: string;
+  color?: string;
+}
+
 export interface ItemListResponse {
   items: Etebase.Item[];
   stoken: string | null;
@@ -43,7 +49,7 @@ export async function listCollections(
 ): Promise<Etebase.Collection[]> {
   const collectionManager = account.getCollectionManager();
   const response = await collectionManager.list(collectionType);
-  return response.data;
+  return response.data.filter((collection) => !(collection as any).isDeleted);
 }
 
 /**
@@ -63,15 +69,15 @@ export async function getCollection(
 export async function updateCollectionMeta(
   account: Etebase.Account,
   collection: Etebase.Collection,
-  meta: CollectionMeta,
+  meta: CollectionMetaUpdate,
 ): Promise<Etebase.Collection> {
   const collectionManager = account.getCollectionManager();
   const currentMeta = (collection as any).getMeta?.() ?? {};
   const nextMeta = {
     ...currentMeta,
-    name: meta.name,
-    description: meta.description,
-    color: meta.color,
+    ...(meta.name !== undefined ? { name: meta.name } : {}),
+    ...(meta.description !== undefined ? { description: meta.description } : {}),
+    ...(meta.color !== undefined ? { color: meta.color } : {}),
   };
 
   if (typeof (collection as any).setMeta === 'function') {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,7 +41,7 @@ export {
   deleteItem,
   batchUpload,
 } from './etebase/collections.js';
-export type { CollectionMeta, ItemListResponse } from './etebase/collections.js';
+export type { CollectionMeta, CollectionMetaUpdate, ItemListResponse } from './etebase/collections.js';
 
 // Sync engine
 export { SyncEngine } from './etebase/sync.js';


### PR DESCRIPTION
## Summary
- Filter deleted Etebase collection tombstones before web stores see them.
- Reconcile calendar/task/contact collections during manual sync, including default recreation, SyncEngine tracking updates, and stale local item cleanup.
- Add calendar collection color updates via metadata and a minimal existing-calendar color picker.
- Preserve hidden-calendar filtering and add regression coverage.

## Tests
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/core type-check
- pnpm --filter @silentsuite/web exec vitest run app/stores/__tests__/use-etebase-store.test.ts app/stores/__tests__/use-sync-store.test.ts "app/(app)/calendar/__tests__/page.test.tsx"
- pnpm --filter @silentsuite/core exec vitest run src/etebase/collections.test.ts
- git diff --check

## Review
- code-reviewer subagent: green light after re-review.

## Deployment Note
- Production `main` still needs `dev` promoted to receive the existing calendar visibility behavior.