### PR TITLE
docs: improve translation contributor workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Useful feedback right now:
 - Android APK testing across device models and Android versions
 - Bridge compatibility reports for Thunderbird, Apple Calendar, Evolution, GNOME Calendar, and other DAV clients
 - Self-hosting verification on fresh servers
+- Web app translation proposals and review from fluent human translators
 - Docs and trust review for vague privacy claims or confusing setup steps
 
 Open a [GitHub issue](https://github.com/silent-suite/silentsuite/issues) with logs/screenshots where useful. Do not paste secrets, passwords, or private calendar/contact data.
@@ -114,6 +115,7 @@ Bug reports, feature requests, and PRs are welcome.
 - [User Guide](./docs/user-guide/)
 - [Self-Hosting](./docs/self-hosting/)
 - [Contributing](./docs/contributing/)
+- [Translating SilentSuite](./TRANSLATING.md)
 - [docs.silentsuite.io](https://docs.silentsuite.io)
 
 ## Follow along

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -1,25 +1,251 @@
 # Translating SilentSuite
 
-SilentSuite keeps translation source files in Git so translator contributions remain reviewable and attributable.
+Thank you for helping translate SilentSuite. SilentSuite keeps translation source files in Git so translator contributions remain reviewable, attributable, and easy for maintainers to audit.
+
+This guide is written for people who want to help translate the web app, even if they are not regular code contributors.
 
 ## Current Scope
 
 - The web app source locale is English in `apps/web/messages/en.json`.
-- The first implementation is English-only. Do not add new locale files until a maintainer confirms there is a real translator/reviewer for that language.
+- Translation contributions currently use GitHub pull requests.
+- The first production runtime is still English-only. Maintainers will enable additional languages after there is a real translator/reviewer for that language.
 - Android remains on native resources in `android/app/src/main/res/values/strings.xml`.
 - Docs translation is deferred until language maintainers exist.
+- Do not add locale-prefixed routes, a language switcher, Weblate/Crowdin configuration, Android translations, or docs-site localization unless a maintainer explicitly asks for that scope.
 
-## How To Contribute Web Translations
+## Quick Start For Translators
 
-1. Open an issue or pull request describing the language you want to add or improve.
-2. Keep the same JSON key structure as `apps/web/messages/en.json`.
-3. Preserve ICU placeholders exactly, including names and punctuation around them.
-4. Keep privacy and security claims precise. Terms like zero-knowledge, end-to-end encrypted, server, bridge, recovery, account fingerprint, and self-host need maintainer review.
-5. Do not machine-translate large sections without human review.
+1. Open a GitHub issue or comment on an existing translation issue with the language you want to help with.
+2. Wait for a maintainer to confirm the locale code and review plan.
+3. Copy the English source catalog:
+
+   ```bash
+   cp apps/web/messages/en.json apps/web/messages/<locale>.json
+   ```
+
+   Examples: `de.json`, `fr.json`, `nl.json`, `pt-BR.json`.
+
+4. Translate message **values** only. Keep the same JSON keys and nesting.
+5. Run the validation command:
+
+   ```bash
+   pnpm i18n:check
+   ```
+
+6. Optional: print a completeness report:
+
+   ```bash
+   pnpm i18n:report
+   ```
+
+7. Open a pull request and include the locale, reviewer, and validation command output.
+
+## Translator Checklist
+
+Before opening your pull request:
+
+- [ ] I started from `apps/web/messages/en.json`.
+- [ ] I translated message values, not JSON keys.
+- [ ] I preserved the JSON nesting exactly.
+- [ ] I preserved every placeholder exactly, for example `{count}` or `{name}`.
+- [ ] I did not translate file paths, commands, URLs, email addresses, or code identifiers.
+- [ ] I kept privacy and security claims precise.
+- [ ] A fluent human reviewed the translation, especially privacy/security wording.
+- [ ] I ran `pnpm i18n:check` successfully.
+
+## Message File Rules
+
+Translation files live in:
+
+```text
+apps/web/messages/<locale>.json
+```
+
+Use English as the source of truth:
+
+```text
+apps/web/messages/en.json
+```
+
+Keep stable semantic keys. Translate values only:
+
+```json
+{
+  "Navigation": {
+    "calendar": "Calendar"
+  }
+}
+```
+
+For German, this becomes:
+
+```json
+{
+  "Navigation": {
+    "calendar": "Kalender"
+  }
+}
+```
+
+Do not change the key:
+
+```json
+{
+  "Navigation": {
+    "kalender": "Kalender"
+  }
+}
+```
+
+## Placeholders And ICU Messages
+
+Some messages include placeholders. Preserve placeholder names exactly.
+
+Source:
+
+```json
+{
+  "itemsRemaining": "{count} items remaining"
+}
+```
+
+Good translation:
+
+```json
+{
+  "itemsRemaining": "Noch {count} Einträge übrig"
+}
+```
+
+Bad translation, because `{count}` was renamed:
+
+```json
+{
+  "itemsRemaining": "Noch {anzahl} Einträge übrig"
+}
+```
+
+The validation command checks placeholder names and will fail if a translated message loses or adds placeholders compared with English. It is intentionally lightweight and does not fully parse ICU plural/select syntax, so ask for maintainer review when adding complex ICU messages.
+
+## What Not To Translate
+
+Do not translate:
+
+- JSON keys.
+- Placeholder names such as `{count}`, `{name}`, `{date}`.
+- Product and protocol names unless a maintainer approves a localized term:
+  - SilentSuite
+  - Etebase
+  - CalDAV
+  - CardDAV
+  - WebDAV
+  - Android
+  - GitHub
+- URLs, email addresses, file paths, command examples, package names, and code identifiers.
+- Cryptographic algorithm names such as XChaCha20-Poly1305, Argon2id, and libsodium.
+- Technical labels where localization would make support or security review confusing.
+
+## Tone And Style
+
+SilentSuite's UI should sound clear, calm, and practical.
+
+Use wording that is:
+
+- Direct and easy to understand.
+- Careful with privacy and security claims.
+- Honest about limitations.
+- Consistent with the English source.
+
+Avoid:
+
+- Marketing exaggeration.
+- Adding stronger promises than the English source makes.
+- Softening security-critical distinctions.
+- Turning precise terms like “encrypted” or “plaintext” into vague words like “safe” or “data”.
+
+Examples:
+
+| Prefer | Avoid |
+|---|---|
+| “Your calendar contents stay encrypted.” | “Your data is completely invisible forever.” |
+| “The server stores ciphertext.” | “The server has no data.” |
+| “It is not a recovery secret.” | “It cannot affect your account.” |
+
+## Privacy And Security Glossary
+
+Some terms need special care because SilentSuite is privacy/security software.
+
+| English term | Translator guidance |
+|---|---|
+| zero-knowledge | Use a precise local security/privacy equivalent. If unsure, ask a maintainer. |
+| end-to-end encrypted | Must mean encrypted before leaving the device and decrypted only on user devices. |
+| plaintext | Preserve the distinction between readable plaintext and encrypted ciphertext. |
+| ciphertext | Keep the meaning “encrypted, unreadable content”. |
+| server | Do not imply the server can read calendar, contact, or task contents. |
+| bridge | Preserve the meaning of the local CalDAV/CardDAV bridge; do not imply a cloud proxy. |
+| recovery secret | Do not translate as a normal password or account reset code. |
+| account fingerprint | Do not imply a biometric fingerprint, identity document, or recovery secret. |
+| self-host | Preserve the meaning “run your own server/deployment”. |
+
+If a sentence describes what SilentSuite, the server, or maintainers can or cannot see, translate conservatively and ask for maintainer review.
+
+## Validation Commands
+
+Run this from the repository root:
+
+```bash
+pnpm i18n:check
+```
+
+This checks every `apps/web/messages/*.json` file for:
+
+- malformed JSON
+- invalid message shapes
+- missing keys compared with `apps/web/messages/en.json`
+- extra or stale keys
+- placeholder mismatches
+
+To print a completeness report without failing on incomplete work-in-progress locale files:
+
+```bash
+pnpm i18n:report
+```
+
+The report command still exits non-zero for malformed catalogs that cannot be read safely.
+
+Example output:
+
+```text
+Web translation message validation
+
+Source locale: en
+Reference keys: 26
+
+Locale  Complete  Keys
+------  --------  ----
+en        100.0%    26/26
+de         92.3%    24/26
+```
+
+A translation pull request should pass `pnpm i18n:check` before review.
+
+## Pull Request Notes
+
+Please include:
+
+- The language and locale code.
+- Whether this is a new locale or an update to an existing locale.
+- Who reviewed the translation fluently.
+- The output of `pnpm i18n:check`.
+- Any privacy/security wording that needs maintainer attention.
+
+Do not paste private calendar, contact, task, account, billing, or log data into issues or pull requests.
 
 ## Platform Decision
 
 GitHub pull requests are accepted for the initial English source catalog and small translation updates. Hosted Weblate is the preferred future translation UI if non-technical translator demand grows; self-hosted Weblate remains the fallback if hosted eligibility is not available. Crowdin is not selected for now because its open-source eligibility can be ambiguous for projects with related commercial subscriptions.
+
+The platform decision does not block translation files from living in Git. That keeps contributions reviewable and allows a future translation platform to sync against the same source files.
 
 ## Attribution
 

--- a/apps/docs/contributing/index.md
+++ b/apps/docs/contributing/index.md
@@ -11,6 +11,7 @@ Thank you for your interest in contributing to SilentSuite. This guide will help
 | [Code Conventions](./code-conventions.md) | Style guide and patterns we follow |
 | [Testing](./testing.md) | How to run and write tests |
 | [Pull Request Guide](./pull-request-guide.md) | How to submit changes |
+| [Translation Guide](https://github.com/silent-suite/silentsuite/blob/main/TRANSLATING.md) | Help translate the web app safely and consistently |
 
 ---
 
@@ -19,6 +20,7 @@ Thank you for your interest in contributing to SilentSuite. This guide will help
 1. **Read the [Development Setup](./dev-setup.md) guide** to get the project running locally.
 2. **Check existing issues** on [GitHub](https://github.com/silent-suite/silentsuite/issues) for something to work on, or open a new issue to discuss your idea before writing code.
 3. **Follow the [Pull Request Guide](./pull-request-guide.md)** when submitting changes.
+4. **For translations, read the [Translation Guide](https://github.com/silent-suite/silentsuite/blob/main/TRANSLATING.md)** before adding or updating locale files.
 
 ## Code of Conduct
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "i18n:check": "node scripts/validate-messages.mjs",
+    "i18n:report": "node scripts/validate-messages.mjs --report"
   },
   "dependencies": {
     "@ducanh2912/next-pwa": "^10.2.9",

--- a/apps/web/scripts/validate-messages.mjs
+++ b/apps/web/scripts/validate-messages.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const messagesDir = path.resolve(scriptDir, '..', 'messages')
+const sourceLocale = 'en'
+const sourceFile = `${sourceLocale}.json`
+const placeholderPattern = /\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:,[^}]*)?\}/g
+
+function usage() {
+  console.log(`Usage: node scripts/validate-messages.mjs [--check|--report]
+
+Checks web app message catalogs in apps/web/messages.
+
+--check   Validate locale files and exit non-zero on problems (default)
+--report  Print completeness details; exits non-zero only for malformed catalogs`)
+}
+
+function parseArgs(argv) {
+  const args = new Set(argv)
+  if (args.has('--help') || args.has('-h')) {
+    usage()
+    process.exit(0)
+  }
+
+  const allowed = new Set(['--check', '--report'])
+  for (const arg of args) {
+    if (!allowed.has(arg)) {
+      console.error(`Unknown argument: ${arg}`)
+      usage()
+      process.exit(2)
+    }
+  }
+
+  return {
+    report: args.has('--report'),
+  }
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch (error) {
+    return { __parseError: error }
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function flattenMessages(value, prefix = '', result = {}, shapeErrors = []) {
+  if (typeof value === 'string') {
+    result[prefix] = value
+    return { result, shapeErrors }
+  }
+
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      if (key.includes('.')) {
+        const location = prefix ? `${prefix}.${key}` : key
+        shapeErrors.push(`${location} must use nested JSON objects instead of dots in key names`)
+      }
+      const nextPrefix = prefix ? `${prefix}.${key}` : key
+      flattenMessages(child, nextPrefix, result, shapeErrors)
+    }
+    return { result, shapeErrors }
+  }
+
+  const location = prefix || '<root>'
+  shapeErrors.push(`${location} must be a string or nested object, got ${Array.isArray(value) ? 'array' : typeof value}`)
+  return { result, shapeErrors }
+}
+
+function extractPlaceholders(message) {
+  const placeholders = new Set()
+  for (const match of message.matchAll(placeholderPattern)) {
+    placeholders.add(match[1])
+  }
+  return [...placeholders].sort()
+}
+
+function isValidLocaleCode(locale) {
+  try {
+    // Intl.Locale accepts BCP 47-style tags such as en, de, pt-BR, and zh-Hans.
+    // Keep this intentionally light so maintainers can still decide which valid locales to enable.
+    new Intl.Locale(locale)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function difference(left, right) {
+  const rightSet = new Set(right)
+  return left.filter((item) => !rightSet.has(item))
+}
+
+function percent(part, whole) {
+  if (whole === 0) return '100.0%'
+  return `${((part / whole) * 100).toFixed(1)}%`
+}
+
+function formatList(items, indent = '    ') {
+  return items.map((item) => `${indent}- ${item}`).join('\n')
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2))
+
+  if (!fs.existsSync(messagesDir)) {
+    console.error(`Messages directory not found: ${messagesDir}`)
+    process.exit(1)
+  }
+
+  const files = fs.readdirSync(messagesDir).filter((file) => file.endsWith('.json')).sort()
+
+  if (!files.includes(sourceFile)) {
+    console.error(`Source locale file is missing: ${path.join(messagesDir, sourceFile)}`)
+    process.exit(1)
+  }
+
+  const catalogs = new Map()
+  const parseErrors = []
+
+  for (const file of files) {
+    const filePath = path.join(messagesDir, file)
+    const parsed = readJson(filePath)
+    if (parsed && parsed.__parseError) {
+      parseErrors.push(`${file}: ${parsed.__parseError.message}`)
+      continue
+    }
+    catalogs.set(file, parsed)
+  }
+
+  const sourceCatalog = catalogs.get(sourceFile)
+  const sourceFlattened = sourceCatalog ? flattenMessages(sourceCatalog) : { result: {}, shapeErrors: [] }
+  const sourceMessages = sourceFlattened.result
+  const sourceKeys = Object.keys(sourceMessages).sort()
+  const sourcePlaceholderMap = new Map(
+    sourceKeys.map((key) => [key, extractPlaceholders(sourceMessages[key])]),
+  )
+
+  const localeReports = []
+  let hasValidationErrors = parseErrors.length > 0 || sourceFlattened.shapeErrors.length > 0
+  let hasFatalErrors = parseErrors.length > 0 || sourceFlattened.shapeErrors.length > 0
+
+  for (const file of files) {
+    if (!catalogs.has(file)) continue
+
+    const locale = path.basename(file, '.json')
+    const flattened = flattenMessages(catalogs.get(file))
+    const messages = flattened.result
+    const keys = Object.keys(messages).sort()
+    const localeCodeErrors = isValidLocaleCode(locale) ? [] : [`invalid locale code: ${locale}`]
+    const missing = difference(sourceKeys, keys)
+    const extra = difference(keys, sourceKeys)
+    const placeholderMismatches = []
+
+    for (const key of keys) {
+      if (!sourcePlaceholderMap.has(key)) continue
+      const expected = sourcePlaceholderMap.get(key)
+      const actual = extractPlaceholders(messages[key])
+      const missingPlaceholders = difference(expected, actual)
+      const extraPlaceholders = difference(actual, expected)
+      if (missingPlaceholders.length > 0 || extraPlaceholders.length > 0) {
+        placeholderMismatches.push({ key, missing: missingPlaceholders, extra: extraPlaceholders })
+      }
+    }
+
+    const errors = [
+      ...localeCodeErrors,
+      ...flattened.shapeErrors,
+      ...missing.map((key) => `missing key: ${key}`),
+      ...extra.map((key) => `extra key: ${key}`),
+      ...placeholderMismatches.map((item) => {
+        const parts = []
+        if (item.missing.length > 0) parts.push(`missing placeholders: ${item.missing.join(', ')}`)
+        if (item.extra.length > 0) parts.push(`extra placeholders: ${item.extra.join(', ')}`)
+        return `placeholder mismatch at ${item.key}: ${parts.join('; ')}`
+      }),
+    ]
+
+    if (errors.length > 0) hasValidationErrors = true
+    if (flattened.shapeErrors.length > 0) hasFatalErrors = true
+
+    localeReports.push({
+      locale,
+      file,
+      keys: keys.length,
+      expectedKeys: sourceKeys.length,
+      completeness: percent(sourceKeys.length - missing.length, sourceKeys.length),
+      localeCodeErrors,
+      missing,
+      extra,
+      shapeErrors: flattened.shapeErrors,
+      placeholderMismatches,
+      errors,
+    })
+  }
+
+  console.log('Web translation message validation')
+  console.log('')
+  console.log(`Messages directory: ${path.relative(process.cwd(), messagesDir) || '.'}`)
+  console.log(`Source locale: ${sourceLocale}`)
+  console.log(`Reference keys: ${sourceKeys.length}`)
+  console.log('')
+
+  if (parseErrors.length > 0) {
+    console.log('Parse errors:')
+    console.log(formatList(parseErrors))
+    console.log('')
+  }
+
+  if (sourceFlattened.shapeErrors.length > 0) {
+    console.log(`${sourceFile} shape errors:`)
+    console.log(formatList(sourceFlattened.shapeErrors))
+    console.log('')
+  }
+
+  const localeColumnWidth = Math.max('Locale'.length, ...localeReports.map((report) => report.locale.length))
+  console.log(`${'Locale'.padEnd(localeColumnWidth)}  Complete  Keys`)
+  console.log(`${'-'.repeat(localeColumnWidth)}  --------  ----`)
+  for (const report of localeReports) {
+    console.log(
+      `${report.locale.padEnd(localeColumnWidth)}  ${report.completeness.padStart(8)}  ${String(report.keys).padStart(4)}/${report.expectedKeys}`,
+    )
+  }
+  console.log('')
+
+  for (const report of localeReports) {
+    if (!options.report && report.errors.length === 0) continue
+
+    console.log(`${report.file}`)
+    console.log(`  completeness: ${report.completeness} (${report.keys}/${report.expectedKeys} keys)`)
+
+    if (report.localeCodeErrors.length > 0) {
+      console.log('  locale code errors:')
+      console.log(formatList(report.localeCodeErrors, '    '))
+    }
+
+    if (report.shapeErrors.length > 0) {
+      console.log('  shape errors:')
+      console.log(formatList(report.shapeErrors, '    '))
+    }
+
+    if (report.missing.length > 0) {
+      console.log('  missing keys:')
+      console.log(formatList(report.missing, '    '))
+    }
+
+    if (report.extra.length > 0) {
+      console.log('  extra keys:')
+      console.log(formatList(report.extra, '    '))
+    }
+
+    if (report.placeholderMismatches.length > 0) {
+      console.log('  placeholder mismatches:')
+      for (const mismatch of report.placeholderMismatches) {
+        console.log(`    - ${mismatch.key}`)
+        if (mismatch.missing.length > 0) console.log(`      missing: ${mismatch.missing.join(', ')}`)
+        if (mismatch.extra.length > 0) console.log(`      extra: ${mismatch.extra.join(', ')}`)
+      }
+    }
+
+    if (report.errors.length === 0) {
+      console.log('  status: ok')
+    }
+    console.log('')
+  }
+
+  const shouldFail = options.report ? hasFatalErrors : hasValidationErrors
+
+  if (shouldFail) {
+    console.error(options.report ? 'i18n report found malformed catalogs.' : 'i18n validation failed.')
+    process.exit(1)
+  }
+
+  if (options.report && hasValidationErrors) {
+    console.log('i18n report complete; run pnpm i18n:check for strict validation status.')
+    return
+  }
+
+  console.log(options.report ? 'i18n report complete.' : 'i18n validation passed.')
+}
+
+main()

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -11,6 +11,7 @@ Thank you for your interest in contributing to SilentSuite. This guide will help
 | [Code Conventions](./code-conventions.md) | Style guide and patterns we follow |
 | [Testing](./testing.md) | How to run and write tests |
 | [Pull Request Guide](./pull-request-guide.md) | How to submit changes |
+| [Translation Guide](../../TRANSLATING.md) | Help translate the web app safely and consistently |
 
 ---
 
@@ -19,6 +20,7 @@ Thank you for your interest in contributing to SilentSuite. This guide will help
 1. **Read the [Development Setup](./dev-setup.md) guide** to get the project running locally.
 2. **Check existing issues** on [GitHub](https://github.com/silent-suite/silentsuite/issues) for something to work on, or open a new issue to discuss your idea before writing code.
 3. **Follow the [Pull Request Guide](./pull-request-guide.md)** when submitting changes.
+4. **For translations, read the [Translation Guide](../../TRANSLATING.md)** before adding or updating locale files.
 
 ## Code of Conduct
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build:docs": "turbo build --filter=@silentsuite/docs",
     "lint": "turbo lint",
     "test": "turbo test",
-    "type-check": "turbo type-check"
+    "type-check": "turbo type-check",
+    "i18n:check": "pnpm --filter @silentsuite/web i18n:check",
+    "i18n:report": "pnpm --filter @silentsuite/web i18n:report"
   },
   "devDependencies": {
     "turbo": "^2.4.0"


### PR DESCRIPTION
## Summary
- add strict web message catalog validation and completeness reporting commands
- expand `TRANSLATING.md` into a beginner-friendly translator workflow with placeholder, tone, and privacy/security guidance
- link the translation guide from README and contributor docs

## Validation
- `pnpm i18n:check`
- `pnpm i18n:report`
- negative smoke: temporary incomplete `de.json` fails `pnpm i18n:check`
- negative smoke: temporary flat dotted-key `de.json` fails `pnpm i18n:check`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web test`
- `pnpm --filter @silentsuite/web build`
- `pnpm --filter @silentsuite/docs build`
- `git diff --check`

Closes #237
