### PR TITLE
feat(core): add sharing invitation wrappers

### DIFF
--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand'
 import { ETEBASE_SERVER_URL } from '@/app/lib/config'
 import type {
+  CollectionAccessLevel,
   CollectionType,
   SyncChangeEvent,
 } from '@silentsuite/core'
@@ -373,6 +374,46 @@ interface EtebaseActions {
   reconcileCollections: () => Promise<void>
 
   /**
+   * List pending incoming sharing invitations for the current account.
+   */
+  listIncomingInvitations: () => Promise<any[]>
+
+  /**
+   * Accept an incoming sharing invitation, then reconcile collections so the shared collection appears.
+   */
+  acceptInvitation: (invitation: any) => Promise<boolean>
+
+  /**
+   * Reject an incoming sharing invitation.
+   */
+  rejectInvitation: (invitation: any) => Promise<boolean>
+
+  /**
+   * Invite another user to an existing collection.
+   */
+  inviteToCollection: (type: CollectionTypeKey, collectionUid: string, username: string, accessLevel: CollectionAccessLevel) => Promise<boolean>
+
+  /**
+   * List members for a collection.
+   */
+  listCollectionMembers: (type: CollectionTypeKey, collectionUid: string) => Promise<any[]>
+
+  /**
+   * Remove a member from a collection.
+   */
+  removeCollectionMember: (type: CollectionTypeKey, collectionUid: string, username: string) => Promise<boolean>
+
+  /**
+   * Leave a shared collection as the current account.
+   */
+  leaveCollection: (type: CollectionTypeKey, collectionUid: string) => Promise<boolean>
+
+  /**
+   * Change a member's access level.
+   */
+  modifyCollectionMemberAccess: (type: CollectionTypeKey, collectionUid: string, username: string, accessLevel: CollectionAccessLevel) => Promise<boolean>
+
+  /**
    * Delete every item inside a collection while keeping the collection itself.
    */
   deleteItemsInCollection: (type: CollectionTypeKey, collectionUid: string) => Promise<number>
@@ -727,6 +768,149 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       throw err
     } finally {
       syncEngine?.resume?.()
+    }
+  },
+
+  listIncomingInvitations: async () => {
+    const { account } = get()
+    if (!account) return []
+
+    try {
+      const core = await import('@silentsuite/core')
+      return await core.listIncomingInvitations(account)
+    } catch (err) {
+      console.error('[etebase-store] Failed to list incoming invitations', getSafeErrorDetails(err))
+      showErrorToast('Failed to load sharing invitations. Please try again.')
+      return []
+    }
+  },
+
+  acceptInvitation: async (invitation: any) => {
+    const { account } = get()
+    if (!account) {
+      logger.warn('[etebase-store] Cannot accept invitation: no account')
+      return false
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      await core.acceptInvitation(account, invitation)
+      await get().reconcileCollections()
+      return true
+    } catch (err) {
+      console.error('[etebase-store] Failed to accept invitation', getSafeErrorDetails(err))
+      showErrorToast('Failed to accept sharing invitation. Please try again.')
+      return false
+    }
+  },
+
+  rejectInvitation: async (invitation: any) => {
+    const { account } = get()
+    if (!account) {
+      logger.warn('[etebase-store] Cannot reject invitation: no account')
+      return false
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      await core.rejectInvitation(account, invitation)
+      return true
+    } catch (err) {
+      console.error('[etebase-store] Failed to reject invitation', getSafeErrorDetails(err))
+      showErrorToast('Failed to reject sharing invitation. Please try again.')
+      return false
+    }
+  },
+
+  inviteToCollection: async (type: CollectionTypeKey, collectionUid: string, username: string, accessLevel: CollectionAccessLevel) => {
+    const { account, collections } = get()
+    const collection = resolveCollection(collections, type, collectionUid)
+    if (!account || !collection) {
+      logger.warn(`[etebase-store] Cannot invite to ${type} collection ${collectionUid}: missing account or collection`)
+      return false
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      await core.inviteToCollection(account, collection, username, accessLevel)
+      return true
+    } catch (err) {
+      console.error('[etebase-store] Failed to create sharing invitation', getSafeErrorDetails(err))
+      showErrorToast('Failed to create sharing invitation. Please verify the username and try again.')
+      return false
+    }
+  },
+
+  listCollectionMembers: async (type: CollectionTypeKey, collectionUid: string) => {
+    const { account, collections } = get()
+    const collection = resolveCollection(collections, type, collectionUid)
+    if (!account || !collection) return []
+
+    try {
+      const core = await import('@silentsuite/core')
+      return await core.listCollectionMembers(account, collection)
+    } catch (err) {
+      console.error('[etebase-store] Failed to list collection members', getSafeErrorDetails(err))
+      showErrorToast('Failed to load collection members. Please try again.')
+      return []
+    }
+  },
+
+  removeCollectionMember: async (type: CollectionTypeKey, collectionUid: string, username: string) => {
+    const { account, collections } = get()
+    const collection = resolveCollection(collections, type, collectionUid)
+    if (!account || !collection) {
+      logger.warn(`[etebase-store] Cannot remove member from ${type} collection ${collectionUid}: missing account or collection`)
+      return false
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      await core.removeCollectionMember(account, collection, username)
+      return true
+    } catch (err) {
+      console.error('[etebase-store] Failed to remove collection member', getSafeErrorDetails(err))
+      showErrorToast('Failed to remove collection member. Please try again.')
+      return false
+    }
+  },
+
+  leaveCollection: async (type: CollectionTypeKey, collectionUid: string) => {
+    const { account, collections } = get()
+    const collection = resolveCollection(collections, type, collectionUid)
+    if (!account || !collection) {
+      logger.warn(`[etebase-store] Cannot leave ${type} collection ${collectionUid}: missing account or collection`)
+      return false
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      await core.leaveCollection(account, collection)
+      await get().reconcileCollections()
+      return true
+    } catch (err) {
+      console.error('[etebase-store] Failed to leave collection', getSafeErrorDetails(err))
+      showErrorToast('Failed to leave shared collection. Please try again.')
+      return false
+    }
+  },
+
+  modifyCollectionMemberAccess: async (type: CollectionTypeKey, collectionUid: string, username: string, accessLevel: CollectionAccessLevel) => {
+    const { account, collections } = get()
+    const collection = resolveCollection(collections, type, collectionUid)
+    if (!account || !collection) {
+      logger.warn(`[etebase-store] Cannot modify member access for ${type} collection ${collectionUid}: missing account or collection`)
+      return false
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      await core.modifyCollectionMemberAccess(account, collection, username, accessLevel)
+      return true
+    } catch (err) {
+      console.error('[etebase-store] Failed to change collection member access', getSafeErrorDetails(err))
+      showErrorToast('Failed to update collection member access. Please try again.')
+      return false
     }
   },
 

--- a/bridge/tests/test_local_cache.py
+++ b/bridge/tests/test_local_cache.py
@@ -202,6 +202,30 @@ class TestCollectionWrapper:
         col = Collection(mgr, cache_col)
         assert col.col_type == "etebase.vcard"
 
+    def test_read_only_reflects_shared_collection_access_level(self, mem_db, user):
+        mock_col = _make_mock_collection("shared-col", "etebase.vevent")
+        mock_col.access_level = 1
+        mgr = self._simple_col_mgr(mock_col)
+        cache_col = CollectionEntity.create(
+            local_user=user, uid="shared-col", eb_col=b"\x00" * 8
+        )
+
+        col = Collection(mgr, cache_col)
+
+        assert col.read_only is True
+
+    def test_read_write_shared_collection_is_not_read_only(self, mem_db, user):
+        mock_col = _make_mock_collection("shared-rw-col", "etebase.vevent")
+        mock_col.access_level = 0
+        mgr = self._simple_col_mgr(mock_col)
+        cache_col = CollectionEntity.create(
+            local_user=user, uid="shared-rw-col", eb_col=b"\x00" * 8
+        )
+
+        col = Collection(mgr, cache_col)
+
+        assert col.read_only is False
+
     def test_meta(self, mem_db, user):
         mock_col = _make_mock_collection("col-1", "etebase.vevent", meta={"name": "My Cal"})
         mgr = self._simple_col_mgr(mock_col)

--- a/packages/core/src/etebase/sharing.test.ts
+++ b/packages/core/src/etebase/sharing.test.ts
@@ -1,0 +1,125 @@
+import * as Etebase from 'etebase';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  acceptInvitation,
+  fetchUserProfile,
+  inviteToCollection,
+  leaveCollection,
+  listCollectionMembers,
+  listIncomingInvitations,
+  listOutgoingInvitations,
+  modifyCollectionMemberAccess,
+  rejectInvitation,
+  removeCollectionMember,
+} from './sharing.js';
+
+function pagedManager<T>(pages: Array<{ data: T[]; iterator?: string | null; done: boolean }>) {
+  const fn = vi.fn(async () => pages.shift());
+  return fn;
+}
+
+describe('sharing invitation wrappers', () => {
+  it('lists incoming invitations across iterator pages', async () => {
+    const first = { uid: 'invite-1' } as Etebase.SignedInvitation;
+    const second = { uid: 'invite-2' } as Etebase.SignedInvitation;
+    const listIncoming = pagedManager([
+      { data: [first], iterator: 'next-page', done: false },
+      { data: [second], iterator: null, done: true },
+    ]);
+    const account = {
+      getInvitationManager: vi.fn().mockReturnValue({ listIncoming }),
+    } as any;
+
+    await expect(listIncomingInvitations(account, { limit: 1 })).resolves.toEqual([first, second]);
+    expect(listIncoming).toHaveBeenNthCalledWith(1, { iterator: null, limit: 1 });
+    expect(listIncoming).toHaveBeenNthCalledWith(2, { iterator: 'next-page', limit: 1 });
+  });
+
+  it('lists outgoing invitations through the invitation manager', async () => {
+    const invitation = { uid: 'outgoing' } as Etebase.SignedInvitation;
+    const listOutgoing = pagedManager([{ data: [invitation], iterator: null, done: true }]);
+    const account = {
+      getInvitationManager: vi.fn().mockReturnValue({ listOutgoing }),
+    } as any;
+
+    await expect(listOutgoingInvitations(account)).resolves.toEqual([invitation]);
+    expect(listOutgoing).toHaveBeenCalledWith({ iterator: null, limit: undefined });
+  });
+
+  it('accepts and rejects invitations without exposing invite contents', async () => {
+    const invitation = { uid: 'invite-1' } as Etebase.SignedInvitation;
+    const accept = vi.fn().mockResolvedValue({});
+    const reject = vi.fn().mockResolvedValue({});
+    const account = {
+      getInvitationManager: vi.fn().mockReturnValue({ accept, reject }),
+    } as any;
+
+    await acceptInvitation(account, invitation);
+    await rejectInvitation(account, invitation);
+
+    expect(accept).toHaveBeenCalledWith(invitation);
+    expect(reject).toHaveBeenCalledWith(invitation);
+  });
+
+  it('fetches a user profile and invites with the fetched public key', async () => {
+    const pubkey = new Uint8Array([1, 2, 3]);
+    const collection = { uid: 'collection-1' } as Etebase.Collection;
+    const fetchUserProfileMock = vi.fn().mockResolvedValue({ pubkey });
+    const invite = vi.fn().mockResolvedValue(undefined);
+    const account = {
+      getInvitationManager: vi.fn().mockReturnValue({ fetchUserProfile: fetchUserProfileMock, invite }),
+    } as any;
+
+    await expect(fetchUserProfile(account, 'friend@example.com')).resolves.toEqual({ pubkey });
+    await inviteToCollection(account, collection, 'friend@example.com', 'readWrite');
+
+    expect(fetchUserProfileMock).toHaveBeenCalledWith('friend@example.com');
+    expect(invite).toHaveBeenCalledWith(
+      collection,
+      'friend@example.com',
+      pubkey,
+      Etebase.CollectionAccessLevel.ReadWrite,
+    );
+  });
+});
+
+describe('sharing member wrappers', () => {
+  it('lists collection members across iterator pages', async () => {
+    const collection = { uid: 'collection-1' } as Etebase.Collection;
+    const owner = { username: 'owner', accessLevel: Etebase.CollectionAccessLevel.Admin };
+    const invited = { username: 'invited', accessLevel: Etebase.CollectionAccessLevel.ReadOnly };
+    const list = pagedManager([
+      { data: [owner], iterator: 'next-members', done: false },
+      { data: [invited], iterator: null, done: true },
+    ]);
+    const getMemberManager = vi.fn().mockReturnValue({ list });
+    const account = {
+      getCollectionManager: vi.fn().mockReturnValue({ getMemberManager }),
+    } as any;
+
+    await expect(listCollectionMembers(account, collection, { limit: 1 })).resolves.toEqual([owner, invited]);
+    expect(getMemberManager).toHaveBeenCalledWith(collection);
+    expect(list).toHaveBeenNthCalledWith(1, { iterator: null, limit: 1 });
+    expect(list).toHaveBeenNthCalledWith(2, { iterator: 'next-members', limit: 1 });
+  });
+
+  it('removes, leaves, and modifies collection membership', async () => {
+    const collection = { uid: 'collection-1' } as Etebase.Collection;
+    const remove = vi.fn().mockResolvedValue({});
+    const leave = vi.fn().mockResolvedValue({});
+    const modifyAccessLevel = vi.fn().mockResolvedValue({});
+    const account = {
+      getCollectionManager: vi.fn().mockReturnValue({
+        getMemberManager: vi.fn().mockReturnValue({ remove, leave, modifyAccessLevel }),
+      }),
+    } as any;
+
+    await removeCollectionMember(account, collection, 'friend@example.com');
+    await leaveCollection(account, collection);
+    await modifyCollectionMemberAccess(account, collection, 'friend@example.com', 'admin');
+
+    expect(remove).toHaveBeenCalledWith('friend@example.com');
+    expect(leave).toHaveBeenCalledTimes(1);
+    expect(modifyAccessLevel).toHaveBeenCalledWith('friend@example.com', Etebase.CollectionAccessLevel.Admin);
+  });
+});

--- a/packages/core/src/etebase/sharing.ts
+++ b/packages/core/src/etebase/sharing.ts
@@ -1,0 +1,169 @@
+import * as Etebase from 'etebase';
+import type { CollectionAccessLevel as SilentSuiteAccessLevel } from './types.js';
+
+export type SharingAccessLevel = SilentSuiteAccessLevel | Etebase.CollectionAccessLevel;
+
+export interface ListSharingOptions {
+  limit?: number;
+}
+
+export interface UserProfile {
+  pubkey: Uint8Array;
+}
+
+export interface CollectionMember {
+  username: string;
+  accessLevel: Etebase.CollectionAccessLevel;
+}
+
+function normalizeAccessLevel(accessLevel: SharingAccessLevel): Etebase.CollectionAccessLevel {
+  if (typeof accessLevel === 'number') return accessLevel;
+  if (accessLevel === 'admin') return Etebase.CollectionAccessLevel.Admin;
+  if (accessLevel === 'readWrite') return Etebase.CollectionAccessLevel.ReadWrite;
+  return Etebase.CollectionAccessLevel.ReadOnly;
+}
+
+async function listWithIterator<T>(
+  listPage: (options: { iterator?: string | null; limit?: number }) => Promise<{
+    data: T[];
+    iterator?: string | null;
+    done: boolean;
+  }>,
+  options: ListSharingOptions = {},
+): Promise<T[]> {
+  const result: T[] = [];
+  let iterator: string | null | undefined = null;
+  let done = false;
+
+  while (!done) {
+    const page = await listPage({
+      iterator,
+      limit: options.limit,
+    });
+    result.push(...page.data);
+    iterator = page.iterator ?? null;
+    done = page.done;
+  }
+
+  return result;
+}
+
+/**
+ * List incoming collection invitations for the account.
+ */
+export async function listIncomingInvitations(
+  account: Etebase.Account,
+  options?: ListSharingOptions,
+): Promise<Etebase.SignedInvitation[]> {
+  const invitationManager = account.getInvitationManager();
+  return listWithIterator<Etebase.SignedInvitation>(
+    (pageOptions) => invitationManager.listIncoming(pageOptions),
+    options,
+  );
+}
+
+/**
+ * List outgoing collection invitations created by the account.
+ */
+export async function listOutgoingInvitations(
+  account: Etebase.Account,
+  options?: ListSharingOptions,
+): Promise<Etebase.SignedInvitation[]> {
+  const invitationManager = account.getInvitationManager();
+  return listWithIterator<Etebase.SignedInvitation>(
+    (pageOptions) => invitationManager.listOutgoing(pageOptions),
+    options,
+  );
+}
+
+/**
+ * Accept an incoming invitation and create the local collection membership.
+ */
+export async function acceptInvitation(
+  account: Etebase.Account,
+  invitation: Etebase.SignedInvitation,
+): Promise<void> {
+  const invitationManager = account.getInvitationManager();
+  await invitationManager.accept(invitation);
+}
+
+/**
+ * Reject an incoming invitation.
+ */
+export async function rejectInvitation(
+  account: Etebase.Account,
+  invitation: Etebase.SignedInvitation,
+): Promise<void> {
+  const invitationManager = account.getInvitationManager();
+  await invitationManager.reject(invitation);
+}
+
+/**
+ * Fetch a user's public invitation profile before creating an invite.
+ */
+export async function fetchUserProfile(account: Etebase.Account, username: string): Promise<UserProfile> {
+  const invitationManager = account.getInvitationManager();
+  return invitationManager.fetchUserProfile(username);
+}
+
+/**
+ * Invite another user to a collection using their public invitation profile.
+ */
+export async function inviteToCollection(
+  account: Etebase.Account,
+  collection: Etebase.Collection,
+  username: string,
+  accessLevel: SharingAccessLevel,
+): Promise<void> {
+  const invitationManager = account.getInvitationManager();
+  const profile = await invitationManager.fetchUserProfile(username);
+  await invitationManager.invite(collection, username, profile.pubkey, normalizeAccessLevel(accessLevel));
+}
+
+/**
+ * List members of a shared collection.
+ */
+export async function listCollectionMembers(
+  account: Etebase.Account,
+  collection: Etebase.Collection,
+  options?: ListSharingOptions,
+): Promise<CollectionMember[]> {
+  const memberManager = account.getCollectionManager().getMemberManager(collection);
+  return listWithIterator<CollectionMember>(
+    (pageOptions) => memberManager.list(pageOptions),
+    options,
+  );
+}
+
+/**
+ * Remove a member from a collection.
+ */
+export async function removeCollectionMember(
+  account: Etebase.Account,
+  collection: Etebase.Collection,
+  username: string,
+): Promise<void> {
+  const memberManager = account.getCollectionManager().getMemberManager(collection);
+  await memberManager.remove(username);
+}
+
+/**
+ * Leave a shared collection as the current account.
+ */
+export async function leaveCollection(account: Etebase.Account, collection: Etebase.Collection): Promise<void> {
+  const memberManager = account.getCollectionManager().getMemberManager(collection);
+  await memberManager.leave();
+}
+
+/**
+ * Change a collection member's access level.
+ */
+export async function modifyCollectionMemberAccess(
+  account: Etebase.Account,
+  collection: Etebase.Collection,
+  username: string,
+  accessLevel: SharingAccessLevel,
+): Promise<void> {
+  const memberManager = account.getCollectionManager().getMemberManager(collection);
+  await memberManager.modifyAccessLevel(username, normalizeAccessLevel(accessLevel));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,26 @@ export {
 } from './etebase/collections.js';
 export type { CollectionMeta, CollectionMetaUpdate, ItemListResponse } from './etebase/collections.js';
 
+// Sharing / invitations
+export {
+  listIncomingInvitations,
+  listOutgoingInvitations,
+  acceptInvitation,
+  rejectInvitation,
+  fetchUserProfile,
+  inviteToCollection,
+  listCollectionMembers,
+  removeCollectionMember,
+  leaveCollection,
+  modifyCollectionMemberAccess,
+} from './etebase/sharing.js';
+export type {
+  SharingAccessLevel,
+  ListSharingOptions,
+  UserProfile,
+  CollectionMember,
+} from './etebase/sharing.js';
+
 // Sync engine
 export { SyncEngine } from './etebase/sync.js';
 export type { StokenAdvanceEvent } from './etebase/sync.js';


### PR DESCRIPTION
## Summary
- add typed `@silentsuite/core` wrappers for Etebase sharing invitations and collection members
- expose web store actions to list/accept/reject invitations, invite users, list/remove members, leave shared collections, and modify member access
- add bridge regression coverage that accepted shared collection access levels map to read-only/read-write DAV behavior

## Verification
- `pnpm --filter @silentsuite/core test -- --run src/etebase/sharing.test.ts`
- `pnpm --filter @silentsuite/core type-check`
- `pnpm --filter @silentsuite/web type-check`
- `PYTHONPATH=src python3 -m py_compile tests/test_local_cache.py` from `bridge/`

## Notes
- Local bridge pytest is not installed in `bridge/.venv`; bridge tests should run in CI.
- This is a foundation slice for web sharing UI and bridge/DAV accepted-share validation; it does not add a new visible web sharing page yet.