### PR TITLE
Promote dev to main: Android setup secret hardening

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -28,6 +28,7 @@ import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.syncadapter.requestSync
 import io.silentsuite.sync.ui.AccountActivity
 import io.silentsuite.sync.ui.BaseActivity
+import io.silentsuite.sync.ui.setup.SetupSecretHolder
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -43,7 +44,7 @@ class NewAccountWizardActivity : BaseActivity() {
 
         val extras = requireNotNull(intent.extras) { "NewAccountWizardActivity requires intent extras" }
         account = requireNotNull(extras.getParcelable(EXTRA_ACCOUNT)) { "NewAccountWizardActivity requires EXTRA_ACCOUNT" }
-        val etebaseSession = extras.getString(EXTRA_ETEBASE_SESSION)
+        val etebaseSession = SetupSecretHolder.consumePendingSession(account.name)
 
         setContentView(R.layout.etebase_fragment_activity)
 
@@ -71,12 +72,10 @@ class NewAccountWizardActivity : BaseActivity() {
 
     companion object {
         private val EXTRA_ACCOUNT = "account"
-        private val EXTRA_ETEBASE_SESSION = "etebaseSession"
 
-        fun newIntent(context: Context, account: Account, etebaseSession: String? = null): Intent {
+        fun newIntent(context: Context, account: Account): Intent {
             val intent = Intent(context, NewAccountWizardActivity::class.java)
             intent.putExtra(EXTRA_ACCOUNT, account)
-            if (etebaseSession != null) intent.putExtra(EXTRA_ETEBASE_SESSION, etebaseSession)
             return intent
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/SignupFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/SignupFragment.kt
@@ -174,8 +174,6 @@ class SignupFragment : Fragment() {
 class SignupDoFragment: DialogFragment() {
     private val model: ConfigurationViewModel by viewModels()
 
-    private lateinit var signupCredentials: SignupCredentials
-
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         isCancelable = false
         return ProgressDialogHelper.createIndeterminate(
@@ -189,6 +187,16 @@ class SignupDoFragment: DialogFragment() {
         super.onCreate(savedInstanceState)
 
         if (savedInstanceState == null) {
+            val signupCredentials = SetupSecretHolder.getSignupCredentials()
+            if (signupCredentials == null) {
+                io.silentsuite.sync.log.Logger.log.warning("Signup credentials expired before account creation")
+                SetupSecretHolder.clearSignupCredentials()
+                requireFragmentManager().beginTransaction()
+                        .add(DetectConfigurationFragment.NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
+                        .commitAllowingStateLoss()
+                dismissAllowingStateLoss()
+                return
+            }
             model.signup(requireContext(), signupCredentials)
             model.observe(this) {
                 if (it.isFailed) {
@@ -201,6 +209,7 @@ class SignupDoFragment: DialogFragment() {
                             .addToBackStack(null)
                             .commitAllowingStateLoss()
                 }
+                SetupSecretHolder.clearSignupCredentials()
                 dismissAllowingStateLoss()
             }
         }
@@ -208,9 +217,8 @@ class SignupDoFragment: DialogFragment() {
 
     companion object {
         fun newInstance(signupCredentials: SignupCredentials): SignupDoFragment {
-            val ret = SignupDoFragment()
-            ret.signupCredentials = signupCredentials
-            return ret
+            SetupSecretHolder.setSignupCredentials(signupCredentials)
+            return SignupDoFragment()
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/BaseConfigurationFinder.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/BaseConfigurationFinder.kt
@@ -13,7 +13,6 @@ import com.etebase.client.Client
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.HttpClient
 import io.silentsuite.sync.log.Logger
-import java.io.Serializable
 import java.net.URI
 
 class BaseConfigurationFinder(protected val context: Context, protected val credentials: LoginCredentials) {
@@ -51,10 +50,7 @@ class BaseConfigurationFinder(protected val context: Context, protected val cred
     class Configuration
     // We have to use URI here because HttpUrl is not serializable!
 
-    (val url: URI?, val userName: String, val etebaseSession: String?, var error: Throwable?) : Serializable {
-        var rawPassword: String? = null
-        var password: String? = null
-
+    (val url: URI?, val userName: String, val etebaseSession: String?, var error: Throwable?) {
         val isFailed: Boolean
             get() = this.error != null
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
@@ -38,15 +38,29 @@ class CreateAccountFragment : DialogFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val config = requireArguments().getSerializable(KEY_CONFIG) as Configuration
+        val config = SetupSecretHolder.getPendingConfiguration()
+        if (config == null) {
+            Logger.log.severe("Setup configuration expired before account creation")
+            SetupSecretHolder.clearCredentialsAndConfiguration()
+            parentFragmentManager.beginTransaction()
+                    .add(DetectConfigurationFragment.NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
+                    .commitAllowingStateLoss()
+            dismissAllowingStateLoss()
+            return
+        }
 
         val activity = requireActivity()
-        val account = createAccount(config.userName, config)
+        val account = try {
+            createAccount(config.userName, config)
+        } catch (e: InvalidAccountException) {
+            SetupSecretHolder.clearCredentialsAndConfiguration()
+            throw e
+        }
         if (account != null) {
             activity.setResult(Activity.RESULT_OK)
-            // Pass the freshly-minted session through the intent as well — AccountManager.setUserData
-            // isn't always visible to the next activity's read on the first login.
-            startActivity(ModeSelectionActivity.newIntent(requireContext(), account, config.etebaseSession))
+            SetupSecretHolder.setPendingSession(account.name, config.etebaseSession)
+            SetupSecretHolder.clearCredentialsAndConfiguration()
+            startActivity(ModeSelectionActivity.newIntent(requireContext(), account))
             activity.finish()
         } else {
             // Issue #119: addAccountExplicitly returned false (e.g. partial-state collision
@@ -55,6 +69,7 @@ class CreateAccountFragment : DialogFragment() {
             // staring at a frozen "setting up encryption" progress dialog. Log the failure
             // and dismiss the dialog so the operator notices and the user can retry.
             Logger.log.log(Level.SEVERE, "addAccountExplicitly returned false")
+            SetupSecretHolder.clearCredentialsAndConfiguration()
             dismissAllowingStateLoss()
         }
     }
@@ -67,7 +82,7 @@ class CreateAccountFragment : DialogFragment() {
         Logger.log.log(Level.INFO, "Creating Android account with initial config")
 
         val accountManager = AccountManager.get(context)
-        if (!accountManager.addAccountExplicitly(account, config.password, null))
+        if (!accountManager.addAccountExplicitly(account, null, null))
             return null
 
         AccountSettings.setUserData(accountManager, account, config.url, config.userName)
@@ -101,14 +116,9 @@ class CreateAccountFragment : DialogFragment() {
     }
 
     companion object {
-        private val KEY_CONFIG = "config"
-
         fun newInstance(config: Configuration): CreateAccountFragment {
-            val frag = CreateAccountFragment()
-            val args = Bundle(1)
-            args.putSerializable(KEY_CONFIG, config)
-            frag.arguments = args
-            return frag
+            SetupSecretHolder.setPendingConfiguration(config)
+            return CreateAccountFragment()
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
@@ -38,7 +38,17 @@ class DetectConfigurationFragment : DialogFragment() {
         Logger.log.fine("DetectConfigurationFragment: loading")
 
         if (savedInstanceState == null) {
-            findConfiguration(requireArguments().getParcelable(ARG_LOGIN_CREDENTIALS)!!)
+            val credentials = SetupSecretHolder.getLoginCredentials()
+            if (credentials == null) {
+                Logger.log.warning("Setup login credentials expired before configuration detection")
+                SetupSecretHolder.clearLoginCredentials()
+                parentFragmentManager.beginTransaction()
+                        .add(NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
+                        .commitAllowingStateLoss()
+                dismissAllowingStateLoss()
+            } else {
+                findConfiguration(credentials)
+            }
         }
     }
 
@@ -69,6 +79,7 @@ class DetectConfigurationFragment : DialogFragment() {
         } else
             Logger.log.severe("Configuration detection failed")
 
+        SetupSecretHolder.clearLoginCredentials()
         dismissAllowingStateLoss()
     }
 
@@ -99,14 +110,6 @@ class DetectConfigurationFragment : DialogFragment() {
     }
 
     companion object {
-        protected val ARG_LOGIN_CREDENTIALS = "credentials"
-
-        fun newInstance(credentials: LoginCredentials): DetectConfigurationFragment {
-            val frag = DetectConfigurationFragment()
-            val args = Bundle(1)
-            args.putParcelable(ARG_LOGIN_CREDENTIALS, credentials)
-            frag.arguments = args
-            return frag
-        }
+        fun newInstance(): DetectConfigurationFragment = DetectConfigurationFragment()
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/EncryptionDetailsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/EncryptionDetailsFragment.kt
@@ -1,6 +1,5 @@
 package io.silentsuite.sync.ui.setup
 
-import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -17,14 +16,8 @@ class EncryptionDetailsFragment : Fragment() {
     }
 
     companion object {
-        private const val KEY_CONFIG = "config"
-
         fun newInstance(config: BaseConfigurationFinder.Configuration): EncryptionDetailsFragment {
-            val frag = EncryptionDetailsFragment()
-            val args = Bundle(1)
-            args.putSerializable(KEY_CONFIG, config)
-            frag.arguments = args
-            return frag
+            return EncryptionDetailsFragment()
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/EncryptionDetailsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/EncryptionDetailsFragment.kt
@@ -1,5 +1,6 @@
 package io.silentsuite.sync.ui.setup
 
+import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentials.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentials.kt
@@ -8,38 +8,6 @@
 
 package io.silentsuite.sync.ui.setup
 
-import android.os.Parcel
-import android.os.Parcelable
-import io.silentsuite.sync.Constants
-import io.silentsuite.sync.log.Logger
 import java.net.URI
-import java.net.URISyntaxException
 
-class LoginCredentials(val uri: URI?, val userName: String, val password: String) : Parcelable {
-
-    override fun describeContents(): Int {
-        return 0
-    }
-
-    override fun writeToParcel(dest: Parcel, flags: Int) {
-        dest.writeSerializable(uri)
-        dest.writeString(userName)
-        dest.writeString(password)
-    }
-
-    companion object {
-        @JvmField
-        val CREATOR: Parcelable.Creator<*> = object : Parcelable.Creator<LoginCredentials> {
-            override fun createFromParcel(source: Parcel): LoginCredentials {
-                return LoginCredentials(
-                        source.readSerializable() as URI,
-                        source.readString()!!, source.readString()!!
-                )
-            }
-
-            override fun newArray(size: Int): Array<LoginCredentials?> {
-                return arrayOfNulls(size)
-            }
-        }
-    }
-}
+class LoginCredentials(val uri: URI?, val userName: String, val password: String)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsChangeFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsChangeFragment.kt
@@ -44,8 +44,17 @@ class LoginCredentialsChangeFragment : DialogFragment() {
         account = requireArguments().getParcelable(ARG_ACCOUNT)!!
 
         if (savedInstanceState == null) {
-            val credentials = requireArguments().getParcelable<LoginCredentials>(ARG_LOGIN_CREDENTIALS)!!
-            findConfiguration(credentials)
+            val credentials = SetupSecretHolder.getLoginCredentials()
+            if (credentials == null) {
+                Logger.log.warning("Updated login credentials expired before configuration detection")
+                SetupSecretHolder.clearLoginCredentials()
+                parentFragmentManager.beginTransaction()
+                        .add(DetectConfigurationFragment.NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
+                        .commitAllowingStateLoss()
+                dismissAllowingStateLoss()
+            } else {
+                findConfiguration(credentials)
+            }
         }
     }
 
@@ -81,6 +90,7 @@ class LoginCredentialsChangeFragment : DialogFragment() {
         } else
             Logger.log.severe("Configuration detection failed")
 
+        SetupSecretHolder.clearLoginCredentials()
         dismissAllowingStateLoss()
     }
 
@@ -117,14 +127,13 @@ class LoginCredentialsChangeFragment : DialogFragment() {
     }
 
     companion object {
-        protected val ARG_LOGIN_CREDENTIALS = "credentials"
         protected val ARG_ACCOUNT = "account"
 
         fun newInstance(account: Account, credentials: LoginCredentials): LoginCredentialsChangeFragment {
+            SetupSecretHolder.setLoginCredentials(credentials)
             val frag = LoginCredentialsChangeFragment()
             val args = Bundle(1)
             args.putParcelable(ARG_ACCOUNT, account)
-            args.putParcelable(ARG_LOGIN_CREDENTIALS, credentials)
             frag.arguments = args
             return frag
         }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsChangeFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsChangeFragment.kt
@@ -81,6 +81,7 @@ class LoginCredentialsChangeFragment : DialogFragment() {
                     settings = AccountSettings(requireActivity(), account)
                 } catch (e: InvalidAccountException) {
                     Logger.log.log(Level.INFO, "Account is invalid or doesn't exist (anymore)", e)
+                    SetupSecretHolder.clearLoginCredentials()
                     requireActivity().finish()
                     return
                 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -66,8 +66,10 @@ class LoginCredentialsFragment : Fragment() {
         val login = v.findViewById<View>(R.id.login) as Button
         login.setOnClickListener {
             val credentials = validateLoginData()
-            if (credentials != null)
-                DetectConfigurationFragment.newInstance(credentials).show(requireFragmentManager(), null)
+            if (credentials != null) {
+                SetupSecretHolder.setLoginCredentials(credentials)
+                DetectConfigurationFragment.newInstance().show(requireFragmentManager(), null)
+            }
         }
 
         val forgotPassword = v.findViewById<View>(R.id.forgot_password) as TextView

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/ModeSelectionActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/ModeSelectionActivity.kt
@@ -15,15 +15,13 @@ class ModeSelectionActivity : BaseActivity() {
 
     companion object {
         private const val EXTRA_ACCOUNT = "account"
-        private const val EXTRA_ETEBASE_SESSION = "etebaseSession"
         const val PREF_NAME = "app_mode"
         const val KEY_MODE = "sync_mode"
         const val MODE_BRIDGE = "bridge"
 
-        fun newIntent(context: Context, account: Account, etebaseSession: String? = null): Intent {
+        fun newIntent(context: Context, account: Account): Intent {
             val intent = Intent(context, ModeSelectionActivity::class.java)
             intent.putExtra(EXTRA_ACCOUNT, account)
-            if (etebaseSession != null) intent.putExtra(EXTRA_ETEBASE_SESSION, etebaseSession)
             return intent
         }
     }
@@ -32,7 +30,6 @@ class ModeSelectionActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         val account = requireNotNull(intent.getParcelableExtra<Account>(EXTRA_ACCOUNT)) { "ModeSelectionActivity requires EXTRA_ACCOUNT" }
-        val etebaseSession = intent.getStringExtra(EXTRA_ETEBASE_SESSION)
 
         // Always use bridge mode (walled garden removed)
         getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
@@ -40,7 +37,7 @@ class ModeSelectionActivity : BaseActivity() {
             .putString(KEY_MODE, MODE_BRIDGE)
             .apply()
 
-        startActivity(NewAccountWizardActivity.newIntent(this, account, etebaseSession))
+        startActivity(NewAccountWizardActivity.newIntent(this, account))
         finish()
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/SetupEncryptionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/SetupEncryptionFragment.kt
@@ -1,6 +1,5 @@
 package io.silentsuite.sync.ui.setup
 
-import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 
 /**
@@ -11,14 +10,8 @@ import androidx.fragment.app.DialogFragment
 class SetupEncryptionFragment : DialogFragment() {
 
     companion object {
-        private const val KEY_CONFIG = "config"
-
         fun newInstance(config: BaseConfigurationFinder.Configuration): SetupEncryptionFragment {
-            val frag = SetupEncryptionFragment()
-            val args = Bundle(1)
-            args.putSerializable(KEY_CONFIG, config)
-            frag.arguments = args
-            return frag
+            return SetupEncryptionFragment()
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/SetupSecretHolder.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/SetupSecretHolder.kt
@@ -1,0 +1,61 @@
+package io.silentsuite.sync.ui.setup
+
+import io.silentsuite.sync.ui.etebase.SignupCredentials
+import java.util.concurrent.ConcurrentHashMap
+
+object SetupSecretHolder {
+    @Volatile
+    private var loginCredentials: LoginCredentials? = null
+
+    @Volatile
+    private var signupCredentials: SignupCredentials? = null
+
+    @Volatile
+    private var pendingConfiguration: BaseConfigurationFinder.Configuration? = null
+
+    private val pendingSessions = ConcurrentHashMap<String, String>()
+
+    fun setLoginCredentials(credentials: LoginCredentials) {
+        loginCredentials = credentials
+    }
+
+    fun getLoginCredentials(): LoginCredentials? = loginCredentials
+
+    fun clearLoginCredentials() {
+        loginCredentials = null
+    }
+
+    fun setSignupCredentials(credentials: SignupCredentials) {
+        signupCredentials = credentials
+    }
+
+    fun getSignupCredentials(): SignupCredentials? = signupCredentials
+
+    fun clearSignupCredentials() {
+        signupCredentials = null
+    }
+
+    fun setPendingConfiguration(config: BaseConfigurationFinder.Configuration) {
+        pendingConfiguration = config
+    }
+
+    fun getPendingConfiguration(): BaseConfigurationFinder.Configuration? = pendingConfiguration
+
+    fun clearPendingConfiguration() {
+        pendingConfiguration = null
+    }
+
+    fun setPendingSession(accountName: String, etebaseSession: String?) {
+        if (etebaseSession != null) {
+            pendingSessions[accountName] = etebaseSession
+        }
+    }
+
+    fun consumePendingSession(accountName: String): String? = pendingSessions.remove(accountName)
+
+    fun clearCredentialsAndConfiguration() {
+        loginCredentials = null
+        signupCredentials = null
+        pendingConfiguration = null
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -307,6 +307,7 @@
 
     <string name="setting_up_encryption">Setting up your account</string>
     <string name="setting_up_encryption_content">Setting up end-to-end encryption…</string>
+    <string name="setup_state_expired">Setup expired before it could finish. Please try signing in again.</string>
 
     <string name="account_creation_failed">Account creation failed</string>
     <string name="wrong_encryption_password">Wrong encryption password</string>

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/SetupSecretSerializationTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/SetupSecretSerializationTest.kt
@@ -1,0 +1,42 @@
+package io.silentsuite.sync.ui.setup
+
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import java.io.File
+
+class SetupSecretSerializationTest {
+    private val sourceRoot = File("src/main/java")
+
+    @Test
+    fun loginCredentialsDoesNotSerializePasswordToParcel() {
+        val source = File(sourceRoot, "io/silentsuite/sync/ui/setup/LoginCredentials.kt").readText()
+
+        assertFalse("LoginCredentials must not be Parcelable", source.contains("Parcelable"))
+        assertFalse("LoginCredentials must not write passwords to Parcel", source.contains("writeToParcel"))
+        assertFalse("LoginCredentials must not write password strings to Parcel", source.contains("writeString(password)"))
+    }
+
+    @Test
+    fun setupFlowDoesNotSerializeSetupSecretsThroughAndroidState() {
+        val source = sourceRoot
+            .walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .joinToString("\n") { it.readText() }
+
+        val forbiddenPatterns = listOf(
+            "putParcelable(ARG_LOGIN_CREDENTIALS",
+            "getParcelable<LoginCredentials>",
+            "putSerializable(KEY_CONFIG",
+            "EXTRA_ETEBASE_SESSION",
+            "putExtra(EXTRA_ETEBASE_SESSION",
+            "getStringExtra(EXTRA_ETEBASE_SESSION",
+            "extras.getString(EXTRA_ETEBASE_SESSION",
+            "rawPassword",
+            "var password"
+        )
+
+        forbiddenPatterns.forEach { pattern ->
+            assertFalse("Setup secret serialization pattern must stay removed: $pattern", source.contains(pattern))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- promote SEC-09A Android setup-secret hardening from dev to main
- removes setup password/session serialization through Parcelable, Serializable, Bundle, and Intent extras
- preserves null AccountManager password behavior and adds a static regression test for forbidden setup-secret serialization patterns

## Included PRs
- #244 Harden Android setup secret handling

## Required promotion gates

## Verification before merge
- Confirmed origin/dev is ahead of origin/main only by PR #244 / SEC-09A
- PR #244 checks passed before merge to dev: Android build, web build, dependency audit, lint/typecheck, tests