### PR TITLE
feat(web): expose collection management on mobile web

### DIFF
--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { useCallback, useMemo, useState } from 'react'
-import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
+import { ChevronLeft, ChevronRight, Plus, Folder } from 'lucide-react'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { PullToRefresh } from '@/app/components/PullToRefresh'
+import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
 import { CalendarViewSwitcher } from './components/CalendarViewSwitcher'
 import { CalendarGrid, type SlotClickEvent, type EventClickInfo } from './components/CalendarGrid'
 import { AgendaView } from './components/AgendaView'
@@ -101,6 +102,7 @@ export default function CalendarPage() {
 
   const [createDialog, setCreateDialog] = useState<CreateDialogState | null>(null)
   const [eventInstanceDate, setEventInstanceDate] = useState<Date | undefined>(undefined)
+  const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
 
   const dateLabel = useMemo(
     () => formatDateRange(currentDate, currentView),
@@ -223,6 +225,13 @@ export default function CalendarPage() {
             </button>
           </div>
           {/* On mobile, only agenda view is shown — hide the view switcher */}
+          <button
+            onClick={() => setCollectionSheetOpen(true)}
+            className="md:hidden rounded-md p-2 text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] active:bg-[rgb(var(--surface))] transition-colors"
+            aria-label="Manage calendars"
+          >
+            <Folder className="h-5 w-5" />
+          </button>
         </div>
         <h2 className="text-base font-semibold text-[rgb(var(--foreground))] px-1">{dateLabel}</h2>
       </div>
@@ -276,6 +285,13 @@ export default function CalendarPage() {
 
       {/* Mobile floating add button */}
       <FloatingAddButton />
+
+      {/* Mobile collection management sheet */}
+      <MobileCollectionSheet
+        type="calendar"
+        open={collectionSheetOpen}
+        onClose={() => setCollectionSheetOpen(false)}
+      />
     </div>
   )
 }

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Search, ArrowLeft, Phone, Mail, MapPin, Building2, Cake,
-  StickyNote, User, WifiOff, Plus, Trash2, X, Pencil, Camera, BookUser, List,
+  StickyNote, User, WifiOff, Plus, Trash2, X, Pencil, Camera, BookUser, List, Folder,
 } from 'lucide-react'
 import { useContactStore, getFilteredContacts } from '@/app/stores/use-contact-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
@@ -11,6 +11,7 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 import { ContactsEmptyState, SearchEmptyState, ContactDetailEmptyState } from '@/app/components/empty-state'
 import { ConfirmDialog } from '@/app/components/confirm-dialog'
+import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import type { Contact } from '@silentsuite/core'
@@ -1050,6 +1051,7 @@ export default function ContactsPage() {
   const contactLists = useContactListStore((s) => s.lists)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [showNewForm, setShowNewForm] = useState(false)
+  const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
 
   // Filter contacts by visible lists
   const visibleListIds = useMemo(() => new Set(contactLists.filter(l => l.visible).map(l => l.id)), [contactLists])
@@ -1086,16 +1088,26 @@ export default function ContactsPage() {
         <div className="flex items-center gap-3">
           <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">Contacts</h2>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowNewForm(true)}
-          disabled={!canWrite}
-          className={`flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white transition-colors ${!canWrite ? 'opacity-50 cursor-not-allowed' : 'hover:bg-emerald-500'}`}
-          title={!canWrite ? 'Subscription required' : undefined}
-        >
-          <Plus className="h-4 w-4" />
-          New Contact
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setCollectionSheetOpen(true)}
+            className="md:hidden rounded-md p-1.5 text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+            aria-label="Manage address books"
+          >
+            <Folder className="h-5 w-5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowNewForm(true)}
+            disabled={!canWrite}
+            className={`flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white transition-colors ${!canWrite ? 'opacity-50 cursor-not-allowed' : 'hover:bg-emerald-500'}`}
+            title={!canWrite ? 'Subscription required' : undefined}
+          >
+            <Plus className="h-4 w-4" />
+            New Contact
+          </button>
+        </div>
       </div>
 
       {/* Search */}
@@ -1153,6 +1165,13 @@ export default function ContactsPage() {
           )}
         </div>
       )}
+
+      {/* Mobile collection management sheet */}
+      <MobileCollectionSheet
+        type="contacts"
+        open={collectionSheetOpen}
+        onClose={() => setCollectionSheetOpen(false)}
+      />
     </div>
   )
 }

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { useCallback, useMemo, useState, useRef, useEffect } from 'react'
-import { X, ChevronDown, Calendar, Flag, WifiOff, Plus, AlignLeft, Pencil, List } from 'lucide-react'
+import { X, ChevronDown, Calendar, Flag, WifiOff, Plus, AlignLeft, Pencil, List, Folder } from 'lucide-react'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 
 import { PullToRefresh } from '@/app/components/PullToRefresh'
+import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
 import { TasksEmptyState } from '@/app/components/empty-state'
 import { ConfirmDialog } from '@/app/components/confirm-dialog'
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
@@ -721,6 +722,7 @@ export default function TasksPage() {
   const taskLists = useTaskListStore((s) => s.lists)
   const [showDialog, setShowDialog] = useState(false)
   const [editTask, setEditTask] = useState<Task | null>(null)
+  const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
 
   // Filter tasks by visible lists
   const visibleListIds = useMemo(() => new Set(taskLists.filter(l => l.visible).map(l => l.id)), [taskLists])
@@ -746,15 +748,24 @@ export default function TasksPage() {
         <div className="flex items-center gap-3">
           <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">Tasks</h2>
         </div>
-        <button
-          onClick={() => setShowDialog(true)}
-          disabled={!canWrite}
-          className={`flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 ${!canWrite ? 'opacity-50 cursor-not-allowed' : 'hover:bg-emerald-500'}`}
-          title={!canWrite ? 'Subscription required' : undefined}
-        >
-          <Plus className="h-4 w-4" />
-          New task
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setCollectionSheetOpen(true)}
+            className="md:hidden rounded-md p-1.5 text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+            aria-label="Manage task lists"
+          >
+            <Folder className="h-5 w-5" />
+          </button>
+          <button
+            onClick={() => setShowDialog(true)}
+            disabled={!canWrite}
+            className={`flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 ${!canWrite ? 'opacity-50 cursor-not-allowed' : 'hover:bg-emerald-500'}`}
+            title={!canWrite ? 'Subscription required' : undefined}
+          >
+            <Plus className="h-4 w-4" />
+            New task
+          </button>
+        </div>
       </div>
 
       {/* Quick add */}
@@ -791,6 +802,13 @@ export default function TasksPage() {
           onClose={() => setEditTask(null)}
         />
       )}
+
+      {/* Mobile collection management sheet */}
+      <MobileCollectionSheet
+        type="tasks"
+        open={collectionSheetOpen}
+        onClose={() => setCollectionSheetOpen(false)}
+      />
     </div>
   )
 }

--- a/apps/web/app/components/MobileCollectionSheet.tsx
+++ b/apps/web/app/components/MobileCollectionSheet.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { CalendarListPanel } from './CalendarListPanel'
+import { TaskListPanel } from './TaskListPanel'
+import { ContactListPanel } from './ContactListPanel'
+
+export type MobileCollectionType = 'calendar' | 'tasks' | 'contacts'
+
+interface MobileCollectionSheetProps {
+  type: MobileCollectionType
+  open: boolean
+  onClose: () => void
+}
+
+/**
+ * Mobile-only slide-up sheet that exposes the existing collection management
+ * panels (calendars / task lists / address books) which are otherwise only
+ * reachable via the desktop sidebar (`hidden md:flex`). The panels are reused
+ * as-is so all CRUD logic stays in one place.
+ */
+export function MobileCollectionSheet({ type, open, onClose }: MobileCollectionSheetProps) {
+  if (!open) return null
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-50 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Slide-up sheet */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Collections"
+        className="fixed inset-x-0 bottom-0 z-50 max-h-[80vh] overflow-y-auto rounded-t-xl border-t border-[rgb(var(--border))] bg-[rgb(var(--background))] shadow-2xl"
+      >
+        {/* Header */}
+        <div className="sticky top-0 flex items-center justify-between border-b border-[rgb(var(--border))] bg-[rgb(var(--background))] px-4 py-3">
+          <span className="text-sm font-semibold text-[rgb(var(--foreground))]">Collections</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1.5 text-[rgb(var(--muted))] hover:bg-[rgb(var(--surface))] hover:text-[rgb(var(--foreground))] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2"
+            aria-label="Close collections"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Context-aware collection panel (reused from the desktop sidebar) */}
+        <div className="pb-4">
+          {type === 'calendar' && <CalendarListPanel />}
+          {type === 'tasks' && <TaskListPanel />}
+          {type === 'contacts' && <ContactListPanel />}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/apps/web/app/components/__tests__/MobileCollectionSheet.test.tsx
+++ b/apps/web/app/components/__tests__/MobileCollectionSheet.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// Mock the three collection panels so the sheet is tested in isolation.
+vi.mock('../CalendarListPanel', () => ({
+  CalendarListPanel: () => <div data-testid="cal-panel">calendar</div>,
+}))
+vi.mock('../TaskListPanel', () => ({
+  TaskListPanel: () => <div data-testid="task-panel">tasks</div>,
+}))
+vi.mock('../ContactListPanel', () => ({
+  ContactListPanel: () => <div data-testid="contact-panel">contacts</div>,
+}))
+
+import { MobileCollectionSheet } from '../MobileCollectionSheet'
+
+describe('MobileCollectionSheet', () => {
+  it('renders the calendar panel when open with type "calendar"', () => {
+    render(<MobileCollectionSheet type="calendar" open onClose={() => {}} />)
+    expect(screen.getByTestId('cal-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('task-panel')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('contact-panel')).not.toBeInTheDocument()
+  })
+
+  it('renders the task panel when open with type "tasks"', () => {
+    render(<MobileCollectionSheet type="tasks" open onClose={() => {}} />)
+    expect(screen.getByTestId('task-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('cal-panel')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('contact-panel')).not.toBeInTheDocument()
+  })
+
+  it('renders the contact panel when open with type "contacts"', () => {
+    render(<MobileCollectionSheet type="contacts" open onClose={() => {}} />)
+    expect(screen.getByTestId('contact-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('cal-panel')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('task-panel')).not.toBeInTheDocument()
+  })
+
+  it('renders the Collections header and close button when open', () => {
+    render(<MobileCollectionSheet type="calendar" open onClose={() => {}} />)
+    expect(screen.getByText('Collections')).toBeInTheDocument()
+    expect(screen.getByLabelText('Close collections')).toBeInTheDocument()
+  })
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<MobileCollectionSheet type="calendar" open onClose={onClose} />)
+    fireEvent.click(screen.getByLabelText('Close collections'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <MobileCollectionSheet type="calendar" open={false} onClose={() => {}} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
## Summary
- Add a mobile-only slide-up "Collections" sheet (`MobileCollectionSheet`) that reuses the existing `CalendarListPanel` / `TaskListPanel` / `ContactListPanel` as-is, so mobile web users can discover and manage collections (calendars / task lists / address books) previously reachable only via the desktop sidebar (`hidden md:flex`).
- Add a mobile-only Folder button to the calendar, tasks, and contacts section headers to open the sheet with the right collection type.
- Desktop sidebar is unchanged; all CRUD logic stays in the existing panels.

Closes #294

## Test Plan
- `corepack pnpm --filter @silentsuite/web test -- 'apps/web/app/components/__tests__/MobileCollectionSheet.test.tsx' 'apps/web/app/components/__tests__/CalendarListPanel.test.tsx' 'apps/web/app/components/__tests__/TaskListPanel.test.tsx' 'apps/web/app/components/__tests__/ContactListPanel.test.tsx'` — 268 tests pass (incl. 6 new sheet tests: per-type panel rendering, header/close, onClose callback, renders-nothing-when-closed)
- `corepack pnpm --filter @silentsuite/web type-check` — passes
- `corepack pnpm --filter @silentsuite/web lint` — passes (pre-existing warnings only)
