### PR TITLE
Add collection color parity

### DIFF
--- a/apps/web/app/components/ContactListPanel.tsx
+++ b/apps/web/app/components/ContactListPanel.tsx
@@ -9,6 +9,7 @@ export function ContactListPanel() {
   const { lists, toggleVisibility, getNextColor } = useContactListStore()
   const createCollection = useEtebaseStore((s) => s.createCollection)
   const deleteCollection = useEtebaseStore((s) => s.deleteCollection)
+  const updateCollectionMeta = useEtebaseStore((s) => s.updateCollectionMeta)
   const [isAdding, setIsAdding] = useState(false)
   const [newName, setNewName] = useState('')
   const isCreatingRef = useRef(false)
@@ -31,6 +32,10 @@ export function ContactListPanel() {
     if (!window.confirm(`Delete address book "${name}" and all contacts in it? This cannot be undone.`)) return
     await deleteCollection('contacts', id)
   }, [deleteCollection, lists.length])
+
+  const handleColorChange = useCallback((id: string, color: string) => {
+    void updateCollectionMeta('contacts', id, { color })
+  }, [updateCollectionMeta])
 
   return (
     <div className="px-3 py-2">
@@ -71,6 +76,14 @@ export function ContactListPanel() {
               </span>
             </button>
             <div className="flex items-center gap-0.5">
+              <input
+                type="color"
+                value={list.color}
+                onChange={(e) => handleColorChange(list.id, e.target.value)}
+                className="h-4 w-4 cursor-pointer rounded border border-[rgb(var(--border))] bg-transparent p-0"
+                aria-label={`Change ${list.name} color`}
+                title="Change color"
+              />
               {lists.length > 1 && (
                 <button
                   onClick={() => handleDelete(list.id, list.name)}

--- a/apps/web/app/components/TaskListPanel.tsx
+++ b/apps/web/app/components/TaskListPanel.tsx
@@ -9,6 +9,7 @@ export function TaskListPanel() {
   const { lists, toggleVisibility, getNextColor } = useTaskListStore()
   const createCollection = useEtebaseStore((s) => s.createCollection)
   const deleteCollection = useEtebaseStore((s) => s.deleteCollection)
+  const updateCollectionMeta = useEtebaseStore((s) => s.updateCollectionMeta)
   const [isAdding, setIsAdding] = useState(false)
   const [newName, setNewName] = useState('')
   const isCreatingRef = useRef(false)
@@ -31,6 +32,10 @@ export function TaskListPanel() {
     if (!window.confirm(`Delete task list "${name}" and all tasks in it? This cannot be undone.`)) return
     await deleteCollection('tasks', id)
   }, [deleteCollection, lists.length])
+
+  const handleColorChange = useCallback((id: string, color: string) => {
+    void updateCollectionMeta('tasks', id, { color })
+  }, [updateCollectionMeta])
 
   return (
     <div className="px-3 py-2">
@@ -71,6 +76,14 @@ export function TaskListPanel() {
               </span>
             </button>
             <div className="flex items-center gap-0.5">
+              <input
+                type="color"
+                value={list.color}
+                onChange={(e) => handleColorChange(list.id, e.target.value)}
+                className="h-4 w-4 cursor-pointer rounded border border-[rgb(var(--border))] bg-transparent p-0"
+                aria-label={`Change ${list.name} color`}
+                title="Change color"
+              />
               {lists.length > 1 && (
                 <button
                   onClick={() => handleDelete(list.id, list.name)}

--- a/apps/web/app/components/__tests__/CalendarListPanel.test.tsx
+++ b/apps/web/app/components/__tests__/CalendarListPanel.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const updateCollectionMeta = vi.fn()
+
+const mockCalendarListState = {
+  calendars: [
+    { id: 'cal-1', name: 'Work Calendar', color: '#10b981', visible: true },
+  ],
+  defaultCalendarId: 'cal-1',
+  toggleVisibility: vi.fn(),
+  setDefaultCalendar: vi.fn(),
+  getNextColor: vi.fn(() => '#3b82f6'),
+}
+
+const mockEtebaseState = {
+  createCollection: vi.fn(),
+  deleteCollection: vi.fn(),
+  updateCollectionMeta,
+}
+
+vi.mock('@/app/stores/use-calendar-list-store', () => ({
+  useCalendarListStore: () => mockCalendarListState,
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: <T,>(selector: (s: typeof mockEtebaseState) => T) => selector(mockEtebaseState),
+}))
+
+import { CalendarListPanel } from '../CalendarListPanel'
+
+describe('CalendarListPanel', () => {
+  beforeEach(() => {
+    updateCollectionMeta.mockClear()
+  })
+
+  it('renders calendar color input and persists changes through collection metadata', () => {
+    render(<CalendarListPanel />)
+
+    const colorInput = screen.getByLabelText('Change Work Calendar color')
+    expect(colorInput).toHaveAttribute('type', 'color')
+
+    fireEvent.change(colorInput, { target: { value: '#ff0000' } })
+
+    expect(updateCollectionMeta).toHaveBeenCalledWith('calendar', 'cal-1', { color: '#ff0000' })
+  })
+})

--- a/apps/web/app/components/__tests__/ContactListPanel.test.tsx
+++ b/apps/web/app/components/__tests__/ContactListPanel.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const updateCollectionMeta = vi.fn()
+
+const mockContactListState = {
+  lists: [
+    { id: 'contacts-1', name: 'Work Contacts', color: '#8b5cf6', visible: true },
+  ],
+  toggleVisibility: vi.fn(),
+  getNextColor: vi.fn(() => '#10b981'),
+}
+
+const mockEtebaseState = {
+  createCollection: vi.fn(),
+  deleteCollection: vi.fn(),
+  updateCollectionMeta,
+}
+
+vi.mock('@/app/stores/use-contact-list-store', () => ({
+  useContactListStore: () => mockContactListState,
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: <T,>(selector: (s: typeof mockEtebaseState) => T) => selector(mockEtebaseState),
+}))
+
+import { ContactListPanel } from '../ContactListPanel'
+
+describe('ContactListPanel', () => {
+  beforeEach(() => {
+    updateCollectionMeta.mockClear()
+  })
+
+  it('renders address-book color input and persists changes through collection metadata', () => {
+    render(<ContactListPanel />)
+
+    const colorInput = screen.getByLabelText('Change Work Contacts color')
+    expect(colorInput).toHaveAttribute('type', 'color')
+
+    fireEvent.change(colorInput, { target: { value: '#ff0000' } })
+
+    expect(updateCollectionMeta).toHaveBeenCalledWith('contacts', 'contacts-1', { color: '#ff0000' })
+  })
+})

--- a/apps/web/app/components/__tests__/TaskListPanel.test.tsx
+++ b/apps/web/app/components/__tests__/TaskListPanel.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const updateCollectionMeta = vi.fn()
+
+const mockTaskListState = {
+  lists: [
+    { id: 'tasks-1', name: 'Work Tasks', color: '#3b82f6', visible: true },
+  ],
+  toggleVisibility: vi.fn(),
+  getNextColor: vi.fn(() => '#10b981'),
+}
+
+const mockEtebaseState = {
+  createCollection: vi.fn(),
+  deleteCollection: vi.fn(),
+  updateCollectionMeta,
+}
+
+vi.mock('@/app/stores/use-task-list-store', () => ({
+  useTaskListStore: () => mockTaskListState,
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: <T,>(selector: (s: typeof mockEtebaseState) => T) => selector(mockEtebaseState),
+}))
+
+import { TaskListPanel } from '../TaskListPanel'
+
+describe('TaskListPanel', () => {
+  beforeEach(() => {
+    updateCollectionMeta.mockClear()
+  })
+
+  it('renders task-list color input and persists changes through collection metadata', () => {
+    render(<TaskListPanel />)
+
+    const colorInput = screen.getByLabelText('Change Work Tasks color')
+    expect(colorInput).toHaveAttribute('type', 'color')
+
+    fireEvent.change(colorInput, { target: { value: '#ff0000' } })
+
+    expect(updateCollectionMeta).toHaveBeenCalledWith('tasks', 'tasks-1', { color: '#ff0000' })
+  })
+})

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -18,6 +18,10 @@ const coreMock = vi.hoisted(() => ({
   updateCollectionMeta: vi.fn(),
 }))
 
+const toastStoreMock = vi.hoisted(() => ({
+  showErrorToast: vi.fn(),
+}))
+
 // Stub the offline queue so isOfflineError + enqueue don't try to open IndexedDB.
 vi.mock('@/app/lib/offline-queue', () => offlineQueueMock)
 
@@ -31,14 +35,13 @@ vi.mock('@/app/lib/secure-storage', () => ({
   migrateFromLocalStorage: vi.fn(async () => {}),
 }))
 
-vi.mock('@/app/stores/use-toast-store', () => ({
-  showErrorToast: vi.fn(),
-}))
+vi.mock('@/app/stores/use-toast-store', () => toastStoreMock)
 
 beforeEach(() => {
   coreMock.listCollections.mockReset()
   coreMock.createCollection.mockReset()
   coreMock.updateCollectionMeta.mockReset()
+  toastStoreMock.showErrorToast.mockReset()
 })
 
 interface MockItemManager {
@@ -621,6 +624,14 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
       calendars: [{ id: 'cal-1', name: 'Work', color: '#111111', visible: false }],
       defaultCalendarId: 'cal-1',
     })
+    useTaskListStore.setState({
+      lists: [{ id: 'tasks-1', name: 'Work Tasks', color: '#222222', visible: false }],
+      activeListId: 'tasks-1',
+    })
+    useContactListStore.setState({
+      lists: [{ id: 'contacts-1', name: 'Work Contacts', color: '#333333', visible: false }],
+      activeListId: 'contacts-1',
+    })
     useEtebaseStore.setState({
       account: null,
       collections: { calendar: [], tasks: [], contacts: [] },
@@ -666,5 +677,106 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
       color: '#ff0000',
       visible: false,
     })
+  })
+
+  it('persists task-list color through collection metadata while preserving existing metadata', async () => {
+    const account = { id: 'account' }
+    const collection = mockCollection('tasks-1', {
+      name: 'Work Tasks',
+      description: 'Keep this',
+      color: '#222222',
+    })
+    const updatedCollection = mockCollection('tasks-1', {
+      name: 'Work Tasks',
+      description: 'Keep this',
+      color: '#ff0000',
+    })
+    coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [], tasks: [collection] as any[], contacts: [] },
+      isInitialized: true,
+    })
+
+    const result = await useEtebaseStore.getState().updateCollectionMeta('tasks', 'tasks-1', { color: '#ff0000' })
+
+    expect(result).toBe(true)
+    expect(coreMock.updateCollectionMeta).toHaveBeenCalledWith(account, collection, {
+      name: 'Work Tasks',
+      description: 'Keep this',
+      color: '#ff0000',
+    })
+    expect(useEtebaseStore.getState().collections.tasks[0]).toBe(updatedCollection)
+    expect(useTaskListStore.getState().lists[0]).toMatchObject({
+      id: 'tasks-1',
+      name: 'Work Tasks',
+      color: '#ff0000',
+      visible: false,
+    })
+  })
+
+  it('persists contact-list color through collection metadata while preserving existing metadata', async () => {
+    const account = { id: 'account' }
+    const collection = mockCollection('contacts-1', {
+      name: 'Work Contacts',
+      description: 'Keep this',
+      color: '#333333',
+    })
+    const updatedCollection = mockCollection('contacts-1', {
+      name: 'Work Contacts',
+      description: 'Keep this',
+      color: '#ff0000',
+    })
+    coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [], tasks: [], contacts: [collection] as any[] },
+      isInitialized: true,
+    })
+
+    const result = await useEtebaseStore.getState().updateCollectionMeta('contacts', 'contacts-1', { color: '#ff0000' })
+
+    expect(result).toBe(true)
+    expect(coreMock.updateCollectionMeta).toHaveBeenCalledWith(account, collection, {
+      name: 'Work Contacts',
+      description: 'Keep this',
+      color: '#ff0000',
+    })
+    expect(useEtebaseStore.getState().collections.contacts[0]).toBe(updatedCollection)
+    expect(useContactListStore.getState().lists[0]).toMatchObject({
+      id: 'contacts-1',
+      name: 'Work Contacts',
+      color: '#ff0000',
+      visible: false,
+    })
+  })
+
+  it.each([
+    ['calendar', 'cal-1', 'calendar', 'calendar'] as const,
+    ['tasks', 'tasks-1', 'task list', 'tasks'] as const,
+    ['contacts', 'contacts-1', 'address book', 'contacts'] as const,
+  ])('returns false and preserves local state when %s collection metadata update fails', async (type, collectionUid, label, collectionKey) => {
+    const account = { id: 'account' }
+    const collection = mockCollection(collectionUid, {
+      name: 'Original',
+      description: 'Keep this',
+      color: '#111111',
+    })
+    coreMock.updateCollectionMeta.mockRejectedValue(new Error('upload failed'))
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: {
+        calendar: type === 'calendar' ? [collection] as any[] : [],
+        tasks: type === 'tasks' ? [collection] as any[] : [],
+        contacts: type === 'contacts' ? [collection] as any[] : [],
+      },
+      isInitialized: true,
+    })
+
+    const result = await useEtebaseStore.getState().updateCollectionMeta(type, collectionUid, { color: '#ff0000' })
+
+    expect(result).toBe(false)
+    expect(useEtebaseStore.getState().collections[collectionKey][0]).toBe(collection)
+    expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith(`Failed to update ${label}. Please try again.`)
   })
 })


### PR DESCRIPTION
## Summary
- Add metadata-backed color pickers for task lists and address books
- Keep calendar/task/contact color picker behavior covered by component tests
- Extend collection metadata tests for task/contact success paths and all collection-type failure paths

## Review
- Code-reviewer subagent reviewed the diff twice and reported no blocking issues

## Tests
- pnpm --filter @silentsuite/web test -- app/stores/__tests__/use-etebase-store.test.ts app/components/__tests__/CalendarListPanel.test.tsx app/components/__tests__/TaskListPanel.test.tsx app/components/__tests__/ContactListPanel.test.tsx
- pnpm --filter @silentsuite/web type-check
- git diff --check