### PR TITLE
Surface docs privacy link and audit baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,48 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Audit dependencies
-        run: pnpm audit --audit-level=high
-        continue-on-error: true  # TODO: tighten to fail on high-severity vulnerabilities once existing issues are resolved
+        run: |
+          set +e
+          pnpm audit --audit-level=high --json > pnpm-audit.json
+          audit_status=$?
+          set -e
+
+          node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const fs = require('fs')
+          const report = JSON.parse(fs.readFileSync('pnpm-audit.json', 'utf8'))
+          const counts = report.metadata?.vulnerabilities ?? {}
+          const advisories = Object.values(report.advisories ?? {})
+            .filter((advisory) => ['high', 'critical'].includes(advisory.severity))
+            .sort((a, b) => {
+              const order = { critical: 0, high: 1 }
+              return order[a.severity] - order[b.severity]
+            })
+
+          console.log('## Dependency Audit')
+          console.log('')
+          console.log(`Current baseline: ${counts.critical ?? 0} critical, ${counts.high ?? 0} high, ${counts.moderate ?? 0} moderate, ${counts.low ?? 0} low.`)
+          console.log('')
+          if (advisories.length === 0) {
+            console.log('No high or critical advisories found. This job can be made blocking.')
+          } else {
+            console.log('High/critical audit is intentionally non-blocking while the baseline is remediated.')
+            console.log('')
+            console.log('| Severity | Package | Advisory |')
+            console.log('| --- | --- | --- |')
+            for (const advisory of advisories) {
+              const pkg = advisory.module_name ?? advisory.name ?? 'unknown'
+              const title = String(advisory.title ?? advisory.url ?? 'advisory').replaceAll('|', '\\|')
+              const url = advisory.url ? `[${title}](${advisory.url})` : title
+              console.log(`| ${advisory.severity} | ${pkg} | ${url} |`)
+            }
+          }
+          NODE
+
+          if [ "$audit_status" -ne 0 ]; then
+            echo "::warning title=Dependency audit baseline::pnpm audit found high/critical advisories; see the job summary."
+          fi
+
+          exit 0
 
   build-web:
     name: Build Web App

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,15 @@ jobs:
 
           node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
           const fs = require('fs')
-          const report = JSON.parse(fs.readFileSync('pnpm-audit.json', 'utf8'))
+          let report
+          try {
+            report = JSON.parse(fs.readFileSync('pnpm-audit.json', 'utf8'))
+          } catch (err) {
+            console.log('## Dependency Audit')
+            console.log('')
+            console.log('Dependency audit output could not be parsed. This non-blocking guardrail needs follow-up inspection in the workflow logs.')
+            process.exit(0)
+          }
           const counts = report.metadata?.vulnerabilities ?? {}
           const advisories = Object.values(report.advisories ?? {})
             .filter((advisory) => ['high', 'critical'].includes(advisory.severity))

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -25,6 +25,7 @@ export default defineConfig({
       { text: 'User Guide', link: '/user-guide/getting-started', activeMatch: '/user-guide/' },
       { text: 'Self-Hosting', link: '/self-hosting/quick-start', activeMatch: '/self-hosting/' },
       { text: 'Contributing', link: '/contributing/dev-setup', activeMatch: '/contributing/' },
+      { text: 'Privacy', link: 'https://silentsuite.io/privacy' },
       { text: 'silentsuite.io', link: 'https://silentsuite.io' },
     ],
 


### PR DESCRIPTION
## Summary
- add a visible Privacy link to the docs nav pointing to the updated privacy policy
- replace the opaque non-blocking dependency audit with an intentional baseline summary
- emit a GitHub Actions warning and high/critical advisory table while remediation remains non-blocking

## Linked Internal PR
- Privacy policy update: silent-suite/silentsuite-internal#131

## Verification
- git diff --check origin/dev..HEAD
- pnpm audit --audit-level=high --json baseline parse: current baseline is 2 critical and 17 high advisories
- pnpm --filter @silentsuite/docs build

## Follow-up
Create or link a dependency remediation issue for the current high/critical audit baseline before making the audit job blocking.