### PR TITLE
Add bridge account management

### DIFF
--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -61,6 +61,8 @@ silentsuite-bridge --login
 
 This opens your browser to a login page. Enter your account email and password. The bridge authenticates with the server and stores your session locally.
 
+Running `silentsuite-bridge --login` again adds another account or re-authenticates the same account. It does not remove accounts that are already configured.
+
 ### 2. Note Your Connection URLs
 
 After successful login, the browser shows your CalDAV/CardDAV URLs:
@@ -74,7 +76,42 @@ After successful login, the browser shows your CalDAV/CardDAV URLs:
 
 You can always find these URLs by:
 - Opening the dashboard at `http://localhost:37358/.web/`
-- Using the system tray menu (Copy CalDAV URL / Copy CardDAV URL)
+- Using the system tray menu account entries (Copy CalDAV URL / Copy CardDAV URL)
+
+## Multi-Account Use
+
+The bridge can keep multiple accounts active in one local bridge profile. Each account has its own credentials, local cache namespace, sync thread, and DAV path.
+
+```bash
+silentsuite-bridge --login
+silentsuite-bridge --login
+silentsuite-bridge --list-accounts
+```
+
+Each account uses a URL containing the account email:
+
+```text
+http://localhost:37358/work@example.com/
+http://localhost:37358/personal@example.com/
+```
+
+Use the matching account email and password in your calendar/contact client. A client authenticated as one account cannot access another account's DAV path.
+
+To remove only the local login/session for one account while keeping its local cache for future re-login:
+
+```bash
+silentsuite-bridge --logout work@example.com
+```
+
+To fully remove one account's local bridge data, including its decrypted local cache:
+
+```bash
+silentsuite-bridge --remove-account work@example.com
+```
+
+::: warning
+The bridge local cache contains decrypted calendar, contact, and task data. Use `--remove-account` when retiring a shared or untrusted machine.
+:::
 
 ### 3. Start the Bridge
 
@@ -97,9 +134,9 @@ http://localhost:37358/.web/
 
 The dashboard shows:
 - Connection status
-- Account info
+- All configured accounts
 - Last sync time
-- CalDAV/CardDAV URLs with copy buttons
+- Per-account CalDAV/CardDAV URLs with copy buttons
 - Recent sync log
 
 ## Auto-Start
@@ -144,8 +181,11 @@ silentsuite-bridge
 ```bash
 silentsuite-bridge                    # Start the bridge
 silentsuite-bridge --version          # Show version
-silentsuite-bridge --login            # Browser-based login
-silentsuite-bridge --manual-login     # CLI login (for headless systems)
+silentsuite-bridge --login            # Add or re-authenticate an account
+silentsuite-bridge --list-accounts    # List configured accounts
+silentsuite-bridge --logout EMAIL     # Remove local credentials; keep cache
+silentsuite-bridge --remove-account EMAIL  # Remove credentials and local cache
+silentsuite-bridge --manual-login     # CLI add/re-authenticate (headless/dev)
 silentsuite-bridge --install-autostart  # Install auto-start
 silentsuite-bridge --remove-autostart   # Remove auto-start
 silentsuite-bridge --no-tray          # Start without system tray

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -4,6 +4,24 @@ Local E2EE CalDAV/CardDAV sync daemon for SilentSuite.
 
 Connects to `server.silentsuite.io` by default, or your configured self-hosted server, via the Etebase protocol. It decrypts/encrypts data locally and exposes CalDAV/CardDAV endpoints on `localhost:37358` for use with any standard PIM client (Thunderbird, Apple Calendar, GNOME Calendar, Evolution, etc.).
 
+## Account Commands
+
+`--login` adds a new account or re-authenticates an existing account. It does not remove other configured accounts.
+
+```bash
+silentsuite-bridge --login
+silentsuite-bridge --list-accounts
+silentsuite-bridge --logout user@example.com
+silentsuite-bridge --remove-account user@example.com
+```
+
+- `--list-accounts` prints every configured bridge account and its Etebase server URL.
+- `--logout <email>` removes that account's local credential/session material and stops its runtime sync, but keeps its local cache for faster re-login.
+- `--remove-account <email>` performs logout and deletes that account's local cache rows.
+- DAV URLs are namespaced per account: `http://localhost:37358/user@example.com/`.
+
+The local bridge cache contains decrypted calendar/contact/task data. Use `--remove-account` when retiring a shared or untrusted machine.
+
 ## License
 
 AGPL-3.0-only

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -162,6 +162,7 @@ def _initial_status_check():
                 for key, value in collections.items():
                     totals[key] += value
                 synced += 1
+                update_status("connected", collections=collections, account=user)
                 log_sync_event("info", f"Initial sync complete for {user}")
                 logger.info(
                     "Initial sync for %s: %d calendars, %d contacts, %d tasks",
@@ -188,6 +189,8 @@ def _initial_status_check():
             )
     elif errors:
         update_status("error", error="; ".join(errors))
+    else:
+        update_status("disconnected")
 
 
 def run_server():

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -16,6 +16,14 @@ from . import config
 
 logger = logging.getLogger("silentsuite-bridge")
 
+_ACCOUNT_ACTION_FLAGS = (
+    "--login",
+    "--manual-login",
+    "--list-accounts",
+    "--logout",
+    "--remove-account",
+)
+
 
 def configure_logging():
     """Set up logging for the bridge."""
@@ -135,32 +143,51 @@ def _initial_status_check():
     if not users:
         return
 
-    user = users[0]
-    try:
-        with etesync_for_user(user) as (etesync, _):
-            etesync.sync()
-            # Dashboard mirrors what the bridge actually exposes — one collection
-            # per type — even if the server has more (multi-collection was dropped).
-            collections = {"calendars": 0, "contacts": 0, "tasks": 0}
-            for col in etesync.list():
-                if col.col_type == "etebase.vevent" and collections["calendars"] == 0:
-                    collections["calendars"] = 1
-                elif col.col_type == "etebase.vcard" and collections["contacts"] == 0:
-                    collections["contacts"] = 1
-                elif col.col_type == "etebase.vtodo" and collections["tasks"] == 0:
-                    collections["tasks"] = 1
-            update_status("connected", collections=collections)
-            log_sync_event("info", f"Initial sync complete for {user}")
-            logger.info(
-                "Initial sync: %d calendars, %d contacts, %d tasks",
-                collections["calendars"],
-                collections["contacts"],
-                collections["tasks"],
+    totals = {"calendars": 0, "contacts": 0, "tasks": 0}
+    synced = 0
+    errors = []
+
+    for user in users:
+        try:
+            with etesync_for_user(user) as (etesync, _):
+                etesync.sync()
+                collections = {"calendars": 0, "contacts": 0, "tasks": 0}
+                for col in etesync.list():
+                    if col.col_type == "etebase.vevent":
+                        collections["calendars"] += 1
+                    elif col.col_type == "etebase.vcard":
+                        collections["contacts"] += 1
+                    elif col.col_type == "etebase.vtodo":
+                        collections["tasks"] += 1
+                for key, value in collections.items():
+                    totals[key] += value
+                synced += 1
+                log_sync_event("info", f"Initial sync complete for {user}")
+                logger.info(
+                    "Initial sync for %s: %d calendars, %d contacts, %d tasks",
+                    user,
+                    collections["calendars"],
+                    collections["contacts"],
+                    collections["tasks"],
+                )
+        except Exception as e:
+            logger.warning("Initial status check failed for %s: %s", user, e)
+            errors.append(f"{user}: {e}")
+            log_sync_event("error", f"Initial sync failed for {user}: {e}")
+
+    if synced:
+        update_status(
+            "connected",
+            collections=totals,
+            scope="all configured accounts",
+        )
+        if errors:
+            log_sync_event(
+                "error",
+                f"Initial sync skipped {len(errors)} account(s): {'; '.join(errors)}",
             )
-    except Exception as e:
-        logger.warning("Initial status check failed: %s", e)
-        update_status("error", error=str(e))
-        log_sync_event("error", f"Initial sync failed: {e}")
+    elif errors:
+        update_status("error", error="; ".join(errors))
 
 
 def run_server():
@@ -218,7 +245,11 @@ def main():
         print("Options:")
         print("  --help, -h            Show this help message and exit")
         print("  --version             Show version and exit")
-        print("  --login               Run browser-based login flow")
+        print("  --login               Add or re-authenticate an account")
+        print("  --list-accounts       List configured bridge accounts")
+        print("  --logout ACCOUNT      Remove local credentials; keep cache")
+        print("  --remove-account ACCOUNT")
+        print("                        Remove credentials plus that account's cache")
         print("  --server URL          Etebase server URL (for self-hosters)")
         print("  --manual-login        Run CLI login (for development/testing)")
         print("  --install-autostart   Install auto-start for current platform")
@@ -246,6 +277,60 @@ def main():
 
     configure_logging()
     config.ensure_data_dir()
+
+    action_count = sum(1 for flag in _ACCOUNT_ACTION_FLAGS if flag in sys.argv)
+    if action_count > 1:
+        print("Error: account action flags cannot be combined")
+        sys.exit(1)
+
+    # Handle --list-accounts before any bridge startup side effects.
+    if "--list-accounts" in sys.argv:
+        from .accounts import list_accounts
+        from .radicale.creds import Credentials
+
+        creds = Credentials()
+        users = list_accounts(credentials=creds)
+        if not users:
+            print("No accounts configured.")
+        else:
+            print("Configured accounts:")
+            for user in users:
+                print(f"- {user} ({creds.get_server_url(user)})")
+        sys.exit(0)
+
+    if "--logout" in sys.argv:
+        idx = sys.argv.index("--logout")
+        if idx + 1 >= len(sys.argv) or sys.argv[idx + 1].startswith("--"):
+            print("Error: --logout requires an account argument")
+            sys.exit(1)
+
+        from .accounts import logout_account
+
+        result = logout_account(sys.argv[idx + 1])
+        if result.existed:
+            print(f"Logged out {result.username}. Local cache was retained.")
+            if not result.sync_stopped:
+                print("Warning: sync thread is still shutting down; no duplicate will be started.")
+        else:
+            print(f"Account {result.username} is not configured; nothing to do.")
+        sys.exit(0)
+
+    if "--remove-account" in sys.argv:
+        idx = sys.argv.index("--remove-account")
+        if idx + 1 >= len(sys.argv) or sys.argv[idx + 1].startswith("--"):
+            print("Error: --remove-account requires an account argument")
+            sys.exit(1)
+
+        from .accounts import remove_account
+
+        result = remove_account(sys.argv[idx + 1])
+        if result.existed:
+            print(f"Removed {result.username}. Credentials and local cache were deleted.")
+            if not result.sync_stopped:
+                print("Warning: sync thread is still shutting down; no duplicate will be started.")
+        else:
+            print(f"Account {result.username} is not configured; nothing to do.")
+        sys.exit(0)
 
     # Handle --login (browser-based auth)
     if "--login" in sys.argv:

--- a/bridge/src/silentsuite_bridge/accounts.py
+++ b/bridge/src/silentsuite_bridge/accounts.py
@@ -1,0 +1,120 @@
+"""Account-management helpers for SilentSuite Bridge."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+from dataclasses import dataclass
+
+from . import config
+from .local_cache import clear_cached_user
+from .radicale.creds import Credentials
+from .radicale.etesync_cache import forget_etesync_user
+from .radicale.storage import stop_sync_thread
+
+
+_account_lock = threading.RLock()
+
+
+@dataclass(frozen=True)
+class AccountOperationResult:
+    """Result for local account mutations."""
+
+    username: str
+    existed: bool
+    sync_stopped: bool = True
+    cache_cleared: bool = False
+
+
+def _normalize_username(username: str) -> str:
+    normalized = (username or "").strip()
+    if not normalized:
+        raise ValueError("Account username is required")
+    return normalized
+
+
+def _password_hash(password: str) -> tuple[str, str]:
+    salt = os.urandom(32)
+    password_hash = hashlib.pbkdf2_hmac(
+        "sha256", password.encode(), salt, 600000,
+    ).hex()
+    return salt.hex(), password_hash
+
+
+def store_authenticated_account(
+    username: str,
+    password: str,
+    stored_session: str,
+    server_url: str | None = None,
+    *,
+    credentials: Credentials | None = None,
+) -> AccountOperationResult:
+    """Add or update one authenticated account without touching others."""
+    normalized = _normalize_username(username)
+    if not password:
+        raise ValueError("Account password is required")
+    if server_url is None:
+        server_url = config.ETEBASE_SERVER_URL
+
+    with _account_lock:
+        creds = credentials or Credentials()
+        existed = normalized in creds.list_users()
+        salt_hex, password_hash = _password_hash(password)
+        creds.set_etebase(normalized, stored_session, server_url)
+        creds.set_password_salt(normalized, salt_hex)
+        creds.set_password_hash(normalized, password_hash)
+        creds.save()
+
+    return AccountOperationResult(username=normalized, existed=existed)
+
+
+def list_accounts(*, credentials: Credentials | None = None) -> list[str]:
+    """Return configured account usernames."""
+    with _account_lock:
+        creds = credentials or Credentials()
+        return creds.list_users()
+
+
+def logout_account(
+    username: str,
+    *,
+    credentials: Credentials | None = None,
+) -> AccountOperationResult:
+    """Remove local credential/session material while retaining cache rows."""
+    normalized = _normalize_username(username)
+
+    with _account_lock:
+        creds = credentials or Credentials()
+        existed = normalized in creds.list_users()
+
+        sync_stopped = stop_sync_thread(normalized)
+        forget_etesync_user(normalized)
+
+        if existed:
+            creds.delete(normalized)
+            creds.save()
+
+    return AccountOperationResult(
+        username=normalized,
+        existed=existed,
+        sync_stopped=sync_stopped,
+    )
+
+
+def remove_account(
+    username: str,
+    *,
+    credentials: Credentials | None = None,
+) -> AccountOperationResult:
+    """Remove local credentials plus that account's local decrypted cache."""
+    normalized = _normalize_username(username)
+    logout_result = logout_account(normalized, credentials=credentials)
+    cache_cleared = clear_cached_user(normalized)
+
+    return AccountOperationResult(
+        username=normalized,
+        existed=logout_result.existed or cache_cleared,
+        sync_stopped=logout_result.sync_stopped,
+        cache_cleared=cache_cleared,
+    )

--- a/bridge/src/silentsuite_bridge/accounts.py
+++ b/bridge/src/silentsuite_bridge/accounts.py
@@ -90,6 +90,9 @@ def logout_account(
 
         sync_stopped = stop_sync_thread(normalized)
         forget_etesync_user(normalized)
+        from .web import forget_account_status
+
+        forget_account_status(normalized)
 
         if existed:
             creds.delete(normalized)

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -607,7 +607,7 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
             content_length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(content_length).decode()
             params = urllib.parse.parse_qs(body)
-            email = params.get("email", [""])[0]
+            email = params.get("email", [""])[0].strip()
             password = params.get("password", [""])[0]
             server_url = params.get("server_url", [config.ETEBASE_SERVER_URL])[0].strip()
             if not server_url:

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -12,12 +12,10 @@ For MVP, the auth page is served by the bridge itself.
 In the future, this will redirect to app.silentsuite.io/bridge-auth.
 """
 
-import hashlib
 import html as html_mod
 import http.server
 import json
 import logging
-import os
 import socket
 import threading
 import urllib.parse
@@ -26,7 +24,7 @@ import webbrowser
 from etebase import Account, Client
 
 from . import config
-from .radicale.creds import Credentials
+from .accounts import store_authenticated_account
 
 logger = logging.getLogger("silentsuite-bridge.auth")
 
@@ -585,7 +583,7 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(html.encode())
         elif self.path.startswith("/success"):
             params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
-            email = params.get("email", [""])[0]
+            email = params.get("email", [""])[0].strip()
             dashboard_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/.web/"
             bridge_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{email}/"
 
@@ -646,32 +644,20 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
             if server_url != config.ETEBASE_SERVER_URL:
                 config.ETEBASE_SERVER_URL = server_url
 
-            # Store credentials — clear any existing users first
-            # (bridge supports one account at a time)
-            creds = Credentials()
-            for old_user in creds.list_users():
-                creds.delete(old_user)
-            creds.set_etebase(
+            result = store_authenticated_account(
                 email,
+                password,
                 etebase.save(None),
                 server_url,
             )
 
-            salt = os.urandom(32)
-            password_hash = hashlib.pbkdf2_hmac(
-                "sha256", password.encode(), salt, 600000,
-            ).hex()
-            creds.set_password_salt(email, salt.hex())
-            creds.set_password_hash(email, password_hash)
-            creds.save()
-
-            logger.info("Authentication successful for %s", email)
+            logger.info("Authentication successful for %s", result.username)
 
             # Store the email and server URL for the success handler
-            self.server.authenticated_email = email
+            self.server.authenticated_email = result.username
             self.server.authenticated_server_url = server_url
 
-            redirect_url = f"/success?email={urllib.parse.quote(email)}"
+            redirect_url = f"/success?email={urllib.parse.quote(result.username)}"
             self._json_response(200, {
                 "success": True,
                 "redirect": redirect_url,

--- a/bridge/src/silentsuite_bridge/auth_cli.py
+++ b/bridge/src/silentsuite_bridge/auth_cli.py
@@ -5,15 +5,13 @@ Provides a simple terminal-based login flow for early development.
 """
 
 import getpass
-import hashlib
 import logging
-import os
 import sys
 
 from etebase import Account, Client
 
 from . import config
-from .radicale.creds import Credentials
+from .accounts import store_authenticated_account
 
 logger = logging.getLogger("silentsuite-bridge.auth")
 
@@ -54,31 +52,18 @@ def manual_login():
     print("Authentication successful!")
     print("Saving credentials...")
 
-    creds = Credentials()
-    # Clear any existing users — bridge supports one account at a time
-    for old_user in creds.list_users():
-        creds.delete(old_user)
-    creds.set_etebase(
+    result = store_authenticated_account(
         username,
+        password,
         etebase.save(None),
         config.ETEBASE_SERVER_URL,
     )
 
-    # Store password hash for CalDAV client auth (PBKDF2)
-    salt = os.urandom(32)
-    password_hash = hashlib.pbkdf2_hmac(
-        "sha256", password.encode(), salt, 600000,
-    ).hex()
-    creds.set_password_salt(username, salt.hex())
-    creds.set_password_hash(username, password_hash)
-
-    creds.save()
-
     print()
-    print("Setup complete!")
+    print("Account saved! Existing accounts were left unchanged.")
     print(f"Etebase server: {config.ETEBASE_SERVER_URL}")
-    print(f"CalDAV/CardDAV URL: http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{username}/")
-    print(f"Username: {username}")
+    print(f"CalDAV/CardDAV URL: http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{result.username}/")
+    print(f"Username: {result.username}")
     print("Password: (your account password)")
     print()
     print("Start the bridge with: silentsuite-bridge")

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -22,7 +22,11 @@ logger = logging.getLogger("silentsuite-bridge.cache")
 
 
 def _init_cache_database(db_path=None):
-    """Initialize the cache DB proxy only when it is not already initialized."""
+    """Initialize the cache DB proxy only when it is not already initialized.
+
+    When tests or the running bridge have already initialized the proxy, keep
+    using that database even if a db_path was supplied.
+    """
     database = getattr(db.database_proxy, "obj", None)
     if database is not None:
         return database, False

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -67,8 +67,11 @@ def clear_cached_user(username, db_path=None):
     if not normalized:
         raise ValueError("Account username is required")
 
-    database, _ = _init_cache_database(db_path)
-    with db.database_proxy:
+    database, initialized_here = _init_cache_database(db_path)
+    if database.is_closed():
+        database.connect(reuse_if_open=True)
+
+    try:
         _ensure_cache_tables(database)
         user = models.User.get_or_none(models.User.username == normalized)
         if user is None:
@@ -99,6 +102,9 @@ def clear_cached_user(username, db_path=None):
             ).execute()
         user.delete_instance()
         return True
+    finally:
+        if initialized_here and not database.is_closed():
+            database.close()
 
 
 def _extract_uid(vobject_item):

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -21,6 +21,82 @@ from . import db, models
 logger = logging.getLogger("silentsuite-bridge.cache")
 
 
+def _init_cache_database(db_path=None):
+    """Initialize the cache DB proxy only when it is not already initialized."""
+    database = getattr(db.database_proxy, "obj", None)
+    if database is not None:
+        return database, False
+
+    from playhouse.sqlite_ext import SqliteExtDatabase
+
+    path = db_path or config.DATABASE_FILE
+    directory = os.path.dirname(path)
+    if directory != "" and not os.path.exists(directory):
+        os.makedirs(directory)
+
+    database = SqliteExtDatabase(
+        path,
+        pragmas={
+            "journal_mode": "wal",
+            "foreign_keys": 1,
+        },
+    )
+    db.database_proxy.initialize(database)
+    return database, True
+
+
+def _ensure_cache_tables(database):
+    database.create_tables(
+        [models.Config, models.User, models.CollectionEntity, models.ItemEntity, models.HrefMapper],
+        safe=True,
+    )
+    models.Config.get_or_create(defaults={"db_version": 1})
+
+
+def clear_cached_user(username, db_path=None):
+    """Delete one user's cached rows without needing a live Etebase session.
+
+    Returns True when a cache user row existed and was deleted. Missing users are
+    an idempotent no-op.
+    """
+    normalized = (username or "").strip()
+    if not normalized:
+        raise ValueError("Account username is required")
+
+    database, _ = _init_cache_database(db_path)
+    with db.database_proxy:
+        _ensure_cache_tables(database)
+        user = models.User.get_or_none(models.User.username == normalized)
+        if user is None:
+            return False
+
+        collection_ids = [
+            col.id
+            for col in models.CollectionEntity.select(models.CollectionEntity.id).where(
+                models.CollectionEntity.local_user == user
+            )
+        ]
+        if collection_ids:
+            item_ids = [
+                item.id
+                for item in models.ItemEntity.select(models.ItemEntity.id).where(
+                    models.ItemEntity.collection.in_(collection_ids)
+                )
+            ]
+            if item_ids:
+                models.HrefMapper.delete().where(
+                    models.HrefMapper.content.in_(item_ids)
+                ).execute()
+            models.ItemEntity.delete().where(
+                models.ItemEntity.collection.in_(collection_ids)
+            ).execute()
+            models.CollectionEntity.delete().where(
+                models.CollectionEntity.id.in_(collection_ids)
+            ).execute()
+        user.delete_instance()
+        return True
+
+
 def _extract_uid(vobject_item):
     """Extract UID from a vobject item, handling wrapper components.
 
@@ -331,13 +407,8 @@ class Etebase:
                 raise DoesNotExist(e)
 
     def clear_user(self):
-        with db.database_proxy:
-            for col in self.user.collections:
-                for item in col.items:
-                    item.delete_instance()
-                col.delete_instance()
-            self.user.delete_instance()
-            self.user = None
+        clear_cached_user(self.username)
+        self.user = None
 
 
 class Collection:

--- a/bridge/src/silentsuite_bridge/radicale/etesync_cache.py
+++ b/bridge/src/silentsuite_bridge/radicale/etesync_cache.py
@@ -70,3 +70,9 @@ def etesync_for_user(user):
     with _get_etesync_lock:
         ret = _etesync_cache.etesync_for_user(user)
         yield ret
+
+
+def forget_etesync_user(user):
+    """Evict one user's restored Etebase session from the runtime cache."""
+    with _get_etesync_lock:
+        _etesync_cache._etesync_cache.pop(user, None)

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -50,6 +50,7 @@ class SyncThread(threading.Thread):
     def __init__(self, user, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._force_sync = threading.Event()
+        self._stop_sync = threading.Event()
         self._done_syncing = threading.Event()
         self._done_syncing.set()
         self.user = user
@@ -65,6 +66,11 @@ class SyncThread(threading.Thread):
     def force_sync(self):
         self._force_sync.set()
         self._done_syncing.clear()
+
+    def stop(self):
+        """Request a clean shutdown and wake any interval wait."""
+        self._stop_sync.set()
+        self._force_sync.set()
 
     def request_sync(self):
         if self.last_sync and time.time() - self.last_sync >= SYNC_MINIMUM:
@@ -89,9 +95,13 @@ class SyncThread(threading.Thread):
         return ret
 
     def run(self):
-        while True:
+        while not self._stop_sync.is_set():
             try:
+                if self._stop_sync.is_set():
+                    break
                 with etesync_for_user(self.user) as (etesync, _):
+                    if self._stop_sync.is_set():
+                        break
                     self.last_sync = time.time()
                     self._done_syncing.clear()
                     self.is_syncing = True
@@ -113,7 +123,11 @@ class SyncThread(threading.Thread):
                                 collections["tasks"] += 1
                     except Exception:
                         pass
-                    update_status("connected", collections=collections)
+                    update_status(
+                        "connected",
+                        collections=collections,
+                        account=self.user,
+                    )
                     log_sync_event("sync", f"Synced for {self.user}")
             except Exception as e:
                 logger.exception("Sync error for user %s: %s", self.user, e)
@@ -126,6 +140,8 @@ class SyncThread(threading.Thread):
                 self._force_sync.clear()
                 self._done_syncing.set()
 
+            if self._stop_sync.is_set():
+                break
             if was_re_requested:
                 continue  # immediately loop back to sync without waiting
             self._force_sync.wait(self.interval)
@@ -151,6 +167,36 @@ def get_sync_thread(user):
     """Get the SyncThread for a user, or None."""
     with _sync_threads_lock:
         return _sync_threads.get(user)
+
+
+def stop_sync_thread(user, timeout=2.0):
+    """Stop and remove one user's SyncThread.
+
+    Returns True when no live thread remains. If shutdown times out, the old
+    thread stays registered so start_sync_thread will not create a duplicate.
+    """
+    with _sync_threads_lock:
+        thread = _sync_threads.get(user)
+
+    if thread is None:
+        return True
+
+    thread.stop()
+    if thread is threading.current_thread():
+        logger.warning("SyncThread for user %s cannot join itself", user)
+        return False
+    thread.join(timeout)
+
+    with _sync_threads_lock:
+        current = _sync_threads.get(user)
+        if current is not thread:
+            return True
+        if thread.is_alive():
+            logger.warning("Timed out stopping SyncThread for user %s", user)
+            return False
+        del _sync_threads[user]
+        logger.info("Stopped SyncThread for user %s", user)
+        return True
 
 
 # --- Meta Mapping ---
@@ -503,8 +549,20 @@ class Storage(BaseStorage):
         """Verify storage is accessible."""
         return True
 
+    def _path_belongs_to_user(self, path):
+        attributes = _get_attributes_from_path(path)
+        return not self.user or not attributes or attributes[0] == self.user
+
     def discover(self, path, depth="0"):
         """Discover collections and items under the given path."""
+        if not self._path_belongs_to_user(path):
+            logger.warning(
+                "Rejecting DAV path %s authenticated as %s",
+                path,
+                self.user,
+            )
+            return
+
         attributes = _get_attributes_from_path(path)
 
         if len(attributes) == 3:
@@ -564,6 +622,14 @@ class Storage(BaseStorage):
         # Only handle creating sub-collections (user/collection-uid),
         # not the root user principal
         attributes = _get_attributes_from_path(href)
+        if not self._path_belongs_to_user(href):
+            logger.warning(
+                "Rejecting collection create for path %s authenticated as %s",
+                href,
+                self.user,
+            )
+            raise ComponentNotFoundError(href)
+
         if len(attributes) < 2:
             # Creating the user principal itself — nothing to do
             return Collection(self, href)

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -140,8 +140,6 @@ class SyncThread(threading.Thread):
                 self._force_sync.clear()
                 self._done_syncing.set()
 
-            if self._stop_sync.is_set():
-                break
             if was_re_requested:
                 continue  # immediately loop back to sync without waiting
             self._force_sync.wait(self.interval)

--- a/bridge/src/silentsuite_bridge/tray.py
+++ b/bridge/src/silentsuite_bridge/tray.py
@@ -72,14 +72,13 @@ def _create_icon_image(color, size=64):
     return image
 
 
-def _get_user_email():
-    """Get the first configured user email."""
+def _get_accounts():
+    """Get configured account emails."""
     try:
         creds = Credentials()
-        users = creds.list_users()
-        return users[0] if users else None
+        return creds.list_users()
     except Exception:
-        return None
+        return []
 
 
 class BridgeTray:
@@ -98,7 +97,7 @@ class BridgeTray:
 
     def _build_menu(self):
         """Build the tray menu."""
-        email = _get_user_email()
+        accounts = _get_accounts()
         base_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}"
 
         status_text = {
@@ -108,8 +107,27 @@ class BridgeTray:
             "disconnected": "Disconnected",
         }.get(self._state, self._state)
 
-        caldav_url = f"{base_url}/{email}/" if email else "Not configured"
-        carddav_url = caldav_url
+        if accounts:
+            account_items = []
+            for email in accounts:
+                dav_url = f"{base_url}/{email}/"
+                account_items.append(pystray.MenuItem(
+                    email,
+                    pystray.Menu(
+                        pystray.MenuItem(
+                            "Copy CalDAV URL",
+                            lambda url=dav_url: self._copy_to_clipboard(url),
+                        ),
+                        pystray.MenuItem(
+                            "Copy CardDAV URL",
+                            lambda url=dav_url: self._copy_to_clipboard(url),
+                        ),
+                    ),
+                ))
+        else:
+            account_items = [
+                pystray.MenuItem("No accounts configured", None, enabled=False),
+            ]
 
         return pystray.Menu(
             pystray.MenuItem(
@@ -118,28 +136,19 @@ class BridgeTray:
                 enabled=False,
             ),
             pystray.MenuItem(
-                f"Account: {email or 'Not logged in'}",
+                f"Accounts: {len(accounts)} configured",
                 None,
                 enabled=False,
             ),
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem(
-                "Copy CalDAV URL",
-                lambda: self._copy_to_clipboard(caldav_url),
-                enabled=email is not None,
-            ),
-            pystray.MenuItem(
-                "Copy CardDAV URL",
-                lambda: self._copy_to_clipboard(carddav_url),
-                enabled=email is not None,
-            ),
+            *account_items,
             pystray.Menu.SEPARATOR,
             pystray.MenuItem(
                 "Open Dashboard",
                 lambda: webbrowser.open(f"{base_url}/.web/"),
             ),
             pystray.MenuItem(
-                "Re-authenticate",
+                "Add / Re-authenticate Account",
                 lambda: self._reauthenticate(),
             ),
             pystray.Menu.SEPARATOR,

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -13,6 +13,7 @@ Integrates with Radicale's web module system.
 import html
 import json
 import logging
+import threading
 import time
 from collections import deque
 
@@ -33,6 +34,7 @@ _bridge_status = {
     "collections_by_account": {},
     "collections_scope": "all configured accounts",
 }
+_bridge_status_lock = threading.RLock()
 
 
 def log_sync_event(event_type, message):
@@ -46,24 +48,33 @@ def log_sync_event(event_type, message):
 
 def update_status(state, error=None, collections=None, account=None, scope=None):
     """Update the bridge status."""
-    _bridge_status["state"] = state
-    if state == "connected":
-        _bridge_status["last_sync"] = time.strftime("%Y-%m-%d %H:%M:%S")
-        _bridge_status["error"] = None
-    if error:
-        _bridge_status["error"] = str(error)
-    if collections:
-        if account:
-            _bridge_status.setdefault("collections_by_account", {})[account] = collections
-            _bridge_status["collections"] = _aggregate_collections(
-                _bridge_status["collections_by_account"].values()
-            )
-            _bridge_status["collections_scope"] = "all configured accounts"
-        elif scope:
-            _bridge_status["collections"] = collections
-            _bridge_status["collections_scope"] = scope
-        else:
-            _bridge_status["collections"] = collections
+    with _bridge_status_lock:
+        _bridge_status["state"] = state
+        if state == "connected":
+            _bridge_status["last_sync"] = time.strftime("%Y-%m-%d %H:%M:%S")
+            _bridge_status["error"] = None
+        if error:
+            _bridge_status["error"] = str(error)
+        if collections:
+            if account:
+                _bridge_status.setdefault("collections_by_account", {})[account] = collections
+                _bridge_status["collections"] = _aggregate_collections(
+                    _bridge_status["collections_by_account"].values()
+                )
+                _bridge_status["collections_scope"] = "all configured accounts"
+            elif scope:
+                _bridge_status["collections"] = collections
+                _bridge_status["collections_scope"] = scope
+            else:
+                _bridge_status["collections"] = collections
+
+
+def forget_account_status(account):
+    """Remove one account's in-memory dashboard status."""
+    with _bridge_status_lock:
+        account_collections = _bridge_status.setdefault("collections_by_account", {})
+        account_collections.pop(account, None)
+        _bridge_status["collections"] = _aggregate_collections(account_collections.values())
 
 
 def _aggregate_collections(collections_iterable):
@@ -379,7 +390,14 @@ def _render_dashboard():
 
     base_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}"
 
-    state = _bridge_status["state"]
+    with _bridge_status_lock:
+        state = _bridge_status["state"]
+        last_sync = _bridge_status.get("last_sync", "Never")
+        cols = dict(_bridge_status.get("collections", {}))
+        account_cols = dict(_bridge_status.get("collections_by_account", {}))
+        collections_scope = _bridge_status.get("collections_scope") or "all configured accounts"
+        status_error = _bridge_status.get("error")
+
     status_map = {
         "starting": "Starting...",
         "connected": "Connected",
@@ -388,19 +406,15 @@ def _render_dashboard():
     }
     status_text = status_map.get(state, state)
 
-    last_sync = _bridge_status.get("last_sync", "Never")
-    cols = _bridge_status.get("collections", {})
-    account_cols = _bridge_status.get("collections_by_account", {})
     filtered_account_cols = [account_cols[user] for user in users if user in account_cols]
     if filtered_account_cols:
         cols = _aggregate_collections(filtered_account_cols)
     col_text = f"{cols.get('calendars', 0)} calendars, {cols.get('contacts', 0)} contacts, {cols.get('tasks', 0)} tasks"
-    collections_scope = _bridge_status.get("collections_scope") or "all configured accounts"
     collections_label = f"Collections ({collections_scope})"
 
     error_banner = ""
-    if _bridge_status.get("error"):
-        error_banner = f'<div class="error-banner">{esc(_bridge_status["error"])}</div>'
+    if status_error:
+        error_banner = f'<div class="error-banner">{esc(status_error)}</div>'
 
     # Build sync log HTML
     if _sync_log:
@@ -483,8 +497,14 @@ class Web(BaseWeb):
 
         # API endpoint for JSON status
         if path == "/.web/api/status":
+            with _bridge_status_lock:
+                status = dict(_bridge_status)
+                status["collections"] = dict(_bridge_status.get("collections", {}))
+                status["collections_by_account"] = dict(
+                    _bridge_status.get("collections_by_account", {})
+                )
             data = {
-                "status": _bridge_status,
+                "status": status,
                 "log": list(_sync_log)[:20],
             }
             return (
@@ -520,8 +540,9 @@ class Web(BaseWeb):
                 "is_syncing": is_syncing,
                 "sync_started_at": sync_started_at,
                 "last_sync_duration": last_sync_duration,
-                "collections": _bridge_status.get("collections", {}),
             }
+            with _bridge_status_lock:
+                data["collections"] = dict(_bridge_status.get("collections", {}))
             return (
                 200,
                 {"Content-Type": "application/json"},
@@ -548,6 +569,7 @@ class Web(BaseWeb):
                             "stoken": col.stoken[:20] if col.stoken else None,
                             "local_stoken": col.local_stoken[:20] if col.local_stoken else None,
                             "dirty": col.dirty,
+                            "new": col.new,
                             "deleted": col.deleted,
                             "item_count": len(items),
                             "items": items,
@@ -571,37 +593,6 @@ class Web(BaseWeb):
                 200,
                 {"Content-Type": "application/json"},
                 json.dumps(data).encode(),
-            )
-
-        # Diagnostic dump of cached collections/items
-        if path == "/.web/api/dump":
-            from ..local_cache import models, db
-            dump = {}
-            try:
-                with db.database_proxy:
-                    for col in models.CollectionEntity.select():
-                        items = []
-                        for item in col.items:
-                            items.append({
-                                "uid": item.uid,
-                                "dirty": item.dirty,
-                                "new": item.new,
-                                "deleted": item.deleted,
-                            })
-                        dump[col.uid] = {
-                            "stoken": col.stoken,
-                            "local_stoken": col.local_stoken,
-                            "dirty": col.dirty,
-                            "new": col.new,
-                            "deleted": col.deleted,
-                            "items": items,
-                        }
-            except Exception as e:
-                dump = {"error": str(e)}
-            return (
-                200,
-                {"Content-Type": "application/json"},
-                json.dumps(dump, indent=2).encode(),
             )
 
         return (404, {}, b"Not found")

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -30,6 +30,7 @@ _bridge_status = {
     "last_sync": None,
     "error": None,
     "collections": {"calendars": 0, "contacts": 0, "tasks": 0},
+    "collections_scope": "all configured accounts",
 }
 
 
@@ -42,7 +43,7 @@ def log_sync_event(event_type, message):
     })
 
 
-def update_status(state, error=None, collections=None):
+def update_status(state, error=None, collections=None, account=None, scope=None):
     """Update the bridge status."""
     _bridge_status["state"] = state
     if state == "connected":
@@ -52,6 +53,10 @@ def update_status(state, error=None, collections=None):
         _bridge_status["error"] = str(error)
     if collections:
         _bridge_status["collections"] = collections
+        if account:
+            _bridge_status["collections_scope"] = f"latest sync for {account}"
+        elif scope:
+            _bridge_status["collections_scope"] = scope
 
 
 DASHBOARD_HTML = """<!DOCTYPE html>
@@ -147,6 +152,25 @@ DASHBOARD_HTML = """<!DOCTYPE html>
             font-size: 11px;
         }
         .copy-btn:hover { background: #444; }
+        .account-card {
+            background: #111;
+            border: 1px solid #2a2a2a;
+            border-radius: 10px;
+            padding: 14px;
+            margin-bottom: 12px;
+        }
+        .account-card h4 {
+            font-size: 15px;
+            color: #fff;
+            margin-bottom: 8px;
+            overflow-wrap: anywhere;
+        }
+        .account-meta {
+            color: #888;
+            font-size: 12px;
+            margin-bottom: 10px;
+            overflow-wrap: anywhere;
+        }
 
         .log-section { margin-top: 8px; }
         .log-section h3 {
@@ -201,34 +225,17 @@ DASHBOARD_HTML = """<!DOCTYPE html>
                 <span class="status-text">{{STATUS_TEXT}}</span>
             </div>
             <div class="info-grid">
-                <span class="info-label">Account</span>
-                <span class="info-value">{{USER_EMAIL}}</span>
-                <span class="info-label">Server</span>
-                <span class="info-value"><code>{{SERVER_URL}}</code></span>
                 <span class="info-label">Last sync</span>
                 <span class="info-value">{{LAST_SYNC}}</span>
-                <span class="info-label">Collections</span>
+                <span class="info-label">{{COLLECTIONS_LABEL}}</span>
                 <span class="info-value">{{COLLECTIONS}}</span>
                 <span class="info-label">Sync interval</span>
                 <span class="info-value">{{SYNC_INTERVAL_DISPLAY}}</span>
             </div>
 
             <div class="url-section">
-                <h3>Connection URLs</h3>
-                <div class="url-box">
-                    <div>
-                        <label>CalDAV (Calendars + Tasks)</label>
-                        <code id="caldavUrl">{{CALDAV_URL}}</code>
-                    </div>
-                    <button class="copy-btn" onclick="copy(event, 'caldavUrl')">Copy</button>
-                </div>
-                <div class="url-box">
-                    <div>
-                        <label>CardDAV (Contacts)</label>
-                        <code id="carddavUrl">{{CARDDAV_URL}}</code>
-                    </div>
-                    <button class="copy-btn" onclick="copy(event, 'carddavUrl')">Copy</button>
-                </div>
+                <h3>Configured Accounts</h3>
+                {{ACCOUNT_LIST}}
             </div>
         </div>
 
@@ -354,11 +361,8 @@ def _render_dashboard():
 
     creds = Credentials()
     users = creds.list_users()
-    email = users[0] if users else "Not configured"
 
     base_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}"
-    caldav_url = f"{base_url}/{email}/" if users else "N/A"
-    carddav_url = caldav_url
 
     state = _bridge_status["state"]
     status_map = {
@@ -372,6 +376,8 @@ def _render_dashboard():
     last_sync = _bridge_status.get("last_sync", "Never")
     cols = _bridge_status.get("collections", {})
     col_text = f"{cols.get('calendars', 0)} calendars, {cols.get('contacts', 0)} contacts, {cols.get('tasks', 0)} tasks"
+    collections_scope = _bridge_status.get("collections_scope") or "all configured accounts"
+    collections_label = f"Collections ({collections_scope})"
 
     error_banner = ""
     if _bridge_status.get("error"):
@@ -393,17 +399,37 @@ def _render_dashboard():
     else:
         log_html = '<div class="log-empty">No sync activity yet</div>'
 
+    if users:
+        account_html = ""
+        for index, user in enumerate(users):
+            dav_url = f"{base_url}/{user}/"
+            server_url = creds.get_server_url(user)
+            url_id = f"davUrl{index}"
+            account_html += (
+                '<div class="account-card">'
+                f'<h4>{esc(user)}</h4>'
+                f'<div class="account-meta">Server: <code>{esc(server_url)}</code></div>'
+                '<div class="url-box">'
+                '<div>'
+                '<label>CalDAV/CardDAV URL</label>'
+                f'<code id="{url_id}">{esc(dav_url)}</code>'
+                '</div>'
+                f'<button class="copy-btn" onclick="copy(event, \'{url_id}\')">Copy</button>'
+                '</div>'
+                '</div>'
+            )
+    else:
+        account_html = '<div class="log-empty">No accounts configured</div>'
+
     page = DASHBOARD_HTML
     page = page.replace("{{VERSION}}", esc(__version__))
     page = page.replace("{{ERROR_BANNER}}", error_banner)
     page = page.replace("{{STATUS_STATE}}", esc(state))
     page = page.replace("{{STATUS_TEXT}}", esc(status_text))
-    page = page.replace("{{USER_EMAIL}}", esc(email))
-    page = page.replace("{{SERVER_URL}}", esc(config.ETEBASE_SERVER_URL))
     page = page.replace("{{LAST_SYNC}}", esc(last_sync or "Never"))
+    page = page.replace("{{COLLECTIONS_LABEL}}", esc(collections_label))
     page = page.replace("{{COLLECTIONS}}", esc(col_text))
-    page = page.replace("{{CALDAV_URL}}", esc(caldav_url))
-    page = page.replace("{{CARDDAV_URL}}", esc(carddav_url))
+    page = page.replace("{{ACCOUNT_LIST}}", account_html)
     page = page.replace("{{SYNC_LOG}}", log_html)
 
     # Sync interval display

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -480,11 +480,22 @@ class Web(BaseWeb):
             is_syncing = False
             sync_started_at = None
             last_sync_duration = None
+            latest_completed_sync = None
             for thread in _sync_threads.values():
                 if getattr(thread, "is_syncing", False):
                     is_syncing = True
-                    sync_started_at = getattr(thread, "sync_started_at", None)
-                if getattr(thread, "last_sync_duration", None) is not None:
+                    started_at = getattr(thread, "sync_started_at", None)
+                    if started_at is not None:
+                        if sync_started_at is None or started_at < sync_started_at:
+                            sync_started_at = started_at
+
+                completed_at = getattr(thread, "last_sync", None)
+                if (
+                    getattr(thread, "last_sync_duration", None) is not None
+                    and completed_at is not None
+                    and (latest_completed_sync is None or completed_at > latest_completed_sync)
+                ):
+                    latest_completed_sync = completed_at
                     last_sync_duration = thread.last_sync_duration
             data = {
                 "is_syncing": is_syncing,

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -30,6 +30,7 @@ _bridge_status = {
     "last_sync": None,
     "error": None,
     "collections": {"calendars": 0, "contacts": 0, "tasks": 0},
+    "collections_by_account": {},
     "collections_scope": "all configured accounts",
 }
 
@@ -52,11 +53,25 @@ def update_status(state, error=None, collections=None, account=None, scope=None)
     if error:
         _bridge_status["error"] = str(error)
     if collections:
-        _bridge_status["collections"] = collections
         if account:
-            _bridge_status["collections_scope"] = f"latest sync for {account}"
+            _bridge_status.setdefault("collections_by_account", {})[account] = collections
+            _bridge_status["collections"] = _aggregate_collections(
+                _bridge_status["collections_by_account"].values()
+            )
+            _bridge_status["collections_scope"] = "all configured accounts"
         elif scope:
+            _bridge_status["collections"] = collections
             _bridge_status["collections_scope"] = scope
+        else:
+            _bridge_status["collections"] = collections
+
+
+def _aggregate_collections(collections_iterable):
+    totals = {"calendars": 0, "contacts": 0, "tasks": 0}
+    for collections in collections_iterable:
+        for key in totals:
+            totals[key] += collections.get(key, 0)
+    return totals
 
 
 DASHBOARD_HTML = """<!DOCTYPE html>
@@ -375,6 +390,10 @@ def _render_dashboard():
 
     last_sync = _bridge_status.get("last_sync", "Never")
     cols = _bridge_status.get("collections", {})
+    account_cols = _bridge_status.get("collections_by_account", {})
+    filtered_account_cols = [account_cols[user] for user in users if user in account_cols]
+    if filtered_account_cols:
+        cols = _aggregate_collections(filtered_account_cols)
     col_text = f"{cols.get('calendars', 0)} calendars, {cols.get('contacts', 0)} contacts, {cols.get('tasks', 0)} tasks"
     collections_scope = _bridge_status.get("collections_scope") or "all configured accounts"
     collections_label = f"Collections ({collections_scope})"

--- a/bridge/tests/test_accounts.py
+++ b/bridge/tests/test_accounts.py
@@ -1,0 +1,154 @@
+"""Tests for bridge account-management helpers."""
+
+from silentsuite_bridge import accounts, config
+from silentsuite_bridge.local_cache.models import (
+    CollectionEntity,
+    HrefMapper,
+    ItemEntity,
+    User,
+)
+from silentsuite_bridge.radicale.auth import Auth
+from silentsuite_bridge.radicale.creds import Credentials
+
+
+PASSWORD = "correct horse battery staple"
+
+
+def _radicale_config_stub():
+    from unittest.mock import MagicMock
+
+    cfg = MagicMock()
+    cfg.get.side_effect = lambda section, key: False
+    return cfg
+
+
+def _configure_creds(tmp_path, monkeypatch):
+    path = tmp_path / "creds.json"
+    monkeypatch.setattr(config, "CREDS_FILE", str(path))
+    return path
+
+
+def _seed_cache(username):
+    user = User.create(username=username)
+    col = CollectionEntity.create(local_user=user, uid=f"{username}-col", eb_col=b"col")
+    item = ItemEntity.create(collection=col, uid=f"{username}-item", eb_item=b"item")
+    HrefMapper.create(content=item, href=f"{username}.ics")
+    return user
+
+
+def test_store_authenticated_account_adds_second_account(tmp_path, monkeypatch):
+    _configure_creds(tmp_path, monkeypatch)
+
+    accounts.store_authenticated_account(
+        "alice@example.com", PASSWORD, "alice-session", "https://server-a.test",
+    )
+    accounts.store_authenticated_account(
+        "bob@example.com", PASSWORD, "bob-session", "https://server-b.test",
+    )
+
+    creds = Credentials()
+    assert creds.list_users() == ["alice@example.com", "bob@example.com"]
+    assert creds.get_etebase("alice@example.com") == "alice-session"
+    assert creds.get_etebase("bob@example.com") == "bob-session"
+    assert creds.get_server_url("bob@example.com") == "https://server-b.test"
+
+
+def test_store_authenticated_account_reauth_updates_one_account(tmp_path, monkeypatch):
+    _configure_creds(tmp_path, monkeypatch)
+
+    accounts.store_authenticated_account(
+        "alice@example.com", PASSWORD, "old-session", "https://old.test",
+    )
+    old_hash = Credentials().get_password_hash("alice@example.com")
+
+    result = accounts.store_authenticated_account(
+        " alice@example.com ", "new password", "new-session", "https://new.test",
+    )
+
+    creds = Credentials()
+    assert result.existed is True
+    assert creds.list_users() == ["alice@example.com"]
+    assert creds.get_etebase("alice@example.com") == "new-session"
+    assert creds.get_server_url("alice@example.com") == "https://new.test"
+    assert creds.get_password_hash("alice@example.com") != old_hash
+
+
+def test_logout_one_of_two_preserves_other_credentials_and_cache(
+    tmp_path, monkeypatch, mem_db,
+):
+    _configure_creds(tmp_path, monkeypatch)
+    monkeypatch.setattr(accounts, "stop_sync_thread", lambda user: True)
+    forgotten = []
+    monkeypatch.setattr(accounts, "forget_etesync_user", forgotten.append)
+
+    accounts.store_authenticated_account(
+        "alice@example.com", PASSWORD, "alice-session", "https://server.test",
+    )
+    accounts.store_authenticated_account(
+        "bob@example.com", PASSWORD, "bob-session", "https://server.test",
+    )
+    _seed_cache("alice@example.com")
+
+    result = accounts.logout_account("alice@example.com")
+
+    creds = Credentials()
+    assert result.existed is True
+    assert creds.list_users() == ["bob@example.com"]
+    assert User.get_or_none(User.username == "alice@example.com") is not None
+    assert forgotten == ["alice@example.com"]
+
+
+def test_remove_account_deletes_only_that_users_cache(tmp_path, monkeypatch, mem_db):
+    _configure_creds(tmp_path, monkeypatch)
+    monkeypatch.setattr(accounts, "stop_sync_thread", lambda user: True)
+    monkeypatch.setattr(accounts, "forget_etesync_user", lambda user: None)
+
+    accounts.store_authenticated_account(
+        "alice@example.com", PASSWORD, "alice-session", "https://server.test",
+    )
+    accounts.store_authenticated_account(
+        "bob@example.com", PASSWORD, "bob-session", "https://server.test",
+    )
+    _seed_cache("alice@example.com")
+    _seed_cache("bob@example.com")
+
+    result = accounts.remove_account("alice@example.com")
+
+    creds = Credentials()
+    assert result.existed is True
+    assert result.cache_cleared is True
+    assert creds.list_users() == ["bob@example.com"]
+    assert User.get_or_none(User.username == "alice@example.com") is None
+    assert User.get_or_none(User.username == "bob@example.com") is not None
+    assert Auth(_radicale_config_stub()).login("bob@example.com", PASSWORD) == "bob@example.com"
+
+
+def test_remove_missing_account_is_noop(tmp_path, monkeypatch, mem_db):
+    _configure_creds(tmp_path, monkeypatch)
+    monkeypatch.setattr(accounts, "stop_sync_thread", lambda user: True)
+    monkeypatch.setattr(accounts, "forget_etesync_user", lambda user: None)
+    accounts.store_authenticated_account(
+        "bob@example.com", PASSWORD, "bob-session", "https://server.test",
+    )
+    _seed_cache("bob@example.com")
+
+    result = accounts.remove_account("ghost@example.com")
+
+    assert result.existed is False
+    assert Credentials().list_users() == ["bob@example.com"]
+    assert User.get_or_none(User.username == "bob@example.com") is not None
+
+
+def test_remove_last_account_leaves_no_configured_users(tmp_path, monkeypatch, mem_db):
+    _configure_creds(tmp_path, monkeypatch)
+    monkeypatch.setattr(accounts, "stop_sync_thread", lambda user: True)
+    monkeypatch.setattr(accounts, "forget_etesync_user", lambda user: None)
+    accounts.store_authenticated_account(
+        "alice@example.com", PASSWORD, "alice-session", "https://server.test",
+    )
+    _seed_cache("alice@example.com")
+
+    accounts.remove_account("alice@example.com")
+
+    assert Credentials().list_users() == []
+    assert User.get_or_none(User.username == "alice@example.com") is None

--- a/bridge/tests/test_auth_roundtrip.py
+++ b/bridge/tests/test_auth_roundtrip.py
@@ -32,6 +32,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from silentsuite_bridge import config
+from silentsuite_bridge.accounts import store_authenticated_account
 from silentsuite_bridge.radicale.auth import Auth
 from silentsuite_bridge.radicale.creds import Credentials
 
@@ -226,22 +227,13 @@ class TestEndToEndAuthSetup:
 
     def test_browser_auth_then_caldav_login_round_trip(self, auth, creds_file):
         # Step 1: browser_login persists the session + a salted PBKDF2 hash.
-        creds = Credentials(filename=creds_file)
-        # Wipe any prior users (browser_login does this for single-account mode).
-        for u in creds.list_users():
-            creds.delete(u)
-        creds.set_etebase(
+        store_authenticated_account(
             USERNAME,
-            stored_session="fake-stored-session-blob",
-            server_url="https://test.silentsuite.io",
+            PASSWORD,
+            "fake-stored-session-blob",
+            "https://test.silentsuite.io",
         )
-        salt = os.urandom(32)
-        pwd_hash = hashlib.pbkdf2_hmac(
-            "sha256", PASSWORD.encode(), salt, 600000
-        ).hex()
-        creds.set_password_salt(USERNAME, salt.hex())
-        creds.set_password_hash(USERNAME, pwd_hash)
-        creds.save()
+        creds = Credentials(filename=creds_file)
 
         # Step 2: a CalDAV client connects with those credentials — the
         # bridge's Auth.login (called by Radicale per request) returns the
@@ -256,3 +248,23 @@ class TestEndToEndAuthSetup:
         # elsewhere in the bridge tests).
         assert creds.get_etebase(USERNAME) == "fake-stored-session-blob"
         assert creds.get_server_url(USERNAME) == "https://test.silentsuite.io"
+
+    def test_browser_auth_style_save_preserves_existing_account(self, auth, creds_file):
+        store_authenticated_account(
+            "alice@example.com",
+            PASSWORD,
+            "alice-session",
+            "https://server-a.test",
+        )
+        store_authenticated_account(
+            "bob@example.com",
+            PASSWORD,
+            "bob-session",
+            "https://server-b.test",
+        )
+
+        creds = Credentials(filename=creds_file)
+        assert creds.list_users() == ["alice@example.com", "bob@example.com"]
+        assert creds.get_etebase("alice@example.com") == "alice-session"
+        assert auth.login("alice@example.com", PASSWORD) == "alice@example.com"
+        assert auth.login("bob@example.com", PASSWORD) == "bob@example.com"

--- a/bridge/tests/test_local_cache.py
+++ b/bridge/tests/test_local_cache.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 import pytest
 import vobject
 
-from silentsuite_bridge.local_cache import models, db, Etebase, Collection, Item
+from silentsuite_bridge.local_cache import Collection, Etebase, Item, clear_cached_user, db, models
 from silentsuite_bridge.local_cache.models import (
     CollectionEntity,
     ItemEntity,
@@ -131,6 +131,38 @@ class TestHrefMapper:
         )
         assert created2 is False
         assert mapper2.href == "new.ics"
+
+
+class TestClearCachedUser:
+    """Test session-independent per-user cache deletion."""
+
+    @staticmethod
+    def _seed_user(username):
+        user = User.create(username=username)
+        col = CollectionEntity.create(local_user=user, uid=f"{username}-col", eb_col=b"a")
+        item = ItemEntity.create(collection=col, uid=f"{username}-item", eb_item=b"b")
+        HrefMapper.create(content=item, href=f"{username}.ics")
+        return user
+
+    def test_clear_cached_user_deletes_only_selected_user(self, mem_db):
+        self._seed_user("alice@example.com")
+        self._seed_user("bob@example.com")
+
+        assert clear_cached_user("alice@example.com") is True
+
+        assert User.get_or_none(User.username == "alice@example.com") is None
+        bob = User.get(User.username == "bob@example.com")
+        assert bob.collections.count() == 1
+        assert ItemEntity.select().join(CollectionEntity).where(
+            CollectionEntity.local_user == bob
+        ).count() == 1
+        assert HrefMapper.select().count() == 1
+
+    def test_clear_cached_user_missing_is_idempotent(self, mem_db):
+        self._seed_user("bob@example.com")
+
+        assert clear_cached_user("ghost@example.com") is False
+        assert User.get_or_none(User.username == "bob@example.com") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/bridge/tests/test_main_accounts.py
+++ b/bridge/tests/test_main_accounts.py
@@ -1,0 +1,48 @@
+"""CLI tests for bridge account-management commands."""
+
+import sys
+
+import pytest
+
+from silentsuite_bridge import __main__ as main_module
+from silentsuite_bridge import accounts, config
+
+
+def _run_main(argv, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["silentsuite-bridge", *argv])
+    monkeypatch.setattr(main_module, "configure_logging", lambda: None)
+    monkeypatch.setattr(config, "ensure_data_dir", lambda: None)
+    with pytest.raises(SystemExit) as exc:
+        main_module.main()
+    return exc.value.code
+
+
+def test_list_accounts_prints_all_accounts(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    accounts.store_authenticated_account(
+        "alice@example.com", "password", "alice-session", "https://server-a.test",
+    )
+    accounts.store_authenticated_account(
+        "bob@example.com", "password", "bob-session", "https://server-b.test",
+    )
+
+    code = _run_main(["--list-accounts"], monkeypatch)
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "alice@example.com (https://server-a.test)" in out
+    assert "bob@example.com (https://server-b.test)" in out
+
+
+def test_logout_requires_account_argument(monkeypatch, capsys):
+    code = _run_main(["--logout"], monkeypatch)
+
+    assert code == 1
+    assert "--logout requires an account argument" in capsys.readouterr().out
+
+
+def test_account_actions_cannot_be_combined(monkeypatch, capsys):
+    code = _run_main(["--list-accounts", "--logout", "alice@example.com"], monkeypatch)
+
+    assert code == 1
+    assert "account action flags cannot be combined" in capsys.readouterr().out

--- a/bridge/tests/test_storage.py
+++ b/bridge/tests/test_storage.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
+from radicale.storage import ComponentNotFoundError
 import vobject
 
 from silentsuite_bridge.local_cache import models, db
@@ -286,6 +287,31 @@ class TestDiscover:
             "test@example.com/contacts",
         ]
 
+    @patch("silentsuite_bridge.radicale.storage.etesync_for_user")
+    @patch("silentsuite_bridge.radicale.storage.start_sync_thread")
+    def test_discover_rejects_authenticated_user_path_mismatch(self, mock_start, mock_etesync_ctx):
+        mock_thread = MagicMock()
+        mock_thread.wait_for_sync.return_value = True
+        mock_start.return_value = mock_thread
+
+        mock_etesync = MagicMock()
+        mock_etesync.list.return_value = []
+        mock_etesync_ctx.return_value.__enter__ = MagicMock(
+            return_value=(mock_etesync, False)
+        )
+        mock_etesync_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        from radicale.config import Configuration, DEFAULT_CONFIG_SCHEMA
+
+        configuration = Configuration(DEFAULT_CONFIG_SCHEMA)
+        storage = Storage(configuration)
+
+        with storage.acquire_lock("r", user="alice@example.com"):
+            results = list(storage.discover("/bob@example.com/calendar/item.ics", depth="1"))
+
+        assert results == []
+        mock_etesync.list.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Collection — create_collection
@@ -447,3 +473,36 @@ class TestCreateCollection:
 
         # Should return a fake collection without creating anything on Etebase
         assert result is not None
+
+    @patch("silentsuite_bridge.radicale.storage.log_sync_event")
+    @patch("silentsuite_bridge.radicale.storage.etesync_for_user")
+    @patch("silentsuite_bridge.radicale.storage.start_sync_thread")
+    def test_create_collection_rejects_authenticated_user_path_mismatch(
+        self, mock_start, mock_etesync_ctx, mock_log, mem_db,
+    ):
+        mock_thread = MagicMock()
+        mock_thread.wait_for_sync.return_value = True
+        mock_start.return_value = mock_thread
+
+        mock_etesync = MagicMock()
+        mock_col_mgr = MagicMock()
+        mock_etesync.etebase.get_collection_manager.return_value = mock_col_mgr
+        mock_etesync.user = User.create(username="alice@example.com")
+        mock_etesync_ctx.return_value.__enter__ = MagicMock(
+            return_value=(mock_etesync, False)
+        )
+        mock_etesync_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        from radicale.config import Configuration, DEFAULT_CONFIG_SCHEMA
+
+        configuration = Configuration(DEFAULT_CONFIG_SCHEMA)
+        storage = Storage(configuration)
+
+        with storage.acquire_lock("w", user="alice@example.com"):
+            with pytest.raises(ComponentNotFoundError):
+                storage.create_collection(
+                    "/bob@example.com/new-cal-uid",
+                    props={"tag": "VCALENDAR", "D:displayname": "Work Calendar"},
+                )
+
+        mock_col_mgr.create.assert_not_called()

--- a/bridge/tests/test_sync_thread.py
+++ b/bridge/tests/test_sync_thread.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from silentsuite_bridge.radicale.storage import SyncThread, start_sync_thread
+from silentsuite_bridge.radicale.storage import SyncThread, start_sync_thread, stop_sync_thread
 
 
 class TestSyncThread:
@@ -74,6 +74,12 @@ class TestSyncThread:
         # Setting interval should set _force_sync to wake the wait
         assert t._force_sync.is_set()
 
+    def test_stop_sets_stop_event_and_wakes_wait(self):
+        t = SyncThread("user@test.com")
+        t.stop()
+        assert t._stop_sync.is_set()
+        assert t._force_sync.is_set()
+
 
 class TestSyncThreadRun:
     """Test the SyncThread.run() loop with mocked etesync."""
@@ -93,12 +99,16 @@ class TestSyncThreadRun:
         t.interval = 0.05  # short interval for testing
 
         t.start()
-        time.sleep(0.2)
+        try:
+            time.sleep(0.2)
 
-        assert t.last_sync is not None
-        mock_etesync.sync.assert_called()
-        # Thread should still be alive (looping)
-        assert t.is_alive()
+            assert t.last_sync is not None
+            mock_etesync.sync.assert_called()
+            # Thread should still be alive (looping)
+            assert t.is_alive()
+        finally:
+            t.stop()
+            t.join(1)
 
     @patch("silentsuite_bridge.radicale.storage.etesync_for_user")
     @patch("silentsuite_bridge.radicale.storage.update_status")
@@ -115,13 +125,17 @@ class TestSyncThreadRun:
         t.interval = 300  # very long so it only syncs when forced
 
         t.start()
-        time.sleep(0.15)  # let initial sync complete
-        initial_count = mock_etesync.sync.call_count
+        try:
+            time.sleep(0.15)  # let initial sync complete
+            initial_count = mock_etesync.sync.call_count
 
-        t.force_sync()
-        t.wait_for_sync(timeout=2)
+            t.force_sync()
+            t.wait_for_sync(timeout=2)
 
-        assert mock_etesync.sync.call_count > initial_count
+            assert mock_etesync.sync.call_count > initial_count
+        finally:
+            t.stop()
+            t.join(1)
 
     @patch("silentsuite_bridge.radicale.storage.etesync_for_user")
     @patch("silentsuite_bridge.radicale.storage.update_status")
@@ -138,12 +152,16 @@ class TestSyncThreadRun:
         t.interval = 300
 
         t.start()
-        time.sleep(0.15)
+        try:
+            time.sleep(0.15)
 
-        # Error should be stored and re-raised on wait
-        t.force_sync()
-        with pytest.raises(ConnectionError, match="network down"):
-            t.wait_for_sync(timeout=2)
+            # Error should be stored and re-raised on wait
+            t.force_sync()
+            with pytest.raises(ConnectionError, match="network down"):
+                t.wait_for_sync(timeout=2)
+        finally:
+            t.stop()
+            t.join(1)
 
 
 class TestStartSyncThread:
@@ -177,6 +195,64 @@ class TestStartSyncThread:
 
             result = start_sync_thread("alive@test.com")
             assert result is existing
+            MockThread.assert_not_called()
+        finally:
+            storage._sync_threads = original
+
+    def test_stop_sync_thread_missing_user_is_noop(self):
+        assert stop_sync_thread("missing@test.com", timeout=0) is True
+
+    def test_stop_sync_thread_removes_stopped_thread(self):
+        from silentsuite_bridge.radicale import storage
+
+        original = storage._sync_threads.copy()
+        try:
+            storage._sync_threads.clear()
+            thread = MagicMock()
+            thread.is_alive.return_value = False
+            storage._sync_threads["stopped@test.com"] = thread
+
+            assert stop_sync_thread("stopped@test.com", timeout=0) is True
+
+            thread.stop.assert_called_once()
+            thread.join.assert_called_once_with(0)
+            assert "stopped@test.com" not in storage._sync_threads
+        finally:
+            storage._sync_threads = original
+
+    def test_stop_sync_thread_does_not_join_current_thread(self, monkeypatch):
+        from silentsuite_bridge.radicale import storage
+
+        original = storage._sync_threads.copy()
+        try:
+            storage._sync_threads.clear()
+            thread = MagicMock()
+            monkeypatch.setattr(threading, "current_thread", lambda: thread)
+            storage._sync_threads["self@test.com"] = thread
+
+            assert stop_sync_thread("self@test.com", timeout=0) is False
+
+            thread.stop.assert_called_once()
+            thread.join.assert_not_called()
+            assert storage._sync_threads["self@test.com"] is thread
+        finally:
+            storage._sync_threads = original
+
+    @patch("silentsuite_bridge.radicale.storage.SyncThread")
+    def test_stop_timeout_keeps_thread_and_prevents_duplicate(self, MockThread):
+        from silentsuite_bridge.radicale import storage
+
+        original = storage._sync_threads.copy()
+        try:
+            storage._sync_threads.clear()
+            existing = MagicMock()
+            existing.is_alive.return_value = True
+            storage._sync_threads["slow@test.com"] = existing
+
+            assert stop_sync_thread("slow@test.com", timeout=0) is False
+            assert storage._sync_threads["slow@test.com"] is existing
+
+            assert start_sync_thread("slow@test.com") is existing
             MockThread.assert_not_called()
         finally:
             storage._sync_threads = original

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -1,0 +1,33 @@
+"""Tests for the bridge dashboard renderer."""
+
+from silentsuite_bridge import config
+from silentsuite_bridge.radicale.creds import Credentials
+from silentsuite_bridge.web import _render_dashboard, update_status
+
+
+def test_render_dashboard_lists_each_configured_account(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+
+    creds = Credentials()
+    creds.set_etebase("alice@example.com", "alice-session", "https://server-a.test")
+    creds.set_etebase("bob@example.com", "bob-session", "https://server-b.test")
+    creds.save()
+
+    update_status(
+        "connected",
+        collections={"calendars": 2, "contacts": 1, "tasks": 0},
+        scope="all configured accounts",
+    )
+
+    html = _render_dashboard()
+
+    assert "alice@example.com" in html
+    assert "bob@example.com" in html
+    assert "https://server-a.test" in html
+    assert "https://server-b.test" in html
+    assert "http://127.0.0.1:37358/alice@example.com/" in html
+    assert "http://127.0.0.1:37358/bob@example.com/" in html
+    assert "Collections (all configured accounts)" in html
+    assert "2 calendars, 1 contacts, 0 tasks" in html

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -2,7 +2,12 @@
 
 from silentsuite_bridge import config
 from silentsuite_bridge.radicale.creds import Credentials
-from silentsuite_bridge.web import _bridge_status, _render_dashboard, update_status
+from silentsuite_bridge.web import (
+    _bridge_status,
+    _render_dashboard,
+    forget_account_status,
+    update_status,
+)
 
 
 def _reset_status():
@@ -83,3 +88,26 @@ def test_render_dashboard_handles_no_accounts(tmp_path, monkeypatch):
     html = _render_dashboard()
 
     assert "No accounts configured" in html
+
+
+def test_forget_account_status_removes_one_accounts_counts():
+    _reset_status()
+    update_status(
+        "connected",
+        collections={"calendars": 2, "contacts": 0, "tasks": 1},
+        account="alice@example.com",
+    )
+    update_status(
+        "connected",
+        collections={"calendars": 1, "contacts": 3, "tasks": 0},
+        account="bob@example.com",
+    )
+
+    forget_account_status("alice@example.com")
+
+    assert _bridge_status["collections"] == {
+        "calendars": 1,
+        "contacts": 3,
+        "tasks": 0,
+    }
+    assert "alice@example.com" not in _bridge_status["collections_by_account"]

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -2,10 +2,22 @@
 
 from silentsuite_bridge import config
 from silentsuite_bridge.radicale.creds import Credentials
-from silentsuite_bridge.web import _render_dashboard, update_status
+from silentsuite_bridge.web import _bridge_status, _render_dashboard, update_status
+
+
+def _reset_status():
+    _bridge_status.update({
+        "state": "starting",
+        "last_sync": None,
+        "error": None,
+        "collections": {"calendars": 0, "contacts": 0, "tasks": 0},
+        "collections_by_account": {},
+        "collections_scope": "all configured accounts",
+    })
 
 
 def test_render_dashboard_lists_each_configured_account(tmp_path, monkeypatch):
+    _reset_status()
     monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
     monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
     monkeypatch.setattr(config, "LISTEN_PORT", 37358)
@@ -31,3 +43,43 @@ def test_render_dashboard_lists_each_configured_account(tmp_path, monkeypatch):
     assert "http://127.0.0.1:37358/bob@example.com/" in html
     assert "Collections (all configured accounts)" in html
     assert "2 calendars, 1 contacts, 0 tasks" in html
+
+
+def test_update_status_aggregates_background_sync_counts(tmp_path, monkeypatch):
+    _reset_status()
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+
+    creds = Credentials()
+    creds.set_etebase("alice@example.com", "alice-session", "https://server-a.test")
+    creds.set_etebase("bob@example.com", "bob-session", "https://server-b.test")
+    creds.save()
+
+    update_status(
+        "connected",
+        collections={"calendars": 2, "contacts": 0, "tasks": 1},
+        account="alice@example.com",
+    )
+    update_status(
+        "connected",
+        collections={"calendars": 1, "contacts": 3, "tasks": 0},
+        account="bob@example.com",
+    )
+
+    assert _bridge_status["collections"] == {
+        "calendars": 3,
+        "contacts": 3,
+        "tasks": 1,
+    }
+    assert _bridge_status["collections_scope"] == "all configured accounts"
+
+    html = _render_dashboard()
+    assert "3 calendars, 3 contacts, 1 tasks" in html
+
+
+def test_render_dashboard_handles_no_accounts(tmp_path, monkeypatch):
+    _reset_status()
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+
+    html = _render_dashboard()
+
+    assert "No accounts configured" in html


### PR DESCRIPTION
## Summary
- add account-management helpers for append-only login, list, logout, and remove semantics
- add per-account cache/session/thread cleanup and DAV auth/path isolation
- update CLI, dashboard, tray, docs, and bridge tests for multi-account behavior

Closes #87

## Verification
- Passed: `python3 -m compileall src tests`
- Passed: `git diff --check`
- Blocked locally: `python3 -m pytest tests/test_accounts.py tests/test_auth_roundtrip.py tests/test_local_cache.py tests/test_storage.py tests/test_sync_thread.py tests/test_main_accounts.py` (`pytest` is not installed)
- Blocked locally: `python3 -m ruff check src tests` (`ruff` is not installed)