### PR TITLE
Harden Android log redaction

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/AccountSettings.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/AccountSettings.kt
@@ -95,7 +95,7 @@ constructor(internal val context: Context, internal val account: Account) {
             } catch (ignored: NumberFormatException) {
             }
 
-            Logger.log.fine("Account " + account.name + " has version " + version + ", current version: " + CURRENT_VERSION)
+            Logger.log.fine("Account settings version " + version + ", current version: " + CURRENT_VERSION)
 
             if (version < CURRENT_VERSION)
                 update(version)
@@ -104,7 +104,7 @@ constructor(internal val context: Context, internal val account: Account) {
 
     fun username(): String {
         return accountManager.getUserData(account, KEY_USERNAME)
-                ?: throw IllegalStateException("Username not set for account ${account.name}")
+                ?: throw IllegalStateException("Username not set")
     }
 
     fun username(userName: String) {
@@ -113,7 +113,7 @@ constructor(internal val context: Context, internal val account: Account) {
 
     fun password(): String {
         return accountManager.getPassword(account)
-                ?: throw IllegalStateException("Password not set for account ${account.name}")
+                ?: throw IllegalStateException("Password not set")
     }
 
     fun password(password: String) {
@@ -155,7 +155,7 @@ constructor(internal val context: Context, internal val account: Account) {
 
     private fun update(fromVersion: Int) {
         val toVersion = CURRENT_VERSION
-        Logger.log.info("Updating account " + account.name + " from version " + fromVersion + " to " + toVersion)
+        Logger.log.info("Updating account settings from version " + fromVersion + " to " + toVersion)
         try {
             updateInner(fromVersion)
             accountManager.setUserData(account, KEY_SETTINGS_VERSION, toVersion.toString())
@@ -181,7 +181,7 @@ constructor(internal val context: Context, internal val account: Account) {
             val accountManager = AccountManager.get(context)
             for (account in accountManager.getAccountsByType(App.accountType))
                 try {
-                    Logger.log.info("Checking account " + account.name)
+                    Logger.log.info("Checking account settings")
                     AccountSettings(context, account)
                 } catch (e: InvalidAccountException) {
                     Logger.log.log(Level.SEVERE, "Couldn't check for updated account settings", e)

--- a/android/app/src/main/java/io/silentsuite/sync/EtebaseLocalCache.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/EtebaseLocalCache.kt
@@ -11,12 +11,11 @@ import java.io.File
 import java.util.*
 
 class EtebaseLocalCache private constructor(context: Context, username: String) {
-    // Issue #119: log the resolved filesDir + username before the JNI FileSystemCache.create
-    // call. Native errors here don't propagate as EtebaseException, so without this breadcrumb
-    // a mangled username (e.g. one containing '@' or '.') is invisible from logcat alone.
+    // Issue #119: log the resolved filesDir before the JNI FileSystemCache.create call.
+    // Native errors here don't propagate as EtebaseException, so keep a non-secret breadcrumb.
     private val fsCache: FileSystemCache = run {
         val filesDirPath = context.filesDir.absolutePath
-        Logger.log.info("FileSystemCache.create filesDir=$filesDirPath username=$username")
+        Logger.log.info("FileSystemCache.create filesDir=$filesDirPath usernameProvided=${username.isNotEmpty()}")
         FileSystemCache.create(filesDirPath, username)
     }
     private val filesDir: File = File(context.filesDir, username)
@@ -154,11 +153,11 @@ class EtebaseLocalCache private constructor(context: Context, username: String) 
                         "etebase_session",
                     ).filter { accountManager.getUserData(settings.account, it) != null }
                     Logger.log.severe(
-                        "Etebase session is null: account=${settings.account.name} " +
+                        "Etebase session is null: " +
                                 "sessionOverrideProvided=${sessionOverride != null} " +
                                 "userDataKeys=$userDataKeys"
                     )
-                    throw IllegalStateException("Etebase session is null for account ${settings.account.name}")
+                    throw IllegalStateException("Etebase session is null")
                 }
             return Account.restore(client, session, null)
         }

--- a/android/app/src/main/java/io/silentsuite/sync/HttpClient.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/HttpClient.kt
@@ -77,7 +77,11 @@ class HttpClient private constructor(
                         logger.finest(message)
                     }
                 })
-                loggingInterceptor.level = HttpLoggingInterceptor.Level.BODY
+                loggingInterceptor.redactHeader("Authorization")
+                loggingInterceptor.level = if (BuildConfig.DEBUG)
+                    HttpLoggingInterceptor.Level.BODY
+                else
+                    HttpLoggingInterceptor.Level.NONE
                 orig.addInterceptor(loggingInterceptor)
             }
 

--- a/android/app/src/main/java/io/silentsuite/sync/billing/BillingManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/billing/BillingManager.kt
@@ -135,7 +135,7 @@ class BillingManager private constructor() {
     fun isSyncAllowed(context: Context, account: Account): Boolean {
         val status = getSubscriptionStatus(context, account)
         if (!status.isSyncAllowed) {
-            Logger.log.info("Sync blocked for ${account.name}: subscription status is '${status.status}'")
+            Logger.log.info("Sync blocked: subscription status is '${status.status}'")
             showExpiredNotification(context, account)
         } else {
             // Clear any previous expiry notification when subscription is good
@@ -154,7 +154,7 @@ class BillingManager private constructor() {
         val now = System.currentTimeMillis()
 
         if (cached != null && (now - cached.fetchedAt) < CACHE_TTL_MS) {
-            Logger.log.fine("Using in-memory cached subscription status for ${account.name}: ${cached.status}")
+            Logger.log.fine("Using in-memory cached subscription status: ${cached.status}")
             return cached
         }
 
@@ -171,7 +171,7 @@ class BillingManager private constructor() {
             if (persisted != null) {
                 val lastSuccessfulFetch = getLastSuccessfulFetch(context, account.name)
                 if (lastSuccessfulFetch > 0 && (now - lastSuccessfulFetch) > DEGRADED_MODE_THRESHOLD_MS) {
-                    Logger.log.warning("Billing API unreachable for >24h for ${account.name}, using last known status: ${persisted.status}")
+                    Logger.log.warning("Billing API unreachable for >24h, using last known status: ${persisted.status}")
                     showDegradedModeWarning(context)
                 }
                 // Use persisted status (but with current timestamp for cache purposes)
@@ -283,7 +283,7 @@ class BillingManager private constructor() {
      * over-shares sync credentials and does not authenticate /subscription.
      */
     private fun fetchSubscriptionStatus(_context: Context, account: Account): SubscriptionStatus {
-        Logger.log.fine("Android billing check disabled for ${account.name}; no billing-specific token is available")
+        Logger.log.fine("Android billing check disabled; no billing-specific token is available")
         return SubscriptionStatus.unreachable()
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/log/PlainTextFormatter.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/log/PlainTextFormatter.kt
@@ -9,7 +9,6 @@
 package io.silentsuite.sync.log
 
 import org.apache.commons.lang3.StringUtils
-import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.commons.lang3.time.DateFormatUtils
 import java.util.logging.Formatter
 import java.util.logging.LogRecord
@@ -40,12 +39,12 @@ class PlainTextFormatter private constructor(
 
         r.thrown?.let {
             builder .append("\nEXCEPTION ")
-                    .append(ExceptionUtils.getStackTrace(it))
+            appendThrowable(builder, it)
         }
 
         r.parameters?.let {
             for ((idx, param) in it.withIndex())
-                builder.append("\n\tPARAMETER #").append(idx).append(" = ").append(param)
+                builder.append("\n\tPARAMETER #").append(idx).append(" = <redacted ").append(param?.javaClass?.simpleName ?: "null").append(">")
         }
 
         if (!logcat)
@@ -57,5 +56,19 @@ class PlainTextFormatter private constructor(
     private fun shortClassName(className: String) = className
             .replace(Regex("^at\\.bitfire\\.(dav|cert4an|dav4an|ical4an|vcard4an)droid\\."), "")
             .replace(Regex("\\$.*$"), "")
+
+    private fun appendThrowable(builder: StringBuilder, throwable: Throwable) {
+        builder.append(throwable.javaClass.name)
+        for (frame in throwable.stackTrace)
+            builder.append("\n\tat ").append(frame)
+        for (suppressed in throwable.suppressed) {
+            builder.append("\nSuppressed: ")
+            appendThrowable(builder, suppressed)
+        }
+        throwable.cause?.let { cause ->
+            builder.append("\nCaused by: ")
+            appendThrowable(builder, cause)
+        }
+    }
 
 }

--- a/android/app/src/main/java/io/silentsuite/sync/resource/LocalAddressBook.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/resource/LocalAddressBook.kt
@@ -48,7 +48,7 @@ class LocalAddressBook(
 
             val account = Account(accountName(mainAccount, cachedCollection), App.addressBookAccountType)
             val userData = initialUserData(mainAccount, col.uid)
-            Logger.log.log(Level.INFO, "Creating local address book $account", userData)
+            Logger.log.info("Creating local address book")
             if (!accountManager.addAccountExplicitly(account, null, userData))
                 throw IllegalStateException("Couldn't create address book account")
 
@@ -266,10 +266,10 @@ class LocalAddressBook(
             val currentHash = contact.dataHashCode()
             if (lastHash == currentHash) {
                 // hash is code still the same, contact is not "really dirty" (only metadata been have changed)
-                Logger.log.log(Level.FINE, "Contact data hash has not changed, resetting dirty flag", contact)
+                Logger.log.log(Level.FINE, "Contact data hash has not changed, resetting dirty flag")
                 contact.resetDirty()
             } else {
-                Logger.log.log(Level.FINE, "Contact data has changed from hash $lastHash to $currentHash", contact)
+                Logger.log.log(Level.FINE, "Contact data hash has changed")
                 reallyDirty++
             }
         }
@@ -370,7 +370,7 @@ class LocalAddressBook(
         // find groups without members
         /** should be done using {@link Groups.SUMMARY_COUNT}, but it's not implemented in Android yet */
         queryGroups(null, null).filter { it.getMembers().isEmpty() }.forEach { group ->
-            Logger.log.log(Level.FINE, "Deleting group", group)
+            Logger.log.log(Level.FINE, "Deleting empty group")
             group.delete()
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/resource/LocalContact.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/resource/LocalContact.kt
@@ -32,7 +32,6 @@ import ezvcard.VCardVersion
 import java.io.ByteArrayOutputStream
 import java.io.FileNotFoundException
 import java.util.*
-import java.util.logging.Level
 
 class LocalContact : AndroidContact, LocalAddress {
     companion object {
@@ -62,7 +61,7 @@ class LocalContact : AndroidContact, LocalAddress {
             val contact: Contact
             contact = this.contact!!
 
-            Logger.log.log(Level.FINE, "Preparing upload of VCard $uuid", contact)
+            Logger.log.fine("Preparing upload of VCard resource")
 
             val os = ByteArrayOutputStream()
             contact.write(VCardVersion.V4_0, GROUP_VCARDS, os)
@@ -99,7 +98,7 @@ class LocalContact : AndroidContact, LocalAddress {
             // workaround for Android 7 which sets DIRTY flag when only meta-data is changed
             val hashCode = dataHashCode()
             values.put(COLUMN_HASHCODE, hashCode)
-            Logger.log.finer("Clearing dirty flag with eTag = $eTag, contact hash = $hashCode")
+            Logger.log.finer("Clearing dirty flag for contact resource")
         }
 
         addressBook.provider?.update(rawContactSyncURI(), values, null, null)
@@ -172,7 +171,7 @@ class LocalContact : AndroidContact, LocalAddress {
         // groupMemberships is filled by getContact()
         val dataHash = contact!!.hashCode()
         val groupHash = groupMemberships.hashCode()
-        Logger.log.finest("Calculated data hash = $dataHash, group memberships hash = $groupHash")
+        Logger.log.finest("Calculated contact data hash for dirty workaround")
         return dataHash xor groupHash
     }
 
@@ -182,7 +181,7 @@ class LocalContact : AndroidContact, LocalAddress {
 
         val values = ContentValues(1)
         val hashCode = dataHashCode()
-        Logger.log.fine("Storing contact hash = $hashCode")
+        Logger.log.fine("Storing contact hash for dirty workaround")
         values.put(COLUMN_HASHCODE, hashCode)
 
         if (batch == null)

--- a/android/app/src/main/java/io/silentsuite/sync/resource/LocalEvent.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/resource/LocalEvent.kt
@@ -23,7 +23,6 @@ import net.fortuna.ical4j.model.property.Action
 import net.fortuna.ical4j.model.property.ProdId
 import java.io.ByteArrayOutputStream
 import java.util.*
-import java.util.logging.Level
 
 class LocalEvent : AndroidEvent, LocalResource<Event> {
     companion object {
@@ -45,7 +44,7 @@ class LocalEvent : AndroidEvent, LocalResource<Event> {
 
     override val content: String
         get() {
-            Logger.log.log(Level.FINE, "Preparing upload of event $fileName} ${event}")
+            Logger.log.fine("Preparing upload of event resource")
 
             val os = ByteArrayOutputStream()
             event?.write(os)

--- a/android/app/src/main/java/io/silentsuite/sync/resource/LocalGroup.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/resource/LocalGroup.kt
@@ -26,7 +26,6 @@ import io.silentsuite.sync.log.Logger
 import ezvcard.VCardVersion
 import java.io.ByteArrayOutputStream
 import java.util.*
-import java.util.logging.Level
 
 class LocalGroup : AndroidGroup, LocalAddress {
     companion object {
@@ -63,7 +62,7 @@ class LocalGroup : AndroidGroup, LocalAddress {
 
                     // insert memberships
                     val membersIds = members.map {uid ->
-                        Constants.log.fine("Assigning member: $uid")
+                        Constants.log.fine("Assigning group member")
                         val contact = addressBook.findByUid(uid) as LocalContact?
                         if (contact != null) contact.id else null
                     }.filterNotNull()
@@ -87,7 +86,7 @@ class LocalGroup : AndroidGroup, LocalAddress {
             val contact: Contact
             contact = this.contact!!
 
-            Logger.log.log(Level.FINE, "Preparing upload of VCard $uuid", contact)
+            Logger.log.fine("Preparing upload of group VCard resource")
 
             val os = ByteArrayOutputStream()
             contact.write(VCardVersion.V4_0, GROUP_VCARDS, os)

--- a/android/app/src/main/java/io/silentsuite/sync/resource/LocalTask.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/resource/LocalTask.kt
@@ -17,7 +17,6 @@ import io.silentsuite.sync.log.Logger
 import org.dmfs.tasks.contract.TaskContract
 import java.io.ByteArrayOutputStream
 import java.util.*
-import java.util.logging.Level
 
 class LocalTask : AndroidTask, LocalResource<Task> {
     companion object {
@@ -33,7 +32,7 @@ class LocalTask : AndroidTask, LocalResource<Task> {
 
     override val content: String
         get() {
-            Logger.log.log(Level.FINE, "Preparing upload of task ${fileName} ${task}")
+            Logger.log.fine("Preparing upload of task resource")
 
             val os = ByteArrayOutputStream()
             task?.write(os)

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/AddressBooksSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/AddressBooksSyncAdapterService.kt
@@ -82,11 +82,11 @@ class AddressBooksSyncAdapterService : SyncAdapterService() {
                 val url = addressBook.url
                 val collection = remote[url]
                 if (collection == null) {
-                    Logger.log.fine("Deleting obsolete local addressBook $url")
+                    Logger.log.fine("Deleting obsolete local address book")
                     addressBook.delete()
                 } else {
                     // remote CollectionInfo found for this local collection, update data
-                    Logger.log.fine("Updating local addressBook $url")
+                    Logger.log.fine("Updating local address book")
                     addressBook.update(collection)
                     // we already have a local addressBook for this remote collection, don't take into consideration anymore
                     remote.remove(url)
@@ -96,7 +96,7 @@ class AddressBooksSyncAdapterService : SyncAdapterService() {
             // create new local calendars
             for (url in remote.keys) {
                 val cachedCollection = remote[url]!!
-                Logger.log.info("Adding local calendar list $cachedCollection")
+                Logger.log.info("Adding local address book")
                 LocalAddressBook.create(context, provider, account, cachedCollection)
             }
         }

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/CalendarSyncManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/CalendarSyncManager.kt
@@ -92,10 +92,10 @@ constructor(context: Context, account: Account, settings: AccountSettings, extra
             processEvent(item, event, local)
         } else {
             if (local != null) {
-                Logger.log.info("Removing local record #" + local.id + " which has been deleted on the server")
+                Logger.log.info("Removing local event resource which has been deleted on the server")
                 local.delete()
             } else {
-                Logger.log.warning("Tried deleting a non-existent record: " + item.uid)
+                Logger.log.warning("Tried deleting a non-existent local event resource")
             }
         }
     }
@@ -138,12 +138,12 @@ constructor(context: Context, account: Account, settings: AccountSettings, extra
         var localEvent = _localEvent
         // delete local event, if it exists
         if (localEvent != null) {
-            Logger.log.info("Updating " + newData.uid + " in local calendar")
+            Logger.log.info("Updating local event resource")
             localEvent.eTag = item.etag
             localEvent.update(newData)
             syncResult.stats.numUpdates++
         } else {
-            Logger.log.info("Adding " + newData.uid + " to local calendar")
+            Logger.log.info("Adding local event resource")
             localEvent = LocalEvent(localCalendar(), newData, item.uid, item.etag)
             localEvent.add()
             syncResult.stats.numInserts++

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/CalendarsSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/CalendarsSyncAdapterService.kt
@@ -36,12 +36,12 @@ class CalendarsSyncAdapterService : SyncAdapterService() {
             updateLocalCalendars(provider, account, settings)
 
             val principal = settings.uri?.toHttpUrlOrNull() ?: run {
-                Logger.log.warning("Calendar sync skipped: no valid URI for account ${account.name}")
+                Logger.log.warning("Calendar sync skipped: no valid URI")
                 return
             }
 
             for (calendar in AndroidCalendar.find(account, provider, LocalCalendar.Factory, CalendarContract.Calendars.SYNC_EVENTS + "!=0", null)) {
-                Logger.log.info("Synchronizing calendar #" + calendar.id + ", URL: " + calendar.name)
+                Logger.log.info("Synchronizing calendar #" + calendar.id)
                 CalendarSyncManager(context, account, settings, extras, authority, syncResult, calendar, principal).use {
                     it.performSync()
                 }
@@ -76,11 +76,11 @@ class CalendarsSyncAdapterService : SyncAdapterService() {
                 val url = calendar.name
                 val collection = remote[url]
                 if (collection == null) {
-                    Logger.log.fine("Deleting obsolete local calendar $url")
+                    Logger.log.fine("Deleting obsolete local calendar")
                     calendar.delete()
                 } else {
                     // remote CollectionInfo found for this local collection, update data
-                    Logger.log.fine("Updating local calendar $url")
+                    Logger.log.fine("Updating local calendar")
                     calendar.update(collection, updateColors)
                     // we already have a local calendar for this remote collection, don't take into consideration anymore
                     remote.remove(url)
@@ -90,7 +90,7 @@ class CalendarsSyncAdapterService : SyncAdapterService() {
             // create new local calendars
             for (url in remote.keys) {
                 val cachedCollection = remote[url]!!
-                Logger.log.info("Adding local calendar list $cachedCollection")
+                Logger.log.info("Adding local calendar")
                 LocalCalendar.create(account, provider, cachedCollection)
             }
         }

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/ContactsSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/ContactsSyncAdapterService.kt
@@ -35,22 +35,22 @@ class ContactsSyncAdapterService : SyncAdapterService() {
                 settings = AccountSettings(context, addressBook.mainAccount)
             } catch (e: InvalidAccountException) {
                 Logger.log.info("Skipping sync due to invalid account.")
-                Logger.log.info(e.localizedMessage)
+                Logger.log.info("Invalid account: ${e.javaClass.name}")
                 return
             } catch (e: ContactsStorageException) {
                 Logger.log.info("Skipping sync due to invalid account.")
-                Logger.log.info(e.localizedMessage)
+                Logger.log.info("Invalid account: ${e.javaClass.name}")
                 return
             }
 
             if (!extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL) && !checkSyncConditions(settings))
                 return
 
-            Logger.log.info("Synchronizing address book: " + addressBook.url)
-            Logger.log.info("Taking settings from: " + addressBook.mainAccount)
+            Logger.log.info("Synchronizing address book")
+            Logger.log.info("Taking settings from main account")
 
             val principal = settings.uri?.toHttpUrlOrNull() ?: run {
-                Logger.log.warning("Contacts sync skipped: no valid URI for account ${addressBook.mainAccount.name}")
+                Logger.log.warning("Contacts sync skipped: no valid URI")
                 return
             }
             ContactsSyncManager(context, account, settings, extras, authority, provider, syncResult, addressBook, principal).use {

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/ContactsSyncManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/ContactsSyncManager.kt
@@ -90,7 +90,7 @@ constructor(context: Context, account: Account, settings: AccountSettings, extra
         val batch = BatchOperation(addressBook.provider!!)
         for (contact in addressBook.findDirtyContacts()) {
             try {
-                Logger.log.fine("Looking for changed group memberships of contact " + contact.fileName)
+                Logger.log.fine("Looking for changed group memberships of contact resource")
                 val cachedGroups = contact.getCachedGroupMemberships()
                 val currentGroups = contact.getGroupMemberships()
                 for (groupID in SetUtils.disjunction(cachedGroups, currentGroups)) {
@@ -142,7 +142,7 @@ constructor(context: Context, account: Account, settings: AccountSettings, extra
                 Logger.log.info("Removing local record which has been deleted on the server")
                 local.delete()
             } else {
-                Logger.log.warning("Tried deleting a non-existent record: " + item.uid)
+                Logger.log.warning("Tried deleting a non-existent local contact resource")
             }
         }
     }
@@ -152,7 +152,7 @@ constructor(context: Context, account: Account, settings: AccountSettings, extra
         val uuid = newData.uid
         // update local contact, if it exists
         if (local != null) {
-            Logger.log.log(Level.INFO, "Updating $uuid in local address book")
+            Logger.log.log(Level.INFO, "Updating local address book resource")
 
             if (local is LocalGroup && newData.group) {
                 // update group
@@ -182,13 +182,13 @@ constructor(context: Context, account: Account, settings: AccountSettings, extra
 
         if (local == null) {
             if (newData.group) {
-                Logger.log.log(Level.INFO, "Creating local group", item.uid)
+                Logger.log.log(Level.INFO, "Creating local group")
                 val group = LocalGroup(localAddressBook(), newData, item.uid, item.etag)
                 group.add()
 
                 local = group
             } else {
-                Logger.log.log(Level.INFO, "Creating local contact", item.uid)
+                Logger.log.log(Level.INFO, "Creating local contact")
                 val contact = LocalContact(localAddressBook(), newData, item.uid, item.etag)
                 contact.add()
 

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncAdapterService.kt
@@ -52,7 +52,7 @@ abstract class SyncAdapterService : Service() {
         abstract fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult)
 
         override fun onPerformSync(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
-            Logger.log.log(Level.INFO, "$authority sync of $account has been initiated.", extras.keySet().toTypedArray())
+            Logger.log.log(Level.INFO, "$authority sync has been initiated.", extras.keySet().toTypedArray())
 
             // required for dav4android (ServiceLoader)
             Thread.currentThread().contextClassLoader = context.classLoader
@@ -63,7 +63,7 @@ abstract class SyncAdapterService : Service() {
             // Blocks sync when subscription is cancelled/expired (read-only mode).
             // Allows sync when billing API is unreachable (optimistic for dev/self-hosted).
             if (!BillingManager.getInstance().isSyncAllowed(context, account)) {
-                Logger.log.info("Sync skipped for $account: subscription inactive")
+                Logger.log.info("Sync skipped: subscription inactive")
                 return
             }
 

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncManager.kt
@@ -181,7 +181,7 @@ constructor(protected val context: Context, protected val account: Account, prot
             }
             notifyUserOnSync()
 
-            Logger.log.info("Finished sync with CTag=$remoteCTag")
+            Logger.log.info("Finished sync")
         } catch (e: SSLHandshakeException) {
             syncResult.stats.numIoExceptions++
 
@@ -300,7 +300,7 @@ constructor(protected val context: Context, protected val account: Account, prot
             Logger.log.info("Fetched items. Done=${ret.isDone}")
             return ret
         } else {
-            Logger.log.info("Skipping fetch because local stoken == lastStoken (${remoteCTag})")
+            Logger.log.info("Skipping fetch because local sync token is unchanged")
             return null
         }
     }
@@ -316,7 +316,7 @@ constructor(protected val context: Context, protected val account: Account, prot
                 throw InterruptedException()
             }
             i++
-            Logger.log.info("Processing (${i}/${size}) UID=${item.uid} Etag=${item.etag}")
+            Logger.log.info("Processing remote resource (${i}/${size}) deleted=${item.isDeleted}")
 
             processItem(item)
             persistItem(item)
@@ -362,7 +362,7 @@ constructor(protected val context: Context, protected val account: Account, prot
             for (local in localDirty) {
                 if (remaining <= 0) break
                 remaining--
-                Logger.log.info("Added/changed resource with filename: " + local.fileName)
+                Logger.log.info("Uploaded local ${resourceType(local)} resource")
                 local.clearDirty(chunkPushItems[i].etag)
                 i++
             }
@@ -403,14 +403,7 @@ constructor(protected val context: Context, protected val account: Account, prot
         try {
             item.setContent(local.content)
         } catch (e: Exception) {
-            Logger.log.warning("Failed creating local entry ${local.uuid}")
-            if (local is LocalContact) {
-                Logger.log.warning("Contact with title ${local.contact?.displayName}")
-            } else if (local is LocalEvent) {
-                Logger.log.warning("Event with title ${local.event?.summary}")
-            } else if (local is LocalTask) {
-                Logger.log.warning("Task with title ${local.task?.summary}")
-            }
+            Logger.log.warning("Failed creating local ${resourceType(local)} resource")
             throw e
         }
 
@@ -472,7 +465,7 @@ constructor(protected val context: Context, protected val account: Account, prot
         val readOnly = cachedCollection.col.accessLevel == CollectionAccessLevel.ReadOnly
         if (readOnly) {
             for (local in localList) {
-                Logger.log.info("Restoring locally deleted resource on a read only collection: ${local.uuid}")
+                Logger.log.info("Restoring locally deleted ${resourceType(local)} resource on a read only collection")
                 local.resetDeleted()
                 numDiscarded++
             }
@@ -481,9 +474,8 @@ constructor(protected val context: Context, protected val account: Account, prot
                 if (Thread.interrupted())
                     return ret
 
-                if (local.uuid != null) {
-                    Logger.log.info(local.uuid + " has been deleted locally -> deleting from server")
-                }
+                if (local.uuid != null)
+                    Logger.log.info("Local ${resourceType(local)} resource has been deleted -> deleting from server")
 
                 ret.add(local)
 
@@ -499,7 +491,7 @@ constructor(protected val context: Context, protected val account: Account, prot
         val readOnly = cachedCollection.col.accessLevel == CollectionAccessLevel.ReadOnly
         if (readOnly) {
             for (local in localDirty) {
-                Logger.log.info("Restoring locally modified resource on a read only collection: ${local.uuid}")
+                Logger.log.info("Restoring locally modified ${resourceType(local)} resource on a read only collection")
                 if (local.uuid == null) {
                     // If it was only local, delete.
                     local.delete()
@@ -526,6 +518,14 @@ constructor(protected val context: Context, protected val account: Account, prot
         val displayName = meta.name ?: cachedCollection.col.uid
         val intent = Intent(context, AccountsActivity::class.java)
         notification.notify(context.getString(R.string.sync_journal_readonly, displayName), context.getString(R.string.sync_journal_readonly_message, numDiscarded), null, intent, R.drawable.ic_error_light)
+    }
+
+    private fun resourceType(local: T) = when (local) {
+        is LocalContact -> "contact"
+        is LocalEvent -> "event"
+        is LocalGroup -> "group"
+        is LocalTask -> "task"
+        else -> "local"
     }
 
     companion object {

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/TasksSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/TasksSyncAdapterService.kt
@@ -58,12 +58,12 @@ class TasksSyncAdapterService: SyncAdapterService() {
             updateLocalTaskLists(taskProvider, account, accountSettings)
 
             val principal = accountSettings.uri?.toHttpUrlOrNull() ?: run {
-                Logger.log.warning("Task sync skipped: no valid URI for account ${account.name}")
+                Logger.log.warning("Task sync skipped: no valid URI")
                 return
             }
 
             for (taskList in AndroidTaskList.find(account, taskProvider, LocalTaskList.Factory, "${TaskContract.TaskLists.SYNC_ENABLED}!=0", null)) {
-                Logger.log.info("Synchronizing task list #${taskList.id} [${taskList.syncId}]")
+                Logger.log.info("Synchronizing task list #${taskList.id}")
                 TasksSyncManager(context, account, accountSettings, extras, authority, syncResult, taskList, principal).use {
                     it.performSync()
                 }
@@ -98,11 +98,11 @@ class TasksSyncAdapterService: SyncAdapterService() {
                 val url = taskList.syncId
                 val collection = remote[url]
                 if (collection == null) {
-                    Logger.log.fine("Deleting obsolete local taskList $url")
+                    Logger.log.fine("Deleting obsolete local task list")
                     taskList.delete()
                 } else {
                     // remote CollectionInfo found for this local collection, update data
-                    Logger.log.fine("Updating local taskList $url")
+                    Logger.log.fine("Updating local task list")
                     taskList.update(collection, updateColors)
                     // we already have a local taskList for this remote collection, don't take into consideration anymore
                     remote.remove(url)
@@ -112,7 +112,7 @@ class TasksSyncAdapterService: SyncAdapterService() {
             // create new local calendars
             for (url in remote.keys) {
                 val cachedCollection = remote[url]!!
-                Logger.log.info("Adding local calendar list $cachedCollection")
+                Logger.log.info("Adding local task list")
                 LocalTaskList.create(account, provider, cachedCollection)
             }
         }

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/TasksSyncManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/TasksSyncManager.kt
@@ -84,10 +84,10 @@ class TasksSyncManager(
             processTask(item, task, local)
         } else {
             if (local != null) {
-                Logger.log.info("Removing local record #" + local.id + " which has been deleted on the server")
+                Logger.log.info("Removing local task resource which has been deleted on the server")
                 local.delete()
             } else {
-                Logger.log.warning("Tried deleting a non-existent record: " + item.uid)
+                Logger.log.warning("Tried deleting a non-existent local task resource")
             }
         }
     }
@@ -96,12 +96,12 @@ class TasksSyncManager(
         var localTask = _localTask
         // delete local Task, if it exists
         if (localTask != null) {
-            Logger.log.info("Updating " + item.uid + " in local calendar")
+            Logger.log.info("Updating local task resource")
             localTask.eTag = item.etag
             localTask.update(newData)
             syncResult.stats.numUpdates++
         } else {
-            Logger.log.info("Adding " + item.uid + " to local calendar")
+            Logger.log.info("Adding local task resource")
             localTask = LocalTask(localTaskList(), newData, item.uid, item.etag)
             localTask.add()
             syncResult.stats.numInserts++

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -519,7 +519,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
                             teardownAccountState(acc)
                         } catch (e: Exception) {
                             if (e is kotlinx.coroutines.CancellationException) throw e
-                            Logger.log.warning("Account teardown failed for ${acc.name}: $e")
+                            Logger.log.warning("Account teardown failed: ${e.javaClass.name}")
                         }
                     }
                     for (acc in accounts) {
@@ -742,7 +742,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
                 return info
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
-                Logger.log.log(Level.SEVERE, "AccountInfoViewModel.doLoad failed for ${account.name}", e)
+                Logger.log.log(Level.SEVERE, "AccountInfoViewModel.doLoad failed", e)
                 return info
             }
 
@@ -836,7 +836,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             EtebaseLocalCache.clearUserCache(this@AccountActivity, account.name)
         } catch (e: Throwable) {
             if (e is kotlinx.coroutines.CancellationException) throw e
-            Logger.log.warning("Cache clear failed for ${account.name}: $e")
+            Logger.log.warning("Cache clear failed: ${e.javaClass.name}")
         }
 
         try {
@@ -846,10 +846,10 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
                 etebase.logout()
             }
         } catch (e: EtebaseException) {
-            Logger.log.warning("Server logout failed for ${account.name}: $e")
+            Logger.log.warning("Server logout failed: ${e.javaClass.name}")
         } catch (e: Throwable) {
             if (e is kotlinx.coroutines.CancellationException) throw e
-            Logger.log.warning("Account teardown failed for ${account.name}: $e")
+            Logger.log.warning("Account teardown failed: ${e.javaClass.name}")
         }
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/DebugInfoActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/DebugInfoActivity.kt
@@ -36,7 +36,6 @@ import io.silentsuite.sync.Constants.KEY_ACCOUNT
 import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.resource.LocalAddressBook
 // TODO(Phase2): Replace ACRA with Sentry for crash reporting
-import org.apache.commons.lang3.exception.ExceptionUtils
 import org.apache.commons.lang3.text.WordUtils
 import java.io.File
 import java.util.logging.Level
@@ -125,22 +124,22 @@ class DebugInfoActivity : BaseActivity() {
             if (phase != null)
                 report.append("SYNCHRONIZATION INFO\nSynchronization phase: ").append(phase).append("\n")
             if (account != null)
-                report.append("Account name: ").append(account.name).append("\n")
+                report.append("Account: [redacted]\n")
             if (authority != null)
                 report.append("Authority: ").append(authority).append("\n")
             if (caller != null)
                 report.append("Debug activity source: ").append(caller).append("\n")
 
             if (throwable is com.etebase.client.exceptions.HttpException) {
-                report.append("\nHTTP ERROR:\n").append(throwable.localizedMessage).append("\n")
+                report.append("\nHTTP ERROR:\n").append(throwable.javaClass.name).append("\n")
             }
 
             if (throwable != null)
                 report.append("\nEXCEPTION:\n")
-                        .append(ExceptionUtils.getStackTrace(throwable))
+                        .append(redactedStackTrace(throwable))
 
             if (logs != null)
-                report.append("\nLOGS:\n").append(logs).append("\n")
+                report.append("\nLOGS:\n[redacted from shared debug report]\n")
 
             try {
                 val pm = context.packageManager
@@ -171,26 +170,26 @@ class DebugInfoActivity : BaseActivity() {
                     .append("\n")
             // main accounts
             val accountManager = AccountManager.get(context)
-            for (acct in accountManager.getAccountsByType(context.getString(R.string.account_type)))
+            for ((idx, acct) in accountManager.getAccountsByType(context.getString(R.string.account_type)).withIndex())
                 try {
                     val settings = AccountSettings(context, acct)
-                    report.append("Account: ").append(acct.name).append("\n" + "  Address book sync. interval: ").append(syncStatus(settings, App.addressBooksAuthority)).append("\n" + "  Calendar     sync. interval: ").append(syncStatus(settings, CalendarContract.AUTHORITY)).append("\n" + "  OpenTasks    sync. interval: ").append(syncStatus(settings, ProviderName.OpenTasks.authority)).append("\n" + "  Tasks.org    sync. interval: ").append(syncStatus(settings, ProviderName.TasksOrg.authority)).append("\n" + "  WiFi only: ").append(settings.syncWifiOnly)
+                    report.append("Account #").append(idx + 1).append("\n" + "  Address book sync. interval: ").append(syncStatus(settings, App.addressBooksAuthority)).append("\n" + "  Calendar     sync. interval: ").append(syncStatus(settings, CalendarContract.AUTHORITY)).append("\n" + "  OpenTasks    sync. interval: ").append(syncStatus(settings, ProviderName.OpenTasks.authority)).append("\n" + "  Tasks.org    sync. interval: ").append(syncStatus(settings, ProviderName.TasksOrg.authority)).append("\n" + "  WiFi only: ").append(settings.syncWifiOnly)
                     if (settings.syncWifiOnlySSID != null)
-                        report.append(", SSID: ").append(settings.syncWifiOnlySSID)
+                        report.append(", SSID configured: yes")
                     report.append("\n  [CardDAV] Contact group method: ").append(settings.groupMethod)
                             .append("\n           Manage calendar colors: ").append(settings.manageCalendarColors)
                             .append("\n")
                 } catch (e: InvalidAccountException) {
-                    report.append(acct).append(" is invalid (unsupported settings version) or does not exist\n")
+                    report.append("Account #").append(idx + 1).append(" is invalid (unsupported settings version) or does not exist\n")
                 }
 
             // address book accounts
-            for (acct in accountManager.getAccountsByType(App.addressBookAccountType))
+            for ((idx, acct) in accountManager.getAccountsByType(App.addressBookAccountType).withIndex())
                 try {
                     val addressBook = LocalAddressBook(context, acct, null)
-                    report.append("Address book account: ").append(acct.name).append("\n" + "  Main account: ").append(addressBook.mainAccount).append("\n" + "  URL: ").append(addressBook.url).append("\n" + "  Sync automatically: ").append(ContentResolver.getSyncAutomatically(acct, ContactsContract.AUTHORITY)).append("\n")
+                    report.append("Address book account #").append(idx + 1).append("\n" + "  Main account: [redacted]\n" + "  URL configured: ").append(addressBook.url != null).append("\n" + "  Sync automatically: ").append(ContentResolver.getSyncAutomatically(acct, ContactsContract.AUTHORITY)).append("\n")
                 } catch (e: ContactsStorageException) {
-                    report.append(acct).append(" is invalid: ").append(e.message).append("\n")
+                    report.append("Address book account #").append(idx + 1).append(" is invalid\n")
                 }
 
             report.append("\n")
@@ -218,6 +217,16 @@ class DebugInfoActivity : BaseActivity() {
                 if (interval == AccountSettings.SYNC_INTERVAL_MANUALLY) "manually" else (interval / 60).toString() + " min"
             else
                 "—"
+        }
+
+        private fun redactedStackTrace(throwable: Throwable): String {
+            val builder = StringBuilder(throwable.javaClass.name)
+            for (frame in throwable.stackTrace)
+                builder.append("\n\tat ").append(frame)
+            throwable.cause?.let { cause ->
+                builder.append("\nCaused by: ").append(redactedStackTrace(cause))
+            }
+            return builder.toString()
         }
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/EditCollectionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/EditCollectionFragment.kt
@@ -174,7 +174,7 @@ class EditCollectionFragment : Fragment() {
                 }
                 activity?.finish()
             } catch (e: EtebaseException) {
-                Logger.log.warning(e.localizedMessage)
+                Logger.log.warning("Collection edit failed: ${e.javaClass.name}")
                 context?.let { context ->
                     AlertDialog.Builder(context)
                             .setIcon(R.drawable.ic_info_dark)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.File
 
 class NewAccountWizardActivity : BaseActivity() {
     private lateinit var account: Account
@@ -230,7 +229,7 @@ class WizardFragment : Fragment() {
                 // failures from the very first FS-cache write escaped the coroutine and crashed
                 // the app via the default uncaught-exception handler. Log first so the next
                 // logcat capture pinpoints the failure class even if the dialog is dismissed.
-                Logger.log.severe("createCollections failed: ${e.javaClass.name}: ${e.message}")
+                Logger.log.severe("createCollections failed: ${e.javaClass.name}")
                 reportErrorHelper(requireContext(), e)
             } finally {
                 loadingModel.setLoading(false)
@@ -251,10 +250,9 @@ class WizardFragment : Fragment() {
             // Issue #119: this is the very first on-disk Etebase write per username. If the
             // per-username cols/<colUid>/items directory creation fails, surface enough detail
             // to disambiguate the cause before the exception propagates up to createCollections.
-            val colsPath = File(File(requireContext().filesDir, accountHolder.account.name), "cols").absolutePath
             Logger.log.severe(
-                "etebaseLocalCache.collectionSet failed for colUid=${col.uid} path=$colsPath: " +
-                        "${e.javaClass.name}: ${e.message}"
+                "etebaseLocalCache.collectionSet failed under app files dir: " +
+                        e.javaClass.name
             )
             throw e
         }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
@@ -123,13 +123,13 @@ class ImportFragment : DialogFragment() {
                     if (data != null) {
                         // Get the URI of the selected file
                         val uri = data.data!!
-                        Logger.log.info("Starting import into ${uid} from file ${uri}")
+                        Logger.log.info("Starting import from selected file")
                         try {
                             inputStream = requireActivity().contentResolver.openInputStream(uri)
 
                             Thread(ImportEntriesLoader()).start()
                         } catch (e: Exception) {
-                            Logger.log.severe("File select error: ${e.message}")
+                            Logger.log.severe("File select error: ${e.javaClass.name}")
 
                             val importResult = ImportResult()
                             importResult.e = e
@@ -227,11 +227,11 @@ class ImportFragment : DialogFragment() {
                                     return result
                                 }
                             } catch (e: CalendarStorageException) {
-                                Logger.log.info("Fail" + e.localizedMessage)
+                                Logger.log.info("Import lookup failed: ${e.javaClass.name}")
                                 result.e = e
                                 return result
                             } catch (e: FileNotFoundException) {
-                                Logger.log.info("Fail" + e.localizedMessage)
+                                Logger.log.info("Import lookup failed: ${e.javaClass.name}")
                                 result.e = e
                                 return result
                             }
@@ -248,7 +248,7 @@ class ImportFragment : DialogFragment() {
                                         result.added++
                                     }
                                 } catch (e: CalendarStorageException) {
-                                    e.printStackTrace()
+                                    Logger.log.warning("Calendar import entry failed: ${e.javaClass.name}")
                                 }
 
                                 entryProcessed()
@@ -290,7 +290,7 @@ class ImportFragment : DialogFragment() {
                                     return result
                                 }
                             } catch (e: FileNotFoundException) {
-                                Logger.log.info("Fail" + e.localizedMessage)
+                                Logger.log.info("Import lookup failed: ${e.javaClass.name}")
                                 result.e = e
                                 return result
                             }
@@ -307,7 +307,7 @@ class ImportFragment : DialogFragment() {
                                         result.added++
                                     }
                                 } catch (e: CalendarStorageException) {
-                                    e.printStackTrace()
+                                    Logger.log.warning("Task import entry failed: ${e.javaClass.name}")
                                 }
 
                                 entryProcessed()
@@ -365,7 +365,7 @@ class ImportFragment : DialogFragment() {
                                     }
                                     batch.commit()
                                 } catch (e: ContactsStorageException) {
-                                    e.printStackTrace()
+                                    Logger.log.warning("Contact import entry failed: ${e.javaClass.name}")
                                 }
 
                                 entryProcessed()
@@ -389,7 +389,7 @@ class ImportFragment : DialogFragment() {
                                         result.added++
                                     }
                                 } catch (e: ContactsStorageException) {
-                                    e.printStackTrace()
+                                    Logger.log.warning("Contact group import entry failed: ${e.javaClass.name}")
                                 }
 
                                 entryProcessed()

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/BaseConfigurationFinder.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/BaseConfigurationFinder.kt
@@ -34,7 +34,7 @@ class BaseConfigurationFinder(protected val context: Context, protected val cred
             val etebase = Account.login(client, credentials.userName, credentials.password)
             etebaseSession = etebase.save(null)
         } catch (e: java.lang.Exception) {
-            Logger.log.warning(e.localizedMessage)
+            Logger.log.warning("Configuration lookup failed: ${e.javaClass.name}")
             exception = e
         }
 
@@ -59,7 +59,7 @@ class BaseConfigurationFinder(protected val context: Context, protected val cred
             get() = this.error != null
 
         override fun toString(): String {
-            return "BaseConfigurationFinder.Configuration(url=" + this.url + ", userName=" + this.userName + ", error=" + this.error + ", failed=" + this.isFailed + ")"
+            return "BaseConfigurationFinder.Configuration(urlConfigured=" + (this.url != null) + ", userNameConfigured=" + this.userName.isNotEmpty() + ", error=" + this.error?.javaClass?.name + ", failed=" + this.isFailed + ")"
         }
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
@@ -54,7 +54,7 @@ class CreateAccountFragment : DialogFragment() {
             // garbage-collected). Previously this branch silently no-op'd, leaving the user
             // staring at a frozen "setting up encryption" progress dialog. Log the failure
             // and dismiss the dialog so the operator notices and the user can retry.
-            Logger.log.log(Level.SEVERE, "addAccountExplicitly returned false for ${config.userName}")
+            Logger.log.log(Level.SEVERE, "addAccountExplicitly returned false")
             dismissAllowingStateLoss()
         }
     }
@@ -64,7 +64,7 @@ class CreateAccountFragment : DialogFragment() {
         val account = Account(accountName, App.accountType)
 
         // create Android account
-        Logger.log.log(Level.INFO, "Creating Android account with initial config", arrayOf(account, config.userName, config.url))
+        Logger.log.log(Level.INFO, "Creating Android account with initial config")
 
         val accountManager = AccountManager.get(context)
         if (!accountManager.addAccountExplicitly(account, config.password, null))
@@ -73,7 +73,7 @@ class CreateAccountFragment : DialogFragment() {
         AccountSettings.setUserData(accountManager, account, config.url, config.userName)
 
         // add entries for account to service DB
-        Logger.log.log(Level.INFO, "Writing account configuration to database", config)
+        Logger.log.log(Level.INFO, "Writing account configuration to database")
         try {
             val settings = AccountSettings(requireContext(), account)
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
@@ -54,7 +54,7 @@ class DetectConfigurationFragment : DialogFragment() {
     private fun onLoadFinished(data: Configuration?) {
         if (data != null) {
             if (data.isFailed) {
-                Logger.log.warning("Failed login configuration ${data.error?.localizedMessage}")
+                Logger.log.warning("Failed login configuration ${data.error?.javaClass?.name}")
                 // no service found: show error message
                 requireFragmentManager().beginTransaction()
                         .add(NothingDetectedFragment.newInstance(data.error!!.localizedMessage), null)


### PR DESCRIPTION
## Summary
- scrub Android sync/resource/setup/import log messages to avoid PIM metadata, account names, collection IDs, UIDs, etags, stokens, and exception-message leakage
- redact shared debug reports by removing account names, raw logs, URL values, SSIDs, and exception messages while keeping non-sensitive diagnostics
- disable OkHttp logging in release builds and redact Authorization headers; keep BODY logging debug-only

## Verification
- git diff --check origin/dev...HEAD
- risky Android log sentinel search returned no findings
- implementation review: GREEN LIGHT after patch fixes

## Scope
- first SEC-09C slice only: log/debug-report scrubbing and OkHttp release logging limits
- deferred: contact-photo bounds, backup policy, dependency review, exported/deep-link receiver review, broader printStackTrace notification/dialog audit