### PR TITLE
Protect bridge dashboard APIs

### DIFF
--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -13,9 +13,11 @@ In the future, this will redirect to app.silentsuite.io/bridge-auth.
 """
 
 import html as html_mod
+import hmac
 import http.server
 import json
 import logging
+import secrets
 import socket
 import threading
 import urllib.parse
@@ -141,6 +143,7 @@ AUTH_PAGE_HTML = """<!DOCTYPE html>
         </div>
         <div class="error" id="error"></div>
         <form id="loginForm" method="POST" action="/auth">
+            <input type="hidden" name="csrf_token" value="CSRF_TOKEN">
             <label for="email">Email</label>
             <input type="email" id="email" name="email" required autofocus
                    placeholder="you@example.com">
@@ -569,12 +572,17 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
 
     server_instance = None
 
+    @staticmethod
+    def _valid_csrf(provided, expected):
+        return bool(provided) and bool(expected) and hmac.compare_digest(provided, expected)
+
     def log_message(self, format, *args):
         logger.debug("Auth server: %s", format % args)
 
     def do_GET(self):
         if self.path == "/" or self.path.startswith("/auth"):
             html = AUTH_PAGE_HTML.replace("SERVER_URL", html_mod.escape(config.ETEBASE_SERVER_URL))
+            html = html.replace("CSRF_TOKEN", html_mod.escape(self.server.csrf_token))
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
@@ -616,6 +624,13 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
             email = params.get("email", [""])[0].strip()
             password = params.get("password", [""])[0]
             server_url = params.get("server_url", [config.ETEBASE_SERVER_URL])[0].strip()
+            csrf_token = params.get("csrf_token", [""])[0]
+            if not self._valid_csrf(csrf_token, self.server.csrf_token):
+                self._json_response(403, {
+                    "success": False,
+                    "error": "Invalid CSRF token.",
+                })
+                return
             if not server_url:
                 server_url = config.ETEBASE_SERVER_URL
 
@@ -704,6 +719,7 @@ def browser_login():
     server.auth_complete = threading.Event()
     server.authenticated_email = None
     server.authenticated_server_url = config.ETEBASE_SERVER_URL
+    server.csrf_token = secrets.token_urlsafe(32)
 
     auth_url = f"http://127.0.0.1:{port}/"
 

--- a/bridge/src/silentsuite_bridge/config.py
+++ b/bridge/src/silentsuite_bridge/config.py
@@ -73,6 +73,14 @@ COL_TYPES = [
 LOG_LEVEL = os.environ.get("SILENTSUITE_LOG_LEVEL", "INFO")
 LOG_FILE = os.environ.get("SILENTSUITE_LOG_FILE", None)
 
+# --- Dashboard diagnostics ---
+DASHBOARD_DUMP_ENABLED = os.environ.get("SILENTSUITE_DASHBOARD_DUMP", "").lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
+
 
 def ensure_data_dir():
     """Create the data directory if it doesn't exist."""

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -11,8 +11,10 @@ Integrates with Radicale's web module system.
 """
 
 import html
+import hmac
 import json
 import logging
+import secrets
 import threading
 import time
 from collections import deque
@@ -35,6 +37,25 @@ _bridge_status = {
     "collections_scope": "all configured accounts",
 }
 _bridge_status_lock = threading.RLock()
+# Process-local token protects localhost dashboard POSTs from cross-site form/script submissions.
+_dashboard_csrf_token = secrets.token_urlsafe(32)
+
+
+def _json_response(status, payload):
+    return (
+        status,
+        {"Content-Type": "application/json"},
+        json.dumps(payload).encode(),
+    )
+
+
+def _has_valid_csrf(environ):
+    token = environ.get("HTTP_X_SILENTSUITE_CSRF", "")
+    return bool(token) and hmac.compare_digest(token, _dashboard_csrf_token)
+
+
+def _csrf_error():
+    return _json_response(403, {"error": "Invalid dashboard CSRF token"})
 
 
 def log_sync_event(event_type, message):
@@ -236,6 +257,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
     </style>
 </head>
 <body>
+    <script>window.SILENTSUITE_DASHBOARD_CSRF = '{{CSRF_TOKEN}}';</script>
     <div class="container">
         <h1>SilentSuite Bridge</h1>
         <div class="version">v{{VERSION}}</div>
@@ -289,7 +311,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
                 var btn = document.getElementById('syncNowBtn');
                 btn.textContent = 'Syncing...';
                 btn.disabled = true;
-                fetch('/.web/api/sync', {method:'POST'})
+                fetch('/.web/api/sync', {method:'POST', headers:{'X-SilentSuite-CSRF': window.SILENTSUITE_DASHBOARD_CSRF}})
                     .then(function(r) { return r.json(); })
                     .then(function() { btn.textContent = 'Done!'; setTimeout(function() { location.reload(); }, 1000); })
                     .catch(function() { btn.textContent = 'Error'; })
@@ -298,7 +320,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
             function updateInterval() {
                 var val = document.getElementById('syncInterval').value;
                 var st = document.getElementById('syncIntervalStatus');
-                fetch('/.web/api/settings', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({syncInterval: parseInt(val)})})
+                fetch('/.web/api/settings', {method:'POST', headers:{'Content-Type':'application/json','X-SilentSuite-CSRF': window.SILENTSUITE_DASHBOARD_CSRF}, body: JSON.stringify({syncInterval: parseInt(val)})})
                     .then(function(r) { return r.json(); })
                     .then(function() { st.textContent = 'Saved'; setTimeout(function() { st.textContent = ''; }, 2000); })
                     .catch(function() { st.textContent = 'Error'; });
@@ -464,6 +486,7 @@ def _render_dashboard():
     page = page.replace("{{COLLECTIONS}}", esc(col_text))
     page = page.replace("{{ACCOUNT_LIST}}", account_html)
     page = page.replace("{{SYNC_LOG}}", log_html)
+    page = page.replace("{{CSRF_TOKEN}}", esc(_dashboard_csrf_token))
 
     # Sync interval display
     interval = config.SYNC_INTERVAL
@@ -551,6 +574,8 @@ class Web(BaseWeb):
 
         # Diagnostic: dump all cached items
         if path == "/.web/api/dump":
+            if not config.DASHBOARD_DUMP_ENABLED:
+                return (404, {}, b"Not found")
             from ..local_cache import models, db
             try:
                 with db.database_proxy:
@@ -606,6 +631,8 @@ class Web(BaseWeb):
 
         # Trigger immediate sync
         if path == "/.web/api/sync":
+            if not _has_valid_csrf(environ):
+                return _csrf_error()
             for thread in _sync_threads.values():
                 if thread.is_alive():
                     thread.force_sync()
@@ -619,6 +646,8 @@ class Web(BaseWeb):
 
         # Update settings
         if path == "/.web/api/settings":
+            if not _has_valid_csrf(environ):
+                return _csrf_error()
             try:
                 data = json.loads(body)
             except (json.JSONDecodeError, ValueError):

--- a/bridge/tests/test_auth_browser_csrf.py
+++ b/bridge/tests/test_auth_browser_csrf.py
@@ -1,0 +1,82 @@
+"""Tests for browser-auth CSRF handling."""
+
+import http.server
+import json
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from unittest.mock import patch
+
+from silentsuite_bridge.auth_browser import AUTH_PAGE_HTML, AuthCallbackHandler
+
+
+def _post_auth(server, fields):
+    url = f"http://127.0.0.1:{server.server_address[1]}/auth"
+    request = urllib.request.Request(
+        url,
+        data=urllib.parse.urlencode(fields).encode(),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return response.status, json.loads(response.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
+def _serve_one_auth_request(csrf_token="expected-token"):
+    server = http.server.HTTPServer(("127.0.0.1", 0), AuthCallbackHandler)
+    server.csrf_token = csrf_token
+    thread = threading.Thread(target=server.handle_request)
+    thread.start()
+    return server, thread
+
+
+def test_auth_page_contains_csrf_field():
+    assert 'name="csrf_token"' in AUTH_PAGE_HTML
+    assert 'value="CSRF_TOKEN"' in AUTH_PAGE_HTML
+
+
+def test_auth_csrf_validation_requires_matching_token():
+    assert AuthCallbackHandler._valid_csrf("expected", "expected") is True
+    assert AuthCallbackHandler._valid_csrf("", "expected") is False
+    assert AuthCallbackHandler._valid_csrf("wrong", "expected") is False
+    assert AuthCallbackHandler._valid_csrf("expected", "") is False
+
+
+def test_auth_post_rejects_wrong_csrf_before_login():
+    server, thread = _serve_one_auth_request()
+    try:
+        status, payload = _post_auth(server, {
+            "email": "alice@example.com",
+            "password": "secret",
+            "server_url": "https://server.silentsuite.io",
+            "csrf_token": "wrong-token",
+        })
+    finally:
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 403
+    assert payload == {"success": False, "error": "Invalid CSRF token."}
+
+
+def test_auth_post_with_valid_csrf_reaches_login():
+    server, thread = _serve_one_auth_request()
+    try:
+        with patch("silentsuite_bridge.auth_browser.Account.login", side_effect=Exception("401 Unauthorized")) as login:
+            status, payload = _post_auth(server, {
+                "email": "alice@example.com",
+                "password": "secret",
+                "server_url": "https://server.silentsuite.io",
+                "csrf_token": "expected-token",
+            })
+    finally:
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 401
+    assert payload == {"success": False, "error": "Invalid email or password."}
+    assert login.called

--- a/bridge/tests/test_config.py
+++ b/bridge/tests/test_config.py
@@ -6,11 +6,12 @@ from unittest.mock import patch
 import pytest
 
 
-NETWORK_ENV_KEYS = (
+CONFIG_ENV_KEYS = (
     "SILENTSUITE_LISTEN_ADDRESS",
     "SILENTSUITE_LISTEN_PORT",
     "SILENTSUITE_SERVER_HOSTS",
     "SILENTSUITE_ALLOW_REMOTE",
+    "SILENTSUITE_DASHBOARD_DUMP",
 )
 
 
@@ -18,7 +19,7 @@ def reload_config_with_env(monkeypatch, **values):
     import importlib
     from silentsuite_bridge import config
 
-    for key in NETWORK_ENV_KEYS:
+    for key in CONFIG_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
     for key, value in values.items():
         monkeypatch.setenv(key, value)
@@ -29,7 +30,7 @@ def restore_config(monkeypatch):
     import importlib
     from silentsuite_bridge import config
 
-    for key in NETWORK_ENV_KEYS:
+    for key in CONFIG_ENV_KEYS:
         monkeypatch.delenv(key, raising=False)
     return importlib.reload(config)
 
@@ -68,6 +69,13 @@ class TestConfigDefaults:
         from silentsuite_bridge import config
         assert config.LOG_LEVEL == "INFO"
 
+    def test_dashboard_dump_disabled_by_default(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch)
+        try:
+            assert cfg.DASHBOARD_DUMP_ENABLED is False
+        finally:
+            restore_config(monkeypatch)
+
 
 class TestConfigEnvOverrides:
     """Test that environment variables override defaults."""
@@ -97,6 +105,13 @@ class TestConfigEnvOverrides:
         with patch.dict(os.environ, {"SILENTSUITE_SYNC_MINIMUM": "10"}):
             val = int(os.environ.get("SILENTSUITE_SYNC_MINIMUM", "30"))
             assert val == 10
+
+    def test_dashboard_dump_env_opt_in(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_DASHBOARD_DUMP="true")
+        try:
+            assert cfg.DASHBOARD_DUMP_ENABLED is True
+        finally:
+            restore_config(monkeypatch)
 
     def test_default_network_config_is_loopback_only(self, monkeypatch):
         cfg = reload_config_with_env(monkeypatch)

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -1,13 +1,28 @@
 """Tests for the bridge dashboard renderer."""
 
+import io
+import json
+
 from silentsuite_bridge import config
 from silentsuite_bridge.radicale.creds import Credentials
 from silentsuite_bridge.web import (
+    Web,
     _bridge_status,
+    _dashboard_csrf_token,
     _render_dashboard,
     forget_account_status,
     update_status,
 )
+
+
+def _post_environ(body=b"", csrf_token=None):
+    environ = {
+        "CONTENT_LENGTH": str(len(body)),
+        "wsgi.input": io.BytesIO(body),
+    }
+    if csrf_token is not None:
+        environ["HTTP_X_SILENTSUITE_CSRF"] = csrf_token
+    return environ
 
 
 def _reset_status():
@@ -48,6 +63,8 @@ def test_render_dashboard_lists_each_configured_account(tmp_path, monkeypatch):
     assert "http://127.0.0.1:37358/bob@example.com/" in html
     assert "Collections (all configured accounts)" in html
     assert "2 calendars, 1 contacts, 0 tasks" in html
+    assert "window.SILENTSUITE_DASHBOARD_CSRF" in html
+    assert "X-SilentSuite-CSRF" in html
 
 
 def test_update_status_aggregates_background_sync_counts(tmp_path, monkeypatch):
@@ -111,3 +128,106 @@ def test_forget_account_status_removes_one_accounts_counts():
         "tasks": 0,
     }
     assert "alice@example.com" not in _bridge_status["collections_by_account"]
+
+
+def test_dump_api_returns_404_when_disabled(monkeypatch):
+    monkeypatch.setattr(config, "DASHBOARD_DUMP_ENABLED", False)
+    web = Web.__new__(Web)
+
+    status, headers, body = web.get({}, "", "/.web/api/dump", None)
+
+    assert status == 404
+    assert headers == {}
+    assert body == b"Not found"
+
+
+def test_dashboard_post_requires_csrf_token():
+    web = Web.__new__(Web)
+
+    status, headers, body = web.post(_post_environ(), "", "/.web/api/sync", None)
+
+    assert status == 403
+    assert headers["Content-Type"] == "application/json"
+    assert json.loads(body)["error"] == "Invalid dashboard CSRF token"
+
+
+def test_dashboard_sync_post_accepts_valid_csrf_token():
+    web = Web.__new__(Web)
+
+    status, headers, body = web.post(
+        _post_environ(csrf_token=_dashboard_csrf_token),
+        "",
+        "/.web/api/sync",
+        None,
+    )
+
+    assert status == 200
+    assert headers["Content-Type"] == "application/json"
+    assert json.loads(body) == {"ok": True}
+
+
+def test_dashboard_sync_post_rejects_wrong_csrf_token():
+    web = Web.__new__(Web)
+
+    status, headers, body = web.post(
+        _post_environ(csrf_token="not-the-token"),
+        "",
+        "/.web/api/sync",
+        None,
+    )
+
+    assert status == 403
+    assert headers["Content-Type"] == "application/json"
+    assert json.loads(body)["error"] == "Invalid dashboard CSRF token"
+
+
+def test_dashboard_settings_post_requires_csrf_before_writing(tmp_path, monkeypatch):
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "SETTINGS_FILE", str(settings_file))
+    monkeypatch.setattr(config, "DATA_DIR", str(tmp_path))
+    web = Web.__new__(Web)
+    body = json.dumps({"syncInterval": 60}).encode()
+
+    status, _, _ = web.post(_post_environ(body=body), "", "/.web/api/settings", None)
+
+    assert status == 403
+    assert not settings_file.exists()
+
+
+def test_dashboard_settings_post_rejects_wrong_csrf_before_writing(tmp_path, monkeypatch):
+    settings_file = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "SETTINGS_FILE", str(settings_file))
+    monkeypatch.setattr(config, "DATA_DIR", str(tmp_path))
+    web = Web.__new__(Web)
+    body = json.dumps({"syncInterval": 60}).encode()
+
+    status, headers, response_body = web.post(
+        _post_environ(body=body, csrf_token="not-the-token"),
+        "",
+        "/.web/api/settings",
+        None,
+    )
+
+    assert status == 403
+    assert headers["Content-Type"] == "application/json"
+    assert json.loads(response_body)["error"] == "Invalid dashboard CSRF token"
+    assert not settings_file.exists()
+
+
+def test_dashboard_settings_post_accepts_valid_csrf(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "SETTINGS_FILE", str(tmp_path / "settings.json"))
+    monkeypatch.setattr(config, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "SYNC_INTERVAL", config.SYNC_INTERVAL)
+    web = Web.__new__(Web)
+    body = json.dumps({"syncInterval": 60}).encode()
+
+    status, headers, response_body = web.post(
+        _post_environ(body=body, csrf_token=_dashboard_csrf_token),
+        "",
+        "/.web/api/settings",
+        None,
+    )
+
+    assert status == 200
+    assert headers["Content-Type"] == "application/json"
+    assert json.loads(response_body) == {"ok": True, "syncInterval": 60}


### PR DESCRIPTION
## Summary
- gate the bridge dashboard dump endpoint behind explicit SILENTSUITE_DASHBOARD_DUMP opt-in
- add a per-process dashboard CSRF token for mutating dashboard API POSTs
- add per-session CSRF protection to the browser auth login POST surface

## Verification
- python3 -m py_compile src/silentsuite_bridge/config.py src/silentsuite_bridge/web/__init__.py src/silentsuite_bridge/auth_browser.py tests/test_web_dashboard.py tests/test_config.py tests/test_auth_browser_csrf.py
- git diff --check
- code-reviewer final pass: GREEN LIGHT

## Notes
- Local pytest could not run because pytest/bridge dependencies are not installed in this environment; bridge Python tests are expected to run in CI.