### PR TITLE
Polish Android sync UX states

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -58,6 +58,7 @@ import io.silentsuite.sync.syncadapter.requestSync
 import io.silentsuite.sync.ui.etebase.CollectionActivity
 import io.silentsuite.sync.ui.etebase.InvitationsActivity
 import io.silentsuite.sync.ui.setup.LoginActivity
+import io.silentsuite.sync.utils.TaskProviderHandling
 import io.silentsuite.sync.utils.packageInstalled
 import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
@@ -199,11 +200,13 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         tbTaskDAV.inflateMenu(R.menu.taskdav_actions)
         tbTaskDAV.setOnMenuItemClickListener(this)
         tbTaskDAV.setTitle(R.string.settings_taskdav)
-        if (!packageInstalled(this, tasksOrgPackage)) {
+        val tasksOrgInstalled = packageInstalled(this, tasksOrgPackage)
+        val openTasksInstalled = packageInstalled(this, openTasksPackage)
+        if (!tasksOrgInstalled) {
             val tasksInstallMenuItem = tbTaskDAV.menu.findItem(R.id.install_tasksorg)
             tasksInstallMenuItem.setVisible(true)
         }
-        if (!packageInstalled(this, openTasksPackage)) {
+        if (!openTasksInstalled) {
             val tasksInstallMenuItem = tbTaskDAV.menu.findItem(R.id.install_opentasks)
             tasksInstallMenuItem.setVisible(true)
         }
@@ -565,6 +568,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         if (info.carddav != null) {
             val progress = findViewById<View>(R.id.carddav_refreshing) as ProgressBar
             progress.visibility = if (info.carddav!!.refreshing) View.VISIBLE else View.GONE
+            updateSectionStatus(R.id.carddav_status, info.carddav!!.refreshing)
 
             listCardDAV = findViewById<View>(R.id.address_books) as ListView
             listCardDAV!!.isEnabled = !info.carddav!!.refreshing
@@ -579,6 +583,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         if (info.caldav != null) {
             val progress = findViewById<View>(R.id.caldav_refreshing) as ProgressBar
             progress.visibility = if (info.caldav!!.refreshing) View.VISIBLE else View.GONE
+            updateSectionStatus(R.id.caldav_status, info.caldav!!.refreshing)
 
             listCalDAV = findViewById<View>(R.id.calendars) as ListView
             listCalDAV!!.isEnabled = !info.caldav!!.refreshing
@@ -593,6 +598,8 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         if (info.taskdav != null) {
             val progress = findViewById<View>(R.id.taskdav_refreshing) as ProgressBar
             progress.visibility = if (info.taskdav!!.refreshing) View.VISIBLE else View.GONE
+            val hasTaskProvider = hasSupportedTaskProvider()
+            updateSectionStatus(R.id.taskdav_status, info.taskdav!!.refreshing, setupNeeded = !hasTaskProvider)
 
             listTaskDAV = findViewById<View>(R.id.tasklists) as ListView
             listTaskDAV!!.isEnabled = !info.taskdav!!.refreshing
@@ -603,12 +610,22 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             listTaskDAV!!.adapter = adapter
             listTaskDAV!!.onItemClickListener = onItemClickListener
 
-            if (!packageInstalled(this, tasksOrgPackage) && !packageInstalled(this, openTasksPackage)) {
-                val opentasksWarning = findViewById<View>(R.id.taskdav_opentasks_warning)
-                opentasksWarning.visibility = View.VISIBLE
-            }
+            val opentasksWarning = findViewById<View>(R.id.taskdav_opentasks_warning)
+            opentasksWarning.visibility = if (hasTaskProvider) View.GONE else View.VISIBLE
         }
     }
+
+    private fun updateSectionStatus(statusViewId: Int, refreshing: Boolean, setupNeeded: Boolean = false) {
+        val status = findViewById<TextView>(statusViewId)
+        status.setText(when {
+            setupNeeded -> R.string.account_section_status_setup_needed
+            refreshing -> R.string.account_section_status_syncing
+            else -> R.string.account_section_status_synced
+        })
+    }
+
+    private fun hasSupportedTaskProvider() =
+            TaskProviderHandling.getWantedTaskSyncProvider(this) != null
 
 
     class AccountInfoViewModel : ViewModel(), AccountUpdateService.RefreshingStatusListener, ServiceConnection, SyncStatusObserver {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ItemRevisionsListFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ItemRevisionsListFragment.kt
@@ -70,7 +70,7 @@ class ItemRevisionsListFragment : ListFragment(), AdapterView.OnItemClickListene
                 restored = true
             }
 
-            emptyTextView!!.text = getString(R.string.journal_entries_list_empty)
+            emptyTextView!!.text = getString(R.string.journal_revisions_list_empty)
         }
 
         listView.onItemClickListener = this

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ListEntriesFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ListEntriesFragment.kt
@@ -17,6 +17,7 @@ import io.silentsuite.sync.CachedCollection
 import io.silentsuite.sync.CachedItem
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
+import io.silentsuite.sync.utils.TaskProviderHandling
 import java.text.SimpleDateFormat
 
 
@@ -57,7 +58,7 @@ class ListEntriesFragment : ListFragment(), AdapterView.OnItemClickListener {
                     restored = true
                 }
 
-                emptyTextView!!.text = getString(R.string.journal_entries_list_empty)
+                emptyTextView!!.text = getString(emptyTextRes(requireContext(), col.collectionType))
             }
         }
 
@@ -133,20 +134,38 @@ class ListEntriesFragment : ListFragment(), AdapterView.OnItemClickListener {
 
             val fullContent = item.content
             var content = getLine(fullContent, prefix)
-            content = content ?: "Not found"
+            content = content ?: v.context.getString(R.string.journal_item_title_unavailable)
             tv.text = content
 
             tv = v.findViewById<View>(R.id.description) as TextView
-            // FIXME: Don't use a hard-coded string
-            content = "Modified: ${dateFormatter.format(item.meta.mtime ?: 0)}"
-            tv.text = content
+            val modifiedAt = item.meta.mtime
+            tv.text = if (modifiedAt == null || modifiedAt <= 0L) {
+                v.context.getString(R.string.journal_item_modified_unavailable)
+            } else {
+                v.context.getString(R.string.journal_item_modified, dateFormatter.format(modifiedAt))
+            }
 
             val action = v.findViewById<View>(R.id.action) as ImageView
             if (item.item.isDeleted) {
                 action.setImageResource(R.drawable.action_delete)
+                action.contentDescription = v.context.getString(R.string.journal_item_action_deleted)
             } else {
                 action.setImageResource(R.drawable.action_change)
+                action.contentDescription = v.context.getString(R.string.journal_item_action_changed)
             }
+        }
+
+        private fun emptyTextRes(context: Context, collectionType: String) = when (collectionType) {
+            Constants.ETEBASE_TYPE_CALENDAR -> R.string.journal_entries_list_empty_calendar
+            Constants.ETEBASE_TYPE_TASKS -> {
+                if (TaskProviderHandling.getWantedTaskSyncProvider(context) == null) {
+                    R.string.journal_entries_list_empty_tasks_setup
+                } else {
+                    R.string.journal_entries_list_empty_tasks
+                }
+            }
+            Constants.ETEBASE_TYPE_ADDRESS_BOOK -> R.string.journal_entries_list_empty_contacts
+            else -> R.string.journal_entries_list_empty
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/SignupFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/SignupFragment.kt
@@ -16,7 +16,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.CheckedTextView
 import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -53,12 +52,14 @@ class SignupFragment : Fragment() {
     internal lateinit var editEmail: TextInputLayout
     internal lateinit var editPassword: TextInputLayout
 
-    internal lateinit var showAdvanced: CheckedTextView
+    internal lateinit var showAdvanced: TextView
     internal lateinit var customServer: TextInputEditText
+    private var advancedExpanded = false
 
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val v = inflater.inflate(R.layout.signup_fragment, container, false)
+        advancedExpanded = savedInstanceState?.getBoolean(KEY_ADVANCED_EXPANDED) ?: false
 
         editEmail = v.findViewById(R.id.email)
         editPassword = v.findViewById(R.id.url_password)
@@ -89,18 +90,27 @@ class SignupFragment : Fragment() {
         }
 
         val advancedLayout = v.findViewById<View>(R.id.advanced_layout) as ExpandableLayout
+        if (advancedExpanded) {
+            advancedLayout.expand()
+        }
+        updateAdvancedDisclosure()
 
         showAdvanced.setOnClickListener {
-            if (showAdvanced.isChecked) {
-                showAdvanced.isChecked = false
-                advancedLayout.collapse()
-            } else {
-                showAdvanced.isChecked = true
+            advancedExpanded = !advancedExpanded
+            if (advancedExpanded) {
                 advancedLayout.expand()
+            } else {
+                advancedLayout.collapse()
             }
+            updateAdvancedDisclosure()
         }
 
         return v
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_ADVANCED_EXPANDED, advancedExpanded)
     }
 
     protected fun validateData(): SignupCredentials? {
@@ -123,7 +133,7 @@ class SignupFragment : Fragment() {
         }
 
         var uri: URI? = null
-        if (showAdvanced.isChecked) {
+        if (advancedExpanded) {
             val server = customServer.text.toString()
             if (!server.isEmpty()) {
                 val url = server.toHttpUrlOrNull()
@@ -141,7 +151,15 @@ class SignupFragment : Fragment() {
         return if (valid) SignupCredentials(uri, email, email, password) else null
     }
 
+    private fun updateAdvancedDisclosure() {
+        showAdvanced.contentDescription = getString(
+                if (advancedExpanded) R.string.login_custom_server_expanded else R.string.login_custom_server_collapsed
+        )
+    }
+
     companion object {
+        private const val KEY_ADVANCED_EXPANDED = "advancedExpanded"
+
         fun newInstance(initialEmail: String?, initialPassword: String?): SignupFragment {
             val ret = SignupFragment()
             ret.initialEmail = initialEmail

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ViewCollectionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ViewCollectionFragment.kt
@@ -14,8 +14,8 @@ import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
 import io.silentsuite.sync.resource.LocalCalendar
 import io.silentsuite.sync.ui.BaseActivity
+import io.silentsuite.sync.utils.TaskProviderHandling
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import java.util.*
 
 class ViewCollectionFragment : Fragment() {
     private val collectionModel: CollectionViewModel by activityViewModels()
@@ -65,7 +65,11 @@ class ViewCollectionFragment : Fragment() {
             Constants.ETEBASE_TYPE_TASKS -> {
                 colorSquare.setBackgroundColor(color)
                 val tasksNotShowing = container.findViewById<View>(R.id.tasks_not_showing)
-                tasksNotShowing.visibility = View.VISIBLE
+                tasksNotShowing.visibility = if (TaskProviderHandling.getWantedTaskSyncProvider(requireContext()) == null) {
+                    View.VISIBLE
+                } else {
+                    View.GONE
+                }
             }
             Constants.ETEBASE_TYPE_ADDRESS_BOOK -> {
                 colorSquare.visibility = View.GONE
@@ -82,13 +86,17 @@ class ViewCollectionFragment : Fragment() {
             owner.visibility = View.GONE
         } else {
             owner.visibility = View.VISIBLE
-            owner.text = "Shared with us" // FIXME: Figure out how to represent it and don't use a hardcoded string
+            owner.text = getString(R.string.collection_shared_with_us)
         }
 
         itemsModel.observe(this) {
             val stats = container.findViewById<TextView>(R.id.stats)
             container.findViewById<View>(R.id.progressBar).visibility = View.GONE
-            stats.text = String.format(Locale.getDefault(), "Change log items: %d", it.size)
+            stats.text = if (it.isEmpty()) {
+                getString(R.string.collection_recent_activity_none)
+            } else {
+                resources.getQuantityString(R.plurals.collection_recent_activity_items, it.size, it.size)
+            }
         }
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -14,7 +14,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.CheckedTextView
 import android.widget.EditText
 import android.widget.TextView
 import androidx.fragment.app.Fragment
@@ -33,8 +32,9 @@ class LoginCredentialsFragment : Fragment() {
     internal lateinit var editUserName: EditText
     internal lateinit var editUrlPassword: TextInputLayout
 
-    internal lateinit var showAdvanced: CheckedTextView
+    internal lateinit var showAdvanced: TextView
     internal lateinit var customServer: EditText
+    private var advancedExpanded = false
 
     internal var initialUsername: String? = null
     internal var initialPassword: String? = null
@@ -42,10 +42,11 @@ class LoginCredentialsFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val v = inflater.inflate(R.layout.login_credentials_fragment, container, false)
+        advancedExpanded = savedInstanceState?.getBoolean(KEY_ADVANCED_EXPANDED) ?: false
 
         editUserName = v.findViewById<TextInputEditText>(R.id.user_name)
         editUrlPassword = v.findViewById<TextInputLayout>(R.id.url_password)
-        showAdvanced = v.findViewById<CheckedTextView>(R.id.show_advanced)
+        showAdvanced = v.findViewById<TextView>(R.id.show_advanced)
         customServer = v.findViewById<TextInputEditText>(R.id.custom_server)
 
         if (savedInstanceState == null) {
@@ -73,18 +74,27 @@ class LoginCredentialsFragment : Fragment() {
         forgotPassword.setOnClickListener { WebViewActivity.openUrl(requireContext(), Constants.forgotPassword) }
 
         val advancedLayout = v.findViewById<View>(R.id.advanced_layout) as ExpandableLayout
+        if (advancedExpanded) {
+            advancedLayout.expand()
+        }
+        updateAdvancedDisclosure()
 
         showAdvanced.setOnClickListener {
-            if (showAdvanced.isChecked) {
-                showAdvanced.isChecked = false
-                advancedLayout.collapse()
-            } else {
-                showAdvanced.isChecked = true
+            advancedExpanded = !advancedExpanded
+            if (advancedExpanded) {
                 advancedLayout.expand()
+            } else {
+                advancedLayout.collapse()
             }
+            updateAdvancedDisclosure()
         }
 
         return v
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_ADVANCED_EXPANDED, advancedExpanded)
     }
 
     protected fun validateLoginData(): LoginCredentials? {
@@ -107,7 +117,7 @@ class LoginCredentialsFragment : Fragment() {
         }
 
         var uri: URI? = null
-        if (showAdvanced.isChecked) {
+        if (advancedExpanded) {
             val server = customServer.text.toString()
             // If this field is null, just use the default
             if (!server.isEmpty()) {
@@ -125,7 +135,15 @@ class LoginCredentialsFragment : Fragment() {
         return if (valid) LoginCredentials(uri, userName, password) else null
     }
 
+    private fun updateAdvancedDisclosure() {
+        showAdvanced.contentDescription = getString(
+                if (advancedExpanded) R.string.login_custom_server_expanded else R.string.login_custom_server_collapsed
+        )
+    }
+
     companion object {
+        private const val KEY_ADVANCED_EXPANDED = "advancedExpanded"
+
         fun newInstance(initialUsername: String?, initialPassword: String?): LoginCredentialsFragment {
             val ret = LoginCredentialsFragment()
             ret.initialUsername = initialUsername

--- a/android/app/src/main/res/layout/account_collection_item.xml
+++ b/android/app/src/main/res/layout/account_collection_item.xml
@@ -10,12 +10,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
     android:gravity="center_vertical"
+    android:minHeight="56dp"
     android:orientation="horizontal"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp"
-    android:paddingLeft="12dp"
-    android:paddingRight="12dp">
+    android:paddingTop="10dp"
+    android:paddingBottom="10dp"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp">
 
     <CheckBox
         android:id="@+id/sync"
@@ -38,6 +40,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textStyle="bold"
+            android:ellipsize="end"
+            android:maxLines="1"
             tools:text="Title" />
 
         <TextView
@@ -45,29 +50,35 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorSecondary"
+            android:ellipsize="end"
+            android:maxLines="2"
             tools:text="Description" />
     </LinearLayout>
 
 
     <ImageView
         android:id="@+id/shared"
-        android:layout_width="32dp"
-        android:layout_height="32dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:layout_marginRight="8dp"
+        android:contentDescription="@string/account_collection_shared_indicator"
         android:src="@drawable/ic_members_dark"
         android:visibility="gone" />
 
     <ImageView
         android:id="@+id/read_only"
-        android:layout_width="32dp"
-        android:layout_height="32dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:layout_marginRight="8dp"
+        android:contentDescription="@string/account_collection_read_only_indicator"
         android:src="@drawable/ic_readonly_dark" />
 
     <View
         android:id="@+id/color"
-        android:layout_width="28dp"
-        android:layout_height="28dp"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:importantForAccessibility="no"
         tools:background="@color/green700" />
 
 </LinearLayout>

--- a/android/app/src/main/res/layout/activity_account.xml
+++ b/android/app/src/main/res/layout/activity_account.xml
@@ -51,9 +51,10 @@
                     android:id="@+id/subscription_card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="8dp"
+                    android:layout_marginBottom="12dp"
                     app:cardUseCompatPadding="true"
-                    app:cardElevation="8dp">
+                    app:cardCornerRadius="12dp"
+                    app:cardElevation="2dp">
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -104,9 +105,10 @@
                     android:id="@+id/carddav"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="8dp"
+                    android:layout_marginBottom="12dp"
                     app:cardUseCompatPadding="true"
-                    app:cardElevation="8dp">
+                    app:cardCornerRadius="12dp"
+                    app:cardElevation="2dp">
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -121,7 +123,7 @@
                             style="@style/toolbar_style"
                             app:navigationIcon="@drawable/ic_people_light"
                             app:title="@string/settings_carddav"
-                            android:elevation="2dp" tools:ignore="UnusedAttribute"/>
+                            android:elevation="0dp" tools:ignore="UnusedAttribute"/>
 
                         <ProgressBar
                             android:id="@+id/carddav_refreshing"
@@ -130,6 +132,18 @@
                             android:layout_height="wrap_content"
                             android:visibility="gone"
                             android:indeterminate="true"/>
+
+                        <TextView
+                            android:id="@+id/carddav_status"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="16dp"
+                            android:paddingEnd="16dp"
+                            android:paddingTop="8dp"
+                            android:paddingBottom="4dp"
+                            android:text="@string/account_section_status_loading"
+                            android:textAppearance="?android:attr/textAppearanceSmall"
+                            android:textColor="?android:attr/textColorSecondary" />
 
                         <io.silentsuite.sync.ui.widget.MaximizedListView
                             android:id="@+id/address_books"
@@ -145,8 +159,10 @@
                     android:id="@+id/caldav"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginBottom="12dp"
                     app:cardUseCompatPadding="true"
-                    app:cardElevation="8dp">
+                    app:cardCornerRadius="12dp"
+                    app:cardElevation="2dp">
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -161,7 +177,7 @@
                             style="@style/toolbar_style"
                             app:navigationIcon="@drawable/ic_event_light"
                             app:title="@string/settings_caldav"
-                            android:elevation="2dp" tools:ignore="UnusedAttribute"/>
+                            android:elevation="0dp" tools:ignore="UnusedAttribute"/>
 
                         <ProgressBar
                             android:id="@+id/caldav_refreshing"
@@ -170,6 +186,18 @@
                             android:layout_height="wrap_content"
                             android:visibility="gone"
                             android:indeterminate="true"/>
+
+                        <TextView
+                            android:id="@+id/caldav_status"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="16dp"
+                            android:paddingEnd="16dp"
+                            android:paddingTop="8dp"
+                            android:paddingBottom="4dp"
+                            android:text="@string/account_section_status_loading"
+                            android:textAppearance="?android:attr/textAppearanceSmall"
+                            android:textColor="?android:attr/textColorSecondary" />
 
                         <io.silentsuite.sync.ui.widget.MaximizedListView
                             android:id="@+id/calendars"
@@ -187,7 +215,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:cardUseCompatPadding="true"
-                    app:cardElevation="8dp">
+                    app:cardCornerRadius="12dp"
+                    app:cardElevation="2dp">
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -202,7 +231,7 @@
                             style="@style/toolbar_style"
                             app:navigationIcon="@drawable/ic_task_light"
                             app:title="@string/settings_taskdav"
-                            android:elevation="2dp" tools:ignore="UnusedAttribute"/>
+                            android:elevation="0dp" tools:ignore="UnusedAttribute"/>
 
                         <ProgressBar
                             android:id="@+id/taskdav_refreshing"
@@ -213,14 +242,29 @@
                             android:visibility="gone" />
 
                         <TextView
+                            android:id="@+id/taskdav_status"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingStart="16dp"
+                            android:paddingEnd="16dp"
+                            android:paddingTop="8dp"
+                            android:paddingBottom="4dp"
+                            android:text="@string/account_section_status_loading"
+                            android:textAppearance="?android:attr/textAppearanceSmall"
+                            android:textColor="?android:attr/textColorSecondary" />
+
+                        <TextView
                             android:id="@+id/taskdav_opentasks_warning"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:textAppearance="?android:attr/textAppearanceMedium"
-                            android:paddingTop="8dp"
-                            android:paddingBottom="8dp"
-                            android:paddingLeft="12dp"
-                            android:paddingRight="12dp"
+                            android:layout_marginStart="12dp"
+                            android:layout_marginEnd="12dp"
+                            android:layout_marginTop="4dp"
+                            android:layout_marginBottom="4dp"
+                            android:background="@color/infoColor"
+                            android:textAppearance="?android:attr/textAppearanceSmall"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:padding="12dp"
                             android:text="@string/account_tasks_not_showing"
                             android:visibility="gone" />
 

--- a/android/app/src/main/res/layout/journal_viewer_list_item.xml
+++ b/android/app/src/main/res/layout/journal_viewer_list_item.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:minHeight="48dp"
     android:padding="8dp"
     android:gravity="center_vertical">
 
@@ -35,6 +36,7 @@
     <ImageView
         android:id="@+id/error"
         android:src="@drawable/ic_bug_report"
+        android:contentDescription="@string/journal_item_sync_issue"
         android:layout_width="32dp"
         android:layout_height="32dp"
         android:visibility="gone" />

--- a/android/app/src/main/res/layout/login_credentials_fragment.xml
+++ b/android/app/src/main/res/layout/login_credentials_fragment.xml
@@ -29,6 +29,31 @@
                 android:text="@string/login_enter_service_details"
                 android:layout_marginBottom="14dp"/>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:background="@color/infoColor"
+                android:orientation="vertical"
+                android:padding="12dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/login_bridge_sync"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/login_bridge_encrypted"
+                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textColor="?android:attr/textColorPrimary" />
+
+            </LinearLayout>
+
             <com.google.android.material.textfield.TextInputLayout
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:layout_width="match_parent"
@@ -72,6 +97,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="4dp"
+                android:background="?attr/selectableItemBackground"
+                android:gravity="center_vertical"
+                android:minHeight="48dp"
                 android:text="@string/login_forgot_password"
                 android:textColor="?attr/colorSecondary"/>
 
@@ -85,15 +113,19 @@
                 android:text="@string/login_signup_prompt"
                 android:textColor="?attr/colorSecondary"/>
 
-            <CheckedTextView
+            <TextView
                 android:id="@+id/show_advanced"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="14dp"
                 android:layout_marginLeft="4dp"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:minHeight="48dp"
                 android:textSize="18sp"
                 android:gravity="center_vertical"
-                android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                android:textColor="?attr/colorSecondary"
                 android:text="@string/login_toggle_advanced" />
 
             <net.cachapa.expandablelayout.ExpandableLayout

--- a/android/app/src/main/res/layout/nav_header_accounts.xml
+++ b/android/app/src/main/res/layout/nav_header_accounts.xml
@@ -24,6 +24,7 @@
             android:layout_width="56dp"
             android:layout_height="56dp"
             android:layout_marginBottom="8dp"
+            android:importantForAccessibility="no"
             android:src="@mipmap/ic_launcher"
             tools:ignore="ContentDescription"/>
 
@@ -33,7 +34,9 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center_vertical"
-            android:layout_marginTop="8dp">
+            android:layout_marginTop="8dp"
+            android:background="?android:attr/selectableItemBackground"
+            android:minHeight="48dp">
 
             <TextView
                 android:id="@+id/nav_user_email"
@@ -53,6 +56,7 @@
                 android:layout_height="24dp"
                 android:layout_marginStart="8dp"
                 android:src="@android:drawable/arrow_down_float"
+                android:importantForAccessibility="no"
                 android:visibility="gone"
                 tools:ignore="ContentDescription"/>
 
@@ -97,6 +101,7 @@
             <ImageView
                 android:layout_width="24dp"
                 android:layout_height="24dp"
+                android:importantForAccessibility="no"
                 android:src="@drawable/ic_add_light"
                 android:tint="?android:attr/textColorPrimary"
                 tools:ignore="ContentDescription,UseAppTint"/>

--- a/android/app/src/main/res/layout/signup_fragment.xml
+++ b/android/app/src/main/res/layout/signup_fragment.xml
@@ -72,15 +72,19 @@
                 android:layout_height="wrap_content"
                 android:text="@string/login_encryption_check_password"/>
 
-            <CheckedTextView
+            <TextView
                 android:id="@+id/show_advanced"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="14dp"
                 android:layout_marginLeft="4dp"
+                android:background="?attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:minHeight="48dp"
                 android:textSize="18sp"
                 android:gravity="center_vertical"
-                android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+                android:textColor="?attr/colorSecondary"
                 android:text="@string/login_toggle_advanced" />
 
             <net.cachapa.expandablelayout.ExpandableLayout

--- a/android/app/src/main/res/layout/view_collection_activity.xml
+++ b/android/app/src/main/res/layout/view_collection_activity.xml
@@ -40,7 +40,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="Stats:" />
+                android:text="@string/collection_recent_activity_loading" />
 
             <ProgressBar
                 android:id="@+id/progressBar"

--- a/android/app/src/main/res/layout/view_collection_fragment.xml
+++ b/android/app/src/main/res/layout/view_collection_fragment.xml
@@ -40,7 +40,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="Stats:" />
+                android:text="@string/collection_recent_activity_loading" />
 
             <ProgressBar
                 android:id="@+id/progressBar"

--- a/android/app/src/main/res/menu/activity_accounts_drawer.xml
+++ b/android/app/src/main/res/menu/activity_accounts_drawer.xml
@@ -14,7 +14,7 @@
             android:title="@string/navigation_drawer_logout"/>
     </group>
 
-    <group android:id="@+id/nav_main_group" android:checkableBehavior="none">
+    <group android:id="@+id/nav_sync_group" android:checkableBehavior="none">
         <item
             android:id="@+id/nav_calendar"
             android:icon="@drawable/ic_event_light"
@@ -27,6 +27,9 @@
             android:id="@+id/nav_contacts"
             android:icon="@drawable/ic_account_dark"
             android:title="@string/navigation_drawer_contacts"/>
+    </group>
+
+    <group android:id="@+id/nav_account_tools_group" android:checkableBehavior="none">
         <item
             android:id="@+id/nav_app_settings"
             android:icon="@drawable/ic_settings_dark"
@@ -35,6 +38,9 @@
             android:id="@+id/nav_invitations"
             android:icon="@drawable/ic_people_light"
             android:title="@string/invitations_title"/>
+    </group>
+
+    <group android:id="@+id/nav_security_group" android:checkableBehavior="none">
         <item
             android:id="@+id/nav_show_fingerprint"
             android:icon="@drawable/ic_fingerprint_dark"
@@ -43,6 +49,9 @@
             android:id="@+id/nav_export_data"
             android:icon="@drawable/ic_import_export_black"
             android:title="@string/export_data_title"/>
+    </group>
+
+    <group android:id="@+id/nav_app_group" android:checkableBehavior="none">
         <item
             android:id="@+id/nav_theme"
             android:icon="@drawable/ic_palette"

--- a/android/app/src/main/res/values/plurals.xml
+++ b/android/app/src/main/res/values/plurals.xml
@@ -4,4 +4,8 @@
         <item quantity="one">%d item</item>
         <item quantity="other">%d items</item>
     </plurals>
+    <plurals name="collection_recent_activity_items">
+        <item quantity="one">Recent activity: %d item</item>
+        <item quantity="other">Recent activity: %d items</item>
+    </plurals>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -148,14 +148,20 @@
     <string name="account_synchronizing_now">Synchronizing now</string>
     <string name="account_settings">Account settings</string>
     <string name="account_delete">Sign out</string>
-    <string name="account_show_fingerprint">Encryption fingerprint</string>
+    <string name="account_show_fingerprint">Verify encryption fingerprint</string>
     <string name="account_delete_confirmation_title">Sign out?</string>
     <string name="account_delete_confirmation_text">Local copies of your contacts, calendars and tasks will be removed from this device. Your data on the server is safe.</string>
     <string name="account_delete_collection_last_title">Can\'t delete last collection</string>
     <string name="account_delete_collection_last_text">Deleting the last collection is not allowed, please create a new one if you\'d like to delete this one.</string>
-    <string name="account_showcase_view_collection">Tap a collection to view sync history, import data, or manage members.</string>
-    <string name="account_click_install_tasks">Click here to install OpenTasks!</string>
-    <string name="account_tasks_not_showing">Tasks sync requires a task app (Tasks.org or OpenTasks)</string>
+    <string name="account_showcase_view_collection">Tap a collection to view recent sync activity, import data, or manage members.</string>
+    <string name="account_click_install_tasks">Install OpenTasks</string>
+    <string name="account_tasks_not_showing">Task app needed. Android does not include a built-in task provider. Install Tasks.org or OpenTasks to create and sync tasks.</string>
+    <string name="account_section_status_loading">Checking sync status</string>
+    <string name="account_section_status_synced">Synced</string>
+    <string name="account_section_status_syncing">Syncing</string>
+    <string name="account_section_status_setup_needed">Setup needed</string>
+    <string name="account_collection_shared_indicator">Shared collection</string>
+    <string name="account_collection_read_only_indicator">Read-only collection</string>
     <string name="export_data_title">Export data</string>
     <string name="export_data_success">Export saved</string>
     <string name="export_data_failed">Export failed</string>
@@ -163,11 +169,14 @@
     <string name="show_fingperprint_title">Your Encryption Fingerprint</string>
 
     <!-- ViewCollection -->
-    <string name="change_journal_title">Sync History</string>
-    <string name="tasks_not_showing">* Log is only shown if a task provider is installed.</string>
+    <string name="change_journal_title">Recent sync activity</string>
+    <string name="tasks_not_showing">Task app needed. Android does not include a built-in task provider. Install Tasks.org or OpenTasks to create and sync tasks on this device.</string>
     <string name="account_showcase_import">In order to import contacts and calendars into SilentSuite, you need to click on the menu, and choose \"Import\".</string>
     <string name="account_owner">Owner: %s</string>
     <string name="members_owner_only">Only the owner of this collection (%s) is allowed to view its members.</string>
+    <string name="collection_shared_with_us">Shared with us</string>
+    <string name="collection_recent_activity_loading">Loading recent activity...</string>
+    <string name="collection_recent_activity_none">No recent activity yet</string>
     <string name="not_allowed_title">Not Allowed</string>
     <string name="edit_owner_only">Only the owner of this collection (%s) is allowed to edit it.</string>
     <string name="edit_owner_only_anon">Only the owner of this collection is allowed to edit it.</string>
@@ -268,7 +277,9 @@
     <string name="login_password">Password</string>
     <string name="login_custom_server">Server URL</string>
     <string name="login_custom_server_error">Invalid URL found, did you forget to include https://?</string>
-    <string name="login_toggle_advanced">Show advanced settings</string>
+    <string name="login_toggle_advanced">Custom server</string>
+    <string name="login_custom_server_collapsed">Custom server settings, collapsed</string>
+    <string name="login_custom_server_expanded">Custom server settings, expanded</string>
     <string name="login_encryption_password">Encryption Password</string>
     <string name="login_encryption_set_new_password">Please set your encryption password below, and make sure you got it right, as it *can\'t* be recovered if lost!</string>
     <string name="login_encryption_enter_password">You are logged in as \"%s\". Please enter your encryption password to continue, or log out from the side menu.</string>
@@ -280,7 +291,9 @@
     <string name="login_signup_prompt">Don\'t have an account? Sign up</string>
     <string name="login_finish">Finish</string>
     <string name="login_back">Back</string>
-    <string name="login_enter_service_details">Sign in to silentsuite.io</string>
+    <string name="login_enter_service_details">Connect Android sync</string>
+    <string name="login_bridge_sync">Syncs with your phone\'s calendar, contacts, and task apps.</string>
+    <string name="login_bridge_encrypted">Your data is encrypted before it leaves this device.</string>
     <string name="login_enter_encryption_details">Secret Encryption Password</string>
     <string name="login_encryption_account_label">Account:</string>
     <string name="login_service_details_description">This is your login password, *not* your encryption password!</string>
@@ -392,8 +405,19 @@
     <string name="delete_collection_deleting_collection">Deleting collection</string>
 
     <!-- JournalViewer -->
-    <string name="journal_entries_list_empty">Collection is empty.\nMaybe it\'s still syncing?</string>
-    <string name="journal_entries_loading">Loading change log entries...</string>
+    <string name="journal_entries_list_empty">No recent sync activity.\nCreate or edit items in your Android app, then sync.</string>
+    <string name="journal_entries_list_empty_calendar">No recent calendar activity.\nCreate or edit events in your Android calendar app, then sync.</string>
+    <string name="journal_entries_list_empty_contacts">No recent contact activity.\nCreate or edit contacts in your Android contacts app, then sync.</string>
+    <string name="journal_entries_list_empty_tasks">No recent task activity.\nCreate or edit tasks in your task app, then sync.</string>
+    <string name="journal_entries_list_empty_tasks_setup">Task app needed.\nAndroid does not include a built-in task provider. Install Tasks.org or OpenTasks, then sync.</string>
+    <string name="journal_entries_loading">Loading recent activity...</string>
+    <string name="journal_revisions_list_empty">No revisions available for this item.</string>
+    <string name="journal_item_title_unavailable">Item details unavailable</string>
+    <string name="journal_item_modified">Modified: %s</string>
+    <string name="journal_item_modified_unavailable">Modified date unavailable</string>
+    <string name="journal_item_action_changed">Updated item</string>
+    <string name="journal_item_action_deleted">Deleted item</string>
+    <string name="journal_item_sync_issue">Sync issue</string>
 
     <!-- ExceptionInfoFragment -->
     <string name="exception">An error has occurred.</string>


### PR DESCRIPTION
## Summary
- Replace broken collection detail sync-history states, epoch timestamps, and anxious empty copy
- Reframe task setup guidance and login/custom-server disclosure copy
- Polish Android dashboard status cards, drawer grouping, and accessibility labels

## Verification
- git diff --check
- Static grep checks for removed problem copy/patterns
- Read-only review pass: no blocking findings
- Deferred: ./gradlew :app:processDebugResources and :app:compileDebugKotlin cannot run locally because JAVA_HOME is unset and no java command is on PATH

## Notes
- Scope stayed within Android View/XML/Kotlin UI surfaces
- No sync adapter behavior, AccountManager schema, Etebase cache/protocol, Compose, RecyclerView, or submodule changes