### PR TITLE
Guard server Docker secrets in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 **/.next
 **/.turbo
 **/.git
+secret.txt
+**/secret.txt
 **/dist
 _bmad/
 _bmad-output/

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -5,10 +5,16 @@ on:
     branches: [main, dev]
     paths:
       - 'server/**'
+      - 'Dockerfile.server'
+      - '.dockerignore'
+      - '.github/workflows/ci-server.yml'
   pull_request:
     branches: [main, dev]
     paths:
       - 'server/**'
+      - 'Dockerfile.server'
+      - '.dockerignore'
+      - '.github/workflows/ci-server.yml'
 
 concurrency:
   group: ci-server-${{ github.ref }}
@@ -52,6 +58,13 @@ jobs:
         working-directory: server
         run: python -c "import django; django.setup(); print('Django loaded OK')"
 
+      - name: Verify Docker secret exclusions
+        run: |
+          grep -Fx 'secret.txt' .dockerignore
+          grep -Fx '**/secret.txt' .dockerignore
+          grep -Fx '/secret.txt' server/.dockerignore
+          grep -Fx '**/secret.txt' server/.dockerignore
+
       - name: Lint with ruff
         working-directory: server
         run: ruff check . --select=E,F,I --ignore=E501
@@ -59,4 +72,4 @@ jobs:
 
       - name: Run tests
         working-directory: server
-        run: python -m pytest etebase_server/ -v --tb=short || python manage.py test --verbosity=2
+        run: python -m pytest etebase_server/ -v --tb=short

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'server/**'
       - 'Dockerfile.server'
+      - '.dockerignore'
       - '.github/workflows/deploy-server.yml'
 
 concurrency:

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,4 +1,6 @@
 /db.sqlite3*
+/secret.txt
+**/secret.txt
 Session.vim
 /local_settings.py
 .venv


### PR DESCRIPTION
## Summary
- exclude secret.txt files from root and server Docker build contexts
- add a CI guard that verifies the Docker secret exclusions stay present
- run server pytest directly so pytest failures or zero-test collection cannot be masked by a fallback runner
- trigger server CI/deploy workflows when Docker ignore/build config changes

## Verification
- git diff --check
- grep -Fx 'secret.txt' .dockerignore
- grep -Fx '**/secret.txt' .dockerignore
- grep -Fx '/secret.txt' server/.dockerignore
- grep -Fx '**/secret.txt' server/.dockerignore
- code-reviewer pass: GREEN LIGHT

## Notes
- No local Docker validation per workspace policy.