### PR TITLE
Prepare Android v0.2.0 beta release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -18,10 +18,10 @@ android {
         applicationId "io.silentsuite.android"
 
         minSdkVersion 21
-        targetSdkVersion 34
+        targetSdkVersion 35
 
-        versionCode 3
-        versionName "0.1.4-beta"
+        versionCode 6
+        versionName "0.2.0-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,1 @@
+v0.2.0-beta: multiple calendars, address books, and task lists; Android export backups; clearer sync states; refreshed branding; and Bitcoin/Lightning annual signup via BTCPay.

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,1 @@
+v0.2.0-beta: multiple calendars, address books, and task lists; Android export backups; clearer sync states; refreshed branding; and Bitcoin/Lightning annual signup via BTCPay.


### PR DESCRIPTION
## Summary
- Bump Android release metadata to `versionCode 6`, `versionName 0.2.0-beta`.
- Move Android target SDK to 35 for the release line.
- Add Fastlane changelog entries for version code 6.

## Verification
- `git diff --check`
- Android signed APK/AAB build runs in GitHub Actions after merge/tag per workspace convention.