### PR TITLE
Address public promotion review blockers

### DIFF
--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -25,29 +25,19 @@ The bridge exposes every SilentSuite calendar, task list, and address book as it
 
 ## Install
 
-### One-Line Installer (Recommended)
+### Installer Status
 
-**Linux / macOS:**
+Bridge installer scripts are not yet published as stable `main`/release-tagged endpoints. Until they are, download bridge binaries from the [GitHub releases](https://github.com/silent-suite/silentsuite/releases) page instead of piping an installer URL into your shell.
 
-```bash
-curl -fsSL https://silentsuite.io/bridge/install.sh | sh
-```
+::: warning
+Do not run installer commands from the public `dev` branch. Those scripts may contain unreleased changes and are not part of the stable docs flow.
+:::
 
-**Windows (PowerShell):**
-
-```powershell
-irm https://silentsuite.io/bridge/install.ps1 | iex
-```
-
-The installer will:
+When stable installers are published, they will:
 1. Download the correct binary for your OS and architecture
 2. Install it to `~/.local/bin/`
 3. Optionally set up auto-start
 4. Open the bridge dashboard for first-time login
-
-::: info
-The bridge install URLs are coming soon. The binary distribution pipeline is being finalized. Check back shortly or watch the [GitHub releases](https://github.com/silent-suite/silentsuite/releases) for updates.
-:::
 
 ## First-Time Setup
 

--- a/apps/web/app/(app)/calendar/error.tsx
+++ b/apps/web/app/(app)/calendar/error.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
-import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { createSafeOperationalError, getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function CalendarError({
   error,
@@ -13,7 +13,9 @@ export default function CalendarError({
 }) {
   useEffect(() => {
     console.error('Calendar error boundary caught', getSafeErrorDetails(error))
-    Sentry.captureException(error)
+    Sentry.captureException(createSafeOperationalError('error-boundary', 'calendar'), {
+      extra: { ...getSafeErrorDetails(error), digest: error.digest },
+    })
   }, [error])
 
   return (

--- a/apps/web/app/(app)/contacts/error.tsx
+++ b/apps/web/app/(app)/contacts/error.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
-import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { createSafeOperationalError, getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function ContactsError({
   error,
@@ -13,7 +13,9 @@ export default function ContactsError({
 }) {
   useEffect(() => {
     console.error('Contacts error boundary caught', getSafeErrorDetails(error))
-    Sentry.captureException(error)
+    Sentry.captureException(createSafeOperationalError('error-boundary', 'contacts'), {
+      extra: { ...getSafeErrorDetails(error), digest: error.digest },
+    })
   }, [error])
 
   return (

--- a/apps/web/app/(app)/error.tsx
+++ b/apps/web/app/(app)/error.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
 import { useTranslations } from 'next-intl'
-import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { createSafeOperationalError, getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function AppError({
   error,
@@ -16,7 +16,9 @@ export default function AppError({
 
   useEffect(() => {
     console.error('App error boundary caught', getSafeErrorDetails(error))
-    Sentry.captureException(error)
+    Sentry.captureException(createSafeOperationalError('error-boundary', 'app'), {
+      extra: { ...getSafeErrorDetails(error), digest: error.digest },
+    })
   }, [error])
 
   return (

--- a/apps/web/app/(app)/settings/desktop/page.tsx
+++ b/apps/web/app/(app)/settings/desktop/page.tsx
@@ -1,27 +1,11 @@
 'use client'
 
-import { useCallback, useState } from 'react'
-import { Monitor, ExternalLink, Copy, CheckCircle, ShieldCheck } from 'lucide-react'
+import { Monitor, ExternalLink, ShieldCheck } from 'lucide-react'
 
-const INSTALL_COMMAND = 'curl -fsSL https://silentsuite.io/bridge/install.sh | sh'
-const INSTALL_COMMAND_PS = 'irm https://silentsuite.io/bridge/install.ps1 | iex'
 const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
 const DOCS_URL = 'https://docs.silentsuite.io/user-guide/apps/dav-bridge'
 
 export default function DesktopSettingsPage() {
-  const [copied, setCopied] = useState<'sh' | 'ps' | null>(null)
-
-  const handleCopy = useCallback(async (variant: 'sh' | 'ps') => {
-    const text = variant === 'sh' ? INSTALL_COMMAND : INSTALL_COMMAND_PS
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(variant)
-      setTimeout(() => setCopied(null), 2000)
-    } catch {
-      // Clipboard access may be blocked; users can still select manually
-    }
-  }, [])
-
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -34,71 +18,18 @@ export default function DesktopSettingsPage() {
         </p>
       </div>
 
-      {/* Install one-liner — macOS / Linux */}
+      {/* Installer status */}
       <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
         <div className="flex items-center gap-3">
           <Monitor className="h-5 w-5 text-[rgb(var(--primary))]" />
           <div>
             <p className="text-sm font-medium text-[rgb(var(--foreground))]">
-              Install on macOS or Linux
+              Installers are published through releases
             </p>
             <p className="text-xs text-[rgb(var(--muted))]">
-              Run this in your terminal.
+              Download bridge binaries from GitHub releases until stable installer endpoints are pinned to main or a release tag.
             </p>
           </div>
-        </div>
-
-        <div className="flex items-stretch gap-2">
-          <pre className="flex-1 overflow-x-auto rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs text-[rgb(var(--foreground))] font-mono">
-            <code>{INSTALL_COMMAND}</code>
-          </pre>
-          <button
-            type="button"
-            onClick={() => handleCopy('sh')}
-            aria-label="Copy install command"
-            className="flex items-center gap-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
-          >
-            {copied === 'sh' ? (
-              <CheckCircle className="h-4 w-4 text-emerald-500" />
-            ) : (
-              <Copy className="h-4 w-4" />
-            )}
-            {copied === 'sh' ? 'Copied' : 'Copy'}
-          </button>
-        </div>
-      </div>
-
-      {/* Install one-liner — Windows */}
-      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
-        <div className="flex items-center gap-3">
-          <Monitor className="h-5 w-5 text-[rgb(var(--primary))]" />
-          <div>
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
-              Install on Windows
-            </p>
-            <p className="text-xs text-[rgb(var(--muted))]">
-              Run this in PowerShell.
-            </p>
-          </div>
-        </div>
-
-        <div className="flex items-stretch gap-2">
-          <pre className="flex-1 overflow-x-auto rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs text-[rgb(var(--foreground))] font-mono">
-            <code>{INSTALL_COMMAND_PS}</code>
-          </pre>
-          <button
-            type="button"
-            onClick={() => handleCopy('ps')}
-            aria-label="Copy PowerShell install command"
-            className="flex items-center gap-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
-          >
-            {copied === 'ps' ? (
-              <CheckCircle className="h-4 w-4 text-emerald-500" />
-            ) : (
-              <Copy className="h-4 w-4" />
-            )}
-            {copied === 'ps' ? 'Copied' : 'Copy'}
-          </button>
         </div>
       </div>
 

--- a/apps/web/app/(app)/tasks/error.tsx
+++ b/apps/web/app/(app)/tasks/error.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
-import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { createSafeOperationalError, getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function TasksError({
   error,
@@ -13,7 +13,9 @@ export default function TasksError({
 }) {
   useEffect(() => {
     console.error('Tasks error boundary caught', getSafeErrorDetails(error))
-    Sentry.captureException(error)
+    Sentry.captureException(createSafeOperationalError('error-boundary', 'tasks'), {
+      extra: { ...getSafeErrorDetails(error), digest: error.digest },
+    })
   }, [error])
 
   return (

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
-import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { createSafeOperationalError, getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export default function GlobalError({
   error,
@@ -13,7 +13,9 @@ export default function GlobalError({
 }) {
   useEffect(() => {
     console.error('Global error boundary caught', getSafeErrorDetails(error))
-    Sentry.captureException(error)
+    Sentry.captureException(createSafeOperationalError('error-boundary', 'global'), {
+      extra: { ...getSafeErrorDetails(error), digest: error.digest },
+    })
   }, [error])
 
   return (

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -1031,6 +1031,8 @@ class Web(BaseWeb):
         if path == "/.web/api/dump":
             if not config.DASHBOARD_DUMP_ENABLED:
                 return (404, {}, b"Not found")
+            if not _has_valid_csrf(environ):
+                return _csrf_error()
             from ..local_cache import models, db
             try:
                 with db.database_proxy:
@@ -1060,10 +1062,11 @@ class Web(BaseWeb):
                     json.dumps(result, indent=2).encode(),
                 )
             except Exception as e:
+                logger.warning("Dashboard dump failed: %s", e.__class__.__name__)
                 return (
                     500,
                     {"Content-Type": "application/json"},
-                    json.dumps({"error": str(e)}).encode(),
+                    json.dumps({"error": "Failed to dump dashboard diagnostics"}).encode(),
                 )
 
         # API endpoint for current settings

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -188,6 +188,17 @@ def test_dump_api_returns_404_when_disabled(monkeypatch):
     assert body == b"Not found"
 
 
+def test_dump_api_requires_csrf_when_enabled(monkeypatch):
+    monkeypatch.setattr(config, "DASHBOARD_DUMP_ENABLED", True)
+    web = Web.__new__(Web)
+
+    status, headers, body = web.get({}, "", "/.web/api/dump", None)
+
+    assert status == 403
+    assert headers["Content-Type"] == "application/json"
+    assert json.loads(body)["error"] == "Invalid dashboard CSRF token"
+
+
 def test_root_route_serves_dashboard(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
     web = Web.__new__(Web)

--- a/docker/etebase/etebase-server.ini
+++ b/docker/etebase/etebase-server.ini
@@ -10,8 +10,8 @@ engine = django.db.backends.postgresql
 name = silentsuite
 user = silentsuite
 ; Legacy docker/ stack only. Prefer self-host/ for real installs.
-; This value must match POSTGRES_PASSWORD from docker/.env before building.
-; Do not use a shared/default password.
-password = CHANGE_ME_TO_MATCH_ETEBASE_INI
+; This impossible placeholder intentionally fails until operators replace it
+; with the same strong value used for POSTGRES_PASSWORD in docker/.env.
+password = REPLACE_WITH_STRONG_POSTGRES_PASSWORD_BEFORE_BUILDING
 host = postgres
 port = 5432


### PR DESCRIPTION
## Summary
- Gate the bridge diagnostic dump endpoint behind the dashboard CSRF token and stop returning raw exception text.
- Replace raw Sentry error-boundary captures with safe operational errors plus sparse safe details.
- Remove bridge installer one-liners from docs/web until stable endpoints are pinned to main or a release tag.
- Make the legacy Docker INI placeholder explicit and non-shared.

## Verification
- `git diff --check` passed.
- Local focused tests could not run in the clean worktree because `pytest` and `tsc` are not installed; rely on CI for bridge/web checks.