### PR TITLE
Use Zapstore media URLs

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -20,10 +20,10 @@ tags:
   - sync
 license: GPL-3.0-only
 website: https://silentsuite.io
-icon: android/fastlane/metadata/android/en-US/images/icon.png
+icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/icon.png
 images:
-  - android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-main.png
-  - android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-account.png
-  - android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-create-calendar.png
-  - android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-view-collection.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-main.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-account.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-create-calendar.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-view-collection.png
 release_notes: android/fastlane/metadata/android/en-US/changelogs/6.txt


### PR DESCRIPTION
## Summary

- change `zapstore.yaml` icon and screenshots from local paths to stable raw GitHub URLs pinned to `v0.2.0-beta`
- avoid requiring Blossom media uploads/signing during Zapstore publish
- keep APK and release notes unchanged

## Why

The Zapstore publish reached media upload and failed while trying to sign a Blossom icon-upload auth event through NIP-46. `zsp` supports URL values for `icon` and `images`, so using stable raw GitHub URLs removes that upload/auth step and makes publication more reliable.

## Validation

- `zsp publish --check zapstore.yaml` -> `{"package_id":"io.silentsuite.android"}`
- all five raw GitHub media URLs return `200 image/png`

## Notes

- No Zapstore publication is performed by this PR.
