### PR TITLE
Fix Zapstore release notes path

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -26,5 +26,4 @@ images:
   - android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-account.png
   - android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-create-calendar.png
   - android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-view-collection.png
-release_notes: |
-  v0.2.0-beta: multiple calendars, address books, and task lists; Android export backups; clearer sync states; refreshed branding; and Bitcoin/Lightning annual signup via BTCPay.
+release_notes: android/fastlane/metadata/android/en-US/changelogs/6.txt


### PR DESCRIPTION
## Summary

- change `zapstore.yaml` `release_notes` from inline text to the existing Fastlane changelog file
- keep the Zapstore release pinned to the existing `v0.2.0-beta` APK

## Why

`zsp publish` treats `release_notes` as a file path or URL. The previous inline block passed `zsp publish --check`, but failed at real publish time because `zsp` tried to open the inline text as a file path.

## Validation

- `zsp publish --check zapstore.yaml` -> `{"package_id":"io.silentsuite.android"}`
- confirmed `android/fastlane/metadata/android/en-US/changelogs/6.txt` exists and contains the intended `v0.2.0-beta` release notes

## Notes

- No Zapstore publication is performed by this PR.
