### PR TITLE
feat(core): add labels/categories to events, tasks, and contacts

### DIFF
--- a/packages/core/src/models/calendar-event.test.ts
+++ b/packages/core/src/models/calendar-event.test.ts
@@ -22,6 +22,7 @@ function makeFullEvent(overrides?: Partial<CalendarEvent>): CalendarEvent {
     recurrenceRule: null,
     exceptions: [],
     alarms: [],
+    categories: ['Work', 'Planning'],
     created: new Date(2026, 0, 1, 0, 0, 0),
     updated: new Date(2026, 2, 10, 12, 0, 0),
     ...overrides,
@@ -45,6 +46,62 @@ function makeMinimalEvent(): CalendarEvent {
     updated: new Date(2026, 2, 15, 0, 0, 0),
   };
 }
+
+// ── categories roundtrip (#291) ──
+
+describe('categories roundtrip (#291)', () => {
+  it('roundtrips multiple comma-separated categories', () => {
+    const original = makeFullEvent({ categories: ['Work', 'Planning', 'Q1'] });
+    const ical = toVEvent(original);
+
+    expect(ical).toContain('CATEGORIES:Work,Planning,Q1');
+
+    const restored = fromVEvent(ical);
+    expect(restored.categories).toEqual(['Work', 'Planning', 'Q1']);
+  });
+
+  it('roundtrips a category containing an escaped comma', () => {
+    const original = makeFullEvent({ categories: ['Travel, Inc.', 'Personal'] });
+    const ical = toVEvent(original);
+
+    // Comma inside a value must be escaped as \,
+    expect(ical).toContain('CATEGORIES:Travel\\, Inc.,Personal');
+
+    const restored = fromVEvent(ical);
+    expect(restored.categories).toEqual(['Travel, Inc.', 'Personal']);
+  });
+
+  it('defaults categories to [] when deserializing a legacy record lacking CATEGORIES', () => {
+    const legacy = [
+      'BEGIN:VEVENT',
+      'UID:legacy-nocat',
+      'DTSTART:20260315T100000',
+      'DTEND:20260315T110000',
+      'SUMMARY:Legacy Event',
+      'END:VEVENT',
+    ].join('\r\n');
+
+    const restored = deserializeCalendarEvent(legacy);
+    expect(restored.categories).toEqual([]);
+  });
+
+  it('omits the CATEGORIES line when categories is empty', () => {
+    const event = makeFullEvent({ categories: [] });
+    const ical = toVEvent(event);
+
+    expect(ical).not.toContain('CATEGORIES');
+    expect(fromVEvent(ical).categories).toEqual([]);
+  });
+
+  it('omits the CATEGORIES line when categories is undefined', () => {
+    const event = makeFullEvent();
+    delete event.categories;
+    const ical = toVEvent(event);
+
+    expect(ical).not.toContain('CATEGORIES');
+    expect(fromVEvent(ical).categories).toEqual([]);
+  });
+});
 
 // ── toVEvent / fromVEvent roundtrip ──
 

--- a/packages/core/src/models/calendar-event.ts
+++ b/packages/core/src/models/calendar-event.ts
@@ -13,6 +13,10 @@ export interface CalendarEvent {
   recurrenceRule: string | null;
   exceptions: Date[];
   alarms: VAlarm[];
+  /** User-defined labels/categories for grouping and filtering.
+   *  Round-tripped via the ICS CATEGORIES property (comma-separated).
+   *  Optional so existing callers keep compiling; deserialize paths default to []. */
+  categories?: string[];
   calendarId?: string;
   /** IANA timezone for this event (e.g. 'America/New_York'). When absent,
    *  falls back to user default timezone, then local system timezone. */
@@ -153,6 +157,7 @@ export function toVEvent(event: CalendarEvent): string {
           )
         : undefined,
     valarms: event.alarms.length > 0 ? event.alarms : undefined,
+    categories: event.categories && event.categories.length > 0 ? event.categories : undefined,
     created: formatICalDateTime(event.created),
     lastModified: formatICalDateTime(event.updated),
   };
@@ -202,6 +207,8 @@ export function fromVEvent(veventStr: string): CalendarEvent {
     recurrenceRule: vevent.rrule ?? null,
     exceptions,
     alarms: vevent.valarms ?? [],
+    // Preserve CATEGORIES for round-trip; default to [] for legacy records
+    categories: vevent.categories ?? [],
     // Preserve the TZID from DTSTART so we can round-trip it correctly
     timezone: startTzid ?? undefined,
     created: vevent.created ? parseICalDateValue(vevent.created).date : now,

--- a/packages/core/src/models/contact.test.ts
+++ b/packages/core/src/models/contact.test.ts
@@ -39,6 +39,7 @@ function makeFullContact(overrides?: Partial<Contact>): Contact {
     notes: 'Met at conference',
     birthday: '1990-01-15',
     photoUrl: 'https://example.com/photo.jpg',
+    categories: ['Friends', 'VIP'],
     created_at: new Date(2026, 0, 1, 0, 0, 0),
     updated_at: new Date(2026, 2, 14, 12, 0, 0),
     ...overrides,
@@ -63,6 +64,61 @@ function makeMinimalContact(): Contact {
     updated_at: new Date(2026, 2, 15, 0, 0, 0),
   };
 }
+
+// ── categories roundtrip (#291) ──
+
+describe('categories roundtrip (#291)', () => {
+  it('roundtrips multiple comma-separated categories', () => {
+    const original = makeFullContact({ categories: ['Friends', 'Work', 'Family'] });
+    const vcardStr = toVCard(original);
+
+    expect(vcardStr).toContain('CATEGORIES:Friends,Work,Family');
+
+    const restored = fromVCard(vcardStr);
+    expect(restored.categories).toEqual(['Friends', 'Work', 'Family']);
+  });
+
+  it('roundtrips a category containing an escaped comma', () => {
+    const original = makeFullContact({ categories: ['Team, Alpha', 'VIP'] });
+    const vcardStr = toVCard(original);
+
+    expect(vcardStr).toContain('CATEGORIES:Team\\, Alpha,VIP');
+
+    const restored = fromVCard(vcardStr);
+    expect(restored.categories).toEqual(['Team, Alpha', 'VIP']);
+  });
+
+  it('defaults categories to [] when deserializing a legacy vCard lacking CATEGORIES', () => {
+    const legacy = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:legacy-contact-nocat',
+      'FN:Legacy Contact',
+      'ORG:Old Corp',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const restored = deserializeContact(legacy);
+    expect(restored.categories).toEqual([]);
+  });
+
+  it('omits the CATEGORIES line when categories is empty', () => {
+    const contact = makeFullContact({ categories: [] });
+    const vcardStr = toVCard(contact);
+
+    expect(vcardStr).not.toContain('CATEGORIES');
+    expect(fromVCard(vcardStr).categories).toEqual([]);
+  });
+
+  it('omits the CATEGORIES line when categories is undefined', () => {
+    const contact = makeFullContact();
+    delete contact.categories;
+    const vcardStr = toVCard(contact);
+
+    expect(vcardStr).not.toContain('CATEGORIES');
+    expect(fromVCard(vcardStr).categories).toEqual([]);
+  });
+});
 
 // ── toVCard / fromVCard roundtrip ──
 

--- a/packages/core/src/models/contact.ts
+++ b/packages/core/src/models/contact.ts
@@ -26,6 +26,10 @@ export interface Contact {
   notes: string;
   birthday: string | null;
   photoUrl: string | null;
+  /** User-defined labels/categories for grouping and filtering.
+   *  Round-tripped via the vCard CATEGORIES property (comma-separated).
+   *  Optional so existing callers keep compiling; deserialize paths default to []. */
+  categories?: string[];
   listId?: string;
   created_at: Date;
   updated_at: Date;
@@ -46,6 +50,7 @@ export function toVCard(contact: Contact): string {
     },
     org: contact.organization || undefined,
     title: contact.title || undefined,
+    categories: contact.categories && contact.categories.length > 0 ? contact.categories : undefined,
     note: contact.notes || undefined,
     bday: contact.birthday ?? undefined,
     photo: contact.photoUrl ?? undefined,
@@ -90,6 +95,8 @@ export function fromVCard(vcardStr: string): Contact {
     notes: vcard.note ?? '',
     birthday: vcard.bday ?? null,
     photoUrl: vcard.photo ?? null,
+    // Preserve CATEGORIES for round-trip; default to [] for legacy records
+    categories: vcard.categories ?? [],
     created_at: now,
     updated_at: vcard.rev ? parseRevTimestamp(vcard.rev) : now,
   };

--- a/packages/core/src/models/task.test.ts
+++ b/packages/core/src/models/task.test.ts
@@ -19,6 +19,7 @@ function makeFullTask(overrides?: Partial<Task>): Task {
     due_date: new Date(2026, 2, 20, 17, 0, 0), // March 20, 2026 17:00
     priority: 'high',
     completed: false,
+    categories: ['Work', 'Urgent'],
     created_at: new Date(2026, 0, 1, 0, 0, 0),
     updated_at: new Date(2026, 2, 10, 12, 0, 0),
     ...overrides,
@@ -38,6 +39,61 @@ function makeMinimalTask(): Task {
     updated_at: new Date(2026, 2, 15, 0, 0, 0),
   };
 }
+
+// ── categories roundtrip (#291) ──
+
+describe('categories roundtrip (#291)', () => {
+  it('roundtrips multiple comma-separated categories', () => {
+    const original = makeFullTask({ categories: ['Work', 'Home', 'Errands'] });
+    const vtodo = toVTodo(original);
+
+    expect(vtodo).toContain('CATEGORIES:Work,Home,Errands');
+
+    const restored = fromVTodo(vtodo);
+    expect(restored.categories).toEqual(['Work', 'Home', 'Errands']);
+  });
+
+  it('roundtrips a category containing an escaped comma', () => {
+    const original = makeFullTask({ categories: ['Side, Project', 'Personal'] });
+    const vtodo = toVTodo(original);
+
+    expect(vtodo).toContain('CATEGORIES:Side\\, Project,Personal');
+
+    const restored = fromVTodo(vtodo);
+    expect(restored.categories).toEqual(['Side, Project', 'Personal']);
+  });
+
+  it('defaults categories to [] when deserializing a legacy record lacking CATEGORIES', () => {
+    const legacy = [
+      'BEGIN:VTODO',
+      'UID:legacy-task-nocat',
+      'SUMMARY:Legacy Task',
+      'PRIORITY:5',
+      'STATUS:NEEDS-ACTION',
+      'END:VTODO',
+    ].join('\r\n');
+
+    const restored = deserializeTask(legacy);
+    expect(restored.categories).toEqual([]);
+  });
+
+  it('omits the CATEGORIES line when categories is empty', () => {
+    const task = makeFullTask({ categories: [] });
+    const vtodo = toVTodo(task);
+
+    expect(vtodo).not.toContain('CATEGORIES');
+    expect(fromVTodo(vtodo).categories).toEqual([]);
+  });
+
+  it('omits the CATEGORIES line when categories is undefined', () => {
+    const task = makeFullTask();
+    delete task.categories;
+    const vtodo = toVTodo(task);
+
+    expect(vtodo).not.toContain('CATEGORIES');
+    expect(fromVTodo(vtodo).categories).toEqual([]);
+  });
+});
 
 // ── toVTodo / fromVTodo roundtrip ──
 

--- a/packages/core/src/models/task.ts
+++ b/packages/core/src/models/task.ts
@@ -10,6 +10,10 @@ export interface Task {
   due_date: Date | null;
   priority: Priority;
   completed: boolean;
+  /** User-defined labels/categories for grouping and filtering.
+   *  Round-tripped via the ICS CATEGORIES property (comma-separated).
+   *  Optional so existing callers keep compiling; deserialize paths default to []. */
+  categories?: string[];
   listId?: string;
   created_at: Date;
   updated_at: Date;
@@ -100,6 +104,7 @@ export function toVTodo(task: Task): string {
     priority: PRIORITY_TO_ICAL[task.priority],
     status: task.completed ? 'COMPLETED' : 'NEEDS-ACTION',
     percentComplete: task.completed ? 100 : 0,
+    categories: task.categories && task.categories.length > 0 ? task.categories : undefined,
     created: formatICalUtcDateTime(task.created_at),
     lastModified: formatICalUtcDateTime(task.updated_at),
   };
@@ -141,6 +146,8 @@ export function fromVTodo(vtodoStr: string): Task {
     due_date,
     priority: icalPriorityToModel(vtodo.priority),
     completed,
+    // Preserve CATEGORIES for round-trip; default to [] for legacy records
+    categories: vtodo.categories ?? [],
     created_at: vtodo.created ? parseICalDateValue(vtodo.created) : now,
     updated_at: vtodo.lastModified ? parseICalDateValue(vtodo.lastModified) : now,
   };

--- a/packages/core/src/utils/ical-parser.test.ts
+++ b/packages/core/src/utils/ical-parser.test.ts
@@ -4,8 +4,10 @@ import {
   generateVEvent,
   parseVCalendar,
   generateVCalendar,
+  parseVTodo,
+  generateVTodo,
 } from './ical-parser.js';
-import type { VEvent, VAlarm } from './ical-parser.js';
+import type { VEvent, VAlarm, VTodo } from './ical-parser.js';
 
 // ── Helpers ──
 
@@ -753,5 +755,162 @@ describe('property parsing', () => {
     expect(event.dtstart).toBe('20260315T100000');
     // The TZID value includes the quotes since the parser doesn't strip them
     expect(event.dtstartParams).toBeDefined();
+  });
+});
+
+// ── CATEGORIES (#291) ──
+
+describe('CATEGORIES (VEvent)', () => {
+  it('parses a single CATEGORIES value', () => {
+    const ical = [
+      'BEGIN:VEVENT',
+      'UID:cat-1',
+      'DTSTART:20260315T100000',
+      'CATEGORIES:Work',
+      'END:VEVENT',
+    ].join('\r\n');
+
+    const event = parseVEvent(ical);
+    expect(event.categories).toEqual(['Work']);
+  });
+
+  it('parses multiple comma-separated CATEGORIES', () => {
+    const ical = [
+      'BEGIN:VEVENT',
+      'UID:cat-2',
+      'DTSTART:20260315T100000',
+      'CATEGORIES:Work,Personal,Travel',
+      'END:VEVENT',
+    ].join('\r\n');
+
+    const event = parseVEvent(ical);
+    expect(event.categories).toEqual(['Work', 'Personal', 'Travel']);
+  });
+
+  it('unescapes commas within a single category value', () => {
+    const ical = [
+      'BEGIN:VEVENT',
+      'UID:cat-3',
+      'DTSTART:20260315T100000',
+      'CATEGORIES:Travel\\, Inc.,Personal',
+      'END:VEVENT',
+    ].join('\r\n');
+
+    const event = parseVEvent(ical);
+    expect(event.categories).toEqual(['Travel, Inc.', 'Personal']);
+  });
+
+  it('emits CATEGORIES joined by commas with each value escaped', () => {
+    const event: VEvent = {
+      uid: 'cat-gen',
+      dtstart: '20260315T100000',
+      categories: ['Work', 'Travel, Inc.'],
+    };
+
+    const generated = generateVEvent(event);
+    expect(generated).toContain('CATEGORIES:Work,Travel\\, Inc.');
+  });
+
+  it('roundtrips CATEGORIES through generate/parse', () => {
+    const original: VEvent = {
+      uid: 'cat-rt',
+      dtstart: '20260315T100000',
+      categories: ['Work', 'Personal', 'Side, Project'],
+    };
+
+    const generated = generateVEvent(original);
+    const parsed = parseVEvent(generated);
+    expect(parsed.categories).toEqual(original.categories);
+  });
+
+  it('defaults categories to undefined when CATEGORIES is absent', () => {
+    const ical = [
+      'BEGIN:VEVENT',
+      'UID:cat-none',
+      'DTSTART:20260315T100000',
+      'END:VEVENT',
+    ].join('\r\n');
+
+    const event = parseVEvent(ical);
+    expect(event.categories).toBeUndefined();
+  });
+
+  it('omits CATEGORIES line when categories is empty or undefined', () => {
+    const without: VEvent = { uid: 'cat-omit', dtstart: '20260315T100000' };
+    expect(generateVEvent(without)).not.toContain('CATEGORIES');
+
+    const empty: VEvent = { uid: 'cat-omit2', dtstart: '20260315T100000', categories: [] };
+    expect(generateVEvent(empty)).not.toContain('CATEGORIES');
+  });
+});
+
+describe('CATEGORIES (VTodo)', () => {
+  it('parses multiple comma-separated CATEGORIES from a VTODO', () => {
+    const ical = [
+      'BEGIN:VTODO',
+      'UID:todo-cat-1',
+      'SUMMARY:Task with labels',
+      'CATEGORIES:Work,Urgent',
+      'END:VTODO',
+    ].join('\r\n');
+
+    const todo = parseVTodo(ical);
+    expect(todo.categories).toEqual(['Work', 'Urgent']);
+  });
+
+  it('unescapes commas within a single VTODO category value', () => {
+    const ical = [
+      'BEGIN:VTODO',
+      'UID:todo-cat-2',
+      'SUMMARY:Escaped',
+      'CATEGORIES:Side\\, Project,Personal',
+      'END:VTODO',
+    ].join('\r\n');
+
+    const todo = parseVTodo(ical);
+    expect(todo.categories).toEqual(['Side, Project', 'Personal']);
+  });
+
+  it('emits CATEGORIES in a generated VTODO', () => {
+    const todo: VTodo = {
+      uid: 'todo-cat-gen',
+      summary: 'Labelled task',
+      categories: ['Work', 'Home'],
+    };
+
+    const generated = generateVTodo(todo);
+    expect(generated).toContain('CATEGORIES:Work,Home');
+  });
+
+  it('roundtrips CATEGORIES through VTODO generate/parse', () => {
+    const original: VTodo = {
+      uid: 'todo-cat-rt',
+      summary: 'Roundtrip',
+      categories: ['Errands', 'Weekend, Fun'],
+    };
+
+    const generated = generateVTodo(original);
+    const parsed = parseVTodo(generated);
+    expect(parsed.categories).toEqual(original.categories);
+  });
+
+  it('defaults categories to undefined when VTODO lacks CATEGORIES', () => {
+    const ical = [
+      'BEGIN:VTODO',
+      'UID:todo-cat-none',
+      'SUMMARY:No labels',
+      'END:VTODO',
+    ].join('\r\n');
+
+    const todo = parseVTodo(ical);
+    expect(todo.categories).toBeUndefined();
+  });
+
+  it('omits CATEGORIES line when VTODO categories is empty or undefined', () => {
+    const without: VTodo = { uid: 'todo-cat-omit', summary: 'x' };
+    expect(generateVTodo(without)).not.toContain('CATEGORIES');
+
+    const empty: VTodo = { uid: 'todo-cat-omit2', summary: 'x', categories: [] };
+    expect(generateVTodo(empty)).not.toContain('CATEGORIES');
   });
 });

--- a/packages/core/src/utils/ical-parser.ts
+++ b/packages/core/src/utils/ical-parser.ts
@@ -20,6 +20,8 @@ export interface VEvent {
   transp?: string;
   status?: string;
   valarms?: VAlarm[];
+  /** CATEGORIES (RFC 5545) — comma-separated user labels */
+  categories?: string[];
   /** Raw DTSTART parameters like TZID or VALUE */
   dtstartParams?: Record<string, string>;
   /** Raw DTEND parameters */
@@ -38,6 +40,8 @@ export interface VTodo {
   created?: string;
   lastModified?: string;
   percentComplete?: number;
+  /** CATEGORIES (RFC 5545) — comma-separated user labels */
+  categories?: string[];
 }
 
 export interface VAlarm {
@@ -62,6 +66,25 @@ function unescapeText(text: string): string {
     .replace(/\\,/g, ',')
     .replace(/\\;/g, ';')
     .replace(/\\\\/g, '\\');
+}
+
+/** Split a multi-valued iCalendar text property on unescaped commas, then
+ *  unescape each value. Used for CATEGORIES and similar list properties. */
+function splitCommaValues(value: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let escaped = false;
+  for (const ch of value) {
+    if (ch === ',' && !escaped) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+    escaped = ch === '\\' && !escaped;
+  }
+  parts.push(current);
+  return parts.map((p) => unescapeText(p));
 }
 
 // ── Line folding ──
@@ -284,6 +307,9 @@ export function parseVEvent(ical: string): VEvent {
       case 'STATUS':
         event.status = prop.value;
         break;
+      case 'CATEGORIES':
+        event.categories = splitCommaValues(prop.value).map((c) => c.trim()).filter((c) => c.length > 0);
+        break;
     }
     i++;
   }
@@ -355,6 +381,9 @@ export function generateVEvent(event: VEvent): string {
   if (event.lastModified) lines.push(foldLine(`LAST-MODIFIED:${event.lastModified}`));
   if (event.transp) lines.push(foldLine(`TRANSP:${event.transp}`));
   if (event.status) lines.push(foldLine(`STATUS:${event.status}`));
+  if (event.categories && event.categories.length > 0) {
+    lines.push(foldLine(`CATEGORIES:${event.categories.map(escapeText).join(',')}`));
+  }
 
   if (event.valarms) {
     for (const alarm of event.valarms) {
@@ -428,6 +457,9 @@ export function parseVTodo(ical: string): VTodo {
       case 'PERCENT-COMPLETE':
         todo.percentComplete = parseInt(prop.value, 10);
         break;
+      case 'CATEGORIES':
+        todo.categories = splitCommaValues(prop.value).map((c) => c.trim()).filter((c) => c.length > 0);
+        break;
     }
   }
 
@@ -471,6 +503,9 @@ export function generateVTodo(todo: VTodo): string {
   if (todo.created) lines.push(foldLine(`CREATED:${todo.created}`));
   if (todo.lastModified) lines.push(foldLine(`LAST-MODIFIED:${todo.lastModified}`));
   if (todo.percentComplete !== undefined) lines.push(foldLine(`PERCENT-COMPLETE:${todo.percentComplete}`));
+  if (todo.categories && todo.categories.length > 0) {
+    lines.push(foldLine(`CATEGORIES:${todo.categories.map(escapeText).join(',')}`));
+  }
 
   lines.push('END:VTODO');
   return lines.join('\r\n');

--- a/packages/core/src/utils/vcard-parser.test.ts
+++ b/packages/core/src/utils/vcard-parser.test.ts
@@ -314,3 +314,93 @@ describe('parsing raw vCard strings', () => {
     expect(vcard.adr![0]!.city).toBe('Berlin');
   });
 });
+
+// ── CATEGORIES (#291) ──
+
+describe('CATEGORIES', () => {
+  it('parses a single CATEGORIES value', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:vcf-cat-1',
+      'FN:Jane Doe',
+      'CATEGORIES:Work',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.categories).toEqual(['Work']);
+  });
+
+  it('parses multiple comma-separated CATEGORIES', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:vcf-cat-2',
+      'FN:Jane Doe',
+      'CATEGORIES:Friends,Work,Family',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.categories).toEqual(['Friends', 'Work', 'Family']);
+  });
+
+  it('unescapes commas within a single category value', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:vcf-cat-3',
+      'FN:Jane Doe',
+      'CATEGORIES:Team\\, Alpha,VIP',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.categories).toEqual(['Team, Alpha', 'VIP']);
+  });
+
+  it('emits CATEGORIES joined by commas with each value escaped', () => {
+    const vcard: VCard = {
+      uid: 'vcf-cat-gen',
+      fn: 'Jane Doe',
+      categories: ['Work', 'Team, Alpha'],
+    };
+
+    const generated = generateVCard(vcard);
+    expect(generated).toContain('CATEGORIES:Work,Team\\, Alpha');
+  });
+
+  it('roundtrips CATEGORIES through generate/parse', () => {
+    const original: VCard = {
+      uid: 'vcf-cat-rt',
+      fn: 'Jane Doe',
+      categories: ['Friends', 'VIP', 'Team, Alpha'],
+    };
+
+    const generated = generateVCard(original);
+    const parsed = parseVCard(generated);
+    expect(parsed.categories).toEqual(original.categories);
+  });
+
+  it('defaults categories to undefined when CATEGORIES is absent', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:vcf-cat-none',
+      'FN:Jane Doe',
+      'END:VCARD',
+    ].join('\r\n');
+
+    const vcard = parseVCard(raw);
+    expect(vcard.categories).toBeUndefined();
+  });
+
+  it('omits CATEGORIES line when categories is empty or undefined', () => {
+    const without: VCard = { uid: 'vcf-cat-omit', fn: 'Jane Doe' };
+    expect(generateVCard(without)).not.toContain('CATEGORIES');
+
+    const empty: VCard = { uid: 'vcf-cat-omit2', fn: 'Jane Doe', categories: [] };
+    expect(generateVCard(empty)).not.toContain('CATEGORIES');
+  });
+});

--- a/packages/core/src/utils/vcard-parser.ts
+++ b/packages/core/src/utils/vcard-parser.ts
@@ -38,6 +38,8 @@ export interface VCard {
   adr?: VCardAddress[];
   org?: string;
   title?: string;
+  /** CATEGORIES (RFC 2426/6350) — comma-separated user labels */
+  categories?: string[];
   note?: string;
   bday?: string;
   photo?: string;
@@ -60,6 +62,25 @@ function unescapeText(text: string): string {
     .replace(/\\,/g, ',')
     .replace(/\\;/g, ';')
     .replace(/\\\\/g, '\\');
+}
+
+/** Split a multi-valued vCard text property on unescaped commas, then
+ *  unescape each value. Used for CATEGORIES and similar list properties. */
+function splitCommaValues(value: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let escaped = false;
+  for (const ch of value) {
+    if (ch === ',' && !escaped) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+    escaped = ch === '\\' && !escaped;
+  }
+  parts.push(current);
+  return parts.map((p) => unescapeText(p));
 }
 
 // ── Line folding ──
@@ -256,6 +277,9 @@ export function parseVCard(vcardStr: string): VCard {
       case 'TITLE':
         vcard.title = unescapeText(prop.value);
         break;
+      case 'CATEGORIES':
+        vcard.categories = splitCommaValues(prop.value).map((c) => c.trim()).filter((c) => c.length > 0);
+        break;
       case 'NOTE':
         vcard.note = unescapeText(prop.value);
         break;
@@ -369,6 +393,9 @@ export function generateVCard(vcard: VCard): string {
 
   if (vcard.org) lines.push(foldLine(`ORG:${escapeText(vcard.org)}`));
   if (vcard.title) lines.push(foldLine(`TITLE:${escapeText(vcard.title)}`));
+  if (vcard.categories && vcard.categories.length > 0) {
+    lines.push(foldLine(`CATEGORIES:${vcard.categories.map(escapeText).join(',')}`));
+  }
   if (vcard.note) lines.push(foldLine(`NOTE:${escapeText(vcard.note)}`));
   if (vcard.bday) lines.push(foldLine(`BDAY:${vcard.bday}`));
   if (vcard.photo) {


### PR DESCRIPTION
## What
Part 1 of 3 for #291. Adds labels/categories support to the core domain models and the ICS/vCard parsers, with full round-trip and safe deserialization of legacy data that lacks the field.

This is a **core-only** PR. Web UI (add/remove/display) and filtering/search-by-label come in follow-up PRs (parts 2 and 3).

## Changes
- **`packages/core/src/models/calendar-event.ts`** — add `categories: string[]` to `CalendarEvent`; map to/from ICS `CATEGORIES` in `toVEvent`/`fromVEvent`; default `[]` in deserialization for records missing it.
- **`packages/core/src/models/task.ts`** — add `categories: string[]` to `Task`; round-trip via the VTODO path; default `[]`.
- **`packages/core/src/models/contact.ts`** — add `categories: string[]` to `Contact`; default `[]`.
- **`packages/core/src/utils/ical-parser.ts`** — add `categories?: string[]` to the `VEvent` interface; parse `CATEGORIES` (comma-split, unescape) and emit it in `generateVEvent`; covers the VTODO path for tasks.
- **`packages/core/src/utils/vcard-parser.ts`** — parse and emit vCard `CATEGORIES`.
- **Tests** — round-trip with categories (single + multiple + escaped comma) and deserialize legacy records lacking `CATEGORIES` → `[]`, across calendar-event, task, contact, ical-parser, vcard-parser.

## Migration safety
Every `deserialize*`/`fromVEvent`/`fromVCard` path defaults `categories` to `[]` when the field/property is absent, so existing stored items load without breaking.

## Privacy
All serialization is pure client-side. No network code added; decrypted content never sent server-side.

## What's NOT included (follow-up PRs)
- Part 2: web UI to add/remove/display labels in events, tasks, contacts.
- Part 3: filter/search by label (extends #296 search infra).

## Validation
- `corepack pnpm --filter @silentsuite/core test` — 271 tests pass (12 files), including new categories round-trip + legacy-deserialization tests.
- CI runs lint/typecheck + the full suite on this PR.

## Test plan
- [ ] CI green
- [ ] Reviewer confirms every deserialize path defaults categories to `[]` (migration safety)
- [ ] Reviewer confirms ICS/vCard escaping is correct