### PR TITLE
Harden server auth error responses

### DIFF
--- a/server/etebase_server/fastapi/routers/authentication.py
+++ b/server/etebase_server/fastapi/routers/authentication.py
@@ -1,3 +1,4 @@
+import logging
 import typing as t
 from datetime import datetime
 
@@ -28,6 +29,7 @@ from ..utils import BaseModel, get_user_username_email_kwargs, msgpack_decode, m
 
 User = get_typed_user_model()
 authentication_router = APIRouter(route_class=MsgpackRoute)
+logger = logging.getLogger("etebase_server.fastapi.authentication")
 
 
 class LoginChallengeIn(BaseModel):
@@ -154,7 +156,10 @@ def validate_login_request(
 ):
     enc_key = get_encryption_key(bytes(user.userinfo.salt))
     box = nacl.secret.SecretBox(enc_key)
-    challenge_data = msgpack_decode(box.decrypt(validated_data.challenge))
+    try:
+        challenge_data = msgpack_decode(box.decrypt(validated_data.challenge))
+    except nacl.exceptions.CryptoError:
+        raise HttpError("invalid_challenge", "Invalid challenge data.", status.HTTP_400_BAD_REQUEST)
     now = int(datetime.now().timestamp())
     if validated_data.action != expected_action:
         raise HttpError("wrong_action", f'Expected "{expected_action}" but got something else')
@@ -246,8 +251,9 @@ def signup_save(data: SignupIn, request: Request) -> UserType:
                 raise e
             except django_exceptions.ValidationError as e:
                 transform_validation_error("user", e)
-            except Exception as e:
-                raise HttpError("generic", str(e))
+            except Exception:
+                logger.exception("Unexpected signup error while creating user")
+                raise HttpError("generic", "An error occurred during signup. Please try again.")
 
         if hasattr(instance, "userinfo"):
             raise HttpError("user_exists", "User already exists", status_code=status.HTTP_409_CONFLICT)

--- a/server/etebase_server/fastapi/test_authentication.py
+++ b/server/etebase_server/fastapi/test_authentication.py
@@ -13,6 +13,8 @@ delegates to).
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import nacl.signing
 import pytest
 from django.test.utils import override_settings
@@ -143,19 +145,7 @@ class TestLogin:
         assert response.status_code == 400
         assert decode_response(response)["code"] == "wrong_host"
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "validate_login_request in routers/authentication.py:156-157 "
-            "doesn't catch nacl.exceptions.CryptoError, so undecryptable "
-            "challenge bytes surface as a 500 instead of a clean 400. "
-            "Not exploitable — no user data leaks — but the route should "
-            "raise HttpError('invalid_challenge', ..., 400). When that fix "
-            "lands, this xfail will flip to XPASS and strict mode will "
-            "force removing the marker."
-        ),
-    )
-    def test_login_with_garbage_challenge_bytes_fails(
+    def test_login_with_garbage_challenge_bytes_returns_client_error(
         self, auth_app, user_factory, signing_key
     ):
         # Skip the real challenge endpoint and send random bytes — the
@@ -174,7 +164,8 @@ class TestLogin:
         )
         response = msgpack_post(client, f"{AUTH_PREFIX}/login/", body)
 
-        assert response.status_code in (400, 422)
+        assert response.status_code == 400
+        assert decode_response(response)["code"] == "invalid_challenge"
 
 
 @pytest.mark.django_db(transaction=True)
@@ -214,6 +205,29 @@ class TestSignup:
 
         assert response.status_code == 409
         assert decode_response(response)["code"] == "user_exists"
+
+    def test_signup_unexpected_creation_error_returns_safe_detail(
+        self, auth_client, login_pubkey, encryption_pubkey, user_salt
+    ):
+        body = {
+            "user": {"username": "test_user_error", "email": "error@example.com"},
+            "salt": user_salt,
+            "loginPubkey": login_pubkey,
+            "pubkey": encryption_pubkey,
+            "encryptedContent": b"\x00" * 64,
+        }
+
+        with patch(
+            "etebase_server.fastapi.routers.authentication.create_user",
+            side_effect=Exception("raw database hostname secret"),
+        ):
+            response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
+
+        decoded = decode_response(response)
+        assert response.status_code == 400
+        assert decoded["code"] == "generic"
+        assert decoded["detail"] == "An error occurred during signup. Please try again."
+        assert "raw database hostname secret" not in decoded["detail"]
 
 
 @pytest.mark.django_db(transaction=True)
@@ -299,6 +313,33 @@ class TestChangePassword:
 
         info = UserInfo.objects.get(owner__username="test_user_alice")
         assert bytes(info.loginPubkey) == bytes(signing_key.verify_key)
+
+    def test_change_password_with_garbage_challenge_bytes_returns_client_error(
+        self, auth_app, user_factory, signing_key
+    ):
+        from fastapi.testclient import TestClient
+
+        client = TestClient(auth_app, raise_server_exceptions=False)
+        user_factory(username="test_user_alice")
+        token = self._auth_token(client, signing_key)
+        attacker_key = nacl.signing.SigningKey.generate()
+        body = build_signed_response(
+            username="test_user_alice",
+            challenge_bytes=b"\x00" * 64,
+            signing_key=attacker_key,
+            action="changePassword",
+            extra={"loginPubkey": b"\x01" * 32, "encryptedContent": b"\x02" * 64},
+        )
+
+        response = msgpack_post(
+            client,
+            f"{AUTH_PREFIX}/change_password/",
+            body,
+            headers={"Authorization": f"Token {token}"},
+        )
+
+        assert response.status_code == 400
+        assert decode_response(response)["code"] == "invalid_challenge"
 
     def test_change_password_succeeds_with_correct_signature(
         self, auth_client, user_factory, signing_key


### PR DESCRIPTION
## Summary
- return a clean invalid_challenge 400 when encrypted login/change-password challenge data cannot be decrypted
- stop returning raw unexpected signup exception strings to clients
- add tests for garbage challenge handling on login/change-password and sanitized signup errors

## Verification
- python3 -m py_compile etebase_server/fastapi/routers/authentication.py etebase_server/fastapi/test_authentication.py
- git diff --check
- code-reviewer pass: GREEN LIGHT

## Notes
- Local pytest and ruff could not run because pytest/ruff are not installed in this environment; server CI is expected to run them.