### PR TITLE
Add cross-platform account fingerprint

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -344,13 +344,19 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
     }
 
     private fun showFingerprintDialog() {
+        val fingerprint = formattedFingerprint ?: getString(R.string.fingerprint_unavailable)
         val view = layoutInflater.inflate(R.layout.fingerprint_alertdialog, null)
         view.findViewById<View>(R.id.body).visibility = View.GONE
-        (view.findViewById<View>(R.id.fingerprint) as TextView).text = formattedFingerprint
+        (view.findViewById<View>(R.id.fingerprint) as TextView).text = fingerprint
         AlertDialog.Builder(this@AccountActivity)
                 .setIcon(R.drawable.ic_fingerprint_dark)
                 .setTitle(R.string.show_fingperprint_title)
                 .setView(view)
+                .setNeutralButton(R.string.copy_fingerprint) { _, _ ->
+                    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    clipboard.setPrimaryClip(ClipData.newPlainText("account fingerprint", fingerprint))
+                    Toast.makeText(this, R.string.fingerprint_copied, Toast.LENGTH_SHORT).show()
+                }
                 .setPositiveButton(android.R.string.yes) { _, _ -> }
                 .create()
                 .show()

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -105,7 +105,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
                 return Utils.prettyFingerprint(invitationManager.pubkey)
             } catch (e: Exception) {
                 e.printStackTrace()
-                return e.localizedMessage
+                return null
             }
         }
 
@@ -344,18 +344,23 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
     }
 
     private fun showFingerprintDialog() {
-        val fingerprint = formattedFingerprint ?: getString(R.string.fingerprint_unavailable)
+        val fingerprint = formattedFingerprint
+        val displayFingerprint = fingerprint ?: getString(R.string.fingerprint_unavailable)
         val view = layoutInflater.inflate(R.layout.fingerprint_alertdialog, null)
         view.findViewById<View>(R.id.body).visibility = View.GONE
-        (view.findViewById<View>(R.id.fingerprint) as TextView).text = fingerprint
+        (view.findViewById<View>(R.id.fingerprint) as TextView).text = displayFingerprint
         AlertDialog.Builder(this@AccountActivity)
                 .setIcon(R.drawable.ic_fingerprint_dark)
                 .setTitle(R.string.show_fingperprint_title)
                 .setView(view)
                 .setNeutralButton(R.string.copy_fingerprint) { _, _ ->
-                    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-                    clipboard.setPrimaryClip(ClipData.newPlainText("account fingerprint", fingerprint))
-                    Toast.makeText(this, R.string.fingerprint_copied, Toast.LENGTH_SHORT).show()
+                    if (fingerprint == null) {
+                        Toast.makeText(this, R.string.fingerprint_unavailable, Toast.LENGTH_SHORT).show()
+                    } else {
+                        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                        clipboard.setPrimaryClip(ClipData.newPlainText("account fingerprint", fingerprint))
+                        Toast.makeText(this, R.string.fingerprint_copied, Toast.LENGTH_SHORT).show()
+                    }
                 }
                 .setPositiveButton(android.R.string.yes) { _, _ -> }
                 .create()

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -167,6 +167,9 @@
     <string name="export_data_failed">Export failed</string>
 
     <string name="show_fingperprint_title">Your Encryption Fingerprint</string>
+    <string name="copy_fingerprint">Copy fingerprint</string>
+    <string name="fingerprint_copied">Fingerprint copied</string>
+    <string name="fingerprint_unavailable">Fingerprint unavailable</string>
 
     <!-- ViewCollection -->
     <string name="change_journal_title">Recent sync activity</string>

--- a/apps/web/app/(app)/settings/security/page.tsx
+++ b/apps/web/app/(app)/settings/security/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { useTranslations } from 'next-intl'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -33,6 +34,67 @@ const passwordSchema = z
   })
 
 type PasswordFormData = z.infer<typeof passwordSchema>
+
+// ---------------------------------------------------------------------------
+// Account Fingerprint Section
+// ---------------------------------------------------------------------------
+
+function AccountFingerprintSection() {
+  const t = useTranslations('SettingsSecurity.AccountFingerprint')
+  const fingerprint = useEtebaseStore((s) => s.accountFingerprint)
+  const [revealed, setRevealed] = useState(false)
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
+
+  const copyFingerprint = async () => {
+    if (!fingerprint) return
+
+    try {
+      await navigator.clipboard.writeText(fingerprint)
+      setCopyStatus('copied')
+    } catch {
+      setCopyStatus('failed')
+    }
+
+    window.setTimeout(() => setCopyStatus('idle'), 2000)
+  }
+
+  return (
+    <section className="rounded-lg border border-[rgb(var(--border))] p-4 space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">{t('title')}</h2>
+        <p className="text-xs text-[rgb(var(--muted))]">
+          {t('description')}
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3 space-y-3">
+        <code className="block whitespace-pre-wrap break-words font-mono text-xs text-[rgb(var(--foreground))]">
+          {fingerprint ? (revealed ? fingerprint : t('hidden')) : t('unavailable')}
+        </code>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={!fingerprint}
+            onClick={() => setRevealed((value) => !value)}
+          >
+            {revealed ? t('hide') : t('reveal')}
+          </Button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            disabled={!fingerprint || !revealed}
+            onClick={copyFingerprint}
+          >
+            {copyStatus === 'copied' ? t('copied') : copyStatus === 'failed' ? t('copyFailed') : t('copy')}
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}
 
 // ---------------------------------------------------------------------------
 // Change Password Section
@@ -284,6 +346,7 @@ function DeleteAccountSection() {
 export default function SecurityPage() {
   return (
     <div className="space-y-6">
+      <AccountFingerprintSection />
       <ChangePasswordSection />
       <DeleteAccountSection />
     </div>

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -322,6 +322,8 @@ function collectionDisplayName(type: CollectionTypeKey): string {
 interface EtebaseState {
   // The live Account object (null until session restored)
   account: any | null
+  // Stable account public-key fingerprint for cross-device verification.
+  accountFingerprint: string | null
   // Collection references keyed by type; each type may have multiple collections.
   collections: Record<CollectionTypeKey, any[]>
   // Item cache: itemUid -> Etebase.Item (needed for update/delete which require the Item object)
@@ -428,6 +430,7 @@ interface EtebaseActions {
 
 export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) => ({
   account: null,
+  accountFingerprint: null,
   collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
   itemCache: new Map(),
   itemTypeMap: new Map(),
@@ -450,7 +453,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       logger.debug('[etebase-store] Restoring Etebase session...')
       const serverUrl = getServerUrl()
       const account = await core.restoreSession(serverUrl, savedSession)
-      set({ account })
+      const accountFingerprint = core.getAccountFingerprint(account)
+      set({ account, accountFingerprint })
       logger.debug('[etebase-store] Session restored')
 
       // Local-cache fingerprint check: if a different account previously
@@ -459,8 +463,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const cacheEnabled = isLocalCacheEnabled()
       if (cacheEnabled) {
         try {
-          const username = (account as any)?.user?.username ?? 'unknown'
-          await cacheEnsureFingerprint(String(username))
+          await cacheEnsureFingerprint(accountFingerprint)
         } catch (err) {
           logger.warn('[etebase-store] Cache fingerprint check failed', err)
         }
@@ -1242,6 +1245,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     }
     set({
       account: null,
+      accountFingerprint: null,
       collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -19,5 +19,18 @@
     "tryAgain": "Try again",
     "goToCalendar": "Go to Calendar",
     "contactPrefix": "If this keeps happening, contact us at"
+  },
+  "SettingsSecurity": {
+    "AccountFingerprint": {
+      "title": "Account fingerprint",
+      "description": "Compare this fingerprint with Android and the bridge to confirm they are connected to the same encrypted account. It is not a recovery secret.",
+      "hidden": "Hidden until revealed",
+      "unavailable": "Fingerprint unavailable. Make sure sync has finished initializing, then try again.",
+      "reveal": "Reveal fingerprint",
+      "hide": "Hide fingerprint",
+      "copy": "Copy fingerprint",
+      "copied": "Fingerprint copied",
+      "copyFailed": "Copy failed"
+    }
   }
 }

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -226,6 +226,22 @@ def _aggregate_collections(collections_iterable):
     return totals
 
 
+def _account_fingerprint(creds, username):
+    stored_session = creds.get_etebase(username)
+    if not stored_session:
+        return None
+
+    server_url = creds.get_server_url(username) or config.ETEBASE_SERVER_URL
+    try:
+        from etebase import Account, Client, pretty_fingerprint
+
+        account = Account.restore(Client("silentsuite-bridge", server_url), stored_session, None)
+        return pretty_fingerprint(account.get_invitation_manager().pubkey)
+    except Exception:
+        logger.warning("Failed to compute bridge account fingerprint", exc_info=True)
+        return None
+
+
 DASHBOARD_HTML = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -336,6 +352,44 @@ DASHBOARD_HTML = """<!DOCTYPE html>
             font-size: 12px;
             margin-bottom: 10px;
             overflow-wrap: anywhere;
+        }
+        .fingerprint-box {
+            background: #0b0b0b;
+            border: 1px solid #242424;
+            border-radius: 8px;
+            padding: 10px 12px;
+            margin-bottom: 8px;
+        }
+        .fingerprint-box label {
+            color: #666;
+            display: block;
+            font-size: 12px;
+            margin-bottom: 4px;
+        }
+        .fingerprint-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 12px;
+        }
+        .fingerprint-row code {
+            color: #fff;
+            display: block;
+            font-size: 12px;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+        .fingerprint-row code.hidden { color: #777; font-family: inherit; }
+        .fingerprint-actions {
+            display: flex;
+            flex-shrink: 0;
+            gap: 6px;
+        }
+        .fingerprint-help {
+            color: #777;
+            font-size: 11px;
+            line-height: 1.4;
+            margin-top: 6px;
         }
         .section-title-row {
             display: flex;
@@ -629,6 +683,25 @@ DASHBOARD_HTML = """<!DOCTYPE html>
                     'Remove {account}? This deletes local bridge credentials and that account\'s local decrypted bridge cache on this computer. Other accounts are not affected.'
                 );
             }
+            function toggleFingerprint(id, button) {
+                var el = document.getElementById(id);
+                if (!el) return;
+                var copyBtn = document.querySelector('[data-copy-target="' + id + '"]');
+                var revealed = el.getAttribute('data-revealed') === 'true';
+                if (revealed) {
+                    el.textContent = 'Hidden until revealed';
+                    el.classList.add('hidden');
+                    el.setAttribute('data-revealed', 'false');
+                    button.textContent = 'Reveal';
+                    if (copyBtn) copyBtn.disabled = true;
+                } else {
+                    el.textContent = el.getAttribute('data-fingerprint') || '';
+                    el.classList.remove('hidden');
+                    el.setAttribute('data-revealed', 'true');
+                    button.textContent = 'Hide';
+                    if (copyBtn) copyBtn.disabled = false;
+                }
+            }
             function triggerSync() {
                 var btn = document.getElementById('syncNowBtn');
                 btn.textContent = 'Syncing...';
@@ -794,11 +867,40 @@ def _render_dashboard():
             dav_url = f"{base_url}/{user}/"
             server_url = creds.get_server_url(user)
             url_id = f"davUrl{index}"
+            fingerprint = _account_fingerprint(creds, user)
+            fingerprint_id = f"accountFingerprint{index}"
+            if fingerprint:
+                fingerprint_html = (
+                    '<div class="fingerprint-box">'
+                    '<label>Account fingerprint</label>'
+                    '<div class="fingerprint-row">'
+                    '<div>'
+                    f'<code id="{fingerprint_id}" class="hidden" data-revealed="false" '
+                    f'data-fingerprint="{esc(fingerprint)}">Hidden until revealed</code>'
+                    '<div class="fingerprint-help">Compare this with Android and the web app. '
+                    'It is not a recovery secret.</div>'
+                    '</div>'
+                    '<div class="fingerprint-actions">'
+                    f'<button class="copy-btn" onclick="toggleFingerprint(\'{fingerprint_id}\', this)">Reveal</button>'
+                    f'<button class="copy-btn" data-copy-target="{fingerprint_id}" '
+                    f'onclick="copy(event, \'{fingerprint_id}\')" disabled>Copy</button>'
+                    '</div>'
+                    '</div>'
+                    '</div>'
+                )
+            else:
+                fingerprint_html = (
+                    '<div class="fingerprint-box">'
+                    '<label>Account fingerprint</label>'
+                    '<div class="fingerprint-help">Fingerprint unavailable. Re-authenticate this account if it does not appear.</div>'
+                    '</div>'
+                )
             account_attr = esc(user)
             account_html += (
                 '<div class="account-card">'
                 f'<h4>{esc(user)}</h4>'
                 f'<div class="account-meta">Server: <code>{esc(server_url)}</code></div>'
+                f'{fingerprint_html}'
                 '<div class="url-box">'
                 '<div>'
                 '<label>CalDAV/CardDAV URL</label>'

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -48,6 +48,11 @@ def test_render_dashboard_lists_each_configured_account(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
     monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
     monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(
+        web_module,
+        "_account_fingerprint",
+        lambda _creds, username: f"fingerprint for {username}",
+    )
 
     creds = Credentials()
     creds.set_etebase("alice@example.com", "alice-session", "https://server-a.test")
@@ -78,11 +83,17 @@ def test_render_dashboard_lists_each_configured_account(tmp_path, monkeypatch):
     assert 'data-account="alice@example.com"' in html
     assert 'onclick="logoutAccount(this)"' in html
     assert 'onclick="removeAccount(this)"' in html
+    assert 'data-fingerprint="fingerprint for alice@example.com"' in html
+    assert "Hidden until revealed" in html
+    assert "Compare this with Android and the web app" in html
+    assert 'onclick="toggleFingerprint(\'accountFingerprint0\', this)"' in html
+    assert 'data-copy-target="accountFingerprint0"' in html
 
 
 def test_update_status_aggregates_background_sync_counts(tmp_path, monkeypatch):
     _reset_status()
     monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    monkeypatch.setattr(web_module, "_account_fingerprint", lambda _creds, _username: None)
 
     creds = Credentials()
     creds.set_etebase("alice@example.com", "alice-session", "https://server-a.test")
@@ -128,6 +139,7 @@ def test_render_dashboard_handles_no_accounts(tmp_path, monkeypatch):
 def test_render_dashboard_escapes_account_action_attributes(tmp_path, monkeypatch):
     _reset_status()
     monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    monkeypatch.setattr(web_module, "_account_fingerprint", lambda _creds, _username: None)
 
     username = "evil\"'<account@example.com"
     creds = Credentials()

--- a/packages/core/src/etebase/client.test.ts
+++ b/packages/core/src/etebase/client.test.ts
@@ -1,0 +1,22 @@
+import * as Etebase from 'etebase';
+import { describe, expect, it, vi } from 'vitest';
+import { getAccountFingerprint } from './client.js';
+
+vi.mock('etebase', () => ({
+  getPrettyFingerprint: vi.fn().mockReturnValue('abcd ef12 3456'),
+}));
+
+describe('getAccountFingerprint', () => {
+  it('formats the account invitation public key fingerprint', () => {
+    const pubkey = new Uint8Array([1, 2, 3, 4]);
+    const account = {
+      getInvitationManager: vi.fn().mockReturnValue({ pubkey }),
+    };
+
+    const fingerprint = getAccountFingerprint(account as any);
+
+    expect(account.getInvitationManager).toHaveBeenCalledTimes(1);
+    expect(Etebase.getPrettyFingerprint).toHaveBeenCalledWith(pubkey);
+    expect(fingerprint).toBe('abcd ef12 3456');
+  });
+});

--- a/packages/core/src/etebase/client.ts
+++ b/packages/core/src/etebase/client.ts
@@ -61,6 +61,14 @@ export async function saveSession(
 }
 
 /**
+ * Return the stable account public-key fingerprint used for cross-device verification.
+ */
+export function getAccountFingerprint(account: Etebase.Account): string {
+  const invitationManager = account.getInvitationManager();
+  return Etebase.getPrettyFingerprint(invitationManager.pubkey);
+}
+
+/**
  * Change the account password.
  */
 export async function changePassword(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export {
   logIn,
   restoreSession,
   saveSession,
+  getAccountFingerprint,
   changePassword,
   logout,
 } from './etebase/client.js';


### PR DESCRIPTION
## Summary
- Add a shared Etebase account fingerprint helper using the account invitation public key and SDK pretty-fingerprint formatting.
- Show a hidden-by-default account fingerprint with reveal/copy controls in web Settings/Security and the bridge dashboard.
- Add copy-to-clipboard support to Android's existing account fingerprint dialog.

Closes #231

## Validation
- pnpm --filter @silentsuite/core type-check
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/core test
- pnpm --filter @silentsuite/web test
- pnpm --filter @silentsuite/web build
- python3 -m py_compile bridge/src/silentsuite_bridge/web/__init__.py bridge/tests/test_web_dashboard.py

## Notes
- Android build validation is expected in GitHub Actions per workspace rules.
- Full bridge pytest remains CI/dependency-environment coverage; local Python dependencies are not installed here.
- Web build emits the existing Sentry setup/deprecation warnings and the known non-fatal standalone trace-copy warning.