### PR TITLE
chore(android): prepare v0.2.2-beta release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
 
-        versionCode 6
-        versionName "0.2.0-beta"
+        versionCode 7
+        versionName "0.2.2-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,0 +1,1 @@
+v0.2.2-beta: improves Android local contact imports for vCard 4 telephone numbers, reports failed/partial imports more clearly without exposing private contact details, hardens Android setup secrets and debug logging, and includes the latest import compatibility and privacy fixes.

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,0 +1,1 @@
+v0.2.2-beta: improves Android local contact imports for vCard 4 telephone numbers, reports failed/partial imports more clearly without exposing private contact details, hardens Android setup secrets and debug logging, and includes the latest import compatibility and privacy fixes.


### PR DESCRIPTION
## Summary
- bump Android release metadata to `versionCode 7` / `versionName "0.2.2-beta"`
- add Play/F-Droid Fastlane changelog text for the Android import/privacy fixes
- keep release notes body staged separately for the `v0.2.2-beta` GitHub Release

## Validation
- `git diff --check`
- checked Android version fields and changelog files

## Notes
- This is release-prep metadata only; Android signed APK/AAB and bridge binaries should be built and attached by the tag-triggered workflows after `v0.2.2-beta` is created on `main`.