### PR TITLE
security: split Android PR builds from release signing (SEC-R4.1)

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -81,16 +81,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -127,7 +127,7 @@ jobs:
         run: jarsigner -verify -certs -verbose app/build/outputs/bundle/release/*.aab
 
       - name: Upload signed release APK and AAB
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: silentsuite-release-${{ github.sha }}
           path: |

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -16,8 +16,63 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  # ─────────────────────────────────────────────────────────────────────
+  # PR / dev / main builds — unsigned, no signing secrets accessible.
+  # Validates that the Android project compiles and assembles.
+  # ─────────────────────────────────────────────────────────────────────
+  build-pr:
+    name: Build (unsigned, PR/dev/main)
+    if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: android
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('android/**/*.gradle', 'android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug --no-daemon
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: silentsuite-debug-${{ github.sha }}
+          path: |
+            android/app/build/outputs/apk/debug/*.apk
+          retention-days: 14
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Release builds — signed, only on version tags.
+  # Uses a protected GitHub Environment so signing secrets are not
+  # accessible to PRs, forks, or non-tag pushes.
+  # ─────────────────────────────────────────────────────────────────────
+  build-release:
+    name: Build (signed, tag release)
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: android-release
     permissions:
       contents: write
     defaults:
@@ -80,8 +135,7 @@ jobs:
             android/app/build/outputs/bundle/release/*.aab
           retention-days: 30
 
-      - name: Rename Android artifacts for release (tag push only)
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Rename Android artifacts for release
         run: |
           mv app/build/outputs/apk/release/app-release.apk \
              "app/build/outputs/apk/release/silentsuite-android-${{ github.ref_name }}.apk"
@@ -94,8 +148,7 @@ jobs:
           sha256sum "silentsuite-android-${{ github.ref_name }}.aab" \
             > "silentsuite-android-${{ github.ref_name }}.aab.sha256"
 
-      - name: Attach Android artifacts to umbrella GitHub Release (tag push only)
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Attach Android artifacts to umbrella GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Security remediation epic **SEC-R4.1** — split the Android build workflow so PRs and branch pushes cannot access release signing secrets.

From the 2026-06-14 security remediation implementation plan.

## Problem

The previous workflow ran a single job on every PR, branch push, and tag push. That job decoded `ANDROID_KEYSTORE_BASE64`, referenced signing passwords, and built signed release artifacts — even on PRs from external contributors.

## Changes

Split `.github/workflows/build-android.yml` into two jobs:

### `build-pr` (PR / dev / main)
- **Permissions:** `contents: read` only
- **No signing secrets referenced** — no `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, or `ANDROID_KEY_ALIAS`
- Builds `assembleDebug` (unsigned, sufficient for CI validation)
- Uploads debug APK artifact (14-day retention)

### `build-release` (tag `v*` only)
- **Environment:** `android-release` (protected GitHub Environment — requires manual approval before signing secrets are available)
- **Permissions:** `contents: write` (for GitHub Release attachment)
- Decodes keystore, builds signed release APK + AAB
- Verifies APK and AAB signatures
- Renames artifacts and attaches to draft GitHub Release
- `softprops/action-gh-release` remains SHA-pinned

## Security properties

| Property | Before | After |
|----------|--------|-------|
| PR access to signing secrets | ✅ referenced | ❌ not referenced |
| PR permissions | `contents: write` | `contents: read` |
| Signed artifacts on PRs | ✅ produced | ❌ debug only |
| Release signing trigger | all pushes | `v*` tags only |
| Environment protection | none | `android-release` |

## ⚠️ Owner action required

The `android-release` GitHub Environment must be created in repo settings (Settings → Environments → New environment → `android-release`) with required reviewers configured. Until then, the tag release job will run without approval gating.

## Validation

GitHub Actions only — Android builds run in CI, not on `ss` per AGENTS.md S2.