### PR TITLE
Guard bridge remote binds

### DIFF
--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -268,6 +268,7 @@ def main():
         print("  SILENTSUITE_SERVER_URL       Etebase server URL")
         print("  SILENTSUITE_LISTEN_ADDRESS   Listen address (default: 127.0.0.1)")
         print("  SILENTSUITE_LISTEN_PORT      Listen port (default: 37358)")
+        print("  SILENTSUITE_SERVER_HOSTS     Radicale host specs (default: listen address:port)")
         print("  SILENTSUITE_ALLOW_REMOTE     Allow non-loopback bind and disable dashboard")
         print("  SILENTSUITE_DATA_DIR         Data directory path")
         print("  SILENTSUITE_LOG_LEVEL        Log level (default: INFO)")

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -50,7 +50,10 @@ def build_radicale_configuration():
     """
     from radicale.config import Configuration, DEFAULT_CONFIG_SCHEMA
 
+    config.validate_network_config()
+
     configuration = Configuration(DEFAULT_CONFIG_SCHEMA)
+    web_type = "silentsuite_bridge.web" if config.is_dashboard_enabled() else "none"
     configuration.update(
         {
             "server": {
@@ -63,7 +66,7 @@ def build_radicale_configuration():
                 "type": "silentsuite_bridge.radicale.storage",
             },
             "web": {
-                "type": "silentsuite_bridge.web",
+                "type": web_type,
             },
             "logging": {
                 "level": config.LOG_LEVEL.lower(),
@@ -204,13 +207,15 @@ def run_server():
         __version__,
         config.SERVER_HOSTS,
     )
+    if config.is_remote_bind_configured():
+        logger.warning(
+            "Remote bridge bind enabled by SILENTSUITE_ALLOW_REMOTE=1. "
+            "DAV traffic is plaintext HTTP unless protected by your own proxy/VPN."
+        )
+        logger.warning("Bridge dashboard disabled while remote bind is configured.")
     logger.info("Etebase server: %s", config.ETEBASE_SERVER_URL)
     logger.info("Data directory: %s", config.DATA_DIR)
-    logger.info(
-        "CalDAV/CardDAV URL: http://%s:%d/<username>/",
-        config.LISTEN_ADDRESS,
-        config.LISTEN_PORT,
-    )
+    logger.info("CalDAV/CardDAV host(s): %s", config.SERVER_HOSTS)
 
     # Run initial sync so dashboard shows correct status immediately
     _initial_status_check()
@@ -263,6 +268,7 @@ def main():
         print("  SILENTSUITE_SERVER_URL       Etebase server URL")
         print("  SILENTSUITE_LISTEN_ADDRESS   Listen address (default: 127.0.0.1)")
         print("  SILENTSUITE_LISTEN_PORT      Listen port (default: 37358)")
+        print("  SILENTSUITE_ALLOW_REMOTE     Allow non-loopback bind and disable dashboard")
         print("  SILENTSUITE_DATA_DIR         Data directory path")
         print("  SILENTSUITE_LOG_LEVEL        Log level (default: INFO)")
         print("  SILENTSUITE_LOG_FILE         Log file path")
@@ -279,6 +285,12 @@ def main():
             sys.exit(1)
 
     configure_logging()
+    try:
+        config.validate_network_config()
+    except RuntimeError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
+
     config.ensure_data_dir()
 
     action_count = sum(1 for flag in _ACCOUNT_ACTION_FLAGS if flag in sys.argv)

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -391,9 +391,7 @@ SUCCESS_PAGE_HTML = """<!DOCTYPE html>
                 <button class="copy-btn" onclick="copyUrl(event, 'bridgeUrl')">Copy</button>
             </div>
             <p class="url-note">CalDAV and CardDAV share the same base URL &mdash; this is normal. Your app will discover calendars and contacts automatically.</p>
-            <div class="bookmark-box">
-                &#11088; Bookmark <a href="DASHBOARD_URL">DASHBOARD_URL</a> to find these details later
-            </div>
+            DASHBOARD_BOOKMARK
             <div class="next-step">
                 You're signed in. You can close this tab &mdash; the bridge is already running in the background and will keep syncing on its own.
             </div>
@@ -584,13 +582,21 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
         elif self.path.startswith("/success"):
             params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
             email = params.get("email", [""])[0].strip()
-            dashboard_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/.web/"
             bridge_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{email}/"
+            if config.is_dashboard_enabled():
+                dashboard_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/.web/"
+                dashboard_bookmark = (
+                    '<div class="bookmark-box">&#11088; Bookmark '
+                    f'<a href="{html_mod.escape(dashboard_url)}">{html_mod.escape(dashboard_url)}</a> '
+                    "to find these details later</div>"
+                )
+            else:
+                dashboard_bookmark = '<div class="bookmark-box">Dashboard is disabled for remote bridge binds.</div>'
 
             page = SUCCESS_PAGE_HTML
             page = page.replace("USER_EMAIL", html_mod.escape(email))
             page = page.replace("BRIDGE_URL", html_mod.escape(bridge_url))
-            page = page.replace("DASHBOARD_URL", html_mod.escape(dashboard_url))
+            page = page.replace("DASHBOARD_BOOKMARK", dashboard_bookmark)
 
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -731,13 +737,16 @@ def browser_login():
     email = server.authenticated_email
     if email:
         used_server = server.authenticated_server_url
-        dashboard_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/.web/"
         base_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{email}/"
         print(f"\n  Login successful! Now start the bridge daemon:")
         print(f"    ./silentsuite-bridge")
         print()
         print(f"  Etebase server: {used_server}")
-        print(f"  Dashboard will be available at: {dashboard_url}")
+        if config.is_dashboard_enabled():
+            dashboard_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/.web/"
+            print(f"  Dashboard will be available at: {dashboard_url}")
+        else:
+            print("  Dashboard is disabled for remote bridge binds.")
         print(f"  CalDAV/CardDAV URL for your apps: {base_url}")
         print(f"\n  Full setup guides: https://docs.silentsuite.io/user-guide/apps/dav-bridge\n")
 

--- a/bridge/src/silentsuite_bridge/config.py
+++ b/bridge/src/silentsuite_bridge/config.py
@@ -7,6 +7,7 @@ All defaults point to server.silentsuite.io.
 import json
 import os
 import sys
+from ipaddress import ip_address
 
 from appdirs import user_data_dir
 
@@ -19,10 +20,12 @@ ETEBASE_SERVER_URL = os.environ.get(
 # --- Network ---
 LISTEN_ADDRESS = os.environ.get("SILENTSUITE_LISTEN_ADDRESS", "127.0.0.1")
 LISTEN_PORT = int(os.environ.get("SILENTSUITE_LISTEN_PORT", "37358"))
+DEFAULT_SERVER_HOSTS = f"{LISTEN_ADDRESS}:{LISTEN_PORT}"
 SERVER_HOSTS = os.environ.get(
     "SILENTSUITE_SERVER_HOSTS",
-    f"{LISTEN_ADDRESS}:{LISTEN_PORT}",
+    DEFAULT_SERVER_HOSTS,
 )
+ALLOW_REMOTE = os.environ.get("SILENTSUITE_ALLOW_REMOTE", "").lower() in {"1", "true", "yes", "on"}
 
 # --- Data directories ---
 APP_NAME = "silentsuite-bridge"
@@ -68,6 +71,67 @@ def ensure_data_dir():
     """Create the data directory if it doesn't exist."""
     if not os.path.exists(DATA_DIR):
         os.makedirs(DATA_DIR, mode=0o700)
+
+
+def _extract_host(host_spec: str) -> str:
+    """Extract the host part from a Radicale server host specification."""
+    value = host_spec.strip()
+    if value.startswith("["):
+        end = value.find("]")
+        return value[1:end] if end != -1 else value
+    if value.count(":") == 1:
+        return value.rsplit(":", 1)[0]
+    return value
+
+
+def is_loopback_host(host: str) -> bool:
+    """Return true only for localhost or numeric loopback addresses."""
+    normalized = host.strip().lower()
+    if normalized == "localhost":
+        return True
+    if normalized in {"", "*"}:
+        return False
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def remote_bind_reasons() -> list[str]:
+    """Describe configured bind values that would expose the bridge remotely."""
+    reasons: list[str] = []
+    if not is_loopback_host(LISTEN_ADDRESS):
+        reasons.append(f"SILENTSUITE_LISTEN_ADDRESS={LISTEN_ADDRESS}")
+
+    for host_spec in SERVER_HOSTS.split(","):
+        host_spec = host_spec.strip()
+        if not host_spec:
+            continue
+        host = _extract_host(host_spec)
+        if not is_loopback_host(host):
+            reasons.append(f"SILENTSUITE_SERVER_HOSTS includes {host_spec}")
+
+    return reasons
+
+
+def is_remote_bind_configured() -> bool:
+    return bool(remote_bind_reasons())
+
+
+def is_dashboard_enabled() -> bool:
+    """The dashboard is unauthenticated today, so disable it on remote binds."""
+    return not is_remote_bind_configured()
+
+
+def validate_network_config() -> None:
+    """Fail closed before exposing plaintext DAV/dashboard surfaces remotely."""
+    reasons = remote_bind_reasons()
+    if reasons and not ALLOW_REMOTE:
+        joined = "; ".join(reasons)
+        raise RuntimeError(
+            "SilentSuite Bridge refuses non-loopback bind without SILENTSUITE_ALLOW_REMOTE=1. "
+            f"Remote bind setting(s): {joined}. The bridge exposes decrypted DAV data over HTTP."
+        )
 
 
 def load_settings():

--- a/bridge/src/silentsuite_bridge/config.py
+++ b/bridge/src/silentsuite_bridge/config.py
@@ -20,7 +20,14 @@ ETEBASE_SERVER_URL = os.environ.get(
 # --- Network ---
 LISTEN_ADDRESS = os.environ.get("SILENTSUITE_LISTEN_ADDRESS", "127.0.0.1")
 LISTEN_PORT = int(os.environ.get("SILENTSUITE_LISTEN_PORT", "37358"))
-DEFAULT_SERVER_HOSTS = f"{LISTEN_ADDRESS}:{LISTEN_PORT}"
+
+
+def _format_host_port(host: str, port: int) -> str:
+    """Format host:port for Radicale, bracketing IPv6 literals."""
+    return f"[{host}]:{port}" if ":" in host and not host.startswith("[") else f"{host}:{port}"
+
+
+DEFAULT_SERVER_HOSTS = _format_host_port(LISTEN_ADDRESS, LISTEN_PORT)
 SERVER_HOSTS = os.environ.get(
     "SILENTSUITE_SERVER_HOSTS",
     DEFAULT_SERVER_HOSTS,
@@ -78,9 +85,17 @@ def _extract_host(host_spec: str) -> str:
     value = host_spec.strip()
     if value.startswith("["):
         end = value.find("]")
-        return value[1:end] if end != -1 else value
+        return value[1:end] if end != -1 else value[1:]
     if value.count(":") == 1:
         return value.rsplit(":", 1)[0]
+    if ":" in value:
+        host, port = value.rsplit(":", 1)
+        if port.isdigit():
+            try:
+                ip_address(host)
+                return host
+            except ValueError:
+                pass
     return value
 
 

--- a/bridge/tests/test_config.py
+++ b/bridge/tests/test_config.py
@@ -144,6 +144,47 @@ class TestConfigEnvOverrides:
         finally:
             restore_config(monkeypatch)
 
+    def test_ipv6_loopback_listen_address_default_hosts_are_bracketed(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_LISTEN_ADDRESS="::1")
+        try:
+            assert cfg.DEFAULT_SERVER_HOSTS == "[::1]:37358"
+            cfg.validate_network_config()
+            assert cfg.remote_bind_reasons() == []
+        finally:
+            restore_config(monkeypatch)
+
+    def test_unbracketed_ipv6_loopback_host_with_port_is_allowed(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_SERVER_HOSTS="::1:37358")
+        try:
+            cfg.validate_network_config()
+            assert cfg.remote_bind_reasons() == []
+        finally:
+            restore_config(monkeypatch)
+
+    def test_malformed_ipv6_loopback_bracket_does_not_drop_address_tail(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_SERVER_HOSTS="[::1")
+        try:
+            cfg.validate_network_config()
+            assert cfg.remote_bind_reasons() == []
+        finally:
+            restore_config(monkeypatch)
+
+    def test_localhost_and_127_range_server_hosts_are_allowed(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_SERVER_HOSTS="localhost:37358,127.0.0.2:37358")
+        try:
+            cfg.validate_network_config()
+            assert cfg.remote_bind_reasons() == []
+        finally:
+            restore_config(monkeypatch)
+
+    def test_non_loopback_ipv6_server_host_requires_explicit_opt_in(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_SERVER_HOSTS="[fe80::1]:37358")
+        try:
+            with pytest.raises(RuntimeError, match="SILENTSUITE_SERVER_HOSTS"):
+                cfg.validate_network_config()
+        finally:
+            restore_config(monkeypatch)
+
 
 class TestConfigHelpers:
     """Test config helper functions."""

--- a/bridge/tests/test_config.py
+++ b/bridge/tests/test_config.py
@@ -6,6 +6,34 @@ from unittest.mock import patch
 import pytest
 
 
+NETWORK_ENV_KEYS = (
+    "SILENTSUITE_LISTEN_ADDRESS",
+    "SILENTSUITE_LISTEN_PORT",
+    "SILENTSUITE_SERVER_HOSTS",
+    "SILENTSUITE_ALLOW_REMOTE",
+)
+
+
+def reload_config_with_env(monkeypatch, **values):
+    import importlib
+    from silentsuite_bridge import config
+
+    for key in NETWORK_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+    return importlib.reload(config)
+
+
+def restore_config(monkeypatch):
+    import importlib
+    from silentsuite_bridge import config
+
+    for key in NETWORK_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    return importlib.reload(config)
+
+
 class TestConfigDefaults:
     """Test that config module exposes sensible defaults."""
 
@@ -69,6 +97,52 @@ class TestConfigEnvOverrides:
         with patch.dict(os.environ, {"SILENTSUITE_SYNC_MINIMUM": "10"}):
             val = int(os.environ.get("SILENTSUITE_SYNC_MINIMUM", "30"))
             assert val == 10
+
+    def test_default_network_config_is_loopback_only(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch)
+        try:
+            cfg.validate_network_config()
+            assert cfg.remote_bind_reasons() == []
+            assert cfg.is_dashboard_enabled() is True
+        finally:
+            restore_config(monkeypatch)
+
+    def test_non_loopback_listen_address_requires_explicit_opt_in(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_LISTEN_ADDRESS="0.0.0.0")
+        try:
+            with pytest.raises(RuntimeError, match="SILENTSUITE_ALLOW_REMOTE=1"):
+                cfg.validate_network_config()
+        finally:
+            restore_config(monkeypatch)
+
+    def test_non_loopback_server_hosts_requires_explicit_opt_in(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_SERVER_HOSTS="0.0.0.0:37358")
+        try:
+            with pytest.raises(RuntimeError, match="SILENTSUITE_SERVER_HOSTS"):
+                cfg.validate_network_config()
+        finally:
+            restore_config(monkeypatch)
+
+    def test_remote_opt_in_allows_bind_but_disables_dashboard(self, monkeypatch):
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_LISTEN_ADDRESS="0.0.0.0",
+            SILENTSUITE_ALLOW_REMOTE="1",
+        )
+        try:
+            cfg.validate_network_config()
+            assert cfg.is_remote_bind_configured() is True
+            assert cfg.is_dashboard_enabled() is False
+        finally:
+            restore_config(monkeypatch)
+
+    def test_ipv6_loopback_server_hosts_are_allowed(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_SERVER_HOSTS="[::1]:37358")
+        try:
+            cfg.validate_network_config()
+            assert cfg.remote_bind_reasons() == []
+        finally:
+            restore_config(monkeypatch)
 
 
 class TestConfigHelpers:


### PR DESCRIPTION
## Summary
- reject non-loopback bridge bind settings unless SILENTSUITE_ALLOW_REMOTE is explicitly enabled
- validate the network config both at startup and when building Radicale config
- disable the unauthenticated bridge dashboard whenever remote bind is configured
- update startup and browser-login output so it reflects actual DAV hosts and dashboard availability
- add config tests for loopback defaults, remote rejection, opt-in behavior, and IPv6 loopback

## Verification
- git diff --check origin/dev..HEAD
- python3 -m py_compile bridge/src/silentsuite_bridge/config.py bridge/src/silentsuite_bridge/__main__.py bridge/src/silentsuite_bridge/auth_browser.py bridge/tests/test_config.py

Full bridge pytest was not run locally because this environment lacks bridge runtime test dependencies; CI should validate it.