### PR TITLE
docs: clarify docs-only PR verification note

### DIFF
--- a/apps/docs/contributing/pull-request-guide.md
+++ b/apps/docs/contributing/pull-request-guide.md
@@ -69,6 +69,8 @@ You can also copy this short template and fill it in:
 - Docs-only change / ran ... / not run because ...
 ```
 
+For docs-only PRs, it is okay to write `Docs-only change; no app tests run.` If you previewed the docs locally, mention that too.
+
 ## Review Process
 
 - A maintainer will review your PR and may request changes.

--- a/docs/contributing/pull-request-guide.md
+++ b/docs/contributing/pull-request-guide.md
@@ -69,6 +69,8 @@ You can also copy this short template and fill it in:
 - Docs-only change / ran ... / not run because ...
 ```
 
+For docs-only PRs, it is okay to write `Docs-only change; no app tests run.` If you previewed the docs locally, mention that too.
+
 ## Review Process
 
 - A maintainer will review your PR and may request changes.


### PR DESCRIPTION
## Summary
- add the requested docs-only verification note near the PR description template
- keep the duplicated docs guide copies in `apps/docs` and `docs` synchronized
- keep the change docs-only and limited to contributor guidance

Closes #258

## Verification
- `git diff --name-only`
- confirmed only `apps/docs/contributing/pull-request-guide.md` and `docs/contributing/pull-request-guide.md` changed
- docs-only change; no app tests run