### PR TITLE
security: harden bridge, server auth, collection deps, self-host HTTPS (SEC-R7.4-R7.8)

### DIFF
--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -54,6 +54,37 @@ def _has_valid_csrf(environ):
     return bool(token) and hmac.compare_digest(token, _dashboard_csrf_token)
 
 
+# Localhost Host allowlist for defense-in-depth against DNS-rebinding and
+# cross-origin attacks on the dashboard (SEC-R7.4). The dashboard is
+# loopback-only by default, so only localhost variants are accepted.
+
+
+def _has_valid_host(environ):
+    """Check that the Host header matches a localhost variant.
+
+    Handles IPv4 (127.0.0.1:port), IPv6 ([::1]:port, [::1]), and bare
+    hostnames (localhost) correctly by stripping the port first.
+    """
+    raw = environ.get("HTTP_HOST", "")
+    # Strip port: split on the last colon only (IPv6 has colons in the address).
+    # For bracketed IPv6 like [::1]:37358, extract between [ and ].
+    if raw.startswith("["):
+        # IPv6 with port: [::1]:37358 or IPv6 without port: [::1]
+        bracket_end = raw.find("]")
+        if bracket_end > 0:
+            host = raw[1:bracket_end]
+        else:
+            host = ""
+    else:
+        # IPv4 or hostname, possibly with :port
+        host = raw.rsplit(":", 1)[0] if ":" in raw else raw
+    return host in {"localhost", "127.0.0.1", "::1"}
+
+
+def _host_error():
+    return _json_response(403, {"error": "Dashboard access denied: non-local Host header"})
+
+
 def _csrf_error():
     return _json_response(403, {"error": "Invalid dashboard CSRF token"})
 
@@ -962,6 +993,10 @@ class Web(BaseWeb):
 
     def get(self, environ, base_prefix, path, user):
         """Serve the dashboard for Radicale's web endpoint."""
+        # SEC-R7.4: Reject non-local Host headers before any processing.
+        if not _has_valid_host(environ):
+            return _host_error()
+
         if path in ("", "/", "/.web", "/.web/"):
             html = _render_dashboard()
             return (
@@ -1079,6 +1114,11 @@ class Web(BaseWeb):
 
     def post(self, environ, base_prefix, path, user):
         """Handle POST requests for API endpoints."""
+        # SEC-R7.4: Reject non-local Host headers before any processing.
+        # Defense-in-depth against DNS-rebinding when ALLOW_REMOTE is enabled.
+        if not _has_valid_host(environ):
+            return _host_error()
+
         # Trigger immediate sync
         if path == "/.web/api/sync":
             if not _has_valid_csrf(environ):

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -24,11 +24,25 @@ from silentsuite_bridge.web import (
 )
 
 
-def _post_environ(body=b"", csrf_token=None):
+# Default Host header matching a localhost variant so the SEC-R7.4 Host check
+# accepts the request. Tests that exercise the rejection path set this explicitly.
+_LOCAL_HOST = "localhost:37358"
+
+
+def _get_environ(host=_LOCAL_HOST):
+    environ = {}
+    if host is not None:
+        environ["HTTP_HOST"] = host
+    return environ
+
+
+def _post_environ(body=b"", csrf_token=None, host=_LOCAL_HOST):
     environ = {
         "CONTENT_LENGTH": str(len(body)),
         "wsgi.input": io.BytesIO(body),
     }
+    if host is not None:
+        environ["HTTP_HOST"] = host
     if csrf_token is not None:
         environ["HTTP_X_SILENTSUITE_CSRF"] = csrf_token
     return environ
@@ -56,6 +70,9 @@ def _wsgi_response(app, method, path):
         "REQUEST_METHOD": method,
         "PATH_INFO": path,
         "SCRIPT_NAME": "",
+        # SEC-R7.4: the dashboard rejects non-local Host headers, so requests
+        # routed through the full WSGI stack must carry a localhost Host header.
+        "HTTP_HOST": "127.0.0.1:37358",
         "SERVER_NAME": "127.0.0.1",
         "SERVER_PORT": "37358",
         "SERVER_PROTOCOL": "HTTP/1.1",
@@ -210,7 +227,7 @@ def test_dump_api_returns_404_when_disabled(monkeypatch):
     monkeypatch.setattr(config, "DASHBOARD_DUMP_ENABLED", False)
     web = Web.__new__(Web)
 
-    status, headers, body = web.get({}, "", "/.web/api/dump", None)
+    status, headers, body = web.get(_get_environ(), "", "/.web/api/dump", None)
 
     assert status == 404
     assert headers == {}
@@ -221,7 +238,7 @@ def test_dump_api_requires_csrf_when_enabled(monkeypatch):
     monkeypatch.setattr(config, "DASHBOARD_DUMP_ENABLED", True)
     web = Web.__new__(Web)
 
-    status, headers, body = web.get({}, "", "/.web/api/dump", None)
+    status, headers, body = web.get(_get_environ(), "", "/.web/api/dump", None)
 
     assert status == 403
     assert headers["Content-Type"] == "application/json"
@@ -232,7 +249,7 @@ def test_root_route_serves_dashboard(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
     web = Web.__new__(Web)
 
-    status, headers, body = web.get({}, "", "/", None)
+    status, headers, body = web.get(_get_environ(), "", "/", None)
 
     assert status == 200
     assert headers["Content-Type"] == "text/html; charset=utf-8"
@@ -245,12 +262,45 @@ def test_web_compat_route_serves_dashboard(path, tmp_path, monkeypatch):
     monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
     web = Web.__new__(Web)
 
-    status, headers, body = web.get({}, "", path, None)
+    status, headers, body = web.get(_get_environ(), "", path, None)
 
     assert status == 200
     assert headers["Content-Type"] == "text/html; charset=utf-8"
     assert b"SilentSuite Bridge" in body
     assert b"dashboardLoginForm" in body
+
+
+@pytest.mark.parametrize("path", ["/", "/.web", "/.web/api/status"])
+def test_dashboard_get_rejects_non_local_host(path, tmp_path, monkeypatch):
+    # SEC-R7.4: a non-local Host header (DNS-rebinding / cross-origin) is
+    # rejected before any dashboard processing.
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    web = Web.__new__(Web)
+
+    status, headers, body = web.get(
+        _get_environ(host="evil.example.com"), "", path, None
+    )
+
+    assert status == 403
+    assert headers["Content-Type"] == "application/json"
+    assert "non-local Host" in json.loads(body)["error"]
+
+
+def test_dashboard_post_rejects_non_local_host():
+    # SEC-R7.4: non-local Host headers are rejected on mutating endpoints
+    # before CSRF validation or body parsing.
+    web = Web.__new__(Web)
+
+    status, headers, body = web.post(
+        _post_environ(csrf_token=_dashboard_csrf_token, host="evil.example.com"),
+        "",
+        "/.web/api/sync",
+        None,
+    )
+
+    assert status == 403
+    assert headers["Content-Type"] == "application/json"
+    assert "non-local Host" in json.loads(body)["error"]
 
 
 def test_radicale_root_redirect_terminates_at_dashboard(tmp_path, monkeypatch):

--- a/server/etebase_server/fastapi/dependencies.py
+++ b/server/etebase_server/fastapi/dependencies.py
@@ -36,7 +36,10 @@ def __renew_token(auth_token: AuthToken):
 
 
 def __get_authenticated_user(api_token: str):
-    api_token = api_token.split()[1]
+    parts = api_token.split()
+    if len(parts) != 2:
+        raise AuthenticationFailed(detail="Malformed Authorization header.")
+    api_token = parts[1]
     try:
         token: AuthToken = AuthToken.objects.select_related("user").get(key=api_token)
     except AuthToken.DoesNotExist:

--- a/server/etebase_server/fastapi/routers/collection.py
+++ b/server/etebase_server/fastapi/routers/collection.py
@@ -159,8 +159,16 @@ class ItemDepIn(BaseModel):
     uid: str
     etag: str
 
-    def validate_db(self):
-        item = models.CollectionItem.objects.get(uid=self.uid)
+    def validate_db(self, collection: models.Collection):
+        try:
+            item = collection.items.get(uid=self.uid)
+        except models.CollectionItem.DoesNotExist:
+            raise ValidationError(
+                "wrong_etag",
+                "Dependency item not found in this collection.",
+                status_code=status.HTTP_409_CONFLICT,
+                field=self.uid,
+            )
         etag = self.etag
         if item.etag != etag:
             raise ValidationError(
@@ -175,12 +183,12 @@ class ItemBatchIn(BaseModel):
     items: t.List[CollectionItemIn]
     deps: t.Optional[t.List[ItemDepIn]] = None
 
-    def validate_db(self):
+    def validate_db(self, collection: models.Collection):
         if self.deps is not None:
             errors: t.List[HttpError] = []
             for dep in self.deps:
                 try:
-                    dep.validate_db()
+                    dep.validate_db(collection)
                 except ValidationError as e:
                     errors.append(e)
             if len(errors) > 0:
@@ -480,7 +488,7 @@ def item_bulk_common(
         if stoken and stoken != collection_object.stoken:
             raise HttpError("stale_stoken", "Stoken is too old", status_code=status.HTTP_409_CONFLICT)
 
-        data.validate_db()
+        data.validate_db(collection_object)
 
         errors: t.List[HttpError] = []
         for item in data.items:

--- a/server/etebase_server/myauth/tests.py
+++ b/server/etebase_server/myauth/tests.py
@@ -37,7 +37,7 @@ class DjangoAppLoadTest(TestCase):
         self.assertIn("django.middleware.csrf.CsrfViewMiddleware", settings.MIDDLEWARE)
 
 
-@override_settings(ALLOWED_HOSTS=["*"], DEBUG=True)
+@override_settings(ALLOWED_HOSTS=["*"], DEBUG=True, SECURE_SSL_REDIRECT=False)
 class URLRoutingTest(TestCase):
     """Verify basic URL routing is configured."""
 

--- a/server/etebase_server/settings.py
+++ b/server/etebase_server/settings.py
@@ -221,6 +221,28 @@ if "DJANGO_MEDIA_ROOT" in os.environ:
 if env_flag("ETEBASE_DISABLE_SIGNUP"):
     ETEBASE_CREATE_USER_FUNC = "etebase_server.django.utils.create_user_blocked"
 
+# ──────────────────────────────────────────────────────────────────────
+# Production HTTPS and secure-cookie defaults (SEC-R7.8)
+#
+# These settings are applied when DEBUG=False. Self-hosters behind a TLS
+# proxy should set ETEBASE_BEHIND_PROXY=true so SECURE_PROXY_SSL_HEADER is
+# configured. All values can be overridden via the etebase_server_settings
+# module import below or by environment variables.
+# ──────────────────────────────────────────────────────────────────────
+if not DEBUG:
+    SECURE_SSL_REDIRECT = os.environ.get("ETEBASE_SECURE_SSL_REDIRECT", "true").lower() == "true"
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = int(os.environ.get("ETEBASE_HSTS_SECONDS", "31536000"))
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_REFERRER_POLICY = "same-origin"
+
+# Only set the proxy SSL header when explicitly behind a trusted reverse proxy.
+if os.environ.get("ETEBASE_BEHIND_PROXY", "").lower() in ("1", "true", "yes"):
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
 # Make an `etebase_server_settings` module available to override settings.
 try:
     from etebase_server_settings import *  # noqa: F403


### PR DESCRIPTION
## Summary

Four SEC-R7 security hardening stories for the public repo (bridge, server, self-host).

## SEC-R7.4 — Bridge dashboard Host/Origin defense
- Added `_has_valid_host()` that checks the `Host` header is localhost
- All POST (mutating) endpoints reject non-local Host headers before CSRF/body parsing
- Defense-in-depth against DNS-rebinding when `ALLOW_REMOTE` is enabled

## SEC-R7.5 — Server malformed auth header hardening
- `__get_authenticated_user` now guards `api_token.split()` with a length check
- Malformed `Authorization` headers (scheme-only, no-space) return 401 instead of 500 (IndexError)

## SEC-R7.7 — Server collection item dependency scoping
- `ItemDepIn.validate_db()` and `ItemBatchIn.validate_db()` now receive the collection object
- Dependency lookups are scoped to `collection.items.get(uid=...)` instead of global `CollectionItem.objects.get(uid=...)`
- `DoesNotExist` is caught and returns clean 409, not 500
- Prevents cross-collection dependency probing and etag leakage

## SEC-R7.8 — Self-host Django HTTPS and secure-cookie production defaults
- When `DEBUG=False`: `SECURE_SSL_REDIRECT`, `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, HSTS, content-type nosniff, referrer policy
- `SECURE_PROXY_SSL_HEADER` set when `ETEBASE_BEHIND_PROXY=true`
- All overridable via `etebase_server_settings` module or env vars

## Validation
- Python tests deferred to CI (bridge needs Rust toolchain, server has stale lock — both green in CI per AGENTS.md S2)
- Type-check: Pyright confirms no new errors after the collection.py call-site fix