### PR TITLE
Restore Django admin CSRF protection

### DIFF
--- a/server/etebase_server/myauth/tests.py
+++ b/server/etebase_server/myauth/tests.py
@@ -4,6 +4,8 @@ import os
 import sys
 
 import django
+from django.conf import settings
+from django.test import Client
 from django.test import TestCase, override_settings
 
 # Ensure Django is configured before any imports that need it
@@ -28,9 +30,11 @@ class DjangoAppLoadTest(TestCase):
 
     def test_auth_user_model(self):
         """Custom auth user model should be set."""
-        from django.conf import settings
-
         self.assertEqual(settings.AUTH_USER_MODEL, "myauth.User")
+
+    def test_csrf_middleware_protects_django_admin(self):
+        """Django admin uses session auth and must keep CSRF middleware enabled."""
+        self.assertIn("django.middleware.csrf.CsrfViewMiddleware", settings.MIDDLEWARE)
 
 
 @override_settings(ALLOWED_HOSTS=["*"], DEBUG=True)
@@ -61,3 +65,14 @@ class URLRoutingTest(TestCase):
         """Admin login page should return a response."""
         response = self.client.get("/admin/login/")
         self.assertIn(response.status_code, [200, 301, 302])
+
+    def test_admin_login_post_without_csrf_is_rejected(self):
+        """Admin state-changing POSTs should fail closed without a CSRF token."""
+        client = Client(enforce_csrf_checks=True)
+
+        response = client.post(
+            "/admin/login/",
+            {"username": "admin", "password": "wrong", "next": "/admin/"},
+        )
+
+        self.assertEqual(response.status_code, 403)

--- a/server/etebase_server/settings.py
+++ b/server/etebase_server/settings.py
@@ -64,8 +64,9 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
-    # CsrfViewMiddleware removed — all API auth is via FastAPI dependency injection;
-    # Django admin uses session auth but CSRF is not required for internal dev use.
+    # FastAPI protocol routes are mounted separately; Django middleware protects
+    # the Django admin/session-auth surface.
+    "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",


### PR DESCRIPTION
## Summary
- restore Django CSRF middleware for the admin/session-auth surface
- update the middleware comment to distinguish FastAPI protocol routes from Django admin routes
- add tests that keep CSRF middleware configured and reject admin login POSTs without a CSRF token

## Verification
- git diff --check origin/dev..HEAD
- python3 -m py_compile server/etebase_server/settings.py server/etebase_server/myauth/tests.py

Full Django tests should run in CI because local Django/pytest dependencies are unavailable in this environment.