### PR TITLE
Fix Android accepted invite refresh

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/AddressBooksSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/AddressBooksSyncAdapterService.kt
@@ -39,7 +39,11 @@ class AddressBooksSyncAdapterService : SyncAdapterService() {
             if (!extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL) && !checkSyncConditions(settings))
                 return
 
-            RefreshCollections(account, CollectionInfo.Type.ADDRESS_BOOK).run()
+            RefreshCollections(
+                account,
+                CollectionInfo.Type.ADDRESS_BOOK,
+                extras.getBoolean(EXTRA_FORCE_COLLECTION_REFRESH, false),
+            ).run()
 
             updateLocalAddressBooks(contactsProvider, account, settings)
 

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/CalendarsSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/CalendarsSyncAdapterService.kt
@@ -31,7 +31,11 @@ class CalendarsSyncAdapterService : SyncAdapterService() {
             if (!extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL) && !checkSyncConditions(settings))
                 return
 
-            RefreshCollections(account, CollectionInfo.Type.CALENDAR).run()
+            RefreshCollections(
+                account,
+                CollectionInfo.Type.CALENDAR,
+                extras.getBoolean(EXTRA_FORCE_COLLECTION_REFRESH, false),
+            ).run()
 
             updateLocalCalendars(provider, account, settings)
 

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/RequestSync.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/RequestSync.kt
@@ -9,7 +9,9 @@ import io.silentsuite.sync.App
 import io.silentsuite.sync.utils.TaskProviderHandling
 
 
-fun requestSync(context: Context, account: Account?) {
+const val EXTRA_FORCE_COLLECTION_REFRESH = "io.silentsuite.sync.FORCE_COLLECTION_REFRESH"
+
+fun requestSync(context: Context, account: Account?, forceCollectionRefresh: Boolean = false) {
     val authorities = arrayOf(
             App.addressBooksAuthority,
             CalendarContract.AUTHORITY,
@@ -20,6 +22,9 @@ fun requestSync(context: Context, account: Account?) {
         val extras = Bundle()
         extras.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true)        // manual sync
         extras.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true)     // run immediately (don't queue)
+        if (forceCollectionRefresh) {
+            extras.putBoolean(EXTRA_FORCE_COLLECTION_REFRESH, true)
+        }
         ContentResolver.requestSync(account, authority, extras)
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncAdapterService.kt
@@ -153,7 +153,11 @@ abstract class SyncAdapterService : Service() {
             return true
         }
 
-        inner class RefreshCollections internal constructor(private val account: Account, private val serviceType: CollectionInfo.Type) {
+        inner class RefreshCollections internal constructor(
+            private val account: Account,
+            private val serviceType: CollectionInfo.Type,
+            private val forceRefresh: Boolean = false,
+        ) {
             private val context: Context
 
             init {
@@ -162,7 +166,7 @@ abstract class SyncAdapterService : Service() {
 
             @Throws(InvalidAccountException::class)
             internal fun run() {
-                Logger.log.info("Refreshing " + serviceType + " collections of service #" + serviceType.toString())
+                Logger.log.info("Refreshing " + serviceType + " collections of service #" + serviceType.toString() + if (forceRefresh) " (forced)" else "")
 
                 val settings = AccountSettings(context, account)
                 HttpClient.Builder(context, settings).setForeground(false).build().use { httpClient ->
@@ -172,13 +176,16 @@ abstract class SyncAdapterService : Service() {
                         val now = System.currentTimeMillis()
                         val lastCollectionsFetch = collectionLastFetchMap[account.name] ?: 0
 
-                        if (abs(now - lastCollectionsFetch) <= cacheAge) {
+                        if (!forceRefresh && abs(now - lastCollectionsFetch) <= cacheAge) {
                             return@synchronized
                         }
 
                         val etebase = EtebaseLocalCache.getEtebase(context, httpClient.okHttpClient, settings)
                         val colMgr = etebase.collectionManager
-                        var stoken = etebaseLocalCache.loadStoken()
+                        // Post-invite acceptance must not depend on the previous collection-list
+                        // cursor: a full list refresh makes newly accepted shared collections
+                        // visible even when an old stoken would otherwise hide the membership change.
+                        var stoken = if (forceRefresh) null else etebaseLocalCache.loadStoken()
                         var done = false
                         while (!done) {
                             val colList = colMgr.list(COLLECTION_TYPES, FetchOptions().stoken(stoken))

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/TasksSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/TasksSyncAdapterService.kt
@@ -53,7 +53,11 @@ class TasksSyncAdapterService: SyncAdapterService() {
             if (!extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL) && !checkSyncConditions(accountSettings))
                 return
 
-            RefreshCollections(account, CollectionInfo.Type.TASKS).run()
+            RefreshCollections(
+                account,
+                CollectionInfo.Type.TASKS,
+                extras.getBoolean(EXTRA_FORCE_COLLECTION_REFRESH, false),
+            ).run()
 
             updateLocalTaskLists(taskProvider, account, accountSettings)
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/InvitationsListFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/InvitationsListFragment.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.ListFragment
 import androidx.fragment.app.activityViewModels
@@ -21,7 +22,9 @@ import com.etebase.client.FetchOptions
 import com.etebase.client.SignedInvitation
 import com.etebase.client.Utils
 import io.silentsuite.sync.R
+import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.syncadapter.requestSync
+import kotlinx.coroutines.CancellationException
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -92,10 +95,20 @@ class InvitationsListFragment : ListFragment(), AdapterView.OnItemClickListener 
                     invitationsModel.reject(model.value!!, invitation)
                 }
                 .setPositiveButton(R.string.invitations_accept) { dialogInterface, i ->
-                    invitationsModel.accept(model.value!!, invitation)
-                    val applicationContext = activity?.applicationContext
-                    if (applicationContext != null) {
-                        requestSync(applicationContext, model.value!!.account)
+                    val accountHolder = model.value!!
+                    val applicationContext = requireContext().applicationContext
+                    val account = accountHolder.account
+                    invitationsModel.accept(accountHolder, invitation) { result ->
+                        result.onSuccess {
+                            requestSync(applicationContext, account, forceCollectionRefresh = true)
+                            Toast.makeText(applicationContext, R.string.invitations_accept_success_syncing, Toast.LENGTH_LONG).show()
+                            activity?.finish()
+                        }.onFailure {
+                            Logger.log.warning("Invitation acceptance failed: ${it.javaClass.name}")
+                            context?.let { fragmentContext ->
+                                Toast.makeText(fragmentContext, R.string.invitations_accept_error, Toast.LENGTH_LONG).show()
+                            }
+                        }
                     }
                 }
                 .show()
@@ -148,14 +161,26 @@ class InvitationsViewModel : ViewModel() {
         }
     }
 
-    fun accept(accountCollectionHolder: AccountHolder, invitation: SignedInvitation) {
+    fun accept(accountCollectionHolder: AccountHolder, invitation: SignedInvitation, onComplete: (Result<Unit>) -> Unit = {}) {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                val invitationManager = accountCollectionHolder.etebase.invitationManager
-                invitationManager.accept(invitation)
+            val result = try {
+                withContext(Dispatchers.IO) {
+                    val invitationManager = accountCollectionHolder.etebase.invitationManager
+                    invitationManager.accept(invitation)
+                }
+                Result.success(Unit)
+            } catch (e: Exception) {
+                if (e is CancellationException) {
+                    throw e
+                }
+                Result.failure(e)
             }
-            val ret = invitations.value!!.filter { it != invitation }
-            invitations.value = ret
+
+            if (result.isSuccess) {
+                val ret = invitations.value.orEmpty().filter { it != invitation }
+                invitations.value = ret
+            }
+            onComplete(result)
         }
     }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -214,6 +214,8 @@
     <string name="invitations_accept_reject_dialog">Would you like to accept or reject the invitation?</string>
     <string name="invitations_accept">Accept</string>
     <string name="invitations_reject">Reject</string>
+    <string name="invitations_accept_success_syncing">Invitation accepted. Syncing shared collections…</string>
+    <string name="invitations_accept_error">Couldn\'t accept invitation. Please try again.</string>
 
     <!-- JournalItemActivity -->
     <string name="about">About</string>

--- a/android/app/src/test/java/io/silentsuite/sync/ui/etebase/InvitationAcceptRefreshTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/etebase/InvitationAcceptRefreshTest.kt
@@ -1,0 +1,59 @@
+package io.silentsuite.sync.ui.etebase
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class InvitationAcceptRefreshTest {
+    private val sourceRoot = File("src/main/java")
+
+    @Test
+    fun acceptingInvitationRequestsForcedSyncOnlyAfterAcceptCompletes() {
+        val source = File(sourceRoot, "io/silentsuite/sync/ui/etebase/InvitationsListFragment.kt").readText()
+
+        assertTrue(
+            "accept must report completion before the UI requests sync",
+            source.contains("fun accept(accountCollectionHolder: AccountHolder, invitation: SignedInvitation, onComplete: (Result<Unit>) -> Unit = {})")
+        )
+        assertTrue(
+            "accept must wait for invitationManager.accept(invitation)",
+            source.contains("invitationManager.accept(invitation)")
+        )
+        assertTrue(
+            "sync must be requested from the success callback with forced collection refresh",
+            source.contains("requestSync(applicationContext, account, forceCollectionRefresh = true)")
+        )
+        assertTrue(
+            "application context and account must be captured before the async accept to survive fragment detach",
+            source.contains("val applicationContext = requireContext().applicationContext") &&
+                    source.contains("invitationsModel.accept(accountHolder, invitation)") &&
+                    source.indexOf("val applicationContext = requireContext().applicationContext") <
+                    source.indexOf("invitationsModel.accept(accountHolder, invitation)")
+        )
+        assertFalse(
+            "sync must not be requested immediately after starting the accept coroutine",
+            source.contains("invitationsModel.accept(accountHolder, invitation)\n                    requestSync")
+        )
+    }
+
+    @Test
+    fun forcedPostAcceptSyncBypassesCollectionRefreshSuppressionAndStoken() {
+        val requestSyncSource = File(sourceRoot, "io/silentsuite/sync/syncadapter/RequestSync.kt").readText()
+        val syncAdapterSource = File(sourceRoot, "io/silentsuite/sync/syncadapter/SyncAdapterService.kt").readText()
+
+        assertTrue(
+            "requestSync must expose an explicit forced collection refresh extra",
+            requestSyncSource.contains("EXTRA_FORCE_COLLECTION_REFRESH") &&
+                    requestSyncSource.contains("extras.putBoolean(EXTRA_FORCE_COLLECTION_REFRESH, true)")
+        )
+        assertTrue(
+            "forced refresh must bypass the 5 second collection refresh suppression",
+            syncAdapterSource.contains("if (!forceRefresh && abs(now - lastCollectionsFetch) <= cacheAge)")
+        )
+        assertTrue(
+            "forced refresh must perform a full collection-list fetch instead of reusing the old stoken",
+            syncAdapterSource.contains("var stoken = if (forceRefresh) null else etebaseLocalCache.loadStoken()")
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- wait for Android invitation accept to complete before requesting sync
- add a forced collection-refresh sync extra for post-accept sync
- bypass the 5 second collection refresh suppression and ignore stale collection-list stoken for forced refreshes
- show clear success/failure feedback and return to the account screen after success

Closes #240

## Verification
- Source-level acceptance checks for post-accept forced sync behavior
- `git diff --check`
- `git diff --cached --check`
- `strings.xml` parse check

## CI / manual validation needed
- Android GitHub Actions build
- Android unit test task for `InvitationAcceptRefreshTest`
- Two-account Android manual test: invite, accept, shared calendar appears after forced refresh
