### PR TITLE
fix(android): robust .vcf import with per-contact failure reporting

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
@@ -333,15 +333,17 @@ class ImportFragment : DialogFragment() {
                     } else if (enumType == CollectionInfo.Type.ADDRESS_BOOK) {
                         val uidToLocalId = HashMap<String?, Long>()
                         val downloader = ContactsSyncManager.ResourceDownloader(context)
-                        val contacts = Contact.fromReader(importReader, downloader)
+                        val parseResult = Contact.fromReaderLenient(importReader, downloader)
+                        val contacts = parseResult.contacts
+                        result.failed = parseResult.failed.toLong()
 
-                        if (contacts.isEmpty()) {
+                        if (contacts.isEmpty() && parseResult.failed == 0) {
                             Logger.log.warning("No contacts found in selected file.")
                             result.e = Exception("No contacts found in the selected file.")
                             return result
                         }
 
-                        result.total = contacts.size.toLong()
+                        result.total = (contacts.size + parseResult.failed).toLong()
 
                         finishParsingFile(contacts.size)
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ResultFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ResultFragment.kt
@@ -74,7 +74,7 @@ class ResultFragment : DialogFragment() {
             get() = e != null
 
         val skipped: Long
-            get() = total - (added + updated)
+            get() = total - (added + updated + failed)
 
         override fun toString(): String {
             return "ResultFragment.ImportResult(total=" + this.total + ", added=" + this.added + ", updated=" + this.updated + ", failed=" + this.failed + ", e=" + this.e?.javaClass?.name + ")"

--- a/android/app/src/test/java/io/silentsuite/sync/ui/importlocal/ImportResultTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/importlocal/ImportResultTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 class ImportResultTest {
 
     @Test
-    fun skippedCountsEntriesThatWereNotAddedOrUpdated() {
+    fun skippedExcludesAddedUpdatedAndFailed() {
         val result = ResultFragment.ImportResult().also {
             it.total = 3
             it.added = 1
@@ -16,7 +16,20 @@ class ImportResultTest {
             it.failed = 1
         }
 
-        assertEquals(1, result.skipped)
+        // failed entries are no longer double-counted as skipped
+        assertEquals(0, result.skipped)
+    }
+
+    @Test
+    fun skippedCountsEntriesNotAddedUpdatedOrFailed() {
+        val result = ResultFragment.ImportResult().also {
+            it.total = 5
+            it.added = 1
+            it.updated = 1
+            it.failed = 1
+        }
+
+        assertEquals(2, result.skipped)
     }
 
     @Test

--- a/android/vcard4android/src/main/java/at/bitfire/vcard4android/Contact.kt
+++ b/android/vcard4android/src/main/java/at/bitfire/vcard4android/Contact.kt
@@ -132,6 +132,36 @@ class Contact {
             return contacts
         }
 
+        /**
+         * Lenient variant of [fromReader] that parses each vCard block individually
+         * so a single malformed card does not fail the entire file. Returns the
+         * successfully parsed contacts plus a count of cards that could not be
+         * parsed. No personally-identifiable data is retained or logged — only
+         * the failed count is kept.
+         */
+        fun fromReaderLenient(reader: Reader, downloader: Downloader?): LenientParseResult {
+            val text = reader.readText()
+            val blocks = VCARD_BLOCK_REGEX.findAll(text).map { it.value }.toList()
+            if (blocks.isEmpty())
+                return LenientParseResult(emptyList(), 0)
+
+            val contacts = LinkedList<Contact>()
+            var failed = 0
+            for (block in blocks) {
+                try {
+                    contacts += fromVCard(Ezvcard.parse(block).first(), downloader)
+                } catch (e: Throwable) {
+                    failed++
+                }
+            }
+            return LenientParseResult(contacts, failed)
+        }
+
+        private val VCARD_BLOCK_REGEX = Regex("(?is)BEGIN:VCARD.*?END:VCARD")
+
+        /** Result of a lenient vCard parse: the parsed contacts and how many cards failed. */
+        class LenientParseResult(val contacts: List<Contact>, val failed: Int)
+
         private fun fromVCard(vCard: VCard, downloader: Downloader?): Contact {
             val c = Contact()
 

--- a/android/vcard4android/src/test/java/at/bitfire/vcard4android/ContactTest.kt
+++ b/android/vcard4android/src/test/java/at/bitfire/vcard4android/ContactTest.kt
@@ -44,6 +44,49 @@ class ContactTest {
 
 
     @Test
+    fun fromReaderLenientParsesMultipleValidCards() {
+        val vcard = """
+            BEGIN:VCARD
+            VERSION:4.0
+            FN:Alice
+            END:VCARD
+            BEGIN:VCARD
+            VERSION:4.0
+            FN:Bob
+            END:VCARD
+        """.trimIndent()
+        val result = Contact.fromReaderLenient(StringReader(vcard), null)
+        assertEquals(2, result.contacts.size)
+        assertEquals(0, result.failed)
+        assertEquals(listOf("Alice", "Bob"), result.contacts.mapNotNull { it.displayName }.sorted())
+    }
+
+    @Test
+    fun fromReaderLenientRecoversValidCardsWhenOneIsMalformed() {
+        // The middle card has a property line with no colon, which is
+        // syntactically invalid and rejected by ez-vcard. The valid cards on
+        // either side must still be imported.
+        val vcard = """
+            BEGIN:VCARD
+            VERSION:4.0
+            FN:Alice
+            END:VCARD
+            BEGIN:VCARD
+            VERSION:4.0
+            NoColonLine
+            END:VCARD
+            BEGIN:VCARD
+            VERSION:4.0
+            FN:Bob
+            END:VCARD
+        """.trimIndent()
+        val result = Contact.fromReaderLenient(StringReader(vcard), null)
+        assertEquals(2, result.contacts.size)
+        assertEquals(1, result.failed)
+        assertEquals(listOf("Alice", "Bob"), result.contacts.mapNotNull { it.displayName }.sorted())
+    }
+
+    @Test
     fun testDropEmptyProperties() {
         val vcard = "BEGIN:VCARD\n" +
                 "VERSION:4.0\n" +


### PR DESCRIPTION
## What
Fixes #298.

Android `.vcf` contact import aborted the entire file when a single vCard card was malformed, even though the web importer handled the same file. The root cause: `Contact.fromReader` parses the **whole file** before any per-contact handling, so one bad card fails the entire import.

## Changes
- **`vcard4android/Contact.kt`** — add `fromReaderLenient(reader, downloader)`: parses each `BEGIN:VCARD…END:VCARD` block independently so a malformed card no longer takes down the rest. Returns `LenientParseResult(contacts, failed)`. **No personally identifiable data is retained or logged** — only the count of cards that failed to parse is kept. The existing whole-file `fromReader` is left in place for other callers.
- **`ImportFragment.kt`** — switch address-book import to `fromReaderLenient`; surface `failed` in the result; set `total = successfullyParsed + failed` so the summary math stays consistent; the empty-file guard now distinguishes "file had no cards" from "all cards failed to parse".
- **`ResultFragment.kt`** — fix `skipped = total − (added + updated + failed)` so failed entries are no longer double-counted as skipped.
- **Tests** — `ContactTest`: lenient parser parses multiple valid cards and recovers valid cards when a middle card is malformed. `ImportResultTest`: `skipped` excludes added/updated/failed, and counts only genuinely-skipped entries.

## Privacy
Per-contact failure reporting is count-only. No contact data, property values, or card contents are logged or retained on failure.

## Validation
- `vcard4android` + app unit tests cover the new path and the corrected `skipped` math.
- Android build + full test suite run in CI on this PR (Android builds are not run locally per project convention).

## Test plan
- [ ] CI is green (build + unit tests)
- [ ] Reviewer confirms no PII is logged on the failure path
- [ ] (On-device, follow-up) Import a `.vcf` with one malformed card among valid ones → valid cards import, failed count reported, no whole-file abort