### PR TITLE
fix(android): improve contact import reliability

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
@@ -14,6 +14,7 @@ import at.bitfire.ical4android.*
 import at.bitfire.vcard4android.BatchOperation
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.ContactsStorageException
+import ezvcard.io.CannotParseException
 import io.silentsuite.sync.CachedCollection
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_ADDRESS_BOOK
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_CALENDAR
@@ -160,6 +161,11 @@ class ImportFragment : DialogFragment() {
         }
     }
 
+    private fun safeFailureResult(messageResId: Int, fallbackMessage: String): ImportResult = ImportResult().also {
+        it.e = Exception(fallbackMessage)
+        it.failureMessage = context?.getString(messageResId) ?: fallbackMessage
+    }
+
     private inner class ImportEntriesLoader : Runnable {
         private fun finishParsingFile(length: Int) {
             if (activity == null) {
@@ -183,9 +189,18 @@ class ImportFragment : DialogFragment() {
         }
 
         override fun run() {
-            val result = loadInBackground()
+            val result = try {
+                loadInBackground()
+            } catch (e: RuntimeException) {
+                Logger.log.severe("Import failed unexpectedly: ${e.javaClass.name}")
+                safeFailureResult(
+                        R.string.import_dialog_unexpected_failure,
+                        "The import could not be completed. Please try again or report the problem."
+                )
+            }
 
-            requireActivity().runOnUiThread { loadFinished(result) }
+            val importActivity = activity ?: return
+            importActivity.runOnUiThread { loadFinished(result) }
         }
 
         fun loadInBackground(): ImportResult {
@@ -346,14 +361,14 @@ class ImportFragment : DialogFragment() {
                             for (contact in contacts.filter { contact -> !contact.group }) {
                                 try {
                                     var localContact = localAddressBook.findByUid(contact.uid!!) as LocalContact?
+                                    var addedContact = false
 
                                     if (localContact != null) {
                                         localContact.updateAsDirty(contact)
-                                        result.updated++
                                     } else {
                                         localContact = LocalContact(localAddressBook, contact, contact.uid, null)
                                         localContact.createAsDirty()
-                                        result.added++
+                                        addedContact = true
                                     }
 
                                     uidToLocalId[contact.uid] = localContact.id!!
@@ -364,7 +379,13 @@ class ImportFragment : DialogFragment() {
                                         localContact.addToGroup(batch, localAddressBook.findOrCreateGroup(category))
                                     }
                                     batch.commit()
+
+                                    if (addedContact)
+                                        result.added++
+                                    else
+                                        result.updated++
                                 } catch (e: ContactsStorageException) {
+                                    result.failed++
                                     Logger.log.warning("Contact import entry failed: ${e.javaClass.name}")
                                 }
 
@@ -389,6 +410,7 @@ class ImportFragment : DialogFragment() {
                                         result.added++
                                     }
                                 } catch (e: ContactsStorageException) {
+                                    result.failed++
                                     Logger.log.warning("Contact group import entry failed: ${e.javaClass.name}")
                                 }
 
@@ -407,15 +429,24 @@ class ImportFragment : DialogFragment() {
                 return result
             } catch (e: FileNotFoundException) {
                 result.e = e
+                result.failureMessage = this@ImportFragment.context?.getString(R.string.import_dialog_failed_generic)
+                return result
+            } catch (e: CannotParseException) {
+                Logger.log.warning("Contact import parse failed: ${e.javaClass.name}")
+                result.e = e
+                result.failureMessage = this@ImportFragment.context?.getString(R.string.import_dialog_contacts_parse_failed)
                 return result
             } catch (e: InvalidCalendarException) {
                 result.e = e
+                result.failureMessage = this@ImportFragment.context?.getString(R.string.import_dialog_failed_generic)
                 return result
             } catch (e: IOException) {
                 result.e = e
+                result.failureMessage = this@ImportFragment.context?.getString(R.string.import_dialog_failed_generic)
                 return result
             } catch (e: ContactsStorageException) {
                 result.e = e
+                result.failureMessage = this@ImportFragment.context?.getString(R.string.import_dialog_failed_generic)
                 return result
             }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ResultFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ResultFragment.kt
@@ -32,23 +32,29 @@ class ResultFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         if (result!!.isFailed) {
+            val failureMessage = result!!.failureMessage ?: getString(R.string.import_dialog_failed_generic)
             return AlertDialog.Builder(requireActivity())
                     .setTitle(R.string.import_dialog_failed_title)
                     .setIcon(R.drawable.ic_error_dark)
-                    .setMessage(getString(R.string.import_dialog_failed_body, result!!.e!!.localizedMessage))
+                    .setMessage(getString(R.string.import_dialog_failed_body, failureMessage))
                     .setNegativeButton(android.R.string.no) { dialog, which ->
                         // dismiss
                     }
                     .setPositiveButton(android.R.string.yes) { dialog, which ->
                         // TODO(Phase2): Report to Sentry once integrated
-                        Logger.log.severe("Import failed: ${result!!.e}")
+                        Logger.log.severe("Import failed: ${result!!.e!!.javaClass.name}")
                     }
                     .create()
         } else {
+            val message = if (result!!.failed > 0) {
+                getString(R.string.import_dialog_partial_success, result!!.total, result!!.added, result!!.updated, result!!.skipped, result!!.failed)
+            } else {
+                getString(R.string.import_dialog_success, result!!.total, result!!.added, result!!.updated, result!!.skipped)
+            }
             return AlertDialog.Builder(requireActivity())
                     .setTitle(R.string.import_dialog_title)
                     .setIcon(R.drawable.ic_import_export_black)
-                    .setMessage(getString(R.string.import_dialog_success, result!!.total, result!!.added, result!!.updated, result!!.skipped))
+                    .setMessage(message)
                     .setPositiveButton(android.R.string.ok) { dialog, which ->
                         // dismiss
                     }
@@ -60,7 +66,9 @@ class ResultFragment : DialogFragment() {
         var total: Long = 0
         var added: Long = 0
         var updated: Long = 0
+        var failed: Long = 0
         var e: Exception? = null
+        var failureMessage: String? = null
 
         val isFailed: Boolean
             get() = e != null
@@ -69,7 +77,7 @@ class ResultFragment : DialogFragment() {
             get() = total - (added + updated)
 
         override fun toString(): String {
-            return "ResultFragment.ImportResult(total=" + this.total + ", added=" + this.added + ", updated=" + this.updated + ", e=" + this.e + ")"
+            return "ResultFragment.ImportResult(total=" + this.total + ", added=" + this.added + ", updated=" + this.updated + ", failed=" + this.failed + ", e=" + this.e?.javaClass?.name + ")"
         }
     }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -331,9 +331,13 @@
     <string name="import_dialog_title">Import</string>
     <string name="import_dialog_failed_title">Import Failed</string>
     <string name="import_dialog_failed_body">Reason: %s\nReport to developers?</string>
+    <string name="import_dialog_failed_generic">The import could not be completed. Please try again or report the problem.</string>
+    <string name="import_dialog_contacts_parse_failed">The selected contacts file could not be parsed. Please export it again or try importing it in the web app.</string>
+    <string name="import_dialog_unexpected_failure">The import could not be completed. Please try again or report the problem.</string>
     <string name="import_dialog_loading_file">Loading file (may take a while)...</string>
     <string name="import_dialog_adding_entries">Adding entries...</string>
-    <string name="import_dialog_success">Processed %1$d entries.\nAdded: %2$d\nChanged: %3$d\nSkipped (failed): %4$d</string>
+    <string name="import_dialog_success">Processed %1$d entries.\nAdded: %2$d\nChanged: %3$d\nSkipped: %4$d</string>
+    <string name="import_dialog_partial_success">Processed %1$d entries.\nAdded: %2$d\nChanged: %3$d\nSkipped: %4$d\nFailed: %5$d\n\nSome entries could not be imported.</string>
     <string name="import_permission_required">Reading storage permission is required for import.</string>
     <string name="import_account_top_notice">Please choose an account to import all of its entries from.</string>
     <string name="choose_file">Choose file</string>

--- a/android/app/src/test/java/io/silentsuite/sync/ui/importlocal/ImportResultTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/importlocal/ImportResultTest.kt
@@ -1,0 +1,35 @@
+package io.silentsuite.sync.ui.importlocal
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImportResultTest {
+
+    @Test
+    fun skippedCountsEntriesThatWereNotAddedOrUpdated() {
+        val result = ResultFragment.ImportResult().also {
+            it.total = 3
+            it.added = 1
+            it.updated = 1
+            it.failed = 1
+        }
+
+        assertEquals(1, result.skipped)
+    }
+
+    @Test
+    fun toStringDoesNotIncludeRawExceptionMessage() {
+        val result = ResultFragment.ImportResult().also {
+            it.e = Exception("private contact payload +155****4567")
+            it.failureMessage = "Safe import failure"
+        }
+
+        val description = result.toString()
+        assertTrue(description.contains("java.lang.Exception"))
+        assertFalse(description.contains("private contact payload"))
+        assertFalse(description.contains("+155****4567"))
+        assertFalse(description.contains("Safe import failure"))
+    }
+}

--- a/android/vcard4android/src/main/java/at/bitfire/vcard4android/Contact.kt
+++ b/android/vcard4android/src/main/java/at/bitfire/vcard4android/Contact.kt
@@ -168,8 +168,9 @@ class Contact {
                     is Title -> c.jobTitle = StringUtils.trimToNull(prop.value)
                     is Role -> c.jobDescription = StringUtils.trimToNull(prop.value)
 
-                    is Telephone -> if (!prop.text.isNullOrBlank())
-                        c.phoneNumbers += LabeledProperty(prop, findLabel(prop.group))
+                    is Telephone -> telephoneWithText(prop)?.let {
+                        c.phoneNumbers += LabeledProperty(it, findLabel(it.group))
+                    }
                     is Email -> if (!prop.value.isNullOrBlank())
                         c.emails += LabeledProperty(prop, findLabel(prop.group))
                     is Impp -> c.impps += LabeledProperty(prop, findLabel(prop.group))
@@ -275,6 +276,19 @@ class Contact {
             } catch(e: URISyntaxException) {
                 Constants.log.warning("Invalid URI for UID: $uriString")
                 uriString
+            }
+        }
+
+        private fun telephoneWithText(telephone: Telephone): Telephone? {
+            val existingText = StringUtils.trimToNull(telephone.text)
+            if (existingText != null)
+                return telephone
+
+            val uri = telephone.uri ?: return null
+            val text = StringUtils.trimToNull(uri.toString().removePrefix("tel:").removePrefix("TEL:")) ?: return null
+            return Telephone(text).also { normalized ->
+                normalized.group = telephone.group
+                normalized.parameters = ezvcard.parameter.VCardParameters(telephone.parameters)
             }
         }
 

--- a/android/vcard4android/src/test/java/at/bitfire/vcard4android/ContactTest.kt
+++ b/android/vcard4android/src/test/java/at/bitfire/vcard4android/ContactTest.kt
@@ -61,6 +61,69 @@ class ContactTest {
     }
 
     @Test
+    fun testVCard4TelephoneUriValue() {
+        val vcard = "BEGIN:VCARD\n" +
+                "VERSION:4.0\n" +
+                "FN:Telephone URI\n" +
+                "TEL;VALUE=uri;TYPE=cell:tel:+15551234567\n" +
+                "END:VCARD"
+        val c = Contact.fromReader(StringReader(vcard), null).first()
+
+        assertEquals(1, c.phoneNumbers.size)
+        val phone = c.phoneNumbers.first.property
+        assertEquals("+15551234567", phone.text)
+        assertTrue(phone.types.contains(TelephoneType.CELL))
+    }
+
+    @Test
+    fun testVCard4TelephoneImplicitUriValue() {
+        val vcard = "BEGIN:VCARD\n" +
+                "VERSION:4.0\n" +
+                "FN:Implicit Telephone URI\n" +
+                "TEL;TYPE=cell:tel:+155****4567\n" +
+                "END:VCARD"
+        val c = Contact.fromReader(StringReader(vcard), null).first()
+
+        assertEquals(1, c.phoneNumbers.size)
+        val phone = c.phoneNumbers.first.property
+        assertEquals("+155****4567", phone.text)
+        assertTrue(phone.types.contains(TelephoneType.CELL))
+    }
+
+    @Test
+    fun testVCard4TelephoneUriKeepsExtension() {
+        val vcard = "BEGIN:VCARD\n" +
+                "VERSION:4.0\n" +
+                "FN:Telephone URI Extension\n" +
+                "TEL;VALUE=uri;TYPE=work:tel:+155****4567;ext=89\n" +
+                "END:VCARD"
+        val c = Contact.fromReader(StringReader(vcard), null).first()
+
+        assertEquals(1, c.phoneNumbers.size)
+        val phone = c.phoneNumbers.first.property
+        assertEquals("+155****4567;ext=89", phone.text)
+        assertTrue(phone.types.contains(TelephoneType.WORK))
+    }
+
+    @Test
+    fun testVCard4GroupedTelephoneUriKeepsLabelAndType() {
+        val vcard = "BEGIN:VCARD\n" +
+                "VERSION:4.0\n" +
+                "FN:Grouped Telephone URI\n" +
+                "item1.TEL;VALUE=uri;TYPE=cell,pref:tel:+15551234567\n" +
+                "item1.X-ABLabel:Mobile\n" +
+                "END:VCARD"
+        val c = Contact.fromReader(StringReader(vcard), null).first()
+
+        assertEquals(1, c.phoneNumbers.size)
+        val phone = c.phoneNumbers.first
+        assertEquals("Mobile", phone.label)
+        assertEquals("+15551234567", phone.property.text)
+        assertTrue(phone.property.types.contains(TelephoneType.CELL))
+        assertTrue(phone.property.types.contains(TelephoneType.PREF))
+    }
+
+    @Test
     fun testGenerateOrganizationOnly() {
         val c = Contact()
         c.uid = UUID.randomUUID().toString()


### PR DESCRIPTION
## Summary
- Preserve Android vCard 4 TEL URI imports, including grouped labels, type/pref metadata, and extension parameters.
- Harden Android local import parse/runtime failure handling with privacy-safe user-facing messages.
- Track partial contact/group import failures with explicit failed/skipped counts.
- Add parser and import-result regression tests.

## Test Plan
- [x] `JAVA_HOME=/home/ss/tools/jdk-17.0.18+8 ANDROID_HOME=/home/ss/tools/android-sdk ANDROID_SDK_ROOT=/home/ss/tools/android-sdk ./gradlew :vcard4android:testDebugUnitTest :app:testDebugUnitTest :app:compileDebugKotlin --no-daemon`
- [ ] GitHub Actions Android signed APK/AAB build on PR.

## Release note
Android local contact imports now handle vCard 4 telephone URI numbers more reliably and report parse/partial failures with privacy-safe messages. This requires a new Android app release before users receive the fix.