### PR TITLE
Promote import compatibility fixes

### DIFF
--- a/apps/web/app/components/import/TaskImport.tsx
+++ b/apps/web/app/components/import/TaskImport.tsx
@@ -7,7 +7,7 @@ import type { VTodo } from '@silentsuite/core/utils/ical-parser'
 import FileDropZone from './FileDropZone'
 import ImportPreview from './ImportPreview'
 import ImportListSelector from './ImportListSelector'
-import { parseICalDate } from './import-mappers'
+import { isCompletedVTodo, parseICalDate } from './import-mappers'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
@@ -48,10 +48,11 @@ function extractVTodos(ical: string): VTodo[] {
   let todoLines: string[] = []
 
   for (const line of lines) {
-    if (line.trim() === 'BEGIN:VTODO') {
+    const normalized = line.trim().toUpperCase()
+    if (normalized === 'BEGIN:VTODO') {
       inTodo = true
       todoLines = ['BEGIN:VTODO']
-    } else if (line.trim() === 'END:VTODO') {
+    } else if (normalized === 'END:VTODO') {
       todoLines.push('END:VTODO')
       todos.push(parseVTodo(todoLines.join('\r\n')))
       inTodo = false
@@ -221,6 +222,7 @@ export default function TaskImport({ onImportComplete, heading }: TaskImportProp
         description: task.description ?? '',
         due_date: task.due ? parseICalDate(task.due) : null,
         priority: mapPriorityToStore(task.priority),
+        completed: isCompletedVTodo(task),
         listId: selectedListId,
       }))
       const count = await importTasks(newTasks)

--- a/apps/web/app/components/import/__tests__/import-mappers.test.ts
+++ b/apps/web/app/components/import/__tests__/import-mappers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { vEventToImportEvent, parseICalDate } from '../import-mappers'
-import type { VEvent } from '@silentsuite/core/utils/ical-parser'
+import { vEventToImportEvent, parseICalDate, isCompletedVTodo } from '../import-mappers'
+import type { VEvent, VTodo } from '@silentsuite/core/utils/ical-parser'
 
 describe('vEventToImportEvent', () => {
   it('propagates source TZID into the import payload', () => {
@@ -47,6 +47,87 @@ describe('vEventToImportEvent', () => {
     expect(payload.timezone).toBeUndefined()
     expect(payload.allDay).toBe(false)
   })
+
+  it('uses DURATION when DTEND is absent', () => {
+    const event: VEvent = {
+      uid: 'duration@example',
+      summary: 'Long workshop',
+      dtstart: '20260601T090000',
+      duration: 'PT3H',
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.endDate.getTime() - payload.startDate.getTime()).toBe(3 * 60 * 60 * 1000)
+  })
+
+  it('prefers DTEND over DURATION when both are present', () => {
+    const event: VEvent = {
+      uid: 'duration-with-end@example',
+      summary: 'Workshop',
+      dtstart: '20260601T090000',
+      dtend: '20260601T100000',
+      duration: 'PT3H',
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.endDate.getTime() - payload.startDate.getTime()).toBe(60 * 60 * 1000)
+  })
+
+  it('defaults all-day events without DTEND to one day', () => {
+    const event: VEvent = {
+      uid: 'all-day-no-end@example',
+      summary: 'Holiday',
+      dtstart: '20260601',
+      dtstartParams: { VALUE: 'DATE' },
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.allDay).toBe(true)
+    expect(payload.startDate.getFullYear()).toBe(2026)
+    expect(payload.startDate.getMonth()).toBe(5)
+    expect(payload.startDate.getDate()).toBe(1)
+    expect(payload.endDate.getFullYear()).toBe(2026)
+    expect(payload.endDate.getMonth()).toBe(5)
+    expect(payload.endDate.getDate()).toBe(2)
+  })
+
+  it('falls back to one day for invalid timed DURATION on all-day events', () => {
+    const event: VEvent = {
+      uid: 'all-day-invalid-duration@example',
+      summary: 'Holiday',
+      dtstart: '20260601',
+      dtstartParams: { VALUE: 'DATE' },
+      duration: 'PT3H',
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.allDay).toBe(true)
+    expect(payload.endDate.getFullYear()).toBe(2026)
+    expect(payload.endDate.getMonth()).toBe(5)
+    expect(payload.endDate.getDate()).toBe(2)
+  })
+
+  it('maps EXDATE values into import exceptions', () => {
+    const event: VEvent = {
+      uid: 'recurring@example',
+      summary: 'Daily standup',
+      dtstart: '20260601T090000',
+      dtend: '20260601T093000',
+      rrule: 'FREQ=DAILY;COUNT=3',
+      exdate: ['20260602T090000'],
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.exceptions).toHaveLength(1)
+    expect(payload.exceptions[0]!.getFullYear()).toBe(2026)
+    expect(payload.exceptions[0]!.getMonth()).toBe(5)
+    expect(payload.exceptions[0]!.getDate()).toBe(2)
+  })
 })
 
 describe('parseICalDate', () => {
@@ -75,5 +156,28 @@ describe('parseICalDate', () => {
     expect(d.getFullYear()).toBe(2026)
     expect(d.getMonth()).toBe(5)
     expect(d.getDate()).toBe(1)
+  })
+})
+
+describe('isCompletedVTodo', () => {
+  it('treats completed status as completed', () => {
+    expect(isCompletedVTodo({ status: 'COMPLETED' })).toBe(true)
+  })
+
+  it('treats percent-complete 100 as completed for tasks.org compatibility', () => {
+    const task: Pick<VTodo, 'status' | 'percentComplete'> = {
+      status: 'NEEDS-ACTION',
+      percentComplete: 100,
+    }
+
+    expect(isCompletedVTodo(task)).toBe(true)
+  })
+
+  it('does not let completed timestamp override explicit incomplete status', () => {
+    expect(isCompletedVTodo({ status: 'NEEDS-ACTION', completed: '20260601T100000Z' })).toBe(false)
+  })
+
+  it('treats completed timestamp as completed when status is absent', () => {
+    expect(isCompletedVTodo({ completed: '20260601T100000Z' })).toBe(true)
   })
 })

--- a/apps/web/app/components/import/import-mappers.ts
+++ b/apps/web/app/components/import/import-mappers.ts
@@ -1,5 +1,5 @@
 import { parseICalDateValue } from '@silentsuite/core'
-import type { VEvent } from '@silentsuite/core/utils/ical-parser'
+import type { VEvent, VTodo } from '@silentsuite/core/utils/ical-parser'
 
 export interface ImportEventPayload {
   title: string
@@ -9,9 +9,39 @@ export interface ImportEventPayload {
   endDate: Date
   allDay: boolean
   recurrenceRule: string | null
+  exceptions: Date[]
   alarms: NonNullable<VEvent['valarms']>
   calendarId: string
   timezone: string | undefined
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date)
+  next.setDate(next.getDate() + days)
+  return next
+}
+
+function addICalDuration(start: Date, duration: string, allDay: boolean): Date | null {
+  const match = duration.match(/^P(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/i)
+  if (!match) return null
+
+  const weeks = Number(match[1] ?? 0)
+  const days = Number(match[2] ?? 0)
+  const hours = Number(match[3] ?? 0)
+  const minutes = Number(match[4] ?? 0)
+  const seconds = Number(match[5] ?? 0)
+  if (weeks + days + hours + minutes + seconds === 0) return null
+
+  if (allDay) {
+    return hours + minutes + seconds === 0 ? addDays(start, weeks * 7 + days) : null
+  }
+
+  const ms = (((weeks * 7 + days) * 24 + hours) * 60 + minutes) * 60 * 1000 + seconds * 1000
+  return new Date(start.getTime() + ms)
+}
+
+function defaultEndDate(start: Date, allDay: boolean): Date {
+  return allDay ? addDays(start, 1) : new Date(start.getTime() + 60 * 60 * 1000)
 }
 
 // DTEND TZID note: when DTSTART and DTEND carry different TZIDs the per-side
@@ -27,7 +57,11 @@ export function vEventToImportEvent(
   const { date: start, allDay: isAllDay } = parseICalDateValue(event.dtstart, startTzid)
   const end = event.dtend
     ? parseICalDateValue(event.dtend, endTzid).date
-    : new Date(start.getTime() + 60 * 60 * 1000)
+    : event.duration
+      ? addICalDuration(start, event.duration, isAllDay) ?? defaultEndDate(start, isAllDay)
+      : defaultEndDate(start, isAllDay)
+  const exdateTzid = event.exdateParams?.['TZID'] ?? startTzid
+  const exceptions = event.exdate?.map((date) => parseICalDateValue(date, exdateTzid).date) ?? []
 
   return {
     title: event.summary || 'Untitled Event',
@@ -37,6 +71,7 @@ export function vEventToImportEvent(
     endDate: end,
     allDay: isAllDay,
     recurrenceRule: event.rrule ?? null,
+    exceptions,
     alarms: event.valarms ?? [],
     calendarId,
     timezone: isAllDay ? undefined : startTzid,
@@ -59,4 +94,11 @@ export function parseICalDate(d: string): Date | null {
     parseInt(digits.slice(4, 6)) - 1,
     parseInt(digits.slice(6, 8)),
   )
+}
+
+export function isCompletedVTodo(task: Pick<VTodo, 'status' | 'completed' | 'percentComplete'>): boolean {
+  const status = task.status?.toUpperCase()
+  return status === 'COMPLETED'
+    || task.percentComplete === 100
+    || (status === undefined && task.completed !== undefined)
 }

--- a/apps/web/app/stores/__tests__/use-calendar-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-calendar-store.test.ts
@@ -144,6 +144,24 @@ describe('useCalendarStore.importEvents', () => {
     expect(ical).toContain('DTSTART;VALUE=DATE:')
   })
 
+  it('preserves recurrence exceptions during event import', async () => {
+    const exception = new Date('2026-06-03T09:00:00Z')
+
+    await useCalendarStore.getState().importEvents([
+      {
+        title: 'Daily standup',
+        startDate: new Date('2026-06-01T09:00:00Z'),
+        endDate: new Date('2026-06-01T09:30:00Z'),
+        recurrenceRule: 'FREQ=DAILY;COUNT=3',
+        exceptions: [exception],
+      },
+    ])
+
+    const { events } = useCalendarStore.getState()
+    expect(events[0]!.exceptions).toEqual([exception])
+    expect(serializeCalendarEvent(events[0]!)).toContain('EXDATE:')
+  })
+
   it('routes mixed-calendar imports to each target collection', async () => {
     etebaseMock.state.account = {}
     etebaseMock.state.createItemsBatch.mockImplementation(async (_type: unknown, contents: unknown[]) => (

--- a/apps/web/app/stores/__tests__/use-task-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-task-store.test.ts
@@ -114,4 +114,16 @@ describe('useTaskStore', () => {
     expect(updatedContent).toContain('STATUS:COMPLETED')
     expect(updatedContent).toContain('PERCENT-COMPLETE:100')
   })
+
+  it('preserves completed state during task import', async () => {
+    await useTaskStore.getState().importTasks([
+      { title: 'Already done', completed: true },
+      { title: 'Still open', completed: false },
+    ])
+
+    const { tasks } = useTaskStore.getState()
+    expect(tasks).toHaveLength(2)
+    expect(tasks[0]!.completed).toBe(true)
+    expect(tasks[1]!.completed).toBe(false)
+  })
 })

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -19,6 +19,7 @@ interface NewCalendarEvent {
   endDate: Date
   allDay?: boolean
   recurrenceRule?: string | null
+  exceptions?: Date[]
   alarms?: VAlarm[]
   calendarId?: string
   timezone?: string
@@ -172,7 +173,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
       endDate: newEvent.endDate,
       allDay: newEvent.allDay ?? false,
       recurrenceRule: newEvent.recurrenceRule ?? null,
-      exceptions: [],
+      exceptions: newEvent.exceptions ?? [],
       alarms: newEvent.alarms ?? [],
       calendarId: newEvent.calendarId ?? defaultCalendarId(),
       timezone: newEvent.timezone,
@@ -498,7 +499,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
         endDate: ne.endDate,
         allDay: ne.allDay ?? false,
         recurrenceRule: ne.recurrenceRule ?? null,
-        exceptions: [],
+        exceptions: ne.exceptions ?? [],
         alarms: ne.alarms ?? [],
         calendarId: ne.calendarId ?? defaultCalendarId(),
         timezone: ne.timezone,

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -13,6 +13,7 @@ interface NewTask {
   description?: string
   due_date?: Date | null
   priority?: Priority
+  completed?: boolean
   listId?: string
 }
 
@@ -54,7 +55,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
           description: newTask.description ?? '',
           due_date: newTask.due_date ?? null,
           priority: newTask.priority ?? 'medium',
-          completed: false,
+          completed: newTask.completed ?? false,
           listId: newTask.listId ?? defaultTaskListId(),
           created_at: now,
           updated_at: now,
@@ -192,7 +193,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
             description: nt.description ?? '',
             due_date: nt.due_date ?? null,
             priority: nt.priority ?? 'medium',
-            completed: false,
+            completed: nt.completed ?? false,
             listId: nt.listId ?? defaultTaskListId(),
             created_at: now,
             updated_at: now,

--- a/packages/core/src/utils/vcard-parser.test.ts
+++ b/packages/core/src/utils/vcard-parser.test.ts
@@ -234,4 +234,83 @@ describe('parsing raw vCard strings', () => {
     expect(vcard.email).toHaveLength(1);
     expect(vcard.org).toBe('Smith & Co');
   });
+
+  it('parses iPhone grouped contact properties', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'PRODID:-//Apple Inc.//iOS 18.1//EN',
+      'N:Halber Meister;Bene;;;',
+      'FN:Bene Halber Meister',
+      'item1.TEL;type=pref:+4917671231328',
+      'item1.X-ABLabel:',
+      'item2.EMAIL;type=INTERNET;type=pref:bene@example.com',
+      'item3.ADR;type=HOME:;;Main Street 1;Berlin;;10115;Germany',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.tel).toEqual([{ type: 'pref', value: '+4917671231328' }]);
+    expect(vcard.email).toEqual([{ type: 'internet,pref', value: 'bene@example.com' }]);
+    expect(vcard.adr).toHaveLength(1);
+    expect(vcard.adr![0]!.type).toBe('home');
+    expect(vcard.adr![0]!.street).toBe('Main Street 1');
+  });
+
+  it('preserves repeated iPhone TYPE parameters', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'FN:Bene',
+      'TEL;type=CELL;type=VOICE;type=pref:+4915128724408',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.tel).toEqual([{ type: 'cell,voice,pref', value: '+4915128724408' }]);
+  });
+
+  it('preserves repeated TYPE parameters on grouped iPhone phone properties', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'FN:Bene',
+      'item5.TEL;type=CELL;type=VOICE;type=pref:+4915128724408',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.tel).toEqual([{ type: 'cell,voice,pref', value: '+4915128724408' }]);
+  });
+
+  it('normalizes vCard 4 tel URI values', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:4.0',
+      'FN:Bene',
+      'TEL;VALUE=uri:tel:%2B4912345678',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.tel).toEqual([{ type: 'other', value: '+4912345678' }]);
+  });
+
+  it('does not split escaped semicolons in structured name and address values', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'FN:Jane Doe',
+      'N:Doe\\;Smith;Jane;;;',
+      'ADR;TYPE=home:;;Main\\; Side Street 1;Berlin;;10115;Germany',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.n?.family).toBe('Doe;Smith');
+    expect(vcard.n?.given).toBe('Jane');
+    expect(vcard.adr).toHaveLength(1);
+    expect(vcard.adr![0]!.street).toBe('Main; Side Street 1');
+    expect(vcard.adr![0]!.city).toBe('Berlin');
+  });
 });

--- a/packages/core/src/utils/vcard-parser.ts
+++ b/packages/core/src/utils/vcard-parser.ts
@@ -143,7 +143,8 @@ function parseProperty(line: string): ParsedProperty {
   const value = line.slice(colonIdx + 1);
 
   const semiIdx = left.indexOf(';');
-  const name = (semiIdx === -1 ? left : left.slice(0, semiIdx)).toUpperCase();
+  const rawName = semiIdx === -1 ? left : left.slice(0, semiIdx);
+  const name = rawName.slice(rawName.lastIndexOf('.') + 1).toUpperCase();
   const params: Record<string, string> = {};
 
   if (semiIdx !== -1) {
@@ -151,7 +152,9 @@ function parseProperty(line: string): ParsedProperty {
     for (const part of splitParams(paramStr)) {
       const eqIdx = part.indexOf('=');
       if (eqIdx !== -1) {
-        params[part.slice(0, eqIdx).toUpperCase()] = part.slice(eqIdx + 1);
+        const key = part.slice(0, eqIdx).toUpperCase();
+        const paramValue = part.slice(eqIdx + 1);
+        params[key] = params[key] ? `${params[key]},${paramValue}` : paramValue;
       }
     }
   }
@@ -161,6 +164,36 @@ function parseProperty(line: string): ParsedProperty {
 
 function getTypeParam(params: Record<string, string>): string {
   return (params['TYPE'] ?? 'other').toLowerCase();
+}
+
+function normalizeTelephoneValue(value: string): string {
+  if (!value.toLowerCase().startsWith('tel:')) return value;
+  const rawValue = value.slice(4);
+  try {
+    return decodeURIComponent(rawValue);
+  } catch {
+    return rawValue;
+  }
+}
+
+function splitStructuredValue(value: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let escaped = false;
+
+  for (const ch of value) {
+    if (ch === ';' && !escaped) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+
+    escaped = ch === '\\' && !escaped;
+  }
+
+  parts.push(current);
+  return parts;
 }
 
 // ── Parser ──
@@ -190,7 +223,7 @@ export function parseVCard(vcardStr: string): VCard {
         vcard.fn = unescapeText(prop.value);
         break;
       case 'N': {
-        const parts = prop.value.split(';');
+        const parts = splitStructuredValue(prop.value);
         vcard.n = {
           family: unescapeText(parts[0] ?? ''),
           given: unescapeText(parts[1] ?? ''),
@@ -200,13 +233,13 @@ export function parseVCard(vcardStr: string): VCard {
         break;
       }
       case 'TEL':
-        tels.push({ type: getTypeParam(prop.params), value: prop.value });
+        tels.push({ type: getTypeParam(prop.params), value: normalizeTelephoneValue(prop.value) });
         break;
       case 'EMAIL':
         emails.push({ type: getTypeParam(prop.params), value: prop.value });
         break;
       case 'ADR': {
-        const adrParts = prop.value.split(';');
+        const adrParts = splitStructuredValue(prop.value);
         adrs.push({
           type: getTypeParam(prop.params),
           street: unescapeText(adrParts[2] ?? ''),


### PR DESCRIPTION
Summary:
- Promote PR #246 from dev to main.
- Adds import compatibility fixes for Apple grouped vCards, VTODO completed state, calendar DURATION defaults, and EXDATE preservation.

Promotion scope:
- origin/main..origin/dev contains only PR #246.

Validation from feature PR:
- pnpm --filter @silentsuite/core test -- vcard-parser.test.ts
- pnpm --filter @silentsuite/web test -- app/components/import/__tests__/import-mappers.test.ts app/stores/__tests__/use-calendar-store.test.ts app/stores/__tests__/use-task-store.test.ts
- pnpm --filter @silentsuite/core type-check
- pnpm --filter @silentsuite/web type-check