### PR TITLE
fix: harden offline queue privacy

### DIFF
--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -7,6 +7,7 @@ import {
   getFailedCount,
   replay,
   clearFailed,
+  clearAll,
   retryFailed,
   remove,
   onCountChange,
@@ -17,11 +18,14 @@ import {
   MAX_QUEUE_SIZE,
   STALE_THRESHOLD_MS,
   _resetForTests,
+  _setEncryptedQueuePersistenceAvailableForTests,
 } from '../offline-queue'
 
 beforeEach(async () => {
+  process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'
   // Close existing connection and reset module state
   await _resetForTests()
+  _setEncryptedQueuePersistenceAvailableForTests(true)
   // Clear all IndexedDB databases
   await new Promise<void>((resolve) => {
     const req = indexedDB.deleteDatabase('silentsuite-offline-queue')
@@ -60,6 +64,101 @@ describe('offline-queue', () => {
       expect(await getPendingCount()).toBe(1)
       await enqueue({ type: 'delete', collectionType: 'calendar', itemUid: 'uid-2' })
       expect(await getPendingCount()).toBe(2)
+    })
+  })
+
+  describe('privacy guard', () => {
+    async function readRawMutations(): Promise<unknown[]> {
+      const db = await new Promise<IDBDatabase>((resolve, reject) => {
+        const req = indexedDB.open('silentsuite-offline-queue', 1)
+        req.onupgradeneeded = () => {
+          if (!req.result.objectStoreNames.contains('mutations')) {
+            req.result.createObjectStore('mutations', { keyPath: 'id' })
+          }
+        }
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error)
+      })
+      try {
+        if (!db.objectStoreNames.contains('mutations')) return []
+        return await new Promise<unknown[]>((resolve, reject) => {
+          const tx = db.transaction('mutations', 'readonly')
+          const req = tx.objectStore('mutations').getAll()
+          req.onsuccess = () => resolve(req.result ?? [])
+          req.onerror = () => reject(req.error)
+        })
+      } finally {
+        db.close()
+      }
+    }
+
+    it('refuses to persist plaintext PIM content without encrypted local persistence', async () => {
+      _setEncryptedQueuePersistenceAvailableForTests(false)
+      const sentinel = 'BEGIN:VCALENDAR\nSUMMARY:PRIVATE_SENTINEL_CALENDAR_EVENT\nEND:VCALENDAR'
+
+      await expect(
+        enqueue({ type: 'create', collectionType: 'calendar', content: sentinel, tempId: 'temp-private' }),
+      ).rejects.toThrow(/refuses to persist plaintext calendar create content/)
+
+      expect(JSON.stringify(await readRawMutations())).not.toContain('PRIVATE_SENTINEL_CALENDAR_EVENT')
+      expect(await getAll()).toHaveLength(0)
+    })
+
+    it('still persists content-free deletes without encrypted local persistence', async () => {
+      _setEncryptedQueuePersistenceAvailableForTests(false)
+
+      await enqueue({ type: 'delete', collectionType: 'contacts', collectionUid: 'address-book', itemUid: 'contact-1' })
+
+      const all = await getAll()
+      expect(all).toHaveLength(1)
+      expect(all[0].type).toBe('delete')
+      expect(all[0].content).toBeUndefined()
+    })
+
+    it('purges legacy plaintext content already present in IndexedDB', async () => {
+      await clearAll()
+      const db = await new Promise<IDBDatabase>((resolve, reject) => {
+        const req = indexedDB.open('silentsuite-offline-queue', 1)
+        req.onupgradeneeded = () => {
+          if (!req.result.objectStoreNames.contains('mutations')) {
+            req.result.createObjectStore('mutations', { keyPath: 'id' })
+          }
+        }
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error)
+      })
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction('mutations', 'readwrite')
+        tx.objectStore('mutations').put({
+          id: 'legacy-plaintext',
+          type: 'update',
+          collectionType: 'tasks',
+          collectionUid: 'tasks',
+          itemUid: 'task-1',
+          content: 'BEGIN:VTODO\nSUMMARY:PRIVATE_SENTINEL_TASK\nEND:VTODO',
+          createdAt: Date.now(),
+          retryCount: 0,
+          status: 'pending',
+        })
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error)
+      })
+      db.close()
+
+      _setEncryptedQueuePersistenceAvailableForTests(false)
+
+      expect(await getAll()).toHaveLength(0)
+      expect(JSON.stringify(await readRawMutations())).not.toContain('PRIVATE_SENTINEL_TASK')
+    })
+
+    it('clearAll removes queued mutations for logout/account switch cleanup', async () => {
+      await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: 'tasks', itemUid: 'task-1' })
+      expect(await getPendingCount()).toBe(1)
+
+      await clearAll()
+
+      expect(await getAll()).toHaveLength(0)
+      expect(await getPendingCount()).toBe(0)
     })
   })
 
@@ -199,6 +298,7 @@ describe('offline-queue', () => {
 
       // Close the connection and clear cached promise (simulates a new page load)
       await _resetForTests()
+      _setEncryptedQueuePersistenceAvailableForTests(true)
 
       // Re-read from IndexedDB — this opens a fresh connection
       const all = await getAll()
@@ -509,6 +609,7 @@ describe('offline-queue', () => {
 
       // Simulate module reset (like a page reload)
       await _resetForTests()
+      _setEncryptedQueuePersistenceAvailableForTests(true)
 
       // Verify entries persist across resets
       const count = await getPendingCount()

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -45,6 +45,27 @@ type CountListener = (count: number) => void
 
 let dbPromise: Promise<IDBDatabase> | null = null
 const listeners = new Set<CountListener>()
+let encryptedQueuePersistenceAvailableForTests = false
+
+function isEncryptedQueuePersistenceAvailable(): boolean {
+  // Production has no encrypted offline-queue content store yet. Keep content
+  // persistence fail-closed until a real encrypted queue envelope exists.
+  return encryptedQueuePersistenceAvailableForTests
+}
+
+function hasPersistedPlaintextContent(entry: Pick<QueueEntry, 'content'>): boolean {
+  return typeof entry.content === 'string'
+}
+
+function assertCanPersistEntry(
+  entry: Pick<QueueEntry, 'type' | 'collectionType' | 'content'>,
+): void {
+  if (!hasPersistedPlaintextContent(entry)) return
+  if (isEncryptedQueuePersistenceAvailable()) return
+  throw new Error(
+    `Offline queue refuses to persist plaintext ${entry.collectionType} ${entry.type} content without encrypted local persistence.`,
+  )
+}
 
 function openDB(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise
@@ -96,6 +117,7 @@ function notifyListeners(): void {
 async function compact(
   incoming: Omit<QueueEntry, 'id' | 'createdAt' | 'retryCount' | 'status'>,
 ): Promise<string | null> {
+  assertCanPersistEntry(incoming)
   const entries = await getAll()
   const pending = entries.filter((e) => e.status === 'pending')
 
@@ -202,6 +224,7 @@ export async function enqueue(
     retryCount: 0,
     status: 'pending',
   }
+  assertCanPersistEntry(record)
   return new Promise<string>((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite')
     tx.objectStore(STORE_NAME).put(record)
@@ -217,15 +240,28 @@ export async function enqueue(
 export async function getAll(): Promise<QueueEntry[]> {
   const db = await openDB()
   return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE_NAME, 'readonly')
-    const request = tx.objectStore(STORE_NAME).getAll()
+    // Use a readwrite transaction so legacy plaintext records can be purged
+    // atomically before callers observe the queue.
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    const store = tx.objectStore(STORE_NAME)
+    const request = store.getAll()
+    let safeEntries: QueueEntry[] = []
     request.onsuccess = () => {
       const entries = (request.result as QueueEntry[]).sort(
         (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
       )
-      resolve(entries)
+      if (!isEncryptedQueuePersistenceAvailable()) {
+        safeEntries = entries.filter((entry) => !hasPersistedPlaintextContent(entry))
+        for (const entry of entries) {
+          if (hasPersistedPlaintextContent(entry)) store.delete(entry.id)
+        }
+        return
+      }
+      safeEntries = entries
     }
     request.onerror = () => reject(request.error)
+    tx.oncomplete = () => resolve(safeEntries)
+    tx.onerror = () => reject(tx.error)
   })
 }
 
@@ -248,6 +284,7 @@ export async function remove(id: string): Promise<void> {
 }
 
 async function updateEntry(entry: QueueEntry): Promise<void> {
+  assertCanPersistEntry(entry)
   const db = await openDB()
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite')
@@ -263,6 +300,19 @@ async function updateEntry(entry: QueueEntry): Promise<void> {
 export async function getFailedCount(): Promise<number> {
   const entries = await getAll()
   return entries.filter((e) => e.status === 'failed').length
+}
+
+export async function clearAll(): Promise<void> {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite')
+    tx.objectStore(STORE_NAME).clear()
+    tx.oncomplete = () => {
+      notifyListeners()
+      resolve()
+    }
+    tx.onerror = () => reject(tx.error)
+  })
 }
 
 export async function clearFailed(): Promise<void> {
@@ -382,4 +432,9 @@ export async function _resetForTests(): Promise<void> {
   listeners.clear()
   enqueueListeners.clear()
   counter = 0
+  encryptedQueuePersistenceAvailableForTests = false
+}
+
+export function _setEncryptedQueuePersistenceAvailableForTests(available: boolean): void {
+  encryptedQueuePersistenceAvailableForTests = available
 }

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -6,11 +6,14 @@ vi.stubGlobal('fetch', vi.fn())
 
 // Mock data-cache (used on logout). We use vi.hoisted so the mock fn is
 // declared before vi.mock factory runs (vi.mock is hoisted to the top).
-const { dataCacheClearAll } = vi.hoisted(() => {
-  return { dataCacheClearAll: vi.fn(async () => {}) }
+const { dataCacheClearAll, offlineQueueClearAll } = vi.hoisted(() => {
+  return { dataCacheClearAll: vi.fn(async () => {}), offlineQueueClearAll: vi.fn(async () => {}) }
 })
 vi.mock('@/app/lib/data-cache', () => ({
   clearAll: dataCacheClearAll,
+}))
+vi.mock('@/app/lib/offline-queue', () => ({
+  clearAll: offlineQueueClearAll,
 }))
 
 // In-memory store for secure storage mock
@@ -62,6 +65,7 @@ describe('useAuthStore', () => {
     resetStore()
     vi.mocked(fetch).mockReset()
     dataCacheClearAll.mockClear()
+    offlineQueueClearAll.mockClear()
     secureStore = {}
     localStorage.clear()
     sessionStorage.clear()
@@ -485,6 +489,48 @@ describe('useAuthStore', () => {
     await useAuthStore.getState().logout()
 
     expect(dataCacheClearAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('logout clears the offline queue', async () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'test@example.com', planId: 'pro' },
+      isAuthenticated: true,
+    })
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response)
+
+    await useAuthStore.getState().logout()
+
+    expect(offlineQueueClearAll).toHaveBeenCalledTimes(1)
+  })
+
+  it('login clears the offline queue after Etebase credentials succeed but before storing a new session', async () => {
+    const { secureSet } = await import('@/app/lib/secure-storage')
+    vi.mocked(secureSet).mockClear()
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'user-1', email: 'test@example.com', planId: 'pro', isAdmin: false }),
+    } as Response)
+
+    await useAuthStore.getState().login('test@example.com', 'password123')
+
+    expect(offlineQueueClearAll).toHaveBeenCalledTimes(1)
+    expect(secureSet).toHaveBeenCalledWith('etebase_session', 'mock-saved-session')
+    expect(offlineQueueClearAll.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(secureSet).mock.invocationCallOrder[0],
+    )
+    expect(secureStore.etebase_session).toBe('mock-saved-session')
+  })
+
+  it('login does not clear the current offline queue when Etebase authentication fails', async () => {
+    const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
+    vi.mocked(etebaseLogIn).mockRejectedValueOnce(new Error('unauthorized'))
+
+    await useAuthStore.getState().login('test@example.com', 'wrong-password')
+
+    expect(offlineQueueClearAll).not.toHaveBeenCalled()
+    expect(secureStore.etebase_session).toBeUndefined()
+    expect(useAuthStore.getState().error).toBe('Invalid email or password. Please try again.')
   })
 
   it('logout still completes when the data-cache wipe throws', async () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -7,6 +7,7 @@ import { BILLING_API_URL } from '@/app/lib/config'
 import { COOKIE_MAX_AGE_SELF_HOSTED, COOKIE_MAX_AGE_HOSTED } from '@/app/lib/constants'
 import { secureGet, secureSet, secureRemove, secureClear, migrateFromLocalStorage } from '@/app/lib/secure-storage'
 import { clearAll as clearLocalDataCache } from '@/app/lib/data-cache'
+import { clearAll as clearOfflineQueue } from '@/app/lib/offline-queue'
 
 export interface User {
   isAdmin?: boolean
@@ -425,6 +426,13 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     try {
       const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
       const { authToken, savedSession } = await etebaseLogIn(email, password, serverUrl)
+      // A successful Etebase login may be an account switch in the same browser
+      // profile. The offline queue can contain item UIDs/collection UIDs and,
+      // in future encrypted-cache mode, mutation content. Clear it after the
+      // credentials are verified but before storing a new Etebase session, so
+      // failed login attempts do not destroy the current account's offline work
+      // and queued work from one account cannot replay into another account.
+      await clearOfflineQueue()
       await secureSet('etebase_session', savedSession)
 
       if (isSelfHosted || isCustomServer(serverUrl)) {
@@ -513,6 +521,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       await clearLocalDataCache()
     } catch (err) {
       logger.warn('[auth-store] Failed to clear local data cache during logout:', err)
+    }
+
+    // Clear the offline mutation queue as well. Queue entries are scoped to
+    // the current Etebase account/collections and must not survive logout or
+    // replay after a later account switch.
+    try {
+      await clearOfflineQueue()
+    } catch (err) {
+      logger.warn('[auth-store] Failed to clear offline queue during logout:', err)
     }
 
     // Clear signup-in-progress flag


### PR DESCRIPTION
## Summary
- make the web offline mutation queue fail closed for plaintext PIM mutation `content` unless an encrypted queue persistence layer exists
- purge legacy plaintext queue records on read when encrypted queue persistence is unavailable
- clear queued offline mutations on logout and before login/account switch
- add fake-IndexedDB sentinel regressions proving calendar/task/contact plaintext is not persisted

## Validation
- `pnpm run audit:security`
- `pnpm --filter @silentsuite/web test`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web build`

Notes: `next build` still emits the existing Sentry instrumentation warnings and a non-fatal standalone trace copy warning, but exits 0.
