### PR TITLE
feat(web): export a single calendar, task list, or address book

### DIFF
--- a/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
@@ -1,77 +1,111 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { toVEvent } from '@silentsuite/core'
+import { toVEvent, toVTodo, toVCard } from '@silentsuite/core'
 import { showErrorToast, showWarningToast } from '@/app/stores/use-toast-store'
 import ExportPage from '../page'
+
+// Mutable mock data so individual tests can configure collections + items.
+// `vi.hoisted` runs before the module mocks below are evaluated, which is
+// required because `vi.mock` factories are hoisted above the imports.
+const mockData = vi.hoisted(() => {
+  const now = new Date()
+  return {
+    events: [
+      {
+        id: '1',
+        uid: 'e1',
+        title: 'Meeting',
+        calendarId: 'default',
+        startDate: now,
+        endDate: now,
+        allDay: false,
+        description: '',
+        location: '',
+        recurrenceRule: null,
+        exceptions: [],
+        alarms: [],
+        created: now,
+        updated: now,
+      },
+    ],
+    tasks: [
+      {
+        id: '1',
+        uid: 't1',
+        title: 'Test task',
+        listId: 'default',
+        priority: 'medium',
+        completed: false,
+        created_at: now,
+        updated_at: now,
+      },
+    ],
+    contacts: [
+      {
+        id: '1',
+        uid: 'c1',
+        displayName: 'Alice',
+        listId: 'default',
+        name: { given: 'Alice', family: 'Smith' },
+        phones: [],
+        emails: [],
+        addresses: [],
+        organization: '',
+        title: '',
+        notes: '',
+        birthday: null,
+        photoUrl: null,
+        created_at: now,
+        updated_at: now,
+      },
+    ],
+    calendars: [
+      { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+    ],
+    taskLists: [
+      { id: 'default', name: 'My Tasks', color: '#3b82f6', visible: true },
+    ],
+    contactLists: [
+      { id: 'default', name: 'My Contacts', color: '#8b5cf6', visible: true },
+    ],
+  }
+})
 
 vi.mock('@/app/stores/use-toast-store', () => ({
   showErrorToast: vi.fn(),
   showWarningToast: vi.fn(),
 }))
 
-// Mock stores
+// Mock item stores
 vi.mock('@/app/stores/use-task-store', () => ({
   useTaskStore: (selector: (s: { tasks: unknown[] }) => unknown) =>
-    selector({
-      tasks: [
-        {
-          id: '1',
-          uid: 't1',
-          title: 'Test task',
-          priority: 'medium',
-          completed: false,
-          created_at: new Date(),
-          updated_at: new Date(),
-        },
-      ],
-    }),
+    selector({ tasks: mockData.tasks }),
 }))
 
 vi.mock('@/app/stores/use-contact-store', () => ({
   useContactStore: (selector: (s: { contacts: unknown[] }) => unknown) =>
-    selector({
-      contacts: [
-        {
-          id: '1',
-          uid: 'c1',
-          displayName: 'Alice',
-          name: { given: 'Alice', family: 'Smith' },
-          phones: [],
-          emails: [],
-          addresses: [],
-          organization: '',
-          title: '',
-          notes: '',
-          birthday: null,
-          photoUrl: null,
-          created_at: new Date(),
-          updated_at: new Date(),
-        },
-      ],
-    }),
+    selector({ contacts: mockData.contacts }),
 }))
 
 vi.mock('@/app/stores/use-calendar-store', () => ({
   useCalendarStore: (selector: (s: { events: unknown[] }) => unknown) =>
-    selector({
-      events: [
-        {
-          id: '1',
-          uid: 'e1',
-          title: 'Meeting',
-          startDate: new Date(),
-          endDate: new Date(),
-          allDay: false,
-          description: '',
-          location: '',
-          recurrenceRule: null,
-          exceptions: [],
-          alarms: [],
-          created: new Date(),
-          updated: new Date(),
-        },
-      ],
-    }),
+    selector({ events: mockData.events }),
+}))
+
+// Mock collection-list stores
+vi.mock('@/app/stores/use-calendar-list-store', () => ({
+  useCalendarListStore: (selector: (s: { calendars: unknown[] }) => unknown) =>
+    selector({ calendars: mockData.calendars }),
+}))
+
+vi.mock('@/app/stores/use-task-list-store', () => ({
+  useTaskListStore: (selector: (s: { lists: unknown[] }) => unknown) =>
+    selector({ lists: mockData.taskLists }),
+}))
+
+vi.mock('@/app/stores/use-contact-list-store', () => ({
+  useContactListStore: (selector: (s: { lists: unknown[] }) => unknown) =>
+    selector({ lists: mockData.contactLists }),
 }))
 
 // Mock @silentsuite/core serializers
@@ -133,13 +167,83 @@ vi.stubGlobal('URL', {
   revokeObjectURL: vi.fn(),
 })
 
+/** Reset the shared mock data back to the single-collection defaults. */
+function resetMockData() {
+  const now = new Date()
+  mockData.events = [
+    {
+      id: '1',
+      uid: 'e1',
+      title: 'Meeting',
+      calendarId: 'default',
+      startDate: now,
+      endDate: now,
+      allDay: false,
+      description: '',
+      location: '',
+      recurrenceRule: null,
+      exceptions: [],
+      alarms: [],
+      created: now,
+      updated: now,
+    },
+  ]
+  mockData.tasks = [
+    {
+      id: '1',
+      uid: 't1',
+      title: 'Test task',
+      listId: 'default',
+      priority: 'medium',
+      completed: false,
+      created_at: now,
+      updated_at: now,
+    },
+  ]
+  mockData.contacts = [
+    {
+      id: '1',
+      uid: 'c1',
+      displayName: 'Alice',
+      listId: 'default',
+      name: { given: 'Alice', family: 'Smith' },
+      phones: [],
+      emails: [],
+      addresses: [],
+      organization: '',
+      title: '',
+      notes: '',
+      birthday: null,
+      photoUrl: null,
+      created_at: now,
+      updated_at: now,
+    },
+  ]
+  mockData.calendars = [
+    { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+  ]
+  mockData.taskLists = [
+    { id: 'default', name: 'My Tasks', color: '#3b82f6', visible: true },
+  ]
+  mockData.contactLists = [
+    { id: 'default', name: 'My Contacts', color: '#8b5cf6', visible: true },
+  ]
+}
+
 describe('ExportPage', () => {
   let clickedLink: HTMLAnchorElement | null = null
 
   beforeEach(() => {
     clickedLink = null
+    resetMockData()
     vi.restoreAllMocks()
     vi.clearAllMocks()
+    // Reset the URL stubs each test. An earlier case reassigns
+    // URL.createObjectURL's implementation; without a per-test reset that can
+    // leak a self-referential implementation that recurses (RangeError) into
+    // later tests.
+    ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementation(() => 'blob:mock')
+    ;(URL.revokeObjectURL as ReturnType<typeof vi.fn>).mockImplementation(() => {})
     // Mock document.createElement to capture the download link
     const originalCreateElement = document.createElement.bind(document)
     vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
@@ -164,6 +268,27 @@ describe('ExportPage', () => {
     render(<ExportPage />)
     expect(screen.getByText('Export Data')).toBeInTheDocument()
     expect(screen.getByText(/Download your data in standard formats/)).toBeInTheDocument()
+  })
+
+  it('renders a collection selector for each type', () => {
+    render(<ExportPage />)
+    expect(screen.getByLabelText('Calendar collection')).toBeInTheDocument()
+    expect(screen.getByLabelText('Task list collection')).toBeInTheDocument()
+    expect(screen.getByLabelText('Address book collection')).toBeInTheDocument()
+  })
+
+  it('renders the "All" option plus each collection in the selectors', () => {
+    mockData.calendars = [
+      { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+      { id: 'work', name: 'Work', color: '#3b82f6', visible: true },
+    ]
+    const { container } = render(<ExportPage />)
+    const select = screen.getByLabelText('Calendar collection') as HTMLSelectElement
+    const options = Array.from(select.options).map((o) => o.value)
+    expect(options).toEqual(['all', 'default', 'work'])
+    // sanity: the rendered DOM contains the option text
+    expect(container.textContent).toContain('All calendars')
+    expect(container.textContent).toContain('Work')
   })
 
   it('displays item counts next to export buttons', () => {
@@ -284,5 +409,185 @@ describe('ExportPage', () => {
     ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockImplementation(
       originalCreateObjectURL as () => string,
     )
+  })
+
+  // ── Per-collection selection (issue #299) ──
+
+  it('updates the calendar count when a specific calendar is selected', () => {
+    mockData.calendars = [
+      { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+      { id: 'work', name: 'Work', color: '#3b82f6', visible: true },
+    ]
+    mockData.events = [
+      { ...mockData.events[0]!, id: '1', calendarId: 'default' },
+      { ...mockData.events[0]!, id: '2', title: 'Standup', calendarId: 'work' },
+    ]
+
+    render(<ExportPage />)
+    // "All calendars" aggregates both events
+    expect(screen.getByText(/2 events/)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('Calendar collection'), {
+      target: { value: 'work' },
+    })
+    expect(screen.getByText(/1 event/)).toBeInTheDocument()
+  })
+
+  it('filters events to the selected calendar and serializes only those', () => {
+    mockData.calendars = [
+      { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+      { id: 'work', name: 'Work', color: '#3b82f6', visible: true },
+    ]
+    const workEvent = { ...mockData.events[0]!, id: '2', title: 'Standup', calendarId: 'work' }
+    mockData.events = [
+      { ...mockData.events[0]!, id: '1', calendarId: 'default' },
+      workEvent,
+    ]
+
+    render(<ExportPage />)
+    fireEvent.change(screen.getByLabelText('Calendar collection'), {
+      target: { value: 'work' },
+    })
+    fireEvent.click(screen.getByText(/Export Calendar/))
+
+    // Only the work event should have been serialized
+    expect(vi.mocked(toVEvent)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toVEvent)).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }))
+    expect(clickedLink).not.toBeNull()
+    expect(clickedLink!.download).toBe('silentsuite-calendar-work.ics')
+  })
+
+  it('filters tasks to the selected task list', () => {
+    mockData.taskLists = [
+      { id: 'default', name: 'My Tasks', color: '#3b82f6', visible: true },
+      { id: 'groceries', name: 'Groceries', color: '#10b981', visible: true },
+    ]
+    const groceryTask = { ...mockData.tasks[0]!, id: '2', title: 'Buy milk', listId: 'groceries' }
+    mockData.tasks = [
+      { ...mockData.tasks[0]!, id: '1', listId: 'default' },
+      groceryTask,
+    ]
+
+    render(<ExportPage />)
+    fireEvent.change(screen.getByLabelText('Task list collection'), {
+      target: { value: 'groceries' },
+    })
+    fireEvent.click(screen.getByText(/Export Tasks/))
+
+    expect(vi.mocked(toVTodo)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toVTodo)).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }))
+    expect(clickedLink).not.toBeNull()
+    expect(clickedLink!.download).toBe('silentsuite-tasks-groceries.ics')
+  })
+
+  it('filters contacts to the selected address book', () => {
+    mockData.contactLists = [
+      { id: 'default', name: 'My Contacts', color: '#8b5cf6', visible: true },
+      { id: 'family', name: 'Family', color: '#10b981', visible: true },
+    ]
+    const familyContact = { ...mockData.contacts[0]!, id: '2', displayName: 'Bob', listId: 'family' }
+    mockData.contacts = [
+      { ...mockData.contacts[0]!, id: '1', listId: 'default' },
+      familyContact,
+    ]
+
+    render(<ExportPage />)
+    fireEvent.change(screen.getByLabelText('Address book collection'), {
+      target: { value: 'family' },
+    })
+    fireEvent.click(screen.getByText(/Export Contacts/))
+
+    expect(vi.mocked(toVCard)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toVCard)).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }))
+    expect(clickedLink).not.toBeNull()
+    expect(clickedLink!.download).toBe('silentsuite-contacts-family.vcf')
+  })
+
+  it('treats items with a missing collection id as belonging to the default collection', () => {
+    mockData.calendars = [
+      { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+      { id: 'work', name: 'Work', color: '#3b82f6', visible: true },
+    ]
+    // An event with no calendarId should map to 'default' and be filtered out
+    // when the 'work' calendar is selected.
+    const legacyEvent = { ...mockData.events[0]!, id: '1', calendarId: undefined }
+    const workEvent = { ...mockData.events[0]!, id: '2', title: 'Standup', calendarId: 'work' }
+    mockData.events = [legacyEvent, workEvent] as unknown as typeof mockData.events
+
+    render(<ExportPage />)
+    fireEvent.change(screen.getByLabelText('Calendar collection'), {
+      target: { value: 'work' },
+    })
+    fireEvent.click(screen.getByText(/Export Calendar/))
+
+    expect(vi.mocked(toVEvent)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(toVEvent)).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }))
+  })
+
+  it('sanitizes the collection name in the export filename', () => {
+    mockData.calendars = [
+      { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+      { id: 'wt', name: 'Work & Travel!!', color: '#3b82f6', visible: true },
+    ]
+    mockData.events = [
+      { ...mockData.events[0]!, id: '1', calendarId: 'wt' },
+    ]
+
+    render(<ExportPage />)
+    fireEvent.change(screen.getByLabelText('Calendar collection'), {
+      target: { value: 'wt' },
+    })
+    fireEvent.click(screen.getByText(/Export Calendar/))
+
+    expect(clickedLink).not.toBeNull()
+    expect(clickedLink!.download).toBe('silentsuite-calendar-work-travel.ics')
+  })
+
+  it('disables the per-type export button when the selected collection has no items', () => {
+    mockData.calendars = [
+      { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+      { id: 'empty', name: 'Empty', color: '#3b82f6', visible: true },
+    ]
+    mockData.events = [
+      { ...mockData.events[0]!, id: '1', calendarId: 'default' },
+    ]
+
+    render(<ExportPage />)
+    // Initially (All calendars) the button is enabled
+    expect(screen.getByText(/Export Calendar/).closest('button')!).not.toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Calendar collection'), {
+      target: { value: 'empty' },
+    })
+    // Count drops to zero and the button is disabled
+    expect(screen.getByText(/0 events/)).toBeInTheDocument()
+    expect(screen.getByText(/Export Calendar/).closest('button')!).toBeDisabled()
+  })
+
+  it('keeps the all-data ZIP export independent of the per-type selection', async () => {
+    mockData.calendars = [
+      { id: 'default', name: 'Personal', color: '#10b981', visible: true },
+      { id: 'work', name: 'Work', color: '#3b82f6', visible: true },
+    ]
+    mockData.events = [
+      { ...mockData.events[0]!, id: '1', calendarId: 'default' },
+      { ...mockData.events[0]!, id: '2', title: 'Standup', calendarId: 'work' },
+    ]
+
+    render(<ExportPage />)
+    // Narrow the calendar selection — the ZIP should still include everything.
+    fireEvent.change(screen.getByLabelText('Calendar collection'), {
+      target: { value: 'work' },
+    })
+    fireEvent.click(screen.getByText(/Export All Data/))
+
+    await vi.waitFor(() => {
+      expect(URL.createObjectURL).toHaveBeenCalled()
+    })
+
+    // Both events were serialized for the ZIP, regardless of the selection
+    expect(vi.mocked(toVEvent)).toHaveBeenCalledTimes(2)
+    expect(clickedLink).not.toBeNull()
+    expect(clickedLink!.download).toBe('silentsuite-export.zip')
   })
 })

--- a/apps/web/app/(app)/settings/export/page.tsx
+++ b/apps/web/app/(app)/settings/export/page.tsx
@@ -1,11 +1,14 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Button } from '@silentsuite/ui'
 import { toVEvent, toVTodo, toVCard, type CalendarEvent, type Task, type Contact } from '@silentsuite/core'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
+import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
+import { useTaskListStore } from '@/app/stores/use-task-list-store'
+import { useContactListStore } from '@/app/stores/use-contact-list-store'
 import {
   showErrorToast,
   showWarningToast,
@@ -19,6 +22,9 @@ import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
  * before kicking off the ZIP export.
  */
 const LARGE_EXPORT_THRESHOLD = 1000
+
+/** Sentinel value meaning "export every collection of this type". */
+const ALL_COLLECTIONS = 'all'
 
 function downloadFile(content: string | Blob | Uint8Array, filename: string, mimeType: string) {
   const blob =
@@ -87,19 +93,81 @@ function reportError(label: string, err: unknown) {
   showErrorToast(`${label} failed. Please try again.`)
 }
 
+/** Reduce an arbitrary collection name to a filename-safe slug.
+ * e.g. "Work & Travel!!" -> "work-travel". Falls back to "collection" if the
+ * name contains no usable characters. */
+function sanitizeCollectionName(name: string): string {
+  return (
+    name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'collection'
+  )
+}
+
+/** Build a download filename for a single-type export. When `collectionId` is
+ * `ALL_COLLECTIONS` the legacy aggregate filename is used; otherwise the
+ * sanitized collection name is appended so each exported file is
+ * distinguishable. */
+function buildExportFilename(
+  prefix: 'calendar' | 'tasks' | 'contacts',
+  extension: 'ics' | 'vcf',
+  collectionId: string,
+  collections: ReadonlyArray<{ id: string; name: string }>,
+): string {
+  if (collectionId === ALL_COLLECTIONS) {
+    return `silentsuite-${prefix}.${extension}`
+  }
+  const collection = collections.find((c) => c.id === collectionId)
+  const slug = sanitizeCollectionName(collection?.name ?? collectionId)
+  return `silentsuite-${prefix}-${slug}.${extension}`
+}
+
 export default function ExportPage() {
   const tasks = useTaskStore((s) => s.tasks)
   const contacts = useContactStore((s) => s.contacts)
   const events = useCalendarStore((s) => s.events)
 
+  const calendars = useCalendarListStore((s) => s.calendars)
+  const taskLists = useTaskListStore((s) => s.lists)
+  const contactLists = useContactListStore((s) => s.lists)
+
+  const [selectedCalendarId, setSelectedCalendarId] = useState(ALL_COLLECTIONS)
+  const [selectedTaskListId, setSelectedTaskListId] = useState(ALL_COLLECTIONS)
+  const [selectedContactListId, setSelectedContactListId] = useState(ALL_COLLECTIONS)
+
   const [isExportingAll, setIsExportingAll] = useState(false)
   const [exportProgress, setExportProgress] = useState(0)
 
+  const filteredEvents = useMemo(
+    () =>
+      selectedCalendarId === ALL_COLLECTIONS
+        ? events
+        : events.filter((event) => (event.calendarId ?? 'default') === selectedCalendarId),
+    [events, selectedCalendarId],
+  )
+  const filteredTasks = useMemo(
+    () =>
+      selectedTaskListId === ALL_COLLECTIONS
+        ? tasks
+        : tasks.filter((task) => (task.listId ?? 'default') === selectedTaskListId),
+    [tasks, selectedTaskListId],
+  )
+  const filteredContacts = useMemo(
+    () =>
+      selectedContactListId === ALL_COLLECTIONS
+        ? contacts
+        : contacts.filter((contact) => (contact.listId ?? 'default') === selectedContactListId),
+    [contacts, selectedContactListId],
+  )
+
   function exportCalendar() {
     try {
-      const { vcomponents, skipped } = serializeEvents(events)
+      const { vcomponents, skipped } = serializeEvents(filteredEvents)
       const ics = buildCalendarIcs(vcomponents)
-      downloadFile(ics, 'silentsuite-calendar.ics', 'text/calendar')
+      const filename = buildExportFilename('calendar', 'ics', selectedCalendarId, calendars)
+      downloadFile(ics, filename, 'text/calendar')
       reportSkipped('event', skipped)
     } catch (err) {
       reportError('Calendar export', err)
@@ -108,9 +176,10 @@ export default function ExportPage() {
 
   function exportTasks() {
     try {
-      const { vcomponents, skipped } = serializeTasks(tasks)
+      const { vcomponents, skipped } = serializeTasks(filteredTasks)
       const ics = buildCalendarIcs(vcomponents)
-      downloadFile(ics, 'silentsuite-tasks.ics', 'text/calendar')
+      const filename = buildExportFilename('tasks', 'ics', selectedTaskListId, taskLists)
+      downloadFile(ics, filename, 'text/calendar')
       reportSkipped('task', skipped)
     } catch (err) {
       reportError('Tasks export', err)
@@ -119,9 +188,10 @@ export default function ExportPage() {
 
   function exportContacts() {
     try {
-      const { vcomponents, skipped } = serializeContacts(contacts)
+      const { vcomponents, skipped } = serializeContacts(filteredContacts)
       const vcf = vcomponents.join('\n')
-      downloadFile(vcf, 'silentsuite-contacts.vcf', 'text/vcard')
+      const filename = buildExportFilename('contacts', 'vcf', selectedContactListId, contactLists)
+      downloadFile(vcf, filename, 'text/vcard')
       reportSkipped('contact', skipped)
     } catch (err) {
       reportError('Contacts export', err)
@@ -131,6 +201,9 @@ export default function ExportPage() {
   async function exportAll() {
     if (isExportingAll) return
 
+    // The ZIP is intentionally an all-data export: it always includes every
+    // calendar, task list, and address book regardless of the per-type
+    // selections above. Per-collection exports use the individual buttons.
     const totalItems = events.length + tasks.length + contacts.length
 
     setIsExportingAll(true)
@@ -197,50 +270,129 @@ export default function ExportPage() {
         Download your data in standard formats (ICS, VCF). Your data is always yours.
       </p>
 
-      <div className="flex flex-col gap-3">
-        <Button
-          className="w-full sm:w-auto"
-          disabled={events.length === 0 || isExportingAll}
-          onClick={exportCalendar}
-        >
-          <Download className="mr-2 h-4 w-4" />
-          Export Calendar ({events.length} {events.length === 1 ? 'event' : 'events'})
-        </Button>
-        <Button
-          className="w-full sm:w-auto"
-          disabled={tasks.length === 0 || isExportingAll}
-          onClick={exportTasks}
-        >
-          <Download className="mr-2 h-4 w-4" />
-          Export Tasks ({tasks.length} {tasks.length === 1 ? 'task' : 'tasks'})
-        </Button>
-        <Button
-          className="w-full sm:w-auto"
-          disabled={contacts.length === 0 || isExportingAll}
-          onClick={exportContacts}
-        >
-          <Download className="mr-2 h-4 w-4" />
-          Export Contacts ({contacts.length} {contacts.length === 1 ? 'contact' : 'contacts'})
-        </Button>
-        <Button
-          variant="outline"
-          className="w-full sm:w-auto"
-          disabled={exportAllDisabled}
-          onClick={exportAll}
-          aria-busy={isExportingAll}
-        >
-          {isExportingAll ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Preparing… {exportProgress}%
-            </>
-          ) : (
-            <>
-              <Download className="mr-2 h-4 w-4" />
-              Export All Data (.zip)
-            </>
-          )}
-        </Button>
+      <div className="flex flex-col gap-5">
+        {/* Calendar */}
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="export-calendar-select"
+            className="text-sm font-medium text-[rgb(var(--foreground))]"
+          >
+            Calendar
+          </label>
+          <select
+            id="export-calendar-select"
+            aria-label="Calendar collection"
+            value={selectedCalendarId}
+            onChange={(e) => setSelectedCalendarId(e.target.value)}
+            className="w-full max-w-xs rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          >
+            <option value={ALL_COLLECTIONS}>All calendars</option>
+            {calendars.map((calendar) => (
+              <option key={calendar.id} value={calendar.id}>
+                {calendar.name}
+              </option>
+            ))}
+          </select>
+          <Button
+            className="w-full sm:w-auto"
+            disabled={filteredEvents.length === 0 || isExportingAll}
+            onClick={exportCalendar}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            Export Calendar ({filteredEvents.length} {filteredEvents.length === 1 ? 'event' : 'events'})
+          </Button>
+        </div>
+
+        {/* Tasks */}
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="export-tasks-select"
+            className="text-sm font-medium text-[rgb(var(--foreground))]"
+          >
+            Task list
+          </label>
+          <select
+            id="export-tasks-select"
+            aria-label="Task list collection"
+            value={selectedTaskListId}
+            onChange={(e) => setSelectedTaskListId(e.target.value)}
+            className="w-full max-w-xs rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          >
+            <option value={ALL_COLLECTIONS}>All task lists</option>
+            {taskLists.map((list) => (
+              <option key={list.id} value={list.id}>
+                {list.name}
+              </option>
+            ))}
+          </select>
+          <Button
+            className="w-full sm:w-auto"
+            disabled={filteredTasks.length === 0 || isExportingAll}
+            onClick={exportTasks}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            Export Tasks ({filteredTasks.length} {filteredTasks.length === 1 ? 'task' : 'tasks'})
+          </Button>
+        </div>
+
+        {/* Contacts */}
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="export-contacts-select"
+            className="text-sm font-medium text-[rgb(var(--foreground))]"
+          >
+            Address book
+          </label>
+          <select
+            id="export-contacts-select"
+            aria-label="Address book collection"
+            value={selectedContactListId}
+            onChange={(e) => setSelectedContactListId(e.target.value)}
+            className="w-full max-w-xs rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-1 focus:ring-emerald-500"
+          >
+            <option value={ALL_COLLECTIONS}>All address books</option>
+            {contactLists.map((list) => (
+              <option key={list.id} value={list.id}>
+                {list.name}
+              </option>
+            ))}
+          </select>
+          <Button
+            className="w-full sm:w-auto"
+            disabled={filteredContacts.length === 0 || isExportingAll}
+            onClick={exportContacts}
+          >
+            <Download className="mr-2 h-4 w-4" />
+            Export Contacts ({filteredContacts.length} {filteredContacts.length === 1 ? 'contact' : 'contacts'})
+          </Button>
+        </div>
+
+        {/* All-data ZIP — always exports every collection, independent of the
+            per-type selections above. */}
+        <div className="flex flex-col gap-1 border-t border-[rgb(var(--border))] pt-5">
+          <Button
+            variant="outline"
+            className="w-full sm:w-auto"
+            disabled={exportAllDisabled}
+            onClick={exportAll}
+            aria-busy={isExportingAll}
+          >
+            {isExportingAll ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Preparing… {exportProgress}%
+              </>
+            ) : (
+              <>
+                <Download className="mr-2 h-4 w-4" />
+                Export All Data (.zip)
+              </>
+            )}
+          </Button>
+          <p className="text-xs text-[rgb(var(--muted))]">
+            Includes every calendar, task list, and address book in a single archive.
+          </p>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Add per-type collection selectors to the export page so users can export a single calendar, task list, or address book (in addition to the existing all-of-type and all-data ZIP exports)
- Filter exported items by the selected collection id, with items missing a collection id treated as the default collection
- Sanitize collection names into the download filename (e.g. `silentsuite-calendar-work-travel.ics`)
- Keep the all-data ZIP export independent of the per-type selections and label it clearly
- Fix a pre-existing test-isolation bug where `URL.createObjectURL`'s implementation was restored to itself, causing a `RangeError` that leaked into later tests

Closes #299

## Test Plan
- `corepack pnpm --filter @silentsuite/web test -- 'apps/web/app/(app)/settings/export/__tests__/page.test.tsx'` — 22 tests pass (8 new per-collection tests: selector rendering, all+each option, count update, per-type filtering, missing-collection-id defaulting, filename sanitization, empty-selection disabling, ZIP independence)
- `corepack pnpm --filter @silentsuite/web type-check` — passes
- `corepack pnpm --filter @silentsuite/web lint` — passes (pre-existing warnings only)
