### PR TITLE
fix: reject DAV writes to read-only shared collections

### DIFF
--- a/bridge/silentsuite-bridge.spec
+++ b/bridge/silentsuite-bridge.spec
@@ -156,6 +156,7 @@ a = Analysis(
         "silentsuite_bridge.radicale",
         "silentsuite_bridge.radicale.auth",
         "silentsuite_bridge.radicale.storage",
+        "silentsuite_bridge.radicale.rights",
         "silentsuite_bridge.radicale.creds",
         "silentsuite_bridge.radicale.etesync_cache",
         "silentsuite_bridge.web",

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -65,6 +65,9 @@ def build_radicale_configuration():
             "storage": {
                 "type": "silentsuite_bridge.radicale.storage",
             },
+            "rights": {
+                "type": "silentsuite_bridge.radicale.rights",
+            },
             "web": {
                 "type": web_type,
             },

--- a/bridge/src/silentsuite_bridge/radicale/rights.py
+++ b/bridge/src/silentsuite_bridge/radicale/rights.py
@@ -1,0 +1,50 @@
+"""Radicale rights backend for SilentSuite Bridge.
+
+This keeps the normal owner-only DAV model, but removes write permission for
+already-accepted shared collections that the Etebase account exposes as
+read-only. Invitation handling itself still belongs to native/web clients; DAV
+clients only see accepted collections.
+"""
+
+import logging
+
+from radicale import pathutils
+from radicale.rights.owner_only import Rights as OwnerOnlyRights
+
+from .etesync_cache import etesync_for_user
+
+logger = logging.getLogger("silentsuite-bridge.rights")
+
+
+class Rights(OwnerOnlyRights):
+    """Owner-only rights with read-only shared collection write gating."""
+
+    def authorization(self, user: str, path: str) -> str:
+        permissions = super().authorization(user, path)
+        if "w" not in permissions:
+            return permissions
+
+        sane_path = pathutils.strip_path(path)
+        parts = sane_path.split("/", maxsplit=2)
+        if len(parts) < 2 or not user or parts[0] != user:
+            return permissions
+
+        collection_uid = parts[1]
+        try:
+            with etesync_for_user(user) as (etesync, _):
+                collection = etesync.get(collection_uid)
+        except Exception as exc:
+            # Missing collections include legitimate creates. Preserve the base
+            # owner-only answer and let storage/server code decide.
+            logger.debug(
+                "Could not resolve collection permissions for %s: %s",
+                collection_uid[:8],
+                exc.__class__.__name__,
+            )
+            return permissions
+
+        if getattr(collection, "read_only", False):
+            logger.debug("Granting read-only DAV access to shared collection %s", collection_uid[:8])
+            return permissions.replace("w", "")
+
+        return permissions

--- a/bridge/tests/test_storage.py
+++ b/bridge/tests/test_storage.py
@@ -24,6 +24,7 @@ from silentsuite_bridge.radicale.storage import (
     Storage,
     _get_attributes_from_path,
 )
+from silentsuite_bridge.radicale.rights import Rights as BridgeRights
 from tests.conftest import (
     SAMPLE_VCALENDAR_VEVENT,
     SAMPLE_VCALENDAR_VTODO,
@@ -212,6 +213,55 @@ class TestAcquireLockForcesSync:
             pass
 
         mock_start.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Rights
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeRights:
+    def _rights(self):
+        from radicale.config import Configuration, DEFAULT_CONFIG_SCHEMA
+
+        configuration = Configuration(DEFAULT_CONFIG_SCHEMA)
+        configuration.update(
+            {"auth": {"type": "silentsuite_bridge.radicale.auth"}},
+            source="test",
+            privileged=True,
+        )
+        return BridgeRights(configuration)
+
+    @patch("silentsuite_bridge.radicale.rights.etesync_for_user")
+    def test_read_only_shared_collection_grants_read_without_write(self, mock_etesync_ctx):
+        mock_collection = MagicMock(read_only=True)
+        mock_etesync = MagicMock()
+        mock_etesync.get.return_value = mock_collection
+        mock_etesync_ctx.return_value.__enter__ = MagicMock(return_value=(mock_etesync, False))
+        mock_etesync_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        rights = self._rights()
+
+        assert rights.authorization("user@example.com", "/user@example.com/shared-col") == "r"
+
+    @patch("silentsuite_bridge.radicale.rights.etesync_for_user")
+    def test_writable_collection_keeps_owner_write_permission(self, mock_etesync_ctx):
+        mock_collection = MagicMock(read_only=False)
+        mock_etesync = MagicMock()
+        mock_etesync.get.return_value = mock_collection
+        mock_etesync_ctx.return_value.__enter__ = MagicMock(return_value=(mock_etesync, False))
+        mock_etesync_ctx.return_value.__exit__ = MagicMock(return_value=False)
+
+        rights = self._rights()
+
+        assert rights.authorization("user@example.com", "/user@example.com/owned-col") == "rw"
+
+    @patch("silentsuite_bridge.radicale.rights.etesync_for_user")
+    def test_new_collection_paths_preserve_base_permission(self, mock_etesync_ctx):
+        mock_etesync_ctx.side_effect = RuntimeError("missing cache")
+        rights = self._rights()
+
+        assert rights.authorization("user@example.com", "/user@example.com/new-col") == "rw"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary\n- reject DAV upload/delete/metadata writes against read-only shared collections before mutating the bridge cache\n- add focused storage tests for read-only shared collection write guards\n\n## Verification\n- git diff --check\n- PYTHONPATH=src python3 -m py_compile src/silentsuite_bridge/radicale/storage.py tests/test_storage.py\n- local pytest blocked: etebase dependency requires a Rust compiler on this host; GitHub CI should run bridge tests