### PR TITLE
Harden legacy Docker self-host defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ dist/
 .env.test.local
 .env.production.local
 **/.env
+secret.txt
+**/secret.txt
 
 # Logs
 npm-debug.log*

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,5 +1,8 @@
 NEXT_PUBLIC_BILLING_API_URL=http://localhost:3736
 NEXT_PUBLIC_ETEBASE_SERVER_URL=http://localhost:3735
+# NEXT_PUBLIC_* values are embedded in the browser bundle and public container
+# image layers. Only put public endpoints or publishable client keys here.
+# Never put Stripe secret keys or server-side credentials in this file.
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51TAx8aPZr2w1sOdtvpdnjDy7I4P6zKxthjFpbdjwyxQA5HJaOCyIKA6Zg4nGG0ffjqnvtD9MdBut281pIqcyaBtt00WOqXFXWL
 # Set to "true" for self-hosted deployments (disables billing UI)
 # NEXT_PUBLIC_SELF_HOSTED=true

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,9 +1,11 @@
-# Docker environment variables for SilentSuite
-# Copy this file to .env and customize for your deployment:
+# Legacy Docker environment variables for SilentSuite.
+# Prefer ../self-host/ for real self-hosted installs. This legacy stack is kept
+# only for local development and old workflows.
+# Copy this file to .env and customize before running docker compose:
 #   cp .env.example .env
 #
 # WARNING: Never commit .env to version control!
 
-# PostgreSQL password — MUST be changed for production deployments.
-# This must match the password in etebase-server.ini [database] section.
-POSTGRES_PASSWORD=silentsuite_dev
+# PostgreSQL password. This must match docker/etebase/etebase-server.ini before
+# building the legacy etebase image. Do not use a shared/default password.
+POSTGRES_PASSWORD=CHANGE_ME_TO_MATCH_ETEBASE_INI

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,8 +10,10 @@ documents reverse-proxy/TLS setup.
 If you still run this legacy stack locally:
 
 - Copy `.env.example` to `.env` and set a unique `POSTGRES_PASSWORD`.
-- Update `etebase/etebase-server.ini` so its database password matches `.env`.
+- Update `etebase/etebase-server.ini` so its database password matches `.env`,
+  then rebuild the image with `docker compose build etebase` because the legacy
+  Dockerfile copies that INI file at build time.
 - Keep the default loopback-only ports and put any public access behind your
   reverse proxy/TLS layer.
 - Use `docker-compose.dev.yml` only for disposable local development; it contains
-  intentional dev-only defaults.
+  intentional dev-only defaults and exposes Postgres on all interfaces.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,17 @@
+# Legacy Docker Stack
+
+This directory is retained for older local-development workflows only. Do not use
+it for new self-hosted deployments.
+
+Use `../self-host/` instead. The current self-host stack pins the server image,
+binds the sync server to host loopback by default, generates credentials, and
+documents reverse-proxy/TLS setup.
+
+If you still run this legacy stack locally:
+
+- Copy `.env.example` to `.env` and set a unique `POSTGRES_PASSWORD`.
+- Update `etebase/etebase-server.ini` so its database password matches `.env`.
+- Keep the default loopback-only ports and put any public access behind your
+  reverse proxy/TLS layer.
+- Use `docker-compose.dev.yml` only for disposable local development; it contains
+  intentional dev-only defaults.

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -3,6 +3,7 @@ services:
     ports:
       - "5432:5432"
     environment:
+      # Dev-only default for disposable local databases. Never use in production.
       POSTGRES_PASSWORD: silentsuite_dev
 
   etebase:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,13 +1,13 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16.9-alpine
     container_name: silentsuite-postgres
     ports:
       - "127.0.0.1:5432:5432"
     environment:
       POSTGRES_DB: silentsuite
       POSTGRES_USER: silentsuite
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-silentsuite_dev}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in docker/.env}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./postgres/init:/docker-entrypoint-initdb.d
@@ -24,7 +24,7 @@ services:
       dockerfile: Dockerfile
     container_name: silentsuite-etebase
     ports:
-      - "3735:3735"
+      - "127.0.0.1:3735:3735"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker/etebase/etebase-server.ini
+++ b/docker/etebase/etebase-server.ini
@@ -9,9 +9,9 @@ allowed_host1 = server.silentsuite.io
 engine = django.db.backends.postgresql
 name = silentsuite
 user = silentsuite
-; WARNING: Do not use the default password in production!
-; For production, mount a custom etebase-server.ini or rebuild the image.
-; See docker/.env.example for the recommended env-var approach.
-password = silentsuite_dev
+; Legacy docker/ stack only. Prefer self-host/ for real installs.
+; This value must match POSTGRES_PASSWORD from docker/.env before building.
+; Do not use a shared/default password.
+password = CHANGE_ME_TO_MATCH_ETEBASE_INI
 host = postgres
 port = 5432

--- a/self-host/SELF-HOSTING.md
+++ b/self-host/SELF-HOSTING.md
@@ -116,7 +116,7 @@ When pinned, the installer fetches all of `docker-compose.yml`, `update.sh`, `ve
    host = postgres
    port = 5432
    ```
-   Save with `chmod 644` so the container's `etebase` user can read it via the bind mount. Keep the install directory itself at `0750`; `etebase-server.ini` contains the database password and should not live in a shared world-readable directory.
+   Save with `chmod 644` so the container's `etebase` user can read it via the bind mount. Keep the install directory itself at `0750`; `etebase-server.ini` contains the database password and should not live in a shared directory. Users outside the directory owner/group cannot traverse a `0750` directory, but members of that group can still read the file.
 
 5. **Start the stack:**
    ```bash

--- a/self-host/SELF-HOSTING.md
+++ b/self-host/SELF-HOSTING.md
@@ -79,6 +79,7 @@ When pinned, the installer fetches all of `docker-compose.yml`, `update.sh`, `ve
 1. **Create a directory and download the config:**
    ```bash
    mkdir silentsuite-server && cd silentsuite-server
+   chmod 750 .
    curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/docker-compose.yml -o docker-compose.yml
    curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/.env.example -o .env
    curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/success.html -o success.html
@@ -93,6 +94,7 @@ When pinned, the installer fetches all of `docker-compose.yml`, `update.sh`, `ve
 3. **Edit `.env`:**
    - `DATABASE_PASSWORD` -- the generated database password
    - `SUPER_PASS` -- the generated admin password
+   - Save with `chmod 600 .env` so only the host operator can read it.
 
 4. **Create `etebase-server.ini`** (server-side configuration; mounted into the container). Replace `YOUR_DATABASE_PASSWORD` with the value you set in `.env`, and `sync.example.com` with your domain:
    ```ini
@@ -114,7 +116,7 @@ When pinned, the installer fetches all of `docker-compose.yml`, `update.sh`, `ve
    host = postgres
    port = 5432
    ```
-   Save with `chmod 644` so the container's `etebase` user can read it via the bind mount.
+   Save with `chmod 644` so the container's `etebase` user can read it via the bind mount. Keep the install directory itself at `0750`; `etebase-server.ini` contains the database password and should not live in a shared world-readable directory.
 
 5. **Start the stack:**
    ```bash


### PR DESCRIPTION
## Summary
- fail closed on legacy docker/ database password configuration instead of defaulting to silentsuite_dev
- bind legacy Etebase port to host loopback and pin the legacy Postgres image patch tag
- add a legacy docker/ README that redirects real self-hosting to self-host/ and documents dev-only defaults
- document manual self-host file permissions and NEXT_PUBLIC_* public visibility

## Verification
- git diff --check
- pnpm install
- pnpm build:docs
- implementation review gate: GREEN LIGHT

## Notes
- Docker validation was not run locally per workspace no-Docker rule.
- The current self-host/ stack was already loopback-bound and server-image pinned; this PR targets the legacy docker/ footguns plus docs.