### PR TITLE
Add Zapstore publishing metadata

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,0 +1,30 @@
+repository: https://github.com/silent-suite/silentsuite
+release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.2.0-beta/silentsuite-android-v0.2.0-beta.apk
+pubkey: npub1zuusadlzq6vehhaqhqpup0mhnx70q9cnf9hs48t79g6qn4wpg2eqsy8m35
+name: SilentSuite
+summary: Zero-knowledge calendar, contacts, and tasks sync for Android
+description: |
+  SilentSuite is a zero-knowledge sync app for Android calendars, contacts, and tasks. It keeps your productivity data encrypted before it reaches the server, so SilentSuite cannot read your calendar events, address book, or task lists.
+
+  Use your existing Android calendar, contacts, and task apps while syncing private data through SilentSuite. Your plaintext data stays on your devices. Sync data is stored on the server as encrypted blobs, and your encryption keys do not leave your device.
+
+  You can use SilentSuite with a hosted silentsuite.io account, or point the app at your own self-hosted SilentSuite server. The server and client code are open source, so privacy claims can be inspected instead of merely trusted.
+
+  Beta note: SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta; please report issues so we can make the Android experience better.
+tags:
+  - productivity
+  - privacy
+  - calendar
+  - contacts
+  - tasks
+  - sync
+license: GPL-3.0-only
+website: https://silentsuite.io
+icon: android/fastlane/metadata/android/en-US/images/icon.png
+images:
+  - android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-main.png
+  - android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-account.png
+  - android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-create-calendar.png
+  - android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-view-collection.png
+release_notes: |
+  v0.2.0-beta: multiple calendars, address books, and task lists; Android export backups; clearer sync states; refreshed branding; and Bitcoin/Lightning annual signup via BTCPay.


### PR DESCRIPTION
## Summary

- add repo-root `zapstore.yaml` for Zapstore repository verification
- pin Zapstore publishing to the existing `v0.2.0-beta` Android APK
- use the confirmed SilentSuite Nostr pubkey `npub1zuusadlzq6vehhaqhqpup0mhnx70q9cnf9hs48t79g6qn4wpg2eqsy8m35`

## Validation

- `zsp publish --check zapstore.yaml` -> `{"package_id":"io.silentsuite.android"}`
- release APK SHA-256 previously verified: `7aa980638d26c59bb8c34797fb815ad9e76a38ef3f5775e679aef7911cbeb120`
- release APK signing cert SHA-256 previously verified: `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`

## Notes

- This PR intentionally targets `main` because Zapstore first-publish repository whitelisting fetches `zapstore.yaml` from the public source repository/default branch before publishing.
- No Zapstore publication, signing, certificate linking, or upload is performed by this PR.