### PR TITLE
Harden bridge log and cache privacy

### DIFF
--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -103,7 +103,7 @@ def check_credentials():
         if not users:
             return False
 
-    logger.info("Found %d configured user(s): %s", len(users), ", ".join(users))
+    logger.info("Found %d configured user(s)", len(users))
     return True
 
 
@@ -166,18 +166,17 @@ def _initial_status_check():
                     totals[key] += value
                 synced += 1
                 update_status("connected", collections=collections, account=user)
-                log_sync_event("info", f"Initial sync complete for {user}")
+                log_sync_event("info", "Initial sync complete")
                 logger.info(
-                    "Initial sync for %s: %d calendars, %d contacts, %d tasks",
-                    user,
+                    "Initial sync complete: %d calendars, %d contacts, %d tasks",
                     collections["calendars"],
                     collections["contacts"],
                     collections["tasks"],
                 )
         except Exception as e:
-            logger.warning("Initial status check failed for %s: %s", user, e)
-            errors.append(f"{user}: {e}")
-            log_sync_event("error", f"Initial sync failed for {user}: {e}")
+            logger.warning("Initial status check failed for a configured account: %s", e)
+            errors.append(str(e))
+            log_sync_event("error", f"Initial sync failed for an account: {e}")
 
     if synced:
         update_status(
@@ -188,10 +187,10 @@ def _initial_status_check():
         if errors:
             log_sync_event(
                 "error",
-                f"Initial sync skipped {len(errors)} account(s): {'; '.join(errors)}",
+                f"Initial sync skipped {len(errors)} account(s)",
             )
     elif errors:
-        update_status("error", error="; ".join(errors))
+        update_status("error", error=f"Initial status check failed for {len(errors)} account(s)")
     else:
         update_status("disconnected")
 

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -656,7 +656,7 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
                 else:
                     error_msg = f"Authentication failed: {error_msg}"
 
-                logger.warning("Auth failed for %s: %s", email, error_msg)
+                logger.warning("Auth failed: %s", error_msg)
                 self._json_response(401, {
                     "success": False,
                     "error": error_msg,

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -588,8 +588,10 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(html.encode())
         elif self.path.startswith("/success"):
-            params = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
-            email = params.get("email", [""])[0].strip()
+            email = getattr(self.server, "authenticated_email", "") or ""
+            if not email:
+                self.send_error(404)
+                return
             bridge_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{email}/"
             if config.is_dashboard_enabled():
                 dashboard_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/.web/"
@@ -672,13 +674,13 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
                 server_url,
             )
 
-            logger.info("Authentication successful for %s", result.username)
+            logger.info("Authentication successful")
 
             # Store the email and server URL for the success handler
             self.server.authenticated_email = result.username
             self.server.authenticated_server_url = server_url
 
-            redirect_url = f"/success?email={urllib.parse.quote(result.username)}"
+            redirect_url = "/success"
             self._json_response(200, {
                 "success": True,
                 "redirect": redirect_url,

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -11,6 +11,7 @@ Original: https://github.com/etesync/etesync-dav
 import logging
 import os
 import time
+from contextlib import contextmanager
 
 import msgpack
 from etebase import Account, Client, CollectionAccessLevel, FetchOptions
@@ -19,6 +20,29 @@ from .. import config
 from . import db, models
 
 logger = logging.getLogger("silentsuite-bridge.cache")
+
+
+@contextmanager
+def _private_umask():
+    old_umask = os.umask(0o077)
+    try:
+        yield
+    finally:
+        os.umask(old_umask)
+
+
+def _ensure_private_cache_dir(path):
+    directory = os.path.dirname(path)
+    if directory != "" and not os.path.exists(directory):
+        os.makedirs(directory, mode=0o700)
+
+
+def _restrict_cache_database_files(path):
+    if not path or path == ":memory:":
+        return
+    for cache_path in (path, f"{path}-wal", f"{path}-shm"):
+        if os.path.exists(cache_path):
+            os.chmod(cache_path, 0o600)
 
 
 def _init_cache_database(db_path=None):
@@ -34,9 +58,7 @@ def _init_cache_database(db_path=None):
     from playhouse.sqlite_ext import SqliteExtDatabase
 
     path = db_path or config.DATABASE_FILE
-    directory = os.path.dirname(path)
-    if directory != "" and not os.path.exists(directory):
-        os.makedirs(directory)
+    _ensure_private_cache_dir(path)
 
     database = SqliteExtDatabase(
         path,
@@ -50,11 +72,13 @@ def _init_cache_database(db_path=None):
 
 
 def _ensure_cache_tables(database):
-    database.create_tables(
-        [models.Config, models.User, models.CollectionEntity, models.ItemEntity, models.HrefMapper],
-        safe=True,
-    )
-    models.Config.get_or_create(defaults={"db_version": 1})
+    with _private_umask():
+        database.create_tables(
+            [models.Config, models.User, models.CollectionEntity, models.ItemEntity, models.HrefMapper],
+            safe=True,
+        )
+        models.Config.get_or_create(defaults={"db_version": 1})
+    _restrict_cache_database_files(getattr(database, "database", None))
 
 
 def clear_cached_user(username, db_path=None):
@@ -69,7 +93,8 @@ def clear_cached_user(username, db_path=None):
 
     database, initialized_here = _init_cache_database(db_path)
     if database.is_closed():
-        database.connect(reuse_if_open=True)
+        with _private_umask():
+            database.connect(reuse_if_open=True)
 
     try:
         _ensure_cache_tables(database)
@@ -175,16 +200,16 @@ class Etebase:
         self._database = database
         db.database_proxy.initialize(database)
 
-        with db.database_proxy:
-            self._init_db_tables(database)
-            self.user, created = models.User.get_or_create(username=self.username)
+        with _private_umask():
+            with db.database_proxy:
+                self._init_db_tables(database)
+                self.user, created = models.User.get_or_create(username=self.username)
+        _restrict_cache_database_files(getattr(database, "database", None))
 
     def _init_db(self, db_path):
         from playhouse.sqlite_ext import SqliteExtDatabase
 
-        directory = os.path.dirname(db_path)
-        if directory != "" and not os.path.exists(directory):
-            os.makedirs(directory)
+        _ensure_private_cache_dir(db_path)
 
         database = SqliteExtDatabase(
             db_path,
@@ -205,6 +230,7 @@ class Etebase:
             database.create_tables(additional_tables, safe=True)
 
         models.Config.get_or_create(defaults={"db_version": 1})
+        _restrict_cache_database_files(getattr(database, "database", None))
 
     def sync(self):
         """Full bidirectional sync: push local changes, pull remote changes."""
@@ -313,6 +339,10 @@ class Etebase:
                 items_data = list(item_list.data)
 
                 logger.info(
+                    "PULL collection: fetched %d items",
+                    len(items_data),
+                )
+                logger.debug(
                     "PULL %s: fetched %d items (stoken=%s)",
                     uid[:8], len(items_data),
                     str(stoken)[:16] if stoken else "None",
@@ -320,12 +350,12 @@ class Etebase:
 
                 for item in items_data:
                     meta = item.meta
-                    logger.info(
+                    logger.debug(
                         "PULL %s: item uid=%s meta=%s deleted=%s",
                         uid[:8], item.uid[:16], dict(meta), item.deleted,
                     )
                     if "name" not in meta:
-                        logger.info(
+                        logger.debug(
                             "PULL %s: item %s has no 'name' in meta — using item.uid as fallback",
                             uid[:8], item.uid[:16],
                         )
@@ -340,9 +370,9 @@ class Etebase:
                             collection=cache_col,
                             uid=item_uid,
                         )
-                        logger.info("PULL %s: NEW item %s", uid[:8], item_uid)
+                        logger.debug("PULL %s: NEW item %s", uid[:8], item_uid)
                     else:
-                        logger.info("PULL %s: UPDATE item %s", uid[:8], item_uid)
+                        logger.debug("PULL %s: UPDATE item %s", uid[:8], item_uid)
                     cache_item.eb_item = item_mgr.cache_save(item)
                     cache_item.deleted = item.deleted
                     cache_item.save()
@@ -375,22 +405,25 @@ class Etebase:
             item_mgr = col_mgr.get_item_manager(col)
 
             changed = list(self._collection_dirty_get(cache_col))
-            logger.info("PUSH %s: %d dirty/new items to push", uid[:8], len(changed))
+            logger.info("PUSH collection: %d dirty/new items to push", len(changed))
+            logger.debug("PUSH %s: %d dirty/new items to push", uid[:8], len(changed))
 
             if not changed:
                 return
 
             for chunk in batch(changed, CHUNK_PUSH):
                 chunk_items = list(map(lambda x: item_mgr.cache_load(x.eb_item), chunk))
-                logger.info("PUSH %s: uploading batch of %d items", uid[:8], len(chunk_items))
+                logger.info("PUSH collection: uploading batch of %d items", len(chunk_items))
+                logger.debug("PUSH %s: uploading batch of %d items", uid[:8], len(chunk_items))
                 item_mgr.batch(chunk_items, None, None)
-                logger.info("PUSH %s: batch upload SUCCESS", uid[:8])
+                logger.info("PUSH collection: batch upload succeeded")
+                logger.debug("PUSH %s: batch upload SUCCESS", uid[:8])
                 for cache_item, item in zip(chunk, chunk_items):
                     cache_item.eb_item = item_mgr.cache_save(item)
                     cache_item.dirty = False
                     cache_item.new = False
                     cache_item.save()
-                    logger.info("PUSH %s: cleared dirty/new for %s", uid[:8], cache_item.uid)
+                    logger.debug("PUSH %s: cleared dirty/new for %s", uid[:8], cache_item.uid)
 
     # --- CRUD operations ---
 

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -33,8 +33,10 @@ def _private_umask():
 
 def _ensure_private_cache_dir(path):
     directory = os.path.dirname(path)
-    if directory != "" and not os.path.exists(directory):
-        os.makedirs(directory, mode=0o700)
+    if directory != "":
+        if not os.path.exists(directory):
+            os.makedirs(directory, mode=0o700)
+        os.chmod(directory, 0o700)
 
 
 def _restrict_cache_database_files(path):

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -60,13 +60,14 @@ def _init_cache_database(db_path=None):
     path = db_path or config.DATABASE_FILE
     _ensure_private_cache_dir(path)
 
-    database = SqliteExtDatabase(
-        path,
-        pragmas={
-            "journal_mode": "wal",
-            "foreign_keys": 1,
-        },
-    )
+    with _private_umask():
+        database = SqliteExtDatabase(
+            path,
+            pragmas={
+                "journal_mode": "wal",
+                "foreign_keys": 1,
+            },
+        )
     db.database_proxy.initialize(database)
     return database, True
 
@@ -211,13 +212,14 @@ class Etebase:
 
         _ensure_private_cache_dir(db_path)
 
-        database = SqliteExtDatabase(
-            db_path,
-            pragmas={
-                "journal_mode": "wal",
-                "foreign_keys": 1,
-            },
-        )
+        with _private_umask():
+            database = SqliteExtDatabase(
+                db_path,
+                pragmas={
+                    "journal_mode": "wal",
+                    "foreign_keys": 1,
+                },
+            )
 
         self._set_db(database)
 

--- a/bridge/src/silentsuite_bridge/radicale/auth.py
+++ b/bridge/src/silentsuite_bridge/radicale/auth.py
@@ -38,16 +38,15 @@ class Auth(BaseAuth):
         # Check if user exists in credential store
         stored_session = self._creds.get_etebase(login)
         if stored_session is None:
-            logger.warning("Login attempt for unknown user: %s", login)
+            logger.warning("Login attempt for unknown configured user")
             return ""
 
         # Validate password against stored hash
         stored_hash = self._creds.get_password_hash(login)
         if stored_hash is None:
             logger.warning(
-                "No password hash stored for user: %s. "
-                "Please re-authenticate via browser.",
-                login,
+                "No password hash stored for configured user. "
+                "Please re-authenticate via browser."
             )
             return ""
 
@@ -62,10 +61,10 @@ class Auth(BaseAuth):
             password_hash = hashlib.sha256(password.encode()).hexdigest()
 
         if not hmac.compare_digest(password_hash, stored_hash):
-            logger.warning("Invalid password for user: %s", login)
+            logger.warning("Invalid password for configured user")
             return ""
 
-        logger.debug("Successful login for user: %s", login)
+        logger.debug("Successful login for configured user")
 
         # Auto-upgrade legacy SHA-256 hashes to PBKDF2
         if not stored_salt:

--- a/bridge/src/silentsuite_bridge/radicale/auth.py
+++ b/bridge/src/silentsuite_bridge/radicale/auth.py
@@ -69,7 +69,7 @@ class Auth(BaseAuth):
 
         # Auto-upgrade legacy SHA-256 hashes to PBKDF2
         if not stored_salt:
-            logger.info("Upgrading password hash to PBKDF2 for user: %s", login)
+            logger.info("Upgrading password hash to PBKDF2")
             new_salt = os.urandom(32)
             new_hash = hashlib.pbkdf2_hmac(
                 "sha256", password.encode(), new_salt, 600000,

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -555,9 +555,8 @@ class Storage(BaseStorage):
         """Discover collections and items under the given path."""
         if not self._path_belongs_to_user(path):
             logger.warning(
-                "Rejecting DAV path %s authenticated as %s",
+                "Rejecting DAV path %s authenticated as configured account",
                 path,
-                self.user,
             )
             return
 
@@ -622,9 +621,8 @@ class Storage(BaseStorage):
         attributes = _get_attributes_from_path(href)
         if not self._path_belongs_to_user(href):
             logger.warning(
-                "Rejecting collection create for path %s authenticated as %s",
+                "Rejecting collection create for path %s authenticated as configured account",
                 href,
-                self.user,
             )
             raise ComponentNotFoundError(href)
 

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -128,7 +128,7 @@ class SyncThread(threading.Thread):
                         collections=collections,
                         account=self.user,
                     )
-                    log_sync_event("sync", f"Synced for {self.user}")
+                    log_sync_event("sync", "Synced account")
             except Exception as e:
                 logger.exception("Sync error for user %s: %s", self.user, e)
                 self._exception = e
@@ -157,7 +157,7 @@ def start_sync_thread(user):
         thread = SyncThread(user, daemon=True)
         _sync_threads[user] = thread
         thread.start()
-        logger.info("Started SyncThread for user %s (interval=%ds)", user, thread.interval)
+        logger.info("Started SyncThread (interval=%ds)", thread.interval)
         return thread
 
 
@@ -193,7 +193,7 @@ def stop_sync_thread(user, timeout=2.0):
             logger.warning("Timed out stopping SyncThread for user %s", user)
             return False
         del _sync_threads[user]
-        logger.info("Stopped SyncThread for user %s", user)
+        logger.info("Stopped SyncThread")
         return True
 
 
@@ -685,8 +685,8 @@ class Storage(BaseStorage):
             cache_col.dirty = False
             cache_col.save()
 
-        logger.info("Created collection %s (type=%s, name=%s)", col.uid, col_type, meta.get("name"))
-        log_sync_event("sync", f"Created collection {meta.get('name', col.uid)}")
+        logger.info("Created collection (type=%s)", col_type)
+        log_sync_event("sync", "Created collection")
 
         # Upload any items that came with the collection
         collection = Collection(self, posixpath.join("/", attributes[0], col.uid))
@@ -704,7 +704,7 @@ class Storage(BaseStorage):
             return
 
         sync_thread = start_sync_thread(user)
-        logger.info("acquire_lock(%s, user=%s): pre-yield sync", mode, user)
+        logger.info("acquire_lock(%s): pre-yield sync", mode)
         sync_thread.force_sync()
         try:
             sync_thread.wait_for_sync(20)
@@ -727,7 +727,7 @@ class Storage(BaseStorage):
                     etesync.push_collection_list()
                     for col in etesync.list():
                         if etesync.collection_is_dirty(col.uid):
-                            logger.info("acquire_lock: pushing dirty collection %s", col.uid[:8])
+                            logger.info("acquire_lock: pushing dirty collection")
                             etesync.push_collection(col.uid)
                     logger.info("acquire_lock(w): inline push done")
                 except Exception as e:

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -109,7 +109,7 @@ class SyncThread(threading.Thread):
                     etesync.sync()
                     self.last_sync_duration = time.time() - self.sync_started_at
                     self.is_syncing = False
-                    logger.debug("Sync completed for user %s", self.user)
+                    logger.debug("Sync completed for configured account")
 
                     # Update dashboard status with collection counts
                     collections = {"calendars": 0, "contacts": 0, "tasks": 0}
@@ -130,7 +130,7 @@ class SyncThread(threading.Thread):
                     )
                     log_sync_event("sync", "Synced account")
             except Exception as e:
-                logger.exception("Sync error for user %s: %s", self.user, e)
+                logger.exception("Sync error for configured account: %s", e)
                 self._exception = e
                 update_status("error", error=str(e))
                 log_sync_event("error", f"Sync failed: {e}")
@@ -181,7 +181,7 @@ def stop_sync_thread(user, timeout=2.0):
 
     thread.stop()
     if thread is threading.current_thread():
-        logger.warning("SyncThread for user %s cannot join itself", user)
+        logger.warning("SyncThread cannot join itself")
         return False
     thread.join(timeout)
 
@@ -190,7 +190,7 @@ def stop_sync_thread(user, timeout=2.0):
         if current is not thread:
             return True
         if thread.is_alive():
-            logger.warning("Timed out stopping SyncThread for user %s", user)
+            logger.warning("Timed out stopping SyncThread")
             return False
         del _sync_threads[user]
         logger.info("Stopped SyncThread")
@@ -710,7 +710,7 @@ class Storage(BaseStorage):
             sync_thread.wait_for_sync(20)
         except Exception as e:
             logger.warning(
-                "Sync failed for user %s, continuing with local cache: %s", user, e
+                "Sync failed for configured account, continuing with local cache: %s", e
             )
 
         with self._etesync_user_lock, etesync_for_user(user) as (etesync, _):

--- a/bridge/tests/test_auth_browser_csrf.py
+++ b/bridge/tests/test_auth_browser_csrf.py
@@ -6,7 +6,8 @@ import threading
 import urllib.error
 import urllib.parse
 import urllib.request
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from silentsuite_bridge.auth_browser import AUTH_PAGE_HTML, AuthCallbackHandler
 
@@ -24,6 +25,15 @@ def _post_auth(server, fields):
             return response.status, json.loads(response.read())
     except urllib.error.HTTPError as exc:
         return exc.code, json.loads(exc.read())
+
+
+def _get_auth_path(server, path):
+    url = f"http://127.0.0.1:{server.server_address[1]}{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            return response.status, response.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode()
 
 
 def _serve_one_auth_request(csrf_token="expected-token"):
@@ -80,3 +90,45 @@ def test_auth_post_with_valid_csrf_reaches_login():
     assert status == 401
     assert payload == {"success": False, "error": "Invalid email or password."}
     assert login.called
+
+
+def test_auth_success_redirect_does_not_include_email_query():
+    server, thread = _serve_one_auth_request()
+    etebase = MagicMock()
+    etebase.save.return_value = "stored-session"
+    try:
+        with (
+            patch("silentsuite_bridge.auth_browser.Account.login", return_value=etebase),
+            patch(
+                "silentsuite_bridge.auth_browser.store_authenticated_account",
+                return_value=SimpleNamespace(username="alice@example.com"),
+            ),
+        ):
+            status, payload = _post_auth(server, {
+                "email": "alice@example.com",
+                "password": "secret",
+                "server_url": "https://server.silentsuite.io",
+                "csrf_token": "expected-token",
+            })
+    finally:
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert payload == {"success": True, "redirect": "/success"}
+
+
+def test_success_page_requires_completed_authentication():
+    server = http.server.HTTPServer(("127.0.0.1", 0), AuthCallbackHandler)
+    server.csrf_token = "expected-token"
+    server.authenticated_email = None
+    thread = threading.Thread(target=server.handle_request)
+    thread.start()
+    try:
+        status, body = _get_auth_path(server, "/success")
+    finally:
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 404
+    assert "404" in body

--- a/bridge/tests/test_local_cache.py
+++ b/bridge/tests/test_local_cache.py
@@ -1,5 +1,8 @@
 """Tests for the local Etebase cache layer."""
 
+import logging
+import os
+import stat
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
@@ -524,3 +527,130 @@ class TestSyncLogic:
 
             # Key assertion: item_mgr.list() MUST be called even when stokens match
             mock_item_mgr.list.assert_called_once()
+
+    @patch("silentsuite_bridge.local_cache.Account")
+    @patch("silentsuite_bridge.local_cache.Client")
+    def test_pull_collection_info_logs_do_not_expose_item_identifiers_or_metadata(
+        self,
+        MockClient,
+        MockAccount,
+        mem_db,
+        caplog,
+    ):
+        mock_account = MagicMock()
+        MockAccount.restore.return_value = mock_account
+        mock_col_mgr = MagicMock()
+        mock_account.get_collection_manager.return_value = mock_col_mgr
+        mock_col = MagicMock()
+        mock_col_mgr.cache_load.return_value = mock_col
+        mock_item_mgr = MagicMock()
+        mock_col_mgr.get_item_manager.return_value = mock_item_mgr
+        mock_item = MagicMock()
+        mock_item.uid = "private-etebase-item-uid"
+        mock_item.meta = {"name": "private-local-item-uid", "summary": "Private Appointment"}
+        mock_item.deleted = False
+        mock_item_mgr.cache_save.return_value = b"item-cache"
+        mock_item_list = MagicMock()
+        mock_item_list.data = [mock_item]
+        mock_item_list.done = True
+        mock_item_list.stoken = "private-stoken"
+        mock_item_mgr.list.return_value = mock_item_list
+
+        with patch("silentsuite_bridge.local_cache.Etebase._init_db"):
+            etebase = Etebase.__new__(Etebase)
+            etebase.etebase = mock_account
+            etebase.username = "test@example.com"
+            etebase._database = mem_db
+            etebase.stored_session = "fake"
+            db.database_proxy.initialize(mem_db)
+            user_obj = User.create(username="private-log-test@example.com")
+            etebase.user = user_obj
+            CollectionEntity.create(
+                local_user=user_obj,
+                uid="private-collection-uid",
+                eb_col=b"\x00" * 8,
+                local_stoken="private-old-stoken",
+            )
+
+            with caplog.at_level(logging.INFO, logger="silentsuite-bridge.cache"):
+                etebase.pull_collection("private-collection-uid")
+
+        logs = caplog.text
+        assert "fetched 1 items" in logs
+        assert "private-collection-uid" not in logs
+        assert "private-etebase-item-uid" not in logs
+        assert "private-local-item-uid" not in logs
+        assert "Private Appointment" not in logs
+        assert "private-stoken" not in logs
+
+    @patch("silentsuite_bridge.local_cache.Account")
+    @patch("silentsuite_bridge.local_cache.Client")
+    def test_push_collection_info_logs_do_not_expose_item_identifiers(
+        self,
+        MockClient,
+        MockAccount,
+        mem_db,
+        caplog,
+    ):
+        mock_account = MagicMock()
+        MockAccount.restore.return_value = mock_account
+        mock_col_mgr = MagicMock()
+        mock_account.get_collection_manager.return_value = mock_col_mgr
+        mock_col = MagicMock()
+        mock_col_mgr.cache_load.return_value = mock_col
+        mock_item_mgr = MagicMock()
+        mock_col_mgr.get_item_manager.return_value = mock_item_mgr
+        mock_item_mgr.cache_load.return_value = MagicMock()
+        mock_item_mgr.cache_save.return_value = b"saved-item"
+
+        with patch("silentsuite_bridge.local_cache.Etebase._init_db"):
+            etebase = Etebase.__new__(Etebase)
+            etebase.etebase = mock_account
+            etebase.username = "test@example.com"
+            etebase._database = mem_db
+            etebase.stored_session = "fake"
+            db.database_proxy.initialize(mem_db)
+            user_obj = User.create(username="private-push-log-test@example.com")
+            etebase.user = user_obj
+            col = CollectionEntity.create(
+                local_user=user_obj,
+                uid="private-push-collection-uid",
+                eb_col=b"\x00" * 8,
+            )
+            ItemEntity.create(
+                collection=col,
+                uid="private-push-item-uid",
+                eb_item=b"\x00" * 8,
+                dirty=True,
+            )
+
+            with caplog.at_level(logging.INFO, logger="silentsuite-bridge.cache"):
+                etebase.push_collection("private-push-collection-uid")
+
+        logs = caplog.text
+        assert "1 dirty/new items" in logs
+        assert "private-push-collection-uid" not in logs
+        assert "private-push-item-uid" not in logs
+
+
+def test_cache_database_files_are_owner_only(tmp_path):
+    if os.name == "nt":
+        pytest.skip("POSIX file modes are not meaningful on Windows")
+
+    etebase = Etebase.__new__(Etebase)
+    etebase.username = "mode-test@example.com"
+    db_path = tmp_path / "nested" / "bridge_data.db"
+
+    old_umask = os.umask(0o022)
+    try:
+        etebase._init_db(str(db_path))
+    finally:
+        os.umask(old_umask)
+        db.database_proxy.close()
+
+    assert stat.S_IMODE(os.stat(db_path).st_mode) == 0o600
+    assert stat.S_IMODE(os.stat(db_path.parent).st_mode) == 0o700
+    for suffix in ("-wal", "-shm"):
+        sidecar = f"{db_path}{suffix}"
+        if os.path.exists(sidecar):
+            assert stat.S_IMODE(os.stat(sidecar).st_mode) == 0o600

--- a/bridge/tests/test_local_cache.py
+++ b/bridge/tests/test_local_cache.py
@@ -640,6 +640,8 @@ def test_cache_database_files_are_owner_only(tmp_path):
     etebase = Etebase.__new__(Etebase)
     etebase.username = "mode-test@example.com"
     db_path = tmp_path / "nested" / "bridge_data.db"
+    db_path.parent.mkdir(mode=0o755)
+    os.chmod(db_path.parent, 0o755)
 
     old_umask = os.umask(0o022)
     try:


### PR DESCRIPTION
## Summary
- remove account email from browser auth success redirects and guard unauthenticated success-page loads
- move bridge cache item IDs, metadata, stokens, and collection identifiers out of INFO/dashboard logs
- restrict bridge SQLite cache directory and DB/WAL/SHM files to owner-only permissions on cache init paths

## Verification
- python3 -m py_compile src/silentsuite_bridge/__main__.py src/silentsuite_bridge/auth_browser.py src/silentsuite_bridge/local_cache/__init__.py src/silentsuite_bridge/radicale/auth.py src/silentsuite_bridge/radicale/storage.py tests/test_auth_browser_csrf.py tests/test_local_cache.py
- git diff --check
- code-reviewer pass: GREEN LIGHT

## Notes
- Local pytest could not run because pytest/bridge dependencies are not installed in this environment; bridge Python tests are expected to run in CI.