### PR TITLE
fix(web): drop newsletter frequency wording from signup opt-in

### DIFF
--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -338,7 +338,7 @@ function StepCreateAccount({
             className="mt-0.5 h-4 w-4 rounded border-[rgb(var(--border))] bg-[rgb(var(--surface))] text-[rgb(var(--primary))] focus:ring-[rgb(var(--primary))] focus:ring-offset-0"
           />
           <span className="text-xs text-[rgb(var(--muted))] leading-relaxed">
-            Send me product updates and feature announcements (~8/year)
+            Send me product updates and feature announcements
             <br />
             <span className="text-[rgb(var(--muted))]/70">We will never share your email. Unsubscribe anytime.</span>
           </span>


### PR DESCRIPTION
## Summary
- Remove the `(~8/year)` frequency wording from the signup product-updates opt-in so it can no longer be misread (some users read it as the product being 8 years old). The opt-in itself remains optional and its behavior is unchanged.

Closes #288

## Test Plan
- `corepack pnpm --filter @silentsuite/web type-check` — passes
- `corepack pnpm --filter @silentsuite/web lint` — passes (pre-existing warnings only)
- Searched `apps/web` for `8/year|8 times|times per year|per year` — only this one occurrence, now removed
