### PR TITLE
fix(android): UI polish — status bar, toolbar icons, content icon tints, login redesign

### DIFF
--- a/android/app/src/main/res/drawable/ic_delete_light.xml
+++ b/android/app/src/main/res/drawable/ic_delete_light.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_edit_light.xml
+++ b/android/app/src/main/res/drawable/ic_edit_light.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_email_light.xml
+++ b/android/app/src/main/res/drawable/ic_email_light.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,8l-8,5 -8,-5L4,6l8,5 8,-5v2z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_help_light.xml
+++ b/android/app/src/main/res/drawable/ic_help_light.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright © 2013 – 2016 Ricki Hirner (bitfire web engineering).
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the GNU Public License v3.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.gnu.org/licenses/gpl.html
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0" >
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zm1,17h-2v-2h2v2zm2.07,-7.75l-0.9,0.92C13.45,12.9 13,13.5 13,15h-2v-0.5c0,-1.1 0.45,-2.1 1.17,-2.83l1.24,-1.26c0.37,-0.36 0.59,-0.86 0.59,-1.41 0,-1.1 -0.9,-2 -2,-2s-2,0.9 -2,2H8c0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,0.88 -0.36,1.68 -0.93,2.25z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_members_light.xml
+++ b/android/app/src/main/res/drawable/ic_members_light.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M16,13C15.71,13 15.38,13 15.03,13.05C16.19,13.89 17,15 17,16.5V19H23V16.5C23,14.17 18.33,13 16,13M8,13C5.67,13 1,14.17 1,16.5V19H15V16.5C15,14.17 10.33,13 8,13M8,11A3,3 0 0,0 11,8A3,3 0 0,0 8,5A3,3 0 0,0 5,8A3,3 0 0,0 8,11M16,11A3,3 0 0,0 19,8A3,3 0 0,0 16,5A3,3 0 0,0 13,8A3,3 0 0,0 16,11Z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_restore_light.xml
+++ b/android/app/src/main/res/drawable/ic_restore_light.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_save_light.xml
+++ b/android/app/src/main/res/drawable/ic_save_light.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M15,9H5V5H15M12,19A3,3 0 0,1 9,16A3,3 0 0,1 12,13A3,3 0 0,1 15,16A3,3 0 0,1 12,19M17,3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V7L17,3Z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_share_light.xml
+++ b/android/app/src/main/res/drawable/ic_share_light.xml
@@ -1,0 +1,13 @@
+<!--
+  ~ Copyright © 2013 – 2016 Ricki Hirner (bitfire web engineering).
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the GNU Public License v3.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.gnu.org/licenses/gpl.html
+  -->
+
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/android/app/src/main/res/drawable/ic_sync_light.xml
+++ b/android/app/src/main/res/drawable/ic_sync_light.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:tint="?attr/colorControlNormal"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M12,4V1L8,5l4,4V6c3.31,0 6,2.69 6,6 0,1.01 -0.25,1.97 -0.7,2.8l1.46,1.46C19.54,15.03 20,13.57 20,12c0,-4.42 -3.58,-8 -8,-8zm0,14c-3.31,0 -6,-2.69 -6,-6 0,-1.01 0.25,-1.97 0.7,-2.8L5.24,7.74C4.46,8.97 4,10.43 4,12c0,4.42 3.58,8 8,8v3l4,-4 -4,-4v3z"/>
+</vector>

--- a/android/app/src/main/res/drawable/login_info_banner_bg.xml
+++ b/android/app/src/main/res/drawable/login_info_banner_bg.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Rounded background for the login info banner. Uses the theme-aware
+     infoColor so it adapts to light (#E0EDF4) and dark (#0F2A3D) themes. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="@color/infoColor" />
+    <corners android:radius="8dp" />
+</shape>

--- a/android/app/src/main/res/layout/account_collection_item.xml
+++ b/android/app/src/main/res/layout/account_collection_item.xml
@@ -7,6 +7,7 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -64,6 +65,7 @@
         android:layout_marginRight="8dp"
         android:contentDescription="@string/account_collection_shared_indicator"
         android:src="@drawable/ic_members_dark"
+        app:tint="?attr/colorControlNormal"
         android:visibility="gone" />
 
     <ImageView
@@ -72,7 +74,8 @@
         android:layout_height="24dp"
         android:layout_marginRight="8dp"
         android:contentDescription="@string/account_collection_read_only_indicator"
-        android:src="@drawable/ic_readonly_dark" />
+        android:src="@drawable/ic_readonly_dark" 
+        app:tint="?attr/colorControlNormal" />
 
     <View
         android:id="@+id/color"

--- a/android/app/src/main/res/layout/collection_members_list_item.xml
+++ b/android/app/src/main/res/layout/collection_members_list_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -22,6 +23,7 @@
         android:layout_height="32dp"
         android:layout_marginRight="8dp"
         android:src="@drawable/ic_readonly_dark"
+        app:tint="?attr/colorControlNormal"
         android:visibility="gone" />
 
 </LinearLayout>

--- a/android/app/src/main/res/layout/etebase_view_collection_members.xml
+++ b/android/app/src/main/res/layout/etebase_view_collection_members.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -43,7 +44,8 @@
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:layout_gravity="center"
-            android:src="@drawable/ic_account_add_dark" />
+            android:src="@drawable/ic_account_add_dark" 
+            app:tint="?attr/colorControlNormal" />
 
     </LinearLayout>
 

--- a/android/app/src/main/res/layout/import_content_list_account.xml
+++ b/android/app/src/main/res/layout/import_content_list_account.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -11,7 +12,8 @@
         android:layout_gravity="center"
         android:layout_width="40dp"
         android:layout_height="40dp"
-        android:src="@drawable/ic_account_dark" />
+        android:src="@drawable/ic_account_dark" 
+        app:tint="?attr/colorControlNormal" />
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"

--- a/android/app/src/main/res/layout/invitations_list_item.xml
+++ b/android/app/src/main/res/layout/invitations_list_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -22,6 +23,7 @@
         android:layout_height="32dp"
         android:layout_marginRight="8dp"
         android:src="@drawable/ic_readonly_dark"
+        app:tint="?attr/colorControlNormal"
         android:visibility="gone" />
 
 </LinearLayout>

--- a/android/app/src/main/res/layout/login_credentials_fragment.xml
+++ b/android/app/src/main/res/layout/login_credentials_fragment.xml
@@ -27,30 +27,48 @@
                 android:layout_height="wrap_content"
                 style="@style/login_type_headline"
                 android:text="@string/login_enter_service_details"
-                android:layout_marginBottom="14dp"/>
+                android:layout_marginBottom="16dp"/>
 
+            <!-- Info banner: leading icon + rounded, padded background -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="16dp"
-                android:background="@color/infoColor"
-                android:orientation="vertical"
-                android:padding="12dp">
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:background="@drawable/login_info_banner_bg"
+                android:padding="16dp"
+                android:layout_marginBottom="16dp">
 
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/login_bridge_sync"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary" />
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginEnd="12dp"
+                    android:src="@drawable/ic_sync_dark"
+                    app:tint="?android:attr/textColorPrimary"
+                    android:contentDescription="@null" />
 
-                <TextView
-                    android:layout_width="match_parent"
+                <LinearLayout
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="6dp"
-                    android:text="@string/login_bridge_encrypted"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary" />
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/login_bridge_sync"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textColor="?android:attr/textColorPrimary" />
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:text="@string/login_bridge_encrypted"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textColor="?android:attr/textColorPrimary" />
+
+                </LinearLayout>
 
             </LinearLayout>
 
@@ -91,41 +109,20 @@
                     android:hint="@string/login_password"/>
             </com.google.android.material.textfield.TextInputLayout>
 
-
+            <!-- Unified secondary links: same size, left-aligned, ripple -->
             <TextView
                 android:id="@+id/forgot_password"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="4dp"
-                android:background="?attr/selectableItemBackground"
-                android:gravity="center_vertical"
-                android:minHeight="48dp"
-                android:text="@string/login_forgot_password"
-                android:textColor="?attr/colorSecondary"/>
+                style="@style/login_link"
+                android:text="@string/login_forgot_password" />
 
             <TextView
                 android:id="@+id/create_account"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="14dp"
-                android:gravity="center"
-                android:minHeight="48dp"
-                android:text="@string/login_signup_prompt"
-                android:textColor="?attr/colorSecondary"/>
+                style="@style/login_link"
+                android:text="@string/login_signup_prompt" />
 
             <TextView
                 android:id="@+id/show_advanced"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="14dp"
-                android:layout_marginLeft="4dp"
-                android:background="?attr/selectableItemBackground"
-                android:clickable="true"
-                android:focusable="true"
-                android:minHeight="48dp"
-                android:textSize="18sp"
-                android:gravity="center_vertical"
-                android:textColor="?attr/colorSecondary"
+                style="@style/login_link"
                 android:text="@string/login_toggle_advanced" />
 
             <net.cachapa.expandablelayout.ExpandableLayout
@@ -158,11 +155,12 @@
         android:layout_height="wrap_content"
         style="@style/stepper_nav_bar">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/login"
-            android:layout_width="match_parent"
-            android:text="@string/login_login"
-            style="@style/stepper_nav_button"/>
+            style="@style/login_button"
+            app:backgroundTint="?attr/colorSecondary"
+            android:textColor="?attr/colorOnSecondary"
+            android:text="@string/login_login" />
 
     </LinearLayout>
 </LinearLayout>

--- a/android/app/src/main/res/layout/view_collection_members.xml
+++ b/android/app/src/main/res/layout/view_collection_members.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -43,7 +44,8 @@
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:layout_gravity="center"
-            android:src="@drawable/ic_account_add_dark" />
+            android:src="@drawable/ic_account_add_dark" 
+            app:tint="?attr/colorControlNormal" />
 
     </LinearLayout>
 

--- a/android/app/src/main/res/layout/welcome_fragment.xml
+++ b/android/app/src/main/res/layout/welcome_fragment.xml
@@ -56,6 +56,7 @@
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:src="@drawable/ic_sync_dark"
+                app:tint="?attr/colorControlNormal"
                 android:layout_marginEnd="16dp"
                 android:contentDescription="@null" />
 
@@ -89,6 +90,7 @@
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:src="@drawable/ic_fingerprint_dark"
+                app:tint="?attr/colorControlNormal"
                 android:layout_marginEnd="16dp"
                 android:contentDescription="@null" />
 

--- a/android/app/src/main/res/menu/activity_account.xml
+++ b/android/app/src/main/res/menu/activity_account.xml
@@ -11,7 +11,7 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:id="@+id/sync_now"
-          android:icon="@drawable/ic_sync_dark"
+          android:icon="@drawable/ic_sync_light"
           android:title="@string/account_synchronize_now"
           app:showAsAction="always"/>
 

--- a/android/app/src/main/res/menu/activity_create_collection.xml
+++ b/android/app/src/main/res/menu/activity_create_collection.xml
@@ -10,7 +10,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:icon="@drawable/ic_save_dark"
+        android:icon="@drawable/ic_save_light"
         android:onClick="onCreateCollection"
         android:title="@string/create_collection_create"
         app:showAsAction="always" />

--- a/android/app/src/main/res/menu/activity_debug_info.xml
+++ b/android/app/src/main/res/menu/activity_debug_info.xml
@@ -11,7 +11,7 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:icon="@drawable/ic_share_dark"
+        android:icon="@drawable/ic_share_light"
         android:title="@string/send"
         app:showAsAction="always"
         android:onClick="onShare"/>

--- a/android/app/src/main/res/menu/activity_edit_collection.xml
+++ b/android/app/src/main/res/menu/activity_edit_collection.xml
@@ -10,14 +10,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:icon="@drawable/ic_delete_dark"
+        android:icon="@drawable/ic_delete_light"
         android:onClick="onDeleteCollection"
         android:title="@string/delete_collection"
         app:showAsAction="always" />
 
 
     <item
-        android:icon="@drawable/ic_save_dark"
+        android:icon="@drawable/ic_save_light"
         android:onClick="onCreateCollection"
         android:title="@string/create_collection_create"
         app:showAsAction="always" />

--- a/android/app/src/main/res/menu/activity_journal_item.xml
+++ b/android/app/src/main/res/menu/activity_journal_item.xml
@@ -12,14 +12,14 @@
 
     <group android:id="@+id/journal_item_menu_event_invite">
         <item android:title="@string/calendar_attendees_send_email_action"
-            android:icon="@drawable/ic_email_black"
+            android:icon="@drawable/ic_email_light"
             android:onClick="sendEventInvite"
             app:showAsAction="always" />
     </group>
 
     <group android:id="@+id/journal_item_menu_restore">
         <item android:title="@string/journal_item_restore_action"
-            android:icon="@drawable/ic_restore_black"
+            android:icon="@drawable/ic_restore_light"
             android:onClick="restoreItem"
             app:showAsAction="never" />
     </group>

--- a/android/app/src/main/res/menu/activity_login.xml
+++ b/android/app/src/main/res/menu/activity_login.xml
@@ -12,7 +12,7 @@
     
     <item
         android:title="@string/help"
-        android:icon="@drawable/ic_help_dark"
+        android:icon="@drawable/ic_help_light"
         app:showAsAction="always"
         android:onClick="showHelp">
     </item>

--- a/android/app/src/main/res/menu/activity_view_collection.xml
+++ b/android/app/src/main/res/menu/activity_view_collection.xml
@@ -11,12 +11,12 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:title="@string/view_collection_edit"
-        android:icon="@drawable/ic_edit_dark"
+        android:icon="@drawable/ic_edit_light"
         android:onClick="onEditCollection"
         app:showAsAction="always" />
 
     <item android:title="@string/view_collection_members"
-        android:icon="@drawable/ic_members_dark"
+        android:icon="@drawable/ic_members_light"
         android:onClick="onManageMembers"
         app:showAsAction="ifRoom"/>
 

--- a/android/app/src/main/res/menu/collection_item_fragment.xml
+++ b/android/app/src/main/res/menu/collection_item_fragment.xml
@@ -13,13 +13,13 @@
     <group android:id="@+id/journal_item_menu_event_invite">
         <item android:title="@string/calendar_attendees_send_email_action"
             android:id="@+id/on_send_event_invite"
-            android:icon="@drawable/ic_email_black"
+            android:icon="@drawable/ic_email_light"
             app:showAsAction="always" />
     </group>
 
     <group android:id="@+id/journal_item_menu_restore">
         <item android:title="@string/journal_item_restore_action"
-            android:icon="@drawable/ic_restore_black"
+            android:icon="@drawable/ic_restore_light"
             android:id="@+id/on_restore_item"
             app:showAsAction="never" />
     </group>

--- a/android/app/src/main/res/menu/fragment_edit_collection.xml
+++ b/android/app/src/main/res/menu/fragment_edit_collection.xml
@@ -11,14 +11,14 @@
 
     <item
         android:id="@+id/on_delete"
-        android:icon="@drawable/ic_delete_dark"
+        android:icon="@drawable/ic_delete_light"
         android:title="@string/delete_collection"
         app:showAsAction="always" />
 
 
     <item
         android:id="@+id/on_save"
-        android:icon="@drawable/ic_save_dark"
+        android:icon="@drawable/ic_save_light"
         android:title="@string/create_collection_create"
         app:showAsAction="always" />
 

--- a/android/app/src/main/res/menu/fragment_view_collection.xml
+++ b/android/app/src/main/res/menu/fragment_view_collection.xml
@@ -12,12 +12,12 @@
 
     <item android:title="@string/view_collection_edit"
         android:id="@+id/on_edit"
-        android:icon="@drawable/ic_edit_dark"
+        android:icon="@drawable/ic_edit_light"
         app:showAsAction="always" />
 
     <item android:title="@string/view_collection_members"
         android:id="@+id/on_manage_members"
-        android:icon="@drawable/ic_members_dark"
+        android:icon="@drawable/ic_members_light"
         app:showAsAction="ifRoom"/>
 
     <item android:title="@string/view_collection_import"

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -39,6 +39,7 @@
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <item name="android:statusBarColor">@color/navy700</item>
     </style>
 
     <style name="AppTheme.Dialog.Alert" parent="Theme.AppCompat.DayNight.Dialog.Alert">

--- a/android/app/src/main/res/values-v21/styles.xml
+++ b/android/app/src/main/res/values-v21/styles.xml
@@ -12,7 +12,11 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
+        <!-- Solid navy status bar matches the always-navy toolbar so the system
+             time/battery/connectivity icons (light by default) stay readable in
+             both light and dark themes. Previously transparent, which made light
+             status-bar icons invisible on the light offwhite background. -->
+        <item name="android:statusBarColor">@color/navy700</item>
     </style>
 
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -85,6 +85,8 @@
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
+        <!-- Solid navy status bar so light system icons stay readable (see values-v21). -->
+        <item name="android:statusBarColor">@color/navy700</item>
     </style>
 
 

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -102,6 +102,34 @@
     <style name="login_type_headline">
         <item name="android:textSize">22sp</item>
     </style>
+
+    <!-- Unified secondary login links: consistent size, left alignment, ripple.
+         Used by forgot_password, create_account, and show_advanced (Custom server). -->
+    <style name="login_link">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:gravity">center_vertical|start</item>
+        <item name="android:minHeight">48dp</item>
+        <item name="android:paddingTop">6dp</item>
+        <item name="android:paddingBottom">6dp</item>
+        <item name="android:textColor">?attr/colorSecondary</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:background">?attr/selectableItemBackground</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+    </style>
+
+    <!-- Filled primary login button (backgroundTint + textColor set on the element
+         to avoid attr-namespace ambiguity in the style). -->
+    <style name="login_button" parent="Widget.MaterialComponents.Button">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">48dp</item>
+        <item name="android:layout_marginStart">8dp</item>
+        <item name="android:layout_marginEnd">8dp</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:fontFamily">sans-serif-medium</item>
+    </style>
+
     <style name="account_list_card">
         <item name="android:layout_width">match_parent</item>
     </style>


### PR DESCRIPTION
## What
Addresses the Android UI issues reported in the last session: status-bar icons invisible in the light theme, dark toolbar menu icons on the navy app bar, content-surface icons invisible in dark theme, and an inconsistent/misaligned login screen.

Split into four reviewable commits, one per area.

## Group A — Solid navy status bar (`ca9e9d3`)
`AppTheme.NoActionBar` (login/wizard/main activities) set `statusBarColor` to transparent with no `windowLightStatusBar` flag, so system time/battery/connectivity icons defaulted to light and were invisible on the light `offwhite` background. Give the status bar a solid `navy700` fill (matching the always-navy toolbar) in `values-v21`, `values`, and `values-night`, so default light icons are readable in **both** themes. Lowest-risk fix; avoids the API-23-only `windowLightStatusBar` attribute (minSdk 21).

## Group B — White toolbar menu icons (`af13c7b`)
AppCompat toolbars do not auto-tint menu-item icons, so black `ic_*_dark`/`ic_*_black` drawables used as `android:icon` in toolbar menus render nearly invisible on the navy app bar. Added white `_light` variants (`fillColor #FFFFFFFF`) for the nine missing icons (edit, members, share, help, delete, save, sync, email, restore) and swapped the `android:icon` references in the ten affected menu files, matching the existing `ic_event_light`/`ic_people_light` pattern.

## Group C — Content-surface icon tints (`9cf94b2`)
Black `_dark` drawables used as `ImageView android:src` on content surfaces (welcome, collection item, members, import, invitations) are invisible on the `navy600` surface in dark theme. Added `app:tint="?attr/colorControlNormal"` to each affected ImageView so icons resolve dark-on-light in light theme and light-on-dark in dark theme. Added the `app:` namespace to the six layouts that lacked it.

## Group D — Login redesign (`172c84e`)
- Unified the three secondary links (`forgot_password`, `create_account`, `show_advanced`/Custom server) under a shared `login_link` style (14sp, left-aligned, 48dp min height, `colorSecondary`, ripple) — previously mixed sizes and left/center alignment.
- Replaced the flat info banner with a rounded (8dp) `infoColor` card: leading sync icon (tinted to `textColorPrimary`) + the two existing messages. Accessible contrast in both themes via theme-aware `infoColor`/`textColorPrimary`.
- Turned **Log In** into a filled `MaterialButton` (`colorSecondary` background, `colorOnSecondary` text), keeping the existing `login` id and click wiring.
- **All view ids preserved** (`user_name`, `url_password`, `forgot_password`, `create_account`, `show_advanced`, `advanced_layout`, `custom_server`, `login`) and the `ExpandableLayout` expand/collapse verified against `LoginCredentialsFragment.kt` — no code changes.

## Validation
- Android builds run in CI on this PR (not locally, per project convention). Baseline `dev` CI was green before this branch.
- XML well-formedness checked for all touched layouts/styles/drawables.
- No Kotlin changes; all view bindings and click listeners unchanged.

## Test plan
- [ ] CI green (build + lint + tests)
- [ ] Light theme: status-bar time/battery/connectivity icons visible; toolbar menu icons (edit/share/overflow) visible on navy; content icons visible
- [ ] Dark theme: content-surface icons visible on navy surfaces; status bar consistent
- [ ] Login screen: forgot password / Custom server / Sign up links same size and left-aligned; banner shows icon + rounded background; Log In is a filled teal button; Custom server toggle still expands/collapses the server URL field; forgot password and sign up links still navigate