### PR TITLE
feat(android): add pull-to-refresh manual sync gesture

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -154,6 +154,8 @@ dependencies {
 
 
     implementation 'com.google.android.material:material:1.2.0-beta01'
+    // Pull-to-refresh gesture for collection/account list screens (issue #297)
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation "androidx.legacy:legacy-preference-v14:$supportVersion"
     implementation 'com.github.yukuku:ambilwarna:2.0.1'
     implementation ('com.github.worker8:tourguide:1.0.18-SNAPSHOT@aar') {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -64,6 +64,7 @@ import com.google.android.material.navigation.NavigationView
 import com.google.android.material.snackbar.Snackbar
 // Modified by Silent Suite - ACRA removed, will be replaced with Sentry in Phase 2
 import androidx.lifecycle.viewModelScope
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -86,6 +87,8 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
     private var syncStatusSnackbar: Snackbar? = null
     private var syncStatusObserver: Any? = null
+    private var syncActiveObserver: Any? = null
+    private var swipeRefreshLayout: SwipeRefreshLayout? = null
     private var accountListExpanded = false
     private var pendingExportKind: AndroidExportKind? = null
 
@@ -161,6 +164,14 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         // Setup navigation view
         val navigationView = findViewById<NavigationView>(R.id.nav_view)
         navigationView.setNavigationItemSelectedListener(this)
+
+        // Pull-to-refresh: trigger a manual sync for the account (issue #297).
+        swipeRefreshLayout = findViewById(R.id.account_swipe_refresh)
+        swipeRefreshLayout?.apply {
+            setColorSchemeResources(
+                    R.color.teal400, R.color.teal500, R.color.teal600, R.color.teal700)
+            setOnRefreshListener { onAccountSwipeRefresh() }
+        }
 
         // Setup nav header with account switcher
         setupNavHeader(navigationView)
@@ -318,6 +329,12 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         super.onResume()
         onStatusChanged(SYNC_OBSERVER_TYPE_SETTINGS)
         syncStatusObserver = ContentResolver.addStatusChangeListener(SYNC_OBSERVER_TYPE_SETTINGS, this)
+        // Drive the pull-to-refresh spinner from active sync state so it clears
+        // reliably when the sync finishes (success or error).
+        syncActiveObserver = ContentResolver.addStatusChangeListener(SYNC_OBSERVER_TYPE_ACTIVE) { _ ->
+            swipeRefreshLayout?.post { updateSwipeRefreshState() }
+        }
+        updateSwipeRefreshState()
     }
 
     override fun onPause() {
@@ -326,6 +343,8 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             ContentResolver.removeStatusChangeListener(syncStatusObserver)
             syncStatusObserver = null
         }
+        syncActiveObserver?.let { ContentResolver.removeStatusChangeListener(it) }
+        syncActiveObserver = null
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -855,8 +874,30 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
 
     private fun requestSync() {
+        if (isSyncActive()) return        // don't stack a duplicate concurrent sync
         requestSync(applicationContext, account)
         Snackbar.make(findViewById(R.id.coordinator), R.string.account_synchronizing_now, Snackbar.LENGTH_LONG).show()
+    }
+
+    /** Pull-to-refresh handler for the account screen. */
+    private fun onAccountSwipeRefresh() {
+        if (!ContentResolver.getMasterSyncAutomatically()) {
+            // onStatusChanged (SETTINGS observer) already surfaces this state via a Snackbar.
+            swipeRefreshLayout?.isRefreshing = false
+            return
+        }
+        requestSync()
+    }
+
+    /** Syncs the refresh indicator with the current sync state (called by the ACTIVE observer). */
+    private fun updateSwipeRefreshState() {
+        swipeRefreshLayout?.isRefreshing = isSyncActive()
+    }
+
+    private fun isSyncActive(): Boolean {
+        val authorities = mutableListOf(App.addressBooksAuthority, CalendarContract.AUTHORITY)
+        TaskProviderHandling.getWantedTaskSyncProvider(this)?.authority?.let { authorities.add(it) }
+        return authorities.any { ContentResolver.isSyncActive(account, it) }
     }
 
     private fun loadSubscriptionStatus() {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ListEntriesFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ListEntriesFragment.kt
@@ -1,8 +1,11 @@
 package io.silentsuite.sync.ui.etebase
 
+import android.accounts.Account
+import android.content.ContentResolver
 import android.content.Context
 import android.os.Bundle
 import android.os.Parcelable
+import android.provider.CalendarContract
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,20 +16,27 @@ import android.widget.TextView
 import androidx.fragment.app.ListFragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.google.android.material.snackbar.Snackbar
+import io.silentsuite.sync.App
 import io.silentsuite.sync.CachedCollection
 import io.silentsuite.sync.CachedItem
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
+import io.silentsuite.sync.syncadapter.requestSync
 import io.silentsuite.sync.utils.TaskProviderHandling
 import java.text.SimpleDateFormat
 
 
 class ListEntriesFragment : ListFragment(), AdapterView.OnItemClickListener {
+    private val accountModel: AccountViewModel by activityViewModels()
     private val collectionModel: CollectionViewModel by activityViewModels()
     private val itemsModel: ItemsViewModel by activityViewModels()
     private var state: Parcelable? = null
 
     private var emptyTextView: TextView? = null
+    private var swipeRefreshLayout: SwipeRefreshLayout? = null
+    private var syncStatusObserver: Any? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.journal_viewer_list, container, false)
@@ -34,6 +44,7 @@ class ListEntriesFragment : ListFragment(), AdapterView.OnItemClickListener {
         //This is instead of setEmptyText() function because of Google bug
         //See: https://code.google.com/p/android/issues/detail?id=21742
         emptyTextView = view.findViewById<View>(android.R.id.empty) as TextView
+        swipeRefreshLayout = view.findViewById(R.id.swipe_refresh)
 
         return view
     }
@@ -63,10 +74,91 @@ class ListEntriesFragment : ListFragment(), AdapterView.OnItemClickListener {
         }
 
         listView.onItemClickListener = this
+
+        swipeRefreshLayout?.apply {
+            // Match the app accent palette for the refresh indicator.
+            setColorSchemeResources(
+                    R.color.teal400, R.color.teal500, R.color.teal600, R.color.teal700)
+            setOnRefreshListener { onUserRefresh() }
+            // The direct child is a FrameLayout (so the empty view can overlay the
+            // ListView), so delegate scroll-up detection to the real scrollable list.
+            setOnChildScrollUpCallback { _, _ -> listView.canScrollVertically(-1) }
+        }
     }
+
+    override fun onResume() {
+        super.onResume()
+        // Observe active sync state so the refresh indicator clears reliably when the
+        // sync finishes (success or error), and reflects an already-running sync.
+        syncStatusObserver = ContentResolver.addStatusChangeListener(
+                ContentResolver.SYNC_OBSERVER_TYPE_ACTIVE
+        ) { _ -> swipeRefreshLayout?.post { updateRefreshState() } }
+        updateRefreshState()
+    }
+
     override fun onPause() {
         state = listView.onSaveInstanceState()
+        syncStatusObserver?.let { ContentResolver.removeStatusChangeListener(it) }
+        syncStatusObserver = null
         super.onPause()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        swipeRefreshLayout = null
+    }
+
+    /**
+     * Pull-to-refresh handler. Requests a manual sync for the account unless a sync
+     * is already running for one of its authorities (no duplicate concurrent syncs).
+     */
+    private fun onUserRefresh() {
+        val refresh = swipeRefreshLayout ?: return
+        val account = accountModel.value?.account
+        if (account == null) {
+            refresh.isRefreshing = false
+            return
+        }
+        if (!ContentResolver.getMasterSyncAutomatically()) {
+            // System-wide sync is off; the framework would drop the request, so surface
+            // the state and clear the spinner instead of leaving it spinning forever.
+            refresh.isRefreshing = false
+            view?.let {
+                Snackbar.make(it, R.string.accounts_global_sync_disabled, Snackbar.LENGTH_LONG)
+                        .setAction(R.string.accounts_global_sync_enable) {
+                            ContentResolver.setMasterSyncAutomatically(true)
+                        }
+                        .show()
+            }
+            return
+        }
+        if (isSyncActiveForAccount(account)) {
+            // A sync is already in progress; keep the spinner, the SyncStatusObserver
+            // will clear it when no authority is active anymore.
+            return
+        }
+        val context = activity?.applicationContext
+        if (context == null) {
+            refresh.isRefreshing = false
+            return
+        }
+        requestSync(context, account)
+    }
+
+    /**
+     * Updates the refresh indicator to match the current sync state. Called from
+     * [onResume] and whenever the active-sync status changes.
+     */
+    private fun updateRefreshState() {
+        val refresh = swipeRefreshLayout ?: return
+        val account = accountModel.value?.account
+        refresh.isRefreshing = account != null && isSyncActiveForAccount(account)
+    }
+
+    private fun isSyncActiveForAccount(account: Account): Boolean {
+        val authorities = mutableListOf(App.addressBooksAuthority, CalendarContract.AUTHORITY)
+        TaskProviderHandling.getWantedTaskSyncProvider(requireContext())?.authority?.let { authorities.add(it) }
+        return authorities.any { ContentResolver.isSyncActive(account, it) }
     }
 
     override fun onItemClick(parent: AdapterView<*>, view: View, position: Int, id: Long) {

--- a/android/app/src/main/res/layout/activity_account.xml
+++ b/android/app/src/main/res/layout/activity_account.xml
@@ -35,11 +35,16 @@
 
         </com.google.android.material.appbar.AppBarLayout>
 
-        <ScrollView
-            android:id="@+id/parent"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/account_swipe_refresh"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <ScrollView
+            android:id="@+id/parent"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
             <LinearLayout
                 android:orientation="vertical"
@@ -281,6 +286,8 @@
 
             </LinearLayout>
         </ScrollView>
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/android/app/src/main/res/layout/journal_viewer_list.xml
+++ b/android/app/src/main/res/layout/journal_viewer_list.xml
@@ -1,20 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<!--
+  ~ Copyright © 2013 – 2016 Ricki Hirner (bitfire web engineering).
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the GNU Public License v3.0
+  ~ which accompanies this distribution, and is available at
+  ~ http://www.gnu.org/licenses/gpl.html
+  -->
+
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipe_refresh"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <ListView
-        android:id="@id/android:list"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent">
 
-    <TextView
-        android:id="@id/android:empty"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="16dp"
-        android:gravity="center"
-        android:text="@string/journal_entries_loading"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large" />
-</LinearLayout>
+        <ListView
+            android:id="@id/android:list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <TextView
+            android:id="@id/android:empty"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_margin="16dp"
+            android:gravity="center"
+            android:text="@string/journal_entries_loading"
+            android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+    </FrameLayout>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
## What
Fixes #297. Adds a standard Material pull-to-refresh gesture to the Android collection list and account list screens so users can trigger a sync by pulling down.

## Changes
- **`build.gradle`** — add `androidx.swiperefreshlayout:swiperefreshlayout:1.1.0`.
- **`journal_viewer_list.xml`** (collection item list) — wrap the ListView + empty view in `SwipeRefreshLayout` (GPL header preserved).
- **`activity_account.xml`** — wrap the account list sections in `SwipeRefreshLayout`.
- **`ListEntriesFragment.kt`** — `OnRefreshListener` → `requestSync()`; `SyncStatusObserver` (ACTIVE) drives the spinner to match real sync state; `isSyncActiveForAccount()` dedupe guard across all authorities; master-sync-off → Snackbar with enable action + clear spinner; `setOnChildScrollUpCallback` delegates to the ListView.
- **`AccountActivity.kt`** — same pattern for the account list (refresh → `requestSync`, ACTIVE observer drives spinner, lifecycle-managed observers).

## Acceptance criteria
- [x] Pull-down requests a sync on collection + account list screens
- [x] Material refresh indicator (teal color scheme)
- [x] Offline/error handled (master-sync-off → Snackbar + clear spinner)
- [x] No duplicate concurrent syncs (`isSyncActive` guard across authorities)
- [x] Spinner clears reliably (observer-driven from `SYNC_OBSERVER_TYPE_ACTIVE`)

## Validation
- Android builds run in **CI only** (no local Gradle per project convention). Lint + build validate on this PR.
- On-device behavior (gesture feel, spinner timing, sync actually triggered) to be verified by adminuser on XL.

## Test plan
- [ ] CI green (Android build + lint)
- [ ] On-device: pull down on collection list → sync runs, spinner shows, clears on completion
- [ ] On-device: pull while a sync is already running → no second sync, spinner reflects ongoing state
- [ ] On-device: master sync off → Snackbar + spinner clears