### PR TITLE
Promote v0.2.2-beta release metadata

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
 
-        versionCode 6
-        versionName "0.2.0-beta"
+        versionCode 7
+        versionName "0.2.2-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,0 +1,1 @@
+v0.2.2-beta: improves Android local contact imports for vCard 4 telephone numbers, reports failed/partial imports more clearly without exposing private contact details, hardens Android setup secrets and debug logging, and includes the latest import compatibility and privacy fixes.

--- a/fastlane/metadata/android/en-US/changelogs/7.txt
+++ b/fastlane/metadata/android/en-US/changelogs/7.txt
@@ -1,0 +1,1 @@
+v0.2.2-beta: improves Android local contact imports for vCard 4 telephone numbers, reports failed/partial imports more clearly without exposing private contact details, hardens Android setup secrets and debug logging, and includes the latest import compatibility and privacy fixes.


### PR DESCRIPTION
## Summary
- Promote Android release metadata for `v0.2.2-beta` from `dev` to `main`.
- Includes `versionCode 7`, `versionName "0.2.2-beta"`, and Fastlane changelog files for both metadata roots.

## Verification
- PR #265 checks passed before merge to `dev`.
- Latest `dev` push checks passed: Android build, CI lint/typecheck/tests/audit, and web build.
- Promotion diff is release metadata only.

## Release notes
- Release body is staged locally at `/tmp/silentsuite-v0.2.2-beta-release-notes.md` and should be used when creating the `v0.2.2-beta` GitHub Release after this PR lands.