### PR TITLE
fix(web): render multi-day calendar bars in month view

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -16,7 +16,7 @@ import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { expandRecurrence } from '@silentsuite/core'
 import type { CalendarEvent, DateRange } from '@silentsuite/core'
 import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
-import { toAllDayEndPlainDate } from '../lib/all-day'
+import { isMultiDayTimedRange, toAllDayEndPlainDate, toTimedMonthEndPlainDate } from '../lib/all-day'
 
 import '@schedule-x/theme-default/dist/index.css'
 
@@ -154,15 +154,19 @@ function toScheduleXEvents(
   displayEvents: DisplayEvent[],
   calendarColors: Map<string, string>,
   userTz: string,
+  currentView: CalendarView,
 ): CalendarEventExternal[] {
   return displayEvents.map((e) => {
     const color = calendarColors.get(e.calendarId ?? 'default') ?? '#10b981'
+    const renderAsMonthBar = currentView === 'month' && !e.allDay && isMultiDayTimedRange(e.startDate, e.endDate)
     return {
       id: e.id,
       title: e.isRecurring ? `↻ ${e.title}` : e.title,
-      start: e.allDay ? toPlainDate(e.startDate) : toScheduleXDateTime(e.startDate, userTz),
+      start: e.allDay || renderAsMonthBar ? toPlainDate(e.startDate) : toScheduleXDateTime(e.startDate, userTz),
       end: e.allDay
         ? toAllDayEndPlainDate(e.startDate, e.endDate)
+        : renderAsMonthBar
+          ? toTimedMonthEndPlainDate(e.startDate, e.endDate)
         : toScheduleXDateTime(e.endDate, userTz),
       description: e.description || undefined,
       location: e.location || undefined,
@@ -322,7 +326,10 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const displayEventMapRef = useRef(displayEventMap)
   displayEventMapRef.current = displayEventMap
 
-  const sxEvents = useMemo(() => toScheduleXEvents(displayEvents, calendarColors, userTz), [displayEvents, calendarColors, userTz])
+  const sxEvents = useMemo(
+    () => toScheduleXEvents(displayEvents, calendarColors, userTz, currentView),
+    [displayEvents, calendarColors, userTz, currentView],
+  )
 
   // Inject calendar color styles via useInsertionEffect (avoids dangerouslySetInnerHTML)
   useInsertionEffect(() => {

--- a/apps/web/app/(app)/calendar/lib/__tests__/all-day.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/all-day.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import 'temporal-polyfill/global'
-import { toAllDayEndPlainDate, inclusiveAllDayEndDate } from '../all-day'
+import {
+  isMultiDayTimedRange,
+  toAllDayEndPlainDate,
+  inclusiveAllDayEndDate,
+  toTimedMonthEndPlainDate,
+} from '../all-day'
 
 describe('toAllDayEndPlainDate', () => {
   it('returns the start day for a single-day event with iCal-exclusive DTEND', () => {
@@ -80,5 +85,44 @@ describe('inclusiveAllDayEndDate', () => {
     expect(inclusive.getFullYear()).toBe(2026)
     expect(inclusive.getMonth()).toBe(11)
     expect(inclusive.getDate()).toBe(31)
+  })
+})
+
+describe('timed multi-day month rendering helpers', () => {
+  it('detects timed ranges that cross a local date boundary', () => {
+    expect(
+      isMultiDayTimedRange(
+        new Date(2026, 4, 5, 22, 0),
+        new Date(2026, 4, 6, 1, 0),
+      ),
+    ).toBe(true)
+
+    expect(
+      isMultiDayTimedRange(
+        new Date(2026, 4, 5, 9, 0),
+        new Date(2026, 4, 5, 17, 0),
+      ),
+    ).toBe(false)
+  })
+
+  it('uses the end date as the inclusive month-bar end for timed multi-day appointments', () => {
+    const start = new Date(2026, 4, 5, 9, 0)
+    const end = new Date(2026, 4, 7, 11, 30)
+
+    expect(toTimedMonthEndPlainDate(start, end).toString()).toBe('2026-05-07')
+  })
+
+  it('does not paint a timed appointment onto a final midnight-only day', () => {
+    const start = new Date(2026, 4, 5, 9, 0)
+    const end = new Date(2026, 4, 7, 0, 0, 0, 0)
+
+    expect(toTimedMonthEndPlainDate(start, end).toString()).toBe('2026-05-06')
+  })
+
+  it('clamps malformed timed month ranges to the start day', () => {
+    const start = new Date(2026, 4, 5, 9, 0)
+    const end = new Date(2026, 4, 4, 11, 0)
+
+    expect(toTimedMonthEndPlainDate(start, end).toString()).toBe('2026-05-05')
   })
 })

--- a/apps/web/app/(app)/calendar/lib/all-day.ts
+++ b/apps/web/app/(app)/calendar/lib/all-day.ts
@@ -29,6 +29,39 @@ export function toAllDayEndPlainDate(startDate: Date, endDate: Date): Temporal.P
   return Temporal.PlainDate.compare(endPd, startPd) < 0 ? startPd : endPd
 }
 
+/** Return true when a timed event crosses at least one local calendar-day boundary. */
+export function isMultiDayTimedRange(startDate: Date, endDate: Date): boolean {
+  return (
+    startDate.getFullYear() !== endDate.getFullYear() ||
+    startDate.getMonth() !== endDate.getMonth() ||
+    startDate.getDate() !== endDate.getDate()
+  )
+}
+
+/** Compute the inclusive end date for rendering a timed multi-day event in month grids.
+ *
+ * Schedule-X renders spanning bars in the month grid for date-only events. Timed multi-day
+ * events should therefore be handed to month view as PlainDate ranges, while week view keeps
+ * their exact ZonedDateTime start/end. A timed appointment ending exactly at local midnight
+ * does not occupy that final day visually, so clamp the month bar to the prior date.
+ */
+export function toTimedMonthEndPlainDate(startDate: Date, endDate: Date): Temporal.PlainDate {
+  const startPd = dateToPlainDate(startDate)
+  let endPd = dateToPlainDate(endDate)
+
+  if (
+    endDate.getHours() === 0 &&
+    endDate.getMinutes() === 0 &&
+    endDate.getSeconds() === 0 &&
+    endDate.getMilliseconds() === 0 &&
+    Temporal.PlainDate.compare(endPd, startPd) > 0
+  ) {
+    endPd = endPd.subtract({ days: 1 })
+  }
+
+  return Temporal.PlainDate.compare(endPd, startPd) < 0 ? startPd : endPd
+}
+
 /** Convert an iCal-exclusive all-day end Date (next-day local-midnight) into a Date
  * representing the inclusive last day at local-midnight.
  *


### PR DESCRIPTION
## Summary
- Render timed multi-day appointments as date-spanning month bars while preserving exact timed events in week view
- Add month-bar helper logic for midnight-ending timed ranges
- Add regression coverage for timed multi-day month range handling

Closes #289

## Test Plan
- `corepack pnpm --filter @silentsuite/web test -- 'apps/web/app/(app)/calendar/lib/__tests__/all-day.test.ts'` (Vitest ran 25 web test files / 262 tests)
- `corepack pnpm --filter @silentsuite/web type-check`
- `corepack pnpm --filter @silentsuite/web lint` (passes with pre-existing warnings)
- `corepack pnpm --filter @silentsuite/web build` (passes; emits existing Sentry/standalone trace warnings)
