### PR TITLE
Harden Android debug and WebView surfaces

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -305,7 +305,7 @@
 
         <activity
             android:name=".ui.DebugInfoActivity"
-            android:exported="true"
+            android:exported="false"
             android:label="@string/debug_info_title">
         </activity>
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/WebViewActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/WebViewActivity.kt
@@ -31,12 +31,22 @@ class WebViewActivity : BaseActivity() {
         mToolbar = supportActionBar
         mToolbar!!.setDisplayHomeAsUpEnabled(true)
 
-        var uri = intent.getParcelableExtra<Uri>(KEY_URL)!!
+        val initialUri = intent.getParcelableExtra<Uri>(KEY_URL)
+        if (initialUri == null || !isAllowedUrl(initialUri)) {
+            finish()
+            return
+        }
+        var uri = initialUri
         uri = addQueryParams(uri)
         mWebView = findViewById<View>(R.id.webView) as WebView
         mProgressBar = findViewById<View>(R.id.progressBar) as ProgressBar
 
         mWebView!!.settings.javaScriptEnabled = true
+        mWebView!!.settings.allowFileAccess = false
+        mWebView!!.settings.allowContentAccess = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            mWebView!!.settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+        }
         if (savedInstanceState == null) {
             mWebView!!.loadUrl(uri.toString())
         }


### PR DESCRIPTION
## Summary
- make DebugInfoActivity non-exported
- validate the initial WebViewActivity URL before loading
- disable WebView file/content access and block mixed HTTP content

## Verification
- git diff --check
- grep verified DebugInfoActivity exported=false
- grep verified WebView allowFileAccess=false, allowContentAccess=false, and MIXED_CONTENT_NEVER_ALLOW
- code-reviewer pass: GREEN LIGHT

## Notes
- Android builds/tests run in GitHub Actions per workspace policy.