### PR TITLE
feat(web): polish sharing management UI

### DIFF
--- a/apps/web/app/(app)/settings/sharing/page.tsx
+++ b/apps/web/app/(app)/settings/sharing/page.tsx
@@ -14,7 +14,9 @@ type CollectionCard = {
   accessLevel?: number
 }
 
-type MembersByCollection = Record<string, Array<{ username: string; accessLevel: number }>>
+type Member = { username: string; accessLevel: number }
+type MembersByCollection = Record<string, Member[]>
+type AccessDrafts = Record<string, CollectionAccessLevel>
 
 const COLLECTION_LABELS: Record<SharingCollectionType, string> = {
   calendar: 'Calendar',
@@ -43,25 +45,41 @@ function accessLevelLabel(accessLevel?: number): string {
   return 'Unknown access'
 }
 
+function accessLevelValue(accessLevel?: number): CollectionAccessLevel {
+  if (accessLevel === 1) return 'admin'
+  if (accessLevel === 2) return 'readWrite'
+  return 'readOnly'
+}
+
 function invitationTitle(invitation: any): string {
   return invitation?.fromUsername || invitation?.username || 'Unknown sender'
+}
+
+function outgoingInvitationTitle(invitation: any): string {
+  return invitation?.username || invitation?.toUsername || 'Unknown recipient'
 }
 
 export default function SharingSettingsPage() {
   const account = useEtebaseStore((state) => state.account)
   const collections = useEtebaseStore((state) => state.collections)
   const listIncomingInvitations = useEtebaseStore((state) => state.listIncomingInvitations)
+  const listOutgoingInvitations = useEtebaseStore((state) => state.listOutgoingInvitations)
   const acceptInvitation = useEtebaseStore((state) => state.acceptInvitation)
   const rejectInvitation = useEtebaseStore((state) => state.rejectInvitation)
+  const cancelOutgoingInvitation = useEtebaseStore((state) => state.cancelOutgoingInvitation)
   const inviteToCollection = useEtebaseStore((state) => state.inviteToCollection)
   const listCollectionMembers = useEtebaseStore((state) => state.listCollectionMembers)
+  const removeCollectionMember = useEtebaseStore((state) => state.removeCollectionMember)
+  const modifyCollectionMemberAccess = useEtebaseStore((state) => state.modifyCollectionMemberAccess)
   const leaveCollection = useEtebaseStore((state) => state.leaveCollection)
 
-  const [invitations, setInvitations] = useState<any[]>([])
+  const [incomingInvitations, setIncomingInvitations] = useState<any[]>([])
+  const [outgoingInvitations, setOutgoingInvitations] = useState<any[]>([])
   const [members, setMembers] = useState<MembersByCollection>({})
   const [inviteUsernames, setInviteUsernames] = useState<Record<string, string>>({})
   const [inviteAccessLevels, setInviteAccessLevels] = useState<Record<string, CollectionAccessLevel>>({})
-  const [loading, setLoading] = useState(false)
+  const [memberAccessDrafts, setMemberAccessDrafts] = useState<AccessDrafts>({})
+  const [loadingInvites, setLoadingInvites] = useState(false)
   const [message, setMessage] = useState<string | null>(null)
 
   const collectionCards = useMemo<CollectionCard[]>(() => {
@@ -80,18 +98,23 @@ export default function SharingSettingsPage() {
   }, [collections])
 
   async function refreshInvitations() {
-    setLoading(true)
+    setLoadingInvites(true)
     try {
-      setInvitations(await listIncomingInvitations())
+      const [incoming, outgoing] = await Promise.all([
+        listIncomingInvitations(),
+        listOutgoingInvitations(),
+      ])
+      setIncomingInvitations(incoming)
+      setOutgoingInvitations(outgoing)
     } finally {
-      setLoading(false)
+      setLoadingInvites(false)
     }
   }
 
   useEffect(() => {
     if (!account) return
     void refreshInvitations()
-    // listIncomingInvitations is stable enough through Zustand for this client-only page.
+    // Store functions are stable enough for this client-only settings panel.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [account])
 
@@ -113,9 +136,25 @@ export default function SharingSettingsPage() {
     }
   }
 
+  async function handleCancelOutgoing(invitation: any) {
+    setMessage(null)
+    const ok = await cancelOutgoingInvitation(invitation)
+    if (ok) {
+      setMessage('Outgoing invitation cancelled.')
+      await refreshInvitations()
+    }
+  }
+
   async function handleLoadMembers(card: CollectionCard) {
     const loaded = await listCollectionMembers(card.type, card.uid)
     setMembers((current) => ({ ...current, [card.uid]: loaded }))
+    setMemberAccessDrafts((current) => {
+      const next = { ...current }
+      loaded.forEach((member) => {
+        next[`${card.uid}:${member.username}`] = accessLevelValue(member.accessLevel)
+      })
+      return next
+    })
   }
 
   async function handleInvite(card: CollectionCard) {
@@ -129,6 +168,27 @@ export default function SharingSettingsPage() {
     if (ok) {
       setInviteUsernames((current) => ({ ...current, [card.uid]: '' }))
       setMessage(`Invitation sent to ${username}.`)
+      await refreshInvitations()
+      await handleLoadMembers(card)
+    }
+  }
+
+  async function handleRemoveMember(card: CollectionCard, username: string) {
+    const ok = window.confirm(`Remove ${username} from ${card.name}?`)
+    if (!ok) return
+    const removed = await removeCollectionMember(card.type, card.uid, username)
+    if (removed) {
+      setMessage(`${username} was removed from ${card.name}.`)
+      await handleLoadMembers(card)
+    }
+  }
+
+  async function handleChangeMemberAccess(card: CollectionCard, member: Member) {
+    const key = `${card.uid}:${member.username}`
+    const nextAccess = memberAccessDrafts[key] ?? accessLevelValue(member.accessLevel)
+    const changed = await modifyCollectionMemberAccess(card.type, card.uid, member.username, nextAccess)
+    if (changed) {
+      setMessage(`${member.username} is now ${ACCESS_LEVEL_LABELS[nextAccess].toLowerCase()} on ${card.name}.`)
       await handleLoadMembers(card)
     }
   }
@@ -137,16 +197,16 @@ export default function SharingSettingsPage() {
     const ok = window.confirm(`Leave shared ${card.name}? This removes it from this account.`)
     if (!ok) return
     const left = await leaveCollection(card.type, card.uid)
-    if (left) {
-      setMessage(`Left ${card.name}.`)
-    }
+    if (left) setMessage(`Left ${card.name}.`)
   }
 
   if (!account) {
     return (
       <div className="space-y-3">
         <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">Sharing</h2>
-        <p className="text-sm text-[rgb(var(--muted))]">Sign in before managing shared calendars, task lists, or address books.</p>
+        <p className="text-sm text-[rgb(var(--muted))]">
+          Sign in before managing shared calendars, task lists, or address books.
+        </p>
       </div>
     )
   }
@@ -171,14 +231,16 @@ export default function SharingSettingsPage() {
           <div className="flex items-center gap-3">
             <MailPlus className="h-5 w-5 text-[rgb(var(--primary))]" />
             <div>
-              <p className="text-sm font-medium text-[rgb(var(--foreground))]">Incoming invitations</p>
-              <p className="text-xs text-[rgb(var(--muted))]">Accepting an invite refreshes your collections so the share appears in web and DAV clients.</p>
+              <p className="text-sm font-medium text-[rgb(var(--foreground))]">Invitations</p>
+              <p className="text-xs text-[rgb(var(--muted))]">
+                Accepting an invite refreshes collections so the share appears in web and DAV clients.
+              </p>
             </div>
           </div>
           <button
             type="button"
             onClick={refreshInvitations}
-            disabled={loading}
+            disabled={loadingInvites}
             className="inline-flex items-center gap-2 rounded-lg border border-[rgb(var(--border))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--background))] disabled:opacity-50"
           >
             <RefreshCcw className="h-3.5 w-3.5" />
@@ -186,14 +248,15 @@ export default function SharingSettingsPage() {
           </button>
         </div>
 
-        {invitations.length === 0 ? (
-          <p className="text-sm text-[rgb(var(--muted))]">No pending invitations.</p>
-        ) : (
+        <div className="grid gap-3 md:grid-cols-2">
           <div className="space-y-2">
-            {invitations.map((invitation) => (
-              <div key={invitation.uid} className="flex flex-col gap-3 rounded-lg border border-[rgb(var(--border))] p-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">Incoming</p>
+            {incomingInvitations.length === 0 ? (
+              <p className="text-sm text-[rgb(var(--muted))]">No pending incoming invitations.</p>
+            ) : incomingInvitations.map((invitation) => (
+              <div key={invitation.uid} className="rounded-lg border border-[rgb(var(--border))] p-3 space-y-3">
                 <div>
-                  <p className="text-sm font-medium text-[rgb(var(--foreground))]">Invitation from {invitationTitle(invitation)}</p>
+                  <p className="text-sm font-medium text-[rgb(var(--foreground))]">From {invitationTitle(invitation)}</p>
                   <p className="text-xs text-[rgb(var(--muted))]">Access: {accessLevelLabel(invitation.accessLevel)}</p>
                 </div>
                 <div className="flex gap-2">
@@ -207,7 +270,24 @@ export default function SharingSettingsPage() {
               </div>
             ))}
           </div>
-        )}
+
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-[rgb(var(--muted))]">Sent</p>
+            {outgoingInvitations.length === 0 ? (
+              <p className="text-sm text-[rgb(var(--muted))]">No pending sent invitations.</p>
+            ) : outgoingInvitations.map((invitation) => (
+              <div key={invitation.uid} className="rounded-lg border border-[rgb(var(--border))] p-3 space-y-3">
+                <div>
+                  <p className="text-sm font-medium text-[rgb(var(--foreground))]">To {outgoingInvitationTitle(invitation)}</p>
+                  <p className="text-xs text-[rgb(var(--muted))]">Access: {accessLevelLabel(invitation.accessLevel)}</p>
+                </div>
+                <button type="button" onClick={() => handleCancelOutgoing(invitation)} className="rounded-lg border border-[rgb(var(--border))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--background))]">
+                  Cancel invitation
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
       </section>
 
       <section className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-4">
@@ -215,7 +295,9 @@ export default function SharingSettingsPage() {
           <Users className="h-5 w-5 text-[rgb(var(--primary))] mt-0.5" />
           <div>
             <p className="text-sm font-medium text-[rgb(var(--foreground))]">Collection members</p>
-            <p className="text-xs text-[rgb(var(--muted))]">Invite trusted accounts by username/email. Plain calendar, contact, and task data still stays end-to-end encrypted.</p>
+            <p className="text-xs text-[rgb(var(--muted))]">
+              Invite trusted accounts by username/email. Plain calendar, contact, and task data remains encrypted.
+            </p>
           </div>
         </div>
 
@@ -225,7 +307,9 @@ export default function SharingSettingsPage() {
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                   <p className="text-sm font-medium text-[rgb(var(--foreground))]">{card.name}</p>
-                  <p className="text-xs text-[rgb(var(--muted))]">{COLLECTION_LABELS[card.type]} · {accessLevelLabel(card.accessLevel)}</p>
+                  <p className="text-xs text-[rgb(var(--muted))]">
+                    {COLLECTION_LABELS[card.type]} · {accessLevelLabel(card.accessLevel)}
+                  </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <button type="button" onClick={() => handleLoadMembers(card)} className="rounded-lg border border-[rgb(var(--border))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--background))]">
@@ -233,7 +317,7 @@ export default function SharingSettingsPage() {
                   </button>
                   {card.accessLevel !== 1 && (
                     <button type="button" onClick={() => handleLeave(card)} className="rounded-lg border border-[rgb(var(--border))] px-3 py-2 text-xs font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--background))]">
-                      Leave
+                      Leave collection
                     </button>
                   )}
                 </div>
@@ -261,13 +345,35 @@ export default function SharingSettingsPage() {
               </div>
 
               {members[card.uid] && (
-                <ul className="space-y-1 text-xs text-[rgb(var(--muted))]">
-                  {members[card.uid].map((member) => (
-                    <li key={member.username} className="flex justify-between gap-3 rounded border border-[rgb(var(--border))] px-2 py-1">
-                      <span>{member.username}</span>
-                      <span>{accessLevelLabel(member.accessLevel)}</span>
-                    </li>
-                  ))}
+                <ul className="space-y-2 text-xs text-[rgb(var(--muted))]">
+                  {members[card.uid].map((member) => {
+                    const draftKey = `${card.uid}:${member.username}`
+                    return (
+                      <li key={member.username} className="flex flex-col gap-2 rounded border border-[rgb(var(--border))] px-2 py-2 sm:flex-row sm:items-center sm:justify-between">
+                        <span className="font-medium text-[rgb(var(--foreground))]">{member.username}</span>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <select
+                            value={memberAccessDrafts[draftKey] ?? accessLevelValue(member.accessLevel)}
+                            onChange={(event) => setMemberAccessDrafts((current) => ({
+                              ...current,
+                              [draftKey]: event.target.value as CollectionAccessLevel,
+                            }))}
+                            className="rounded border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-2 py-1 text-xs text-[rgb(var(--foreground))]"
+                          >
+                            {Object.entries(ACCESS_LEVEL_LABELS).map(([value, label]) => (
+                              <option key={value} value={value}>{label}</option>
+                            ))}
+                          </select>
+                          <button type="button" onClick={() => handleChangeMemberAccess(card, member)} className="rounded border border-[rgb(var(--border))] px-2 py-1 text-xs text-[rgb(var(--foreground))] hover:bg-[rgb(var(--background))]">
+                            Save
+                          </button>
+                          <button type="button" onClick={() => handleRemoveMember(card, member.username)} className="rounded border border-[rgb(var(--border))] px-2 py-1 text-xs text-[rgb(var(--foreground))] hover:bg-[rgb(var(--background))]">
+                            Remove
+                          </button>
+                        </div>
+                      </li>
+                    )
+                  })}
                 </ul>
               )}
             </div>
@@ -281,7 +387,8 @@ export default function SharingSettingsPage() {
           <div className="space-y-1">
             <p className="text-sm font-medium text-[rgb(var(--foreground))]">Zero-knowledge sharing</p>
             <p className="text-xs text-[rgb(var(--muted))]">
-              Sharing uses Etebase encrypted collection membership. The server only sees encrypted membership material; plaintext events, contacts, and tasks stay on your devices.
+              Sharing uses Etebase encrypted collection membership. The server only sees encrypted membership material;
+              plaintext events, contacts, and tasks stay on your devices.
             </p>
           </div>
         </div>

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -379,6 +379,16 @@ interface EtebaseActions {
   listIncomingInvitations: () => Promise<any[]>
 
   /**
+   * List pending outgoing sharing invitations for the current account.
+   */
+  listOutgoingInvitations: () => Promise<any[]>
+
+  /**
+   * Cancel an outgoing sharing invitation before it is accepted.
+   */
+  cancelOutgoingInvitation: (invitation: any) => Promise<boolean>
+
+  /**
    * Accept an incoming sharing invitation, then reconcile collections so the shared collection appears.
    */
   acceptInvitation: (invitation: any) => Promise<boolean>
@@ -782,6 +792,38 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       console.error('[etebase-store] Failed to list incoming invitations', getSafeErrorDetails(err))
       showErrorToast('Failed to load sharing invitations. Please try again.')
       return []
+    }
+  },
+
+  listOutgoingInvitations: async () => {
+    const { account } = get()
+    if (!account) return []
+
+    try {
+      const core = await import('@silentsuite/core')
+      return await core.listOutgoingInvitations(account)
+    } catch (err) {
+      console.error('[etebase-store] Failed to list outgoing invitations', getSafeErrorDetails(err))
+      showErrorToast('Failed to load sent sharing invitations. Please try again.')
+      return []
+    }
+  },
+
+  cancelOutgoingInvitation: async (invitation: any) => {
+    const { account } = get()
+    if (!account) {
+      logger.warn('[etebase-store] Cannot cancel outgoing invitation: no account')
+      return false
+    }
+
+    try {
+      const core = await import('@silentsuite/core')
+      await core.cancelOutgoingInvitation(account, invitation)
+      return true
+    } catch (err) {
+      console.error('[etebase-store] Failed to cancel outgoing invitation', getSafeErrorDetails(err))
+      showErrorToast('Failed to cancel sharing invitation. Please try again.')
+      return false
     }
   },
 

--- a/packages/core/src/etebase/sharing.test.ts
+++ b/packages/core/src/etebase/sharing.test.ts
@@ -2,6 +2,7 @@ import * as Etebase from 'etebase';
 import { describe, expect, it, vi } from 'vitest';
 import {
   acceptInvitation,
+  cancelOutgoingInvitation,
   fetchUserProfile,
   inviteToCollection,
   leaveCollection,
@@ -46,19 +47,22 @@ describe('sharing invitation wrappers', () => {
     expect(listOutgoing).toHaveBeenCalledWith({ iterator: null, limit: undefined });
   });
 
-  it('accepts and rejects invitations without exposing invite contents', async () => {
+  it('accepts, rejects, and cancels invitations without exposing invite contents', async () => {
     const invitation = { uid: 'invite-1' } as Etebase.SignedInvitation;
     const accept = vi.fn().mockResolvedValue({});
     const reject = vi.fn().mockResolvedValue({});
+    const disinvite = vi.fn().mockResolvedValue({});
     const account = {
-      getInvitationManager: vi.fn().mockReturnValue({ accept, reject }),
+      getInvitationManager: vi.fn().mockReturnValue({ accept, reject, disinvite }),
     } as any;
 
     await acceptInvitation(account, invitation);
     await rejectInvitation(account, invitation);
+    await cancelOutgoingInvitation(account, invitation);
 
     expect(accept).toHaveBeenCalledWith(invitation);
     expect(reject).toHaveBeenCalledWith(invitation);
+    expect(disinvite).toHaveBeenCalledWith(invitation);
   });
 
   it('fetches a user profile and invites with the fetched public key', async () => {

--- a/packages/core/src/etebase/sharing.ts
+++ b/packages/core/src/etebase/sharing.ts
@@ -99,6 +99,17 @@ export async function rejectInvitation(
 }
 
 /**
+ * Cancel an outgoing invitation that has not been accepted yet.
+ */
+export async function cancelOutgoingInvitation(
+  account: Etebase.Account,
+  invitation: Etebase.SignedInvitation,
+): Promise<void> {
+  const invitationManager = account.getInvitationManager();
+  await invitationManager.disinvite(invitation);
+}
+
+/**
  * Fetch a user's public invitation profile before creating an invite.
  */
 export async function fetchUserProfile(account: Etebase.Account, username: string): Promise<UserProfile> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export {
   listOutgoingInvitations,
   acceptInvitation,
   rejectInvitation,
+  cancelOutgoingInvitation,
   fetchUserProfile,
   inviteToCollection,
   listCollectionMembers,


### PR DESCRIPTION
## Summary
- add core/store support for canceling pending outgoing invitations
- show sent invitations in Settings → Sharing and allow canceling them
- expose remove-member and change-access controls in the sharing page
- keep the safer pre-production behavior of hiding “leave collection” for admin/owned-looking collections until ownership is modeled explicitly

## Browser QA
- Unauthenticated navigation correctly redirected to the login screen.
- Browser console showed no JS errors on that route/redirect.
- Full two-account collection sharing still needs authorized test accounts.

## Verification
- `pnpm --filter @silentsuite/core test -- --run src/etebase/sharing.test.ts`
- `pnpm --filter @silentsuite/core type-check`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web build`

## Notes
- Local build succeeded with the existing Sentry instrumentation warnings and the existing traced-file copy warning.
- This should be tested on the dev preview before any `dev → main` promotion.