### PR TITLE
Scrub web privacy logs and guard cache writes

### DIFF
--- a/apps/web/app/(app)/calendar/error.tsx
+++ b/apps/web/app/(app)/calendar/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function CalendarError({
   error,
@@ -11,7 +12,7 @@ export default function CalendarError({
   reset: () => void
 }) {
   useEffect(() => {
-    console.error('Calendar error boundary caught:', error)
+    console.error('Calendar error boundary caught', getSafeErrorDetails(error))
     Sentry.captureException(error)
   }, [error])
 

--- a/apps/web/app/(app)/contacts/error.tsx
+++ b/apps/web/app/(app)/contacts/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function ContactsError({
   error,
@@ -11,7 +12,7 @@ export default function ContactsError({
   reset: () => void
 }) {
   useEffect(() => {
-    console.error('Contacts error boundary caught:', error)
+    console.error('Contacts error boundary caught', getSafeErrorDetails(error))
     Sentry.captureException(error)
   }, [error])
 

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -12,6 +12,7 @@ import { useSyncStore } from '@/app/stores/use-sync-store'
 import { ContactsEmptyState, SearchEmptyState, ContactDetailEmptyState } from '@/app/components/empty-state'
 import { ConfirmDialog } from '@/app/components/confirm-dialog'
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import type { Contact } from '@silentsuite/core'
 
 // ── Helpers ──
@@ -284,7 +285,7 @@ function ContactForm({
       const dataUrl = await processContactPhoto(file)
       setPhotoUrl(dataUrl)
     } catch (err) {
-      console.error('[contacts] Failed to process photo:', err)
+      console.error('[contacts] Failed to process photo', getSafeErrorDetails(err))
     }
     // Reset so the same file can be re-selected
     e.target.value = ''
@@ -633,7 +634,7 @@ function ContactDetail({
       const dataUrl = await processContactPhoto(file)
       updateContact(contact.id, { photoUrl: dataUrl })
     } catch (err) {
-      console.error('[contacts] Failed to process photo:', err)
+      console.error('[contacts] Failed to process photo', getSafeErrorDetails(err))
     }
     e.target.value = ''
   }, [contact.id, updateContact])

--- a/apps/web/app/(app)/error.tsx
+++ b/apps/web/app/(app)/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function AppError({
   error,
@@ -11,7 +12,7 @@ export default function AppError({
   reset: () => void
 }) {
   useEffect(() => {
-    console.error('App error boundary caught:', error)
+    console.error('App error boundary caught', getSafeErrorDetails(error))
     Sentry.captureException(error)
   }, [error])
 

--- a/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
@@ -235,8 +235,9 @@ describe('ExportPage', () => {
   })
 
   it('skips events that fail to serialize and shows a warning toast', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     vi.mocked(toVEvent).mockImplementationOnce(() => {
-      throw new Error('boom — malformed event')
+      throw new Error('boom — PRIVATE_EVENT_TITLE')
     })
 
     render(<ExportPage />)
@@ -248,25 +249,33 @@ describe('ExportPage', () => {
     expect(showWarningToast).toHaveBeenCalledWith(
       expect.stringContaining('1 event'),
     )
+    expect(showWarningToast).not.toHaveBeenCalledWith(
+      expect.stringContaining('browser console'),
+    )
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('Meeting')
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('PRIVATE_EVENT_TITLE')
+    warnSpy.mockRestore()
   })
 
-  it('shows an error toast (with detail) when the download path fails', () => {
+  it('shows a safe error toast when the download path fails', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     // Simulate a real-world failure mode: blob URL creation blocked by a
     // privacy-hardened browser context. Fires after `serializeAll` succeeds,
     // exercising the outer try/catch in `exportCalendar`.
     const originalCreateObjectURL = URL.createObjectURL
     ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementationOnce(
       () => {
-        throw new Error('blob URL creation blocked')
+        throw new Error('PRIVATE_DOWNLOAD_DETAIL')
       },
     )
 
     render(<ExportPage />)
     fireEvent.click(screen.getByText(/Export Calendar/))
 
-    expect(showErrorToast).toHaveBeenCalledWith(
-      expect.stringContaining('Calendar export failed'),
-    )
+    expect(showErrorToast).toHaveBeenCalledWith('Calendar export failed. Please try again.')
+    expect(showErrorToast).not.toHaveBeenCalledWith(expect.stringContaining('PRIVATE_DOWNLOAD_DETAIL'))
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain('PRIVATE_DOWNLOAD_DETAIL')
+    errorSpy.mockRestore()
 
     // restore the spy for downstream tests in this describe block
     ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementation(

--- a/apps/web/app/(app)/settings/export/page.tsx
+++ b/apps/web/app/(app)/settings/export/page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/app/stores/use-toast-store'
 import { Download, Loader2 } from 'lucide-react'
 import JSZip from 'jszip'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 /**
  * Above this combined item count we surface a "this may take a minute" warning
@@ -55,7 +56,7 @@ function serializeAll<T>(items: T[], serialize: (item: T) => string): { vcompone
       vcomponents.push(serialize(item))
     } catch (err) {
       skipped++
-      console.warn('[export] Skipped item that failed to serialize:', err, item)
+      console.warn('[export] Skipped item that failed to serialize', getSafeErrorDetails(err))
     }
   }
   return { vcomponents, skipped }
@@ -76,15 +77,14 @@ function serializeContacts(contacts: Contact[]) {
 function reportSkipped(label: string, skipped: number) {
   if (skipped > 0) {
     showWarningToast(
-      `${skipped} ${label}${skipped === 1 ? '' : 's'} were skipped because they couldn't be serialized — see browser console for details.`,
+      `${skipped} ${label}${skipped === 1 ? '' : 's'} were skipped because they couldn't be serialized.`,
     )
   }
 }
 
 function reportError(label: string, err: unknown) {
-  console.error(`[export] ${label} failed:`, err)
-  const detail = err instanceof Error ? `: ${err.message}` : ''
-  showErrorToast(`${label} failed${detail}. See browser console for details.`)
+  console.error(`[export] ${label} failed`, getSafeErrorDetails(err))
+  showErrorToast(`${label} failed. Please try again.`)
 }
 
 export default function ExportPage() {

--- a/apps/web/app/(app)/tasks/error.tsx
+++ b/apps/web/app/(app)/tasks/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function TasksError({
   error,
@@ -11,7 +12,7 @@ export default function TasksError({
   reset: () => void
 }) {
   useEffect(() => {
-    console.error('Tasks error boundary caught:', error)
+    console.error('Tasks error boundary caught', getSafeErrorDetails(error))
     Sentry.captureException(error)
   }, [error])
 

--- a/apps/web/app/components/import/ContactImport.tsx
+++ b/apps/web/app/components/import/ContactImport.tsx
@@ -10,6 +10,7 @@ import ImportListSelector from './ImportListSelector'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 interface ContactImportProps {
   onImportComplete: (count: number) => void
@@ -106,9 +107,8 @@ export default function ContactImport({ onImportComplete, heading }: ContactImpo
       }
       setContacts(allContacts)
     } catch (err) {
-      console.error('[contact-import] Failed to parse VCF file:', err)
-      const detail = err instanceof Error ? `: ${err.message}` : ''
-      setError(`Failed to parse the file${detail}. Please make sure it is a valid .vcf file.`)
+      console.error('[contact-import] Failed to parse VCF file', getSafeErrorDetails(err))
+      setError('Failed to parse the file. Please make sure it is a valid .vcf file.')
     }
   }, [])
 
@@ -146,9 +146,8 @@ export default function ContactImport({ onImportComplete, heading }: ContactImpo
       setImportedCount(count)
       onImportComplete(count)
     } catch (err) {
-      console.error('[contact-import] Import failed:', err)
-      const detail = err instanceof Error ? `: ${err.message}` : ''
-      setError(`An error occurred while importing contacts${detail}. Please try again.`)
+      console.error('[contact-import] Import failed', getSafeErrorDetails(err))
+      setError('An error occurred while importing contacts. Please try again.')
     } finally {
       setIsImporting(false)
     }

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function GlobalError({
   error,
@@ -11,7 +12,7 @@ export default function GlobalError({
   reset: () => void
 }) {
   useEffect(() => {
-    console.error('Global error boundary caught:', error)
+    console.error('Global error boundary caught', getSafeErrorDetails(error))
     Sentry.captureException(error)
   }, [error])
 

--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -16,13 +16,16 @@ import {
   putMeta,
   clearAll,
   ensureFingerprint,
+  isCacheEnabled,
   CACHE_SCHEMA_VERSION,
   _resetForTests,
+  _setEncryptedCacheAvailableForTests,
   type CachedItem,
 } from '../data-cache'
 
 beforeEach(async () => {
   await _resetForTests()
+  _setEncryptedCacheAvailableForTests(true)
   await new Promise<void>((resolve) => {
     const req = indexedDB.deleteDatabase('silentsuite-data-cache')
     req.onsuccess = () => resolve()
@@ -42,6 +45,29 @@ function makeItem(uid: string, type: 'tasks' | 'contacts' | 'calendar' = 'tasks'
 }
 
 describe('data-cache', () => {
+  describe('encryption guard', () => {
+    it('does not enable cache when the env flag is true but encryption is unavailable', () => {
+      const previous = process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED
+      process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'
+      _setEncryptedCacheAvailableForTests(false)
+
+      expect(isCacheEnabled()).toBe(false)
+
+      process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = previous
+    })
+
+    it('refuses plaintext item writes without an encrypted cache envelope', async () => {
+      _setEncryptedCacheAvailableForTests(false)
+
+      await putItem(makeItem('plain-1', 'tasks', 'PRIVATE TASK SUMMARY'))
+      await putItems([makeItem('plain-2', 'tasks', 'PRIVATE BULK TASK')])
+      await replaceItemsForType('tasks', [makeItem('plain-3', 'tasks', 'PRIVATE REPLACE TYPE')])
+      await replaceItemsForCollection('col-1', [makeItem('plain-4', 'tasks', 'PRIVATE REPLACE COLLECTION')])
+
+      expect(await getItemsByType('tasks')).toEqual([])
+    })
+  })
+
   describe('items CRUD', () => {
     it('starts empty', async () => {
       const items = await getItemsByType('tasks')

--- a/apps/web/app/lib/__tests__/sentry-scrub.test.ts
+++ b/apps/web/app/lib/__tests__/sentry-scrub.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { scrubSentryEvent, SENTRY_REDACTED_TEXT } from '../sentry-scrub'
+
+describe('scrubSentryEvent', () => {
+  it('redacts private strings from high-risk Sentry fields', () => {
+    const event = scrubSentryEvent({
+      message: 'PRIVATE_CALENDAR_TITLE',
+      exception: {
+        values: [{ type: 'Error', value: 'PRIVATE_CONTACT_NAME' }],
+      },
+      breadcrumbs: [{ message: 'PRIVATE_TASK_TITLE', data: { note: 'PRIVATE_NOTE' } }],
+      extra: { raw: 'PRIVATE_EXTRA' },
+      contexts: { parser: { detail: 'PRIVATE_CONTEXT' } },
+      request: {
+        url: 'https://app.silentsuite.io/private-path',
+        query_string: 'q=PRIVATE_QUERY',
+        headers: { Authorization: 'Token PRIVATE_TOKEN' },
+        cookies: 'PRIVATE_COOKIE',
+        data: 'PRIVATE_BODY',
+      },
+    })
+
+    expect(JSON.stringify(event)).not.toContain('PRIVATE_')
+    expect(event.message).toBe(SENTRY_REDACTED_TEXT)
+    expect(event.exception?.values?.[0]?.value).toBe(SENTRY_REDACTED_TEXT)
+    expect(event.breadcrumbs?.[0]?.message).toBe(SENTRY_REDACTED_TEXT)
+    expect(event.request?.headers).toBeUndefined()
+    expect(event.request?.cookies).toBeUndefined()
+    expect(event.request?.data).toBeUndefined()
+  })
+})

--- a/apps/web/app/lib/__tests__/sentry-scrub.test.ts
+++ b/apps/web/app/lib/__tests__/sentry-scrub.test.ts
@@ -11,6 +11,12 @@ describe('scrubSentryEvent', () => {
       breadcrumbs: [{ message: 'PRIVATE_TASK_TITLE', data: { note: 'PRIVATE_NOTE' } }],
       extra: { raw: 'PRIVATE_EXTRA' },
       contexts: { parser: { detail: 'PRIVATE_CONTEXT' } },
+      transaction: 'PRIVATE_TRANSACTION',
+      user: { email: 'PRIVATE_USER_EMAIL' },
+      tags: { item: 'PRIVATE_TAG' },
+      fingerprint: ['PRIVATE_FINGERPRINT'],
+      logger: 'PRIVATE_LOGGER',
+      server_name: 'PRIVATE_SERVER',
       request: {
         url: 'https://app.silentsuite.io/private-path',
         query_string: 'q=PRIVATE_QUERY',
@@ -24,6 +30,12 @@ describe('scrubSentryEvent', () => {
     expect(event.message).toBe(SENTRY_REDACTED_TEXT)
     expect(event.exception?.values?.[0]?.value).toBe(SENTRY_REDACTED_TEXT)
     expect(event.breadcrumbs?.[0]?.message).toBe(SENTRY_REDACTED_TEXT)
+    expect(event.transaction).toBe(SENTRY_REDACTED_TEXT)
+    expect(event.user).toBeUndefined()
+    expect(event.tags?.item).toBe(SENTRY_REDACTED_TEXT)
+    expect(event.fingerprint?.[0]).toBe(SENTRY_REDACTED_TEXT)
+    expect(event.logger).toBe(SENTRY_REDACTED_TEXT)
+    expect(event.server_name).toBe(SENTRY_REDACTED_TEXT)
     expect(event.request?.headers).toBeUndefined()
     expect(event.request?.cookies).toBeUndefined()
     expect(event.request?.data).toBeUndefined()

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -1,5 +1,5 @@
 /**
- * Local data cache for instant reload — IndexedDB-backed, plain JSON values.
+ * Local data cache for instant reload — IndexedDB-backed values.
  *
  * Stores already-decrypted item content (iCal/vCard/vTodo strings) plus
  * per-collection sync cursors (stokens) so that on the next page load the
@@ -8,17 +8,12 @@
  * SCOPE: This module follows the same raw-IDB pattern as `secure-storage.ts`
  * and `offline-queue.ts` — no `idb` / Dexie dependency.
  *
- * AT-REST ENCRYPTION: NOT applied. Decrypted item content sits in plain
- * IndexedDB. This is consistent with the bridge's behavior (it stores its
- * cache in plain SQLite, not sqlcipher) and with the wider PWA ecosystem
- * (Slack, Linear, Notion all do the same). Encrypting the cache at rest is
- * tracked in a separate follow-up that covers webapp + bridge + Android
- * together.
+ * AT-REST ENCRYPTION: required before item content writes are allowed. Until
+ * an encrypted cache envelope exists, decrypted item content writes fail
+ * closed even if the public feature flag is accidentally enabled.
  *
- * Gated by the `NEXT_PUBLIC_LOCAL_CACHE_ENABLED` feature flag in callers.
- * This module itself does not check the flag — the flag is checked at the
- * caller boundaries (sync-provider, etebase-store, auth-store) so this
- * module stays pure and easy to test.
+ * Gated by both the `NEXT_PUBLIC_LOCAL_CACHE_ENABLED` feature flag and the
+ * encrypted-envelope availability check.
  */
 import { logger } from '@/app/lib/logger'
 
@@ -62,6 +57,18 @@ const STORE_META = 'meta'
 const META_KEY = 'singleton'
 
 let dbPromise: Promise<IDBDatabase> | null = null
+let encryptedCacheAvailableForTests: boolean | null = null
+
+function hasEncryptedCacheEnvelope(): boolean {
+  if (encryptedCacheAvailableForTests !== null) return encryptedCacheAvailableForTests
+  return false
+}
+
+function canWriteItemContent(operation: string): boolean {
+  if (hasEncryptedCacheEnvelope()) return true
+  logger.warn(`[data-cache] ${operation} skipped; encrypted cache envelope is unavailable`)
+  return false
+}
 
 function openDB(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise
@@ -138,6 +145,7 @@ export async function getItemsByType(type: CollectionTypeKey): Promise<CachedIte
 
 /** Insert/update a single item. Failures are logged and swallowed. */
 export async function putItem(item: CachedItem): Promise<void> {
+  if (!canWriteItemContent('putItem')) return
   try {
     await withStore(STORE_ITEMS, 'readwrite', (store) => store.put(item))
   } catch (err) {
@@ -148,6 +156,7 @@ export async function putItem(item: CachedItem): Promise<void> {
 /** Bulk insert/update — single transaction for efficiency. */
 export async function putItems(items: CachedItem[]): Promise<void> {
   if (items.length === 0) return
+  if (!canWriteItemContent('putItems')) return
   try {
     const db = await openDB()
     await new Promise<void>((resolve, reject) => {
@@ -178,6 +187,7 @@ export async function replaceItemsForType(
   type: CollectionTypeKey,
   items: CachedItem[],
 ): Promise<void> {
+  if (!canWriteItemContent('replaceItemsForType')) return
   try {
     const db = await openDB()
     await new Promise<void>((resolve, reject) => {
@@ -211,6 +221,7 @@ export async function replaceItemsForCollection(
   collectionUid: string,
   items: CachedItem[],
 ): Promise<void> {
+  if (!canWriteItemContent('replaceItemsForCollection')) return
   try {
     const db = await openDB()
     await new Promise<void>((resolve, reject) => {
@@ -369,12 +380,12 @@ export async function ensureFingerprint(accountFingerprint: string): Promise<boo
 // ── Feature flag helper ──
 
 /**
- * Returns true if the local cache feature is enabled via the env flag.
- * Off by default — when false, the cache is never read or written and
- * the app behaves identically to pre-PR.
+ * Returns true only when the local cache feature is enabled and encrypted
+ * cache storage is available. Off by default, and fail-closed if the flag is
+ * enabled before encryption exists.
  */
 export function isCacheEnabled(): boolean {
-  return process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED === 'true'
+  return process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED === 'true' && hasEncryptedCacheEnvelope()
 }
 
 // ── Test helpers ──
@@ -390,4 +401,10 @@ export async function _resetForTests(): Promise<void> {
     }
   }
   dbPromise = null
+  encryptedCacheAvailableForTests = null
+}
+
+/** Test-only hook that simulates encrypted cache availability. */
+export function _setEncryptedCacheAvailableForTests(value: boolean | null): void {
+  encryptedCacheAvailableForTests = value
 }

--- a/apps/web/app/lib/privacy-safe-errors.ts
+++ b/apps/web/app/lib/privacy-safe-errors.ts
@@ -4,6 +4,10 @@ export function getSafeErrorName(error: unknown): string {
   return typeof error
 }
 
+/**
+ * Keep console/Sentry details intentionally sparse: error messages and stacks
+ * can contain decrypted item content, parser input, URLs, or auth material.
+ */
 export function getSafeErrorDetails(error: unknown): { errorName: string } {
   return { errorName: getSafeErrorName(error) }
 }

--- a/apps/web/app/lib/privacy-safe-errors.ts
+++ b/apps/web/app/lib/privacy-safe-errors.ts
@@ -1,0 +1,13 @@
+export function getSafeErrorName(error: unknown): string {
+  if (error instanceof Error) return error.name || 'Error'
+  if (error === null) return 'null'
+  return typeof error
+}
+
+export function getSafeErrorDetails(error: unknown): { errorName: string } {
+  return { errorName: getSafeErrorName(error) }
+}
+
+export function createSafeOperationalError(component: string, operation: string): Error {
+  return new Error(`${component}: ${operation} failed`)
+}

--- a/apps/web/app/lib/secure-storage.ts
+++ b/apps/web/app/lib/secure-storage.ts
@@ -9,6 +9,7 @@
  * another encryption layer — just move it out of the trivially-scriptable
  * localStorage API.
  */
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 const DB_NAME = 'silentsuite-secure'
 const DB_VERSION = 1
@@ -83,7 +84,7 @@ export async function secureSet(key: string, value: string): Promise<void> {
   try {
     await withStore('readwrite', (store) => store.put(value, key))
   } catch (err) {
-    console.error('[secure-storage] Failed to write to IndexedDB:', err)
+    console.error('[secure-storage] Failed to write to IndexedDB', getSafeErrorDetails(err))
   }
 }
 

--- a/apps/web/app/lib/sentry-scrub.ts
+++ b/apps/web/app/lib/sentry-scrub.ts
@@ -1,0 +1,65 @@
+export const SENTRY_REDACTED_TEXT = '[redacted private data]'
+
+type ScrubbableObject = Record<string, unknown>
+
+type ScrubbableSentryEvent = {
+  message?: string
+  exception?: {
+    values?: Array<ScrubbableObject & { value?: string }>
+  }
+  breadcrumbs?: Array<ScrubbableObject & { message?: string; data?: unknown }>
+  extra?: ScrubbableObject
+  contexts?: ScrubbableObject
+  request?: ScrubbableObject
+}
+
+function scrubValue(value: unknown): unknown {
+  if (typeof value === 'string') return SENTRY_REDACTED_TEXT
+  if (Array.isArray(value)) return value.map(scrubValue)
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as ScrubbableObject).map(([key, nested]) => [key, scrubValue(nested)]),
+    )
+  }
+  return value
+}
+
+export function scrubSentryEvent<T extends object>(event: T): T {
+  const source = event as ScrubbableSentryEvent
+  const scrubbed: ScrubbableSentryEvent = { ...source }
+
+  if (scrubbed.message) scrubbed.message = SENTRY_REDACTED_TEXT
+
+  if (scrubbed.exception?.values) {
+    scrubbed.exception = {
+      ...scrubbed.exception,
+      values: scrubbed.exception.values.map((value) => ({
+        ...value,
+        value: value.value ? SENTRY_REDACTED_TEXT : value.value,
+      })),
+    }
+  }
+
+  if (scrubbed.breadcrumbs) {
+    scrubbed.breadcrumbs = scrubbed.breadcrumbs.map((breadcrumb) => ({
+      ...breadcrumb,
+      message: breadcrumb.message ? SENTRY_REDACTED_TEXT : breadcrumb.message,
+      data: scrubValue(breadcrumb.data),
+    }))
+  }
+
+  if (scrubbed.extra) scrubbed.extra = scrubValue(scrubbed.extra) as ScrubbableObject
+  if (scrubbed.contexts) scrubbed.contexts = scrubValue(scrubbed.contexts) as ScrubbableObject
+  if (scrubbed.request) {
+    scrubbed.request = {
+      ...scrubbed.request,
+      url: scrubbed.request.url ? SENTRY_REDACTED_TEXT : scrubbed.request.url,
+      query_string: scrubbed.request.query_string ? SENTRY_REDACTED_TEXT : scrubbed.request.query_string,
+      cookies: undefined,
+      data: undefined,
+      headers: undefined,
+    }
+  }
+
+  return scrubbed as T
+}

--- a/apps/web/app/lib/sentry-scrub.ts
+++ b/apps/web/app/lib/sentry-scrub.ts
@@ -32,7 +32,7 @@ function scrubValue(value: unknown): unknown {
 
 export function scrubSentryEvent<T extends object>(event: T): T {
   const source = event as ScrubbableSentryEvent
-  const scrubbed: ScrubbableSentryEvent = { ...source }
+  const scrubbed: ScrubbableSentryEvent = source
 
   if (scrubbed.message) scrubbed.message = SENTRY_REDACTED_TEXT
 

--- a/apps/web/app/lib/sentry-scrub.ts
+++ b/apps/web/app/lib/sentry-scrub.ts
@@ -11,6 +11,12 @@ type ScrubbableSentryEvent = {
   extra?: ScrubbableObject
   contexts?: ScrubbableObject
   request?: ScrubbableObject
+  transaction?: string
+  user?: ScrubbableObject
+  tags?: ScrubbableObject
+  fingerprint?: unknown[]
+  logger?: string
+  server_name?: string
 }
 
 function scrubValue(value: unknown): unknown {
@@ -50,6 +56,12 @@ export function scrubSentryEvent<T extends object>(event: T): T {
 
   if (scrubbed.extra) scrubbed.extra = scrubValue(scrubbed.extra) as ScrubbableObject
   if (scrubbed.contexts) scrubbed.contexts = scrubValue(scrubbed.contexts) as ScrubbableObject
+  if (scrubbed.transaction) scrubbed.transaction = SENTRY_REDACTED_TEXT
+  if (scrubbed.user) scrubbed.user = undefined
+  if (scrubbed.tags) scrubbed.tags = scrubValue(scrubbed.tags) as ScrubbableObject
+  if (scrubbed.fingerprint) scrubbed.fingerprint = scrubValue(scrubbed.fingerprint) as unknown[]
+  if (scrubbed.logger) scrubbed.logger = SENTRY_REDACTED_TEXT
+  if (scrubbed.server_name) scrubbed.server_name = SENTRY_REDACTED_TEXT
   if (scrubbed.request) {
     scrubbed.request = {
       ...scrubbed.request,

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -15,6 +15,18 @@ import {
   isCacheEnabled as isLocalCacheEnabled,
   type CachedItem,
 } from '@/app/lib/data-cache'
+import {
+  createSafeOperationalError,
+  getSafeErrorDetails,
+} from '@/app/lib/privacy-safe-errors'
+
+function reportSyncError(operation: string, err: unknown) {
+  Sentry.captureException(createSafeOperationalError('sync-provider', operation), {
+    tags: { component: 'sync-provider', operation },
+    extra: getSafeErrorDetails(err),
+  })
+  logger.error(`[sync-provider] ${operation} failed`, getSafeErrorDetails(err))
+}
 
 /**
  * SyncProvider orchestrates:
@@ -78,10 +90,9 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         setSyncStatus('synced')
         setLastSynced(new Date())
       } catch (err) {
-        Sentry.captureException(err)
-        console.error('[sync-provider] Init failed:', err)
+        reportSyncError('init', err)
         setSyncStatus('error')
-        setError(err instanceof Error ? err.message : 'Sync initialization failed')
+        setError('Sync initialization failed')
       }
     }
 
@@ -113,7 +124,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             useTaskStore.getState().syncFromRemote(tasks)
             logger.log(`[sync-provider] Hydrated ${tasks.length} tasks from cache`)
           } catch (err) {
-            logger.warn('[sync-provider] Failed to hydrate tasks from cache', err)
+            logger.warn('[sync-provider] Failed to hydrate tasks from cache', getSafeErrorDetails(err))
           }
         }
 
@@ -126,7 +137,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             useContactStore.getState().syncFromRemote(contacts)
             logger.log(`[sync-provider] Hydrated ${contacts.length} contacts from cache`)
           } catch (err) {
-            logger.warn('[sync-provider] Failed to hydrate contacts from cache', err)
+            logger.warn('[sync-provider] Failed to hydrate contacts from cache', getSafeErrorDetails(err))
           }
         }
 
@@ -139,11 +150,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             useCalendarStore.getState().syncFromRemote(events)
             logger.log(`[sync-provider] Hydrated ${events.length} events from cache`)
           } catch (err) {
-            logger.warn('[sync-provider] Failed to hydrate calendar events from cache', err)
+            logger.warn('[sync-provider] Failed to hydrate calendar events from cache', getSafeErrorDetails(err))
           }
         }
       } catch (err) {
-        logger.warn('[sync-provider] Cache hydration failed', err)
+        logger.warn('[sync-provider] Cache hydration failed', getSafeErrorDetails(err))
       }
     }
 
@@ -166,7 +177,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         try {
           await cacheReplaceItemsForType(type, records)
         } catch (err) {
-          logger.warn(`[sync-provider] Failed to mirror ${type} to cache`, err)
+          logger.warn(`[sync-provider] Failed to mirror ${type} to cache`, getSafeErrorDetails(err))
         }
       }
 
@@ -186,8 +197,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           await mirrorToCache('tasks', taskItems)
         }
       } catch (err) {
-        Sentry.captureException(err)
-        console.error('[sync-provider] Failed to load tasks:', err)
+        reportSyncError('load tasks', err)
       }
 
       // Load contacts
@@ -204,8 +214,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           await mirrorToCache('contacts', contactItems)
         }
       } catch (err) {
-        Sentry.captureException(err)
-        console.error('[sync-provider] Failed to load contacts:', err)
+        reportSyncError('load contacts', err)
       }
 
       // Load calendar events
@@ -222,8 +231,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           await mirrorToCache('calendar', eventItems)
         }
       } catch (err) {
-        Sentry.captureException(err)
-        console.error('[sync-provider] Failed to load calendar events:', err)
+        reportSyncError('load calendar events', err)
       }
 
       // Load and subscribe account-level preferences after the Etebase item
@@ -232,8 +240,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       try {
         await usePreferencesSyncStore.getState().initialize()
       } catch (err) {
-        Sentry.captureException(err)
-        console.error('[sync-provider] Failed to initialize preferences sync:', err)
+        reportSyncError('initialize preferences sync', err)
       }
     }
 
@@ -258,8 +265,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             })
             useTaskStore.getState().syncFromRemote(tasks)
           } catch (err) {
-            Sentry.captureException(err)
-            console.error('[sync-provider] Failed to sync tasks:', err)
+            reportSyncError('sync tasks', err)
           }
         } else if (collectionType === 'etebase.vcard') {
           try {
@@ -271,8 +277,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             })
             useContactStore.getState().syncFromRemote(contacts)
           } catch (err) {
-            Sentry.captureException(err)
-            console.error('[sync-provider] Failed to sync contacts:', err)
+            reportSyncError('sync contacts', err)
           }
         } else if (collectionType === 'etebase.vevent') {
           try {
@@ -284,16 +289,14 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             })
             useCalendarStore.getState().syncFromRemote(events)
           } catch (err) {
-            Sentry.captureException(err)
-            console.error('[sync-provider] Failed to sync calendar events:', err)
+            reportSyncError('sync calendar events', err)
           }
         } else if (collectionType === 'silentsuite.preferences') {
           try {
             const preferenceItems = await refresher('preferences', event.collectionUid)
             await usePreferencesSyncStore.getState().loadFromRemote(preferenceItems)
           } catch (err) {
-            Sentry.captureException(err)
-            console.error('[sync-provider] Failed to sync preferences:', err)
+            reportSyncError('sync preferences', err)
           }
         }
 

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand'
 
 import type { CalendarEvent, SyncStatus, VAlarm } from '@silentsuite/core'
 import type { RecurrenceScope } from '@/app/(app)/calendar/components/RecurrenceScopeDialog'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { showErrorToast } from '@/app/stores/use-toast-store'
@@ -117,7 +118,7 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
       }
     }
   } catch (err) {
-    console.error(`[calendar-store] Failed to ${mode} event in Etebase:`, err)
+    console.error(`[calendar-store] Failed to ${mode} event in Etebase`, getSafeErrorDetails(err))
     const { enqueue, isOfflineError } = await import('@/app/lib/offline-queue')
     if (!isOfflineError(err)) {
       showErrorToast('Failed to save event. Please try again.')
@@ -243,7 +244,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
           } else {
             showErrorToast('Failed to delete event. Please try again.')
           }
-          console.error('[calendar-store] Failed to delete event in Etebase:', err)
+          console.error('[calendar-store] Failed to delete event in Etebase', getSafeErrorDetails(err))
         }
       } else {
         // Item was created offline — enqueue delete with tempId for compaction
@@ -439,7 +440,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
               } else {
                 showErrorToast('Failed to delete event. Please try again.')
               }
-              console.error('[calendar-store] Failed to delete recurring event in Etebase:', err)
+              console.error('[calendar-store] Failed to delete recurring event in Etebase', getSafeErrorDetails(err))
             }
           } else {
             const { enqueue } = await import('@/app/lib/offline-queue')
@@ -539,7 +540,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
           }))
         }
       } catch (err) {
-        console.error('[calendar-store] Failed to batch import events:', err)
+        console.error('[calendar-store] Failed to batch import events', getSafeErrorDetails(err))
       }
     }
 

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -5,6 +5,7 @@ import type { Contact, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
 
@@ -97,7 +98,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
               return { ...contact, id: itemUid }
             }
           } catch (err) {
-            console.error('[contact-store] Failed to sync new contact to Etebase:', err)
+            console.error('[contact-store] Failed to sync new contact to Etebase', getSafeErrorDetails(err))
             showErrorToast('Failed to save contact. Please try again.')
           }
         }
@@ -126,7 +127,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
               const content = serializeContact(updated)
               await etebase.updateItem('contacts', id, content)
             } catch (err) {
-              console.error('[contact-store] Failed to sync contact update to Etebase:', err)
+              console.error('[contact-store] Failed to sync contact update to Etebase', getSafeErrorDetails(err))
               showErrorToast('Failed to save contact. Please try again.')
             }
           } else {
@@ -150,7 +151,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
             try {
               await etebase.deleteItem('contacts', id)
             } catch (err) {
-              console.error('[contact-store] Failed to sync contact deletion to Etebase:', err)
+              console.error('[contact-store] Failed to sync contact deletion to Etebase', getSafeErrorDetails(err))
               showErrorToast('Failed to delete contact. Please try again.')
             }
           } else {
@@ -224,7 +225,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
               }))
             }
           } catch (err) {
-            console.error('[contact-store] Failed to batch import contacts:', err)
+            console.error('[contact-store] Failed to batch import contacts', getSafeErrorDetails(err))
           }
         }
 

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -794,7 +794,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           try {
             await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid })
           } catch (queueErr) {
-            console.error(`[etebase-store] Failed to enqueue collection item delete:`, queueErr)
+            console.error('[etebase-store] Failed to enqueue collection item delete', getSafeErrorDetails(queueErr))
           }
         }
         removeCachedItems(itemEntries.map(({ uid }) => uid))
@@ -846,7 +846,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         try {
           await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId })
         } catch (queueErr) {
-          console.error(`[etebase-store] Failed to enqueue create:`, queueErr)
+          console.error('[etebase-store] Failed to enqueue create', getSafeErrorDetails(queueErr))
         }
       } else {
         console.error(`[etebase-store] Failed to create ${type} item`, getSafeErrorDetails(err))
@@ -966,7 +966,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const succeeded = lastSuccessfulItemIndex + 1
         const total = items.length
         const noun = type === 'calendar' ? 'events' : type === 'tasks' ? 'tasks' : type === 'contacts' ? 'contacts' : 'preferences'
-        console.error(`[etebase-store] Batch import failed after retries (${succeeded}/${total} ${noun} imported):`, permanentFailure)
+        console.error('[etebase-store] Batch import failed after retries', getSafeErrorDetails(permanentFailure))
         if (succeeded > 0) {
           showErrorToast(`Imported ${succeeded} of ${total} ${noun}. Please try again to import the rest.`)
         } else {
@@ -982,7 +982,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           try {
             await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId })
           } catch (queueErr) {
-            console.error(`[etebase-store] Failed to enqueue create:`, queueErr)
+            console.error('[etebase-store] Failed to enqueue create', getSafeErrorDetails(queueErr))
           }
         }
       } else {
@@ -1017,7 +1017,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         try {
           await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid })
         } catch (queueErr) {
-          console.error(`[etebase-store] Failed to enqueue update:`, queueErr)
+          console.error('[etebase-store] Failed to enqueue update', getSafeErrorDetails(queueErr))
         }
       } else {
         console.error(`[etebase-store] Failed to update ${type} item`, getSafeErrorDetails(err))
@@ -1110,7 +1110,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         try {
           await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid })
         } catch (queueErr) {
-          console.error(`[etebase-store] Failed to enqueue delete:`, queueErr)
+          console.error('[etebase-store] Failed to enqueue delete', getSafeErrorDetails(queueErr))
         }
       } else {
         console.error(`[etebase-store] Failed to delete ${type} item`, getSafeErrorDetails(err))

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -26,6 +26,7 @@ import {
   isCacheEnabled as isLocalCacheEnabled,
   type CachedItem,
 } from '@/app/lib/data-cache'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 /**
  * Holds live Etebase SDK objects (Account, Collections, Items, SyncEngine).
@@ -530,7 +531,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       set({ syncEngine: engine, isInitialized: true })
       logger.debug('[etebase-store] SyncEngine started')
     } catch (err) {
-      console.error('[etebase-store] Initialization failed:', err)
+      console.error('[etebase-store] Initialization failed', getSafeErrorDetails(err))
       // Don't clear the session -- the user might be offline
       // They can retry on next page load
       set({ isInitialized: true })
@@ -560,7 +561,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       await hydrateListStores(newCollections)
       return collection.uid
     } catch (err) {
-      console.error(`[etebase-store] Failed to create ${type} collection:`, err)
+      console.error(`[etebase-store] Failed to create ${type} collection`, getSafeErrorDetails(err))
       showErrorToast(`Failed to create ${collectionDisplayName(type)}. Please try again.`)
       return null
     }
@@ -612,7 +613,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       await hydrateListStores(newCollections)
       return true
     } catch (err) {
-      console.error(`[etebase-store] Failed to delete ${type} collection ${collectionUid}:`, err)
+      console.error(`[etebase-store] Failed to delete ${type} collection`, getSafeErrorDetails(err))
       showErrorToast(`Failed to delete ${collectionDisplayName(type)}. Please try again.`)
       return false
     }
@@ -647,7 +648,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       await hydrateListStores(newCollections)
       return true
     } catch (err) {
-      console.error(`[etebase-store] Failed to update ${type} collection ${collectionUid}:`, err)
+      console.error(`[etebase-store] Failed to update ${type} collection`, getSafeErrorDetails(err))
       showErrorToast(`Failed to update ${collectionDisplayName(type)}. Please try again.`)
       return false
     }
@@ -719,7 +720,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       await hydrateListStores(activeCollections)
       logger.debug(`[etebase-store] Reconciled collections (${removedCollectionCount} removed)`)
     } catch (err) {
-      console.error('[etebase-store] Failed to reconcile collections:', err)
+      console.error('[etebase-store] Failed to reconcile collections', getSafeErrorDetails(err))
       throw err
     } finally {
       syncEngine?.resume?.()
@@ -804,7 +805,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         return Math.max(itemEntries.length, removedLocal)
       }
 
-      console.error(`[etebase-store] Failed to clear ${type} collection ${collectionUid}:`, err)
+      console.error(`[etebase-store] Failed to clear ${type} collection`, getSafeErrorDetails(err))
       if (successfulUids.length > 0) {
         removeCachedItems(successfulUids)
         await removeItemsFromDomainStore(type, collection.uid, successfulUids)
@@ -848,7 +849,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           console.error(`[etebase-store] Failed to enqueue create:`, queueErr)
         }
       } else {
-        console.error(`[etebase-store] Failed to create ${type} item:`, err)
+        console.error(`[etebase-store] Failed to create ${type} item`, getSafeErrorDetails(err))
         showErrorToast(`Failed to save ${type === 'calendar' ? 'event' : type === 'tasks' ? 'task' : type === 'contacts' ? 'contact' : 'preferences'}. Please try again.`)
       }
       return null
@@ -985,7 +986,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           }
         }
       } else {
-        console.error(`[etebase-store] Failed to batch create ${type} items:`, err)
+        console.error(`[etebase-store] Failed to batch create ${type} items`, getSafeErrorDetails(err))
         showErrorToast(`Failed to import ${type === 'calendar' ? 'events' : type === 'tasks' ? 'tasks' : type === 'contacts' ? 'contacts' : 'preferences'}. Please try again.`)
       }
       return contents.map(() => null)
@@ -1019,7 +1020,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           console.error(`[etebase-store] Failed to enqueue update:`, queueErr)
         }
       } else {
-        console.error(`[etebase-store] Failed to update ${type} item ${itemUid}:`, err)
+        console.error(`[etebase-store] Failed to update ${type} item`, getSafeErrorDetails(err))
         showErrorToast(`Failed to save ${type === 'calendar' ? 'event' : type === 'tasks' ? 'task' : type === 'contacts' ? 'contact' : 'preferences'}. Please try again.`)
       }
     }
@@ -1112,7 +1113,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           console.error(`[etebase-store] Failed to enqueue delete:`, queueErr)
         }
       } else {
-        console.error(`[etebase-store] Failed to delete ${type} item ${itemUid}:`, err)
+        console.error(`[etebase-store] Failed to delete ${type} item`, getSafeErrorDetails(err))
         showErrorToast(`Failed to delete ${type === 'calendar' ? 'event' : type === 'tasks' ? 'task' : type === 'contacts' ? 'contact' : 'preferences'}. Please try again.`)
       }
     }
@@ -1229,7 +1230,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       logger.debug(`[etebase-store] Refreshed ${type}: ${allResults.length} items`)
       return allResults
     } catch (err) {
-      console.error(`[etebase-store] Failed to refresh ${type}:`, err)
+      console.error(`[etebase-store] Failed to refresh ${type}`, getSafeErrorDetails(err))
       return get().fetchAllItems(type)
     }
   },

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand'
 import type { SyncStatus } from '@silentsuite/core'
 import { replay, getPendingCount, getFailedCount, onCountChange, getStaleEntries, remove, type QueueEntry } from '@/app/lib/offline-queue'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
 
@@ -259,7 +260,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       const fc = await getFailedCount()
       set({ syncStatus: 'synced', lastSyncedAt: new Date(), error: null, pendingQueueCount: pc, failedQueueCount: fc })
     }).catch((err) => {
-      console.error('[sync-store] Manual sync failed:', err)
+      console.error('[sync-store] Manual sync failed', getSafeErrorDetails(err))
       set({ syncStatus: 'error', error: 'Sync failed' })
       const isOnline = get().isOnline
       showErrorToast(isOnline ? 'Sync failed. Check your connection.' : 'Sync failed. Retrying...')

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -5,6 +5,7 @@ import type { Task, Priority, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
 
@@ -80,7 +81,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               return { ...task, id: itemUid }
             }
           } catch (err) {
-            console.error('[task-store] Failed to sync new task to Etebase:', err)
+            console.error('[task-store] Failed to sync new task to Etebase', getSafeErrorDetails(err))
             showErrorToast('Failed to save task. Please try again.')
           }
         }
@@ -109,7 +110,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               const content = serializeTask(updated)
               await etebase.updateItem('tasks', id, content)
             } catch (err) {
-              console.error('[task-store] Failed to sync task update to Etebase:', err)
+              console.error('[task-store] Failed to sync task update to Etebase', getSafeErrorDetails(err))
               showErrorToast('Failed to save task. Please try again.')
             }
           } else {
@@ -135,7 +136,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
             try {
               await etebase.deleteItem('tasks', id)
             } catch (err) {
-              console.error('[task-store] Failed to sync task deletion to Etebase:', err)
+              console.error('[task-store] Failed to sync task deletion to Etebase', getSafeErrorDetails(err))
               showErrorToast('Failed to delete task. Please try again.')
             }
           } else {
@@ -167,7 +168,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               const content = serializeTask(updated)
               await etebase.updateItem('tasks', id, content)
             } catch (err) {
-              console.error('[task-store] Failed to sync task toggle to Etebase:', err)
+              console.error('[task-store] Failed to sync task toggle to Etebase', getSafeErrorDetails(err))
               showErrorToast('Failed to save task. Please try again.')
             }
           } else {
@@ -230,7 +231,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               }))
             }
           } catch (err) {
-            console.error('[task-store] Failed to batch import tasks:', err)
+            console.error('[task-store] Failed to batch import tasks', getSafeErrorDetails(err))
           }
         }
 

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { scrubSentryEvent } from '@/app/lib/sentry-scrub'
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
 
@@ -7,6 +8,7 @@ if (dsn) {
     dsn,
     environment: process.env.NODE_ENV,
     tracesSampleRate: 0.1,
+    beforeSend: scrubSentryEvent,
     // Replay is expensive — only capture on errors
     replaysOnErrorSampleRate: 1.0,
     replaysSessionSampleRate: 0,

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { scrubSentryEvent } from '@/app/lib/sentry-scrub'
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
 
@@ -7,5 +8,6 @@ if (dsn) {
     dsn,
     environment: process.env.NODE_ENV,
     tracesSampleRate: 0.1,
+    beforeSend: scrubSentryEvent,
   })
 }

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { scrubSentryEvent } from '@/app/lib/sentry-scrub'
 
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
 
@@ -7,5 +8,6 @@ if (dsn) {
     dsn,
     environment: process.env.NODE_ENV,
     tracesSampleRate: 0.1,
+    beforeSend: scrubSentryEvent,
   })
 }


### PR DESCRIPTION
## Summary
- sanitize export, import, sync-provider, and Sentry error reporting so raw private details are not forwarded to logs, toasts, or telemetry
- add Sentry beforeSend scrubbing for high-risk event fields
- make local item-content cache writes fail closed unless encrypted cache storage is available
- add sentinel regression coverage for export logging, Sentry scrubbing, and plaintext cache refusal

## Verification
- git diff --check origin/dev..HEAD
- pnpm --filter @silentsuite/web test "app/lib/__tests__/data-cache.test.ts" "app/lib/__tests__/sentry-scrub.test.ts" "app/(app)/settings/export/__tests__/page.test.tsx"
- pnpm --filter @silentsuite/web type-check