### PR TITLE
docs: point contributor PRs at dev

### DIFF
--- a/apps/docs/contributing/pull-request-guide.md
+++ b/apps/docs/contributing/pull-request-guide.md
@@ -49,7 +49,7 @@ pnpm build
 git push origin your-branch-name
 ```
 
-Open a pull request on GitHub against the `main` branch.
+Open a pull request on GitHub against the `dev` branch.
 
 ## PR Description
 

--- a/docs/contributing/pull-request-guide.md
+++ b/docs/contributing/pull-request-guide.md
@@ -49,7 +49,7 @@ pnpm build
 git push origin your-branch-name
 ```
 
-Open a pull request on GitHub against the `main` branch.
+Open a pull request on GitHub against the `dev` branch.
 
 ## PR Description
 


### PR DESCRIPTION
## Summary
- point the contributor pull request guide at `dev` instead of `main`
- keep the mirrored `apps/docs/` and `docs/` copies in sync

Closes #260

## Validation
- `git diff --check`
- inspected diff: docs-only, two expected lines changed