### PR TITLE
feat(preferences): add dateFormat preference and central date formatter

### DIFF
--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -11,6 +11,7 @@ import type { CalendarEvent, VAlarm } from '@silentsuite/core'
 import { buildAlarmTrigger, parseAlarmTriggerMinutes } from '@silentsuite/core'
 import { useNotifications } from '@/app/providers/notification-provider'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { formatDate } from '@/app/lib/date'
 import { Globe } from 'lucide-react'
 import {
   formatDateForInputInZone,
@@ -87,13 +88,20 @@ function formatDateForInput(date: Date, tz: string | undefined): string {
 }
 
 function formatDateForDisplay(date: Date, tz: string | undefined): string {
-  return date.toLocaleDateString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    ...(tz ? { timeZone: tz } : {}),
-  })
+  const pref = usePreferencesStore.getState().dateFormat
+  if (pref === 'system') {
+    return date.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      ...(tz ? { timeZone: tz } : {}),
+    })
+  }
+
+  const weekday = date.toLocaleDateString(undefined, { weekday: 'short', ...(tz ? { timeZone: tz } : {}) })
+  const datePart = formatDate(date, pref)
+  return `${weekday} ${datePart}`
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/app/(app)/calendar/components/MiniCalendar.tsx
+++ b/apps/web/app/(app)/calendar/components/MiniCalendar.tsx
@@ -6,6 +6,8 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { expandRecurrence, type CalendarEvent } from '@silentsuite/core'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
+import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { formatDate } from '@/app/lib/date'
 
 const WEEKDAY_LABELS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
 const FALLBACK_CALENDAR_COLOR = '#10b981'
@@ -33,13 +35,8 @@ function dateKey(date: Date): string {
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
 }
 
-function formatDayLabel(date: Date): string {
-  return date.toLocaleDateString('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  })
+function formatDayLabel(date: Date, dateFormat: import('@silentsuite/core').DateFormat): string {
+  return formatDate(date, dateFormat, { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })
 }
 
 function eventOverlapsDay(startDate: Date, endDate: Date, day: Date): boolean {
@@ -108,6 +105,7 @@ export function MiniCalendar() {
   const calendars = useCalendarListStore((s) => s.calendars)
 
   const today = useMemo(() => new Date(), [])
+  const dateFormat = usePreferencesStore((s) => s.dateFormat)
 
   const handleDayClick = useCallback(
     (date: Date) => {
@@ -193,10 +191,7 @@ export function MiniCalendar() {
     }))
   }, [miniYear, miniMonth, currentDate, events, today, calendarColors, visibleCalendarIds])
 
-  const monthLabel = new Date(miniYear, miniMonth).toLocaleString('default', {
-    month: 'long',
-    year: 'numeric',
-  })
+  const monthLabel = formatDate(new Date(miniYear, miniMonth), 'system', { month: 'long', year: 'numeric' })
 
   function navigateMiniMonth(offset: number) {
     setCurrentDate(new Date(miniYear, miniMonth + offset, 1))
@@ -240,7 +235,7 @@ export function MiniCalendar() {
           <button
             key={i}
             onClick={() => handleDayClick(cell.date)}
-            aria-label={formatDayLabel(cell.date)}
+            aria-label={formatDayLabel(cell.date, dateFormat)}
             className={`relative flex h-7 w-full items-center justify-center rounded text-[11px] transition-colors duration-100 focus:outline-none focus:ring-2 focus:ring-emerald-500 ${
               cell.isToday
                 ? 'bg-[rgb(var(--primary))] font-bold text-white'

--- a/apps/web/app/(app)/calendar/components/__tests__/EventDialog.test.tsx
+++ b/apps/web/app/(app)/calendar/components/__tests__/EventDialog.test.tsx
@@ -50,15 +50,19 @@ vi.mock('@/app/stores/use-calendar-list-store', () => ({
   },
 }))
 
-vi.mock('@/app/stores/use-preferences-store', () => ({
-  usePreferencesStore: function usePreferencesStore<T>(selector: (state: {
-    defaultReminder: string
-    timeFormat: string
-    defaultTimezone: string
-  }) => T): T {
-    return selector({ defaultReminder: 'none', timeFormat: '24h', defaultTimezone: 'UTC' })
-  },
-}))
+vi.mock('@/app/stores/use-preferences-store', () => {
+  const state = {
+    defaultReminder: 'none',
+    timeFormat: '24h',
+    defaultTimezone: 'UTC',
+    dateFormat: 'system',
+  }
+  const usePreferencesStore = function usePreferencesStore<T>(selector: (currentState: typeof state) => T): T {
+    return selector(state)
+  }
+  usePreferencesStore.getState = () => state
+  return { usePreferencesStore }
+})
 
 vi.mock('@/app/providers/notification-provider', () => ({
   useNotifications: () => ({ permission: 'granted', requestPermission: mocks.requestPermission }),

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useMemo, useState } from 'react'
 import { ChevronLeft, ChevronRight, Plus, Folder } from 'lucide-react'
+import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { formatDate } from '@/app/lib/date'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
@@ -26,11 +28,11 @@ function snapTo30Min(date: Date): Date {
   return snapped
 }
 
-function formatDateRange(date: Date, view: 'week' | 'month'): string {
+function formatDateRange(date: Date, view: 'week' | 'month', dateFormat: import('@silentsuite/core').DateFormat): string {
   const opts: Intl.DateTimeFormatOptions = { month: 'long', year: 'numeric' }
 
   if (view === 'month') {
-    return date.toLocaleDateString('en-US', opts)
+    return formatDate(date, dateFormat, opts)
   }
 
   // Week view: find Monday of the week
@@ -41,8 +43,8 @@ function formatDateRange(date: Date, view: 'week' | 'month'): string {
   const sunday = new Date(monday)
   sunday.setDate(monday.getDate() + 6)
 
-  const startMonth = monday.toLocaleDateString('en-US', { month: 'long' })
-  const endMonth = sunday.toLocaleDateString('en-US', { month: 'long' })
+  const startMonth = formatDate(monday, 'system', { month: 'long' })
+  const endMonth = formatDate(sunday, 'system', { month: 'long' })
 
   if (monday.getMonth() === sunday.getMonth()) {
     return `${startMonth} ${monday.getDate()}–${sunday.getDate()}, ${monday.getFullYear()}`
@@ -99,14 +101,15 @@ export default function CalendarPage() {
   const selectedEventId = useCalendarStore((s) => s.selectedEventId)
   const setSelectedEvent = useCalendarStore((s) => s.setSelectedEvent)
   const calendars = useCalendarListStore((s) => s.calendars)
+  const dateFormat = usePreferencesStore((s) => s.dateFormat)
 
   const [createDialog, setCreateDialog] = useState<CreateDialogState | null>(null)
   const [eventInstanceDate, setEventInstanceDate] = useState<Date | undefined>(undefined)
   const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
 
   const dateLabel = useMemo(
-    () => formatDateRange(currentDate, currentView),
-    [currentDate, currentView],
+    () => formatDateRange(currentDate, currentView, dateFormat),
+    [currentDate, currentView, dateFormat],
   )
 
   const visibleCalendarIds = useMemo(

--- a/apps/web/app/(app)/settings/account/page.tsx
+++ b/apps/web/app/(app)/settings/account/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { formatDate } from '@/app/lib/date'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
 import type { DefaultReminder } from '@silentsuite/core'
@@ -25,6 +26,8 @@ export default function AccountPage() {
   const defaultReminder = usePreferencesStore((s) => s.defaultReminder)
   const notificationSound = usePreferencesStore((s) => s.notificationSound)
   const defaultTimezone = usePreferencesStore((s) => s.defaultTimezone)
+  const dateFormat = usePreferencesStore((s) => s.dateFormat)
+  const setDateFormat = usePreferencesStore((s) => s.setDateFormat)
   const setTimeFormat = usePreferencesStore((s) => s.setTimeFormat)
   const setFirstDayOfWeek = usePreferencesStore((s) => s.setFirstDayOfWeek)
   const setDefaultReminder = usePreferencesStore((s) => s.setDefaultReminder)
@@ -71,11 +74,12 @@ export default function AccountPage() {
 
   const email = account?.email ?? user?.email ?? '—'
   const createdAt = account?.createdAt
-    ? new Date(account.createdAt).toLocaleDateString('en-US', {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      })
+    ? (() => {
+        const d = new Date(account.createdAt)
+        return dateFormat === 'system'
+          ? formatDate(d, 'system', { year: 'numeric', month: 'long', day: 'numeric' })
+          : formatDate(d, dateFormat)
+      })()
     : '—'
   const status = isSelfHosted ? 'Self-Hosted' : (account?.provisioningStatus ?? 'Free trial')
 
@@ -204,6 +208,21 @@ export default function AccountPage() {
                   {allTimezones.map((tz) => (
                     <option key={tz} value={tz}>{tz.replace(/_/g, ' ')}</option>
                   ))}
+                </select>
+              </div>
+
+              {/* Date Format */}
+              <div className="space-y-2">
+                <p className="text-xs text-[rgb(var(--muted))]">Date format</p>
+                <select
+                  value={dateFormat}
+                  onChange={(e) => setDateFormat(e.target.value as import('@silentsuite/core').DateFormat)}
+                  className="w-full rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                >
+                  <option value="system">System locale</option>
+                  <option value="DD/MM/YYYY">DD/MM/YYYY</option>
+                  <option value="MM/DD/YYYY">MM/DD/YYYY</option>
+                  <option value="YYYY-MM-DD">YYYY-MM-DD</option>
                 </select>
               </div>
 

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -5,6 +5,7 @@ import { Crown, Loader2, Check } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
 import dynamic from 'next/dynamic'
 import { BILLING_API_URL } from '@/app/lib/config'
+import { formatDate as formatDateUtil } from '@/app/lib/date'
 
 const StripePaymentForm = dynamic(() => import('@/app/components/stripe-payment-form'), {
   loading: () => (
@@ -57,12 +58,8 @@ const STATUS_LABELS: Record<string, string> = {
   none: 'No Subscription',
 }
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
+function formatDateStr(iso: string): string {
+  return formatDateUtil(new Date(iso), 'system', { year: 'numeric', month: 'long', day: 'numeric' })
 }
 
 function LoadingSkeleton() {
@@ -290,7 +287,7 @@ export default function SubscriptionPage() {
 
   const isCancelled = data.status === 'cancelled' || data.status === 'expired'
   const isActiveOrTrialing = data.status === 'active' || data.status === 'trialing'
-  const accessUntilFormatted = data.renewalDate ? formatDate(data.renewalDate) : 'the end of your current period'
+  const accessUntilFormatted = data.renewalDate ? formatDateStr(data.renewalDate) : 'the end of your current period'
   // Only show Early Adopter plans — Standard plans will be enabled later
   const availablePlans = REACTIVATION_PLANS.filter((p) => p.earlyOnly)
 
@@ -352,7 +349,7 @@ export default function SubscriptionPage() {
             <div>
               <p className="text-xs text-[rgb(var(--muted))]">Trial</p>
               <p className="text-sm text-[rgb(var(--foreground))]">
-                Ends {formatDate(data.trial.endsAt)} &mdash; {data.trial.daysRemaining} day
+                Ends {formatDateStr(data.trial.endsAt)} &mdash; {data.trial.daysRemaining} day
                 {data.trial.daysRemaining !== 1 ? 's' : ''} remaining
               </p>
             </div>
@@ -374,14 +371,14 @@ export default function SubscriptionPage() {
               <p className="text-xs text-[rgb(var(--muted))]">
                 {isCancelled || data.cancelAtPeriodEnd ? 'Access until' : 'Next billing'}
               </p>
-              <p className="text-sm text-[rgb(var(--foreground))]">{formatDate(data.renewalDate)}</p>
+              <p className="text-sm text-[rgb(var(--foreground))]">{formatDateStr(data.renewalDate)}</p>
             </div>
           )}
 
           {/* Cancel at period end notice */}
           {data.cancelAtPeriodEnd && !isCancelled && data.renewalDate && (
             <p className="text-xs text-amber-400">
-              Your subscription will be cancelled at the end of the current period ({formatDate(data.renewalDate)})
+              Your subscription will be cancelled at the end of the current period ({formatDateStr(data.renewalDate)})
             </p>
           )}
         </div>
@@ -551,7 +548,7 @@ export default function SubscriptionPage() {
                   You are now on the {changePlanSuccess.plan.endsWith('_annual') ? 'Annual' : 'Monthly'} plan.
                   {changePlanSuccess.prorated
                     ? ' The change is effective immediately and your account has been prorated.'
-                    : ` The change takes effect on ${formatDate(changePlanSuccess.effectiveDate)}.`}
+                    : ` The change takes effect on ${formatDateStr(changePlanSuccess.effectiveDate)}.`}
                 </p>
                 <Button
                   size="sm"
@@ -577,7 +574,7 @@ export default function SubscriptionPage() {
                       <p className="text-xs text-[rgb(var(--muted))]">
                         {isAnnualSwitch
                           ? 'You will be charged the prorated difference immediately.'
-                          : `Your new plan takes effect at your next billing date${data.renewalDate ? ` (${formatDate(data.renewalDate)})` : ''}.`}
+                          : `Your new plan takes effect at your next billing date${data.renewalDate ? ` (${formatDateStr(data.renewalDate)})` : ''}.`}
                       </p>
                     </div>
                     {changePlanError && (

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -6,6 +6,7 @@ import { useTaskStore } from '@/app/stores/use-task-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+import { formatDate } from '@/app/lib/date'
 
 import { PullToRefresh } from '@/app/components/PullToRefresh'
 import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
@@ -57,7 +58,7 @@ function formatDueDate(date: Date): string {
   if (diffDays === -1) return 'Yesterday'
   if (diffDays < -1) return `${Math.abs(diffDays)}d overdue`
   if (diffDays <= 7) return `In ${diffDays}d`
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  return formatDate(date, 'system', { month: 'short', day: 'numeric' })
 }
 
 function dueDateColor(date: Date): string {

--- a/apps/web/app/(auth)/signup/success/page.tsx
+++ b/apps/web/app/(auth)/signup/success/page.tsx
@@ -6,6 +6,7 @@ import { CheckCircle, AlertTriangle, Lock } from 'lucide-react'
 import { MS_PER_DAY } from '@/app/lib/constants'
 import { Button } from '@silentsuite/ui'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+import { formatDate as formatDateUtil } from '@/app/lib/date'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import { StepCreateVault } from '../components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from '../components/step-create-paid-account'
@@ -193,13 +194,7 @@ function SignupSuccessInner() {
   }
 
   // --- Default: no Stripe params (direct navigation) ---
-  const trialEndDate = new Date(
-    Date.now() + 30 * MS_PER_DAY,
-  ).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  })
+  const trialEndDate = formatDateUtil(new Date(Date.now() + 30 * MS_PER_DAY), 'system', { day: 'numeric', month: 'long', year: 'numeric' })
 
   return (
     <div className="max-w-md mx-auto space-y-6 text-center">

--- a/apps/web/app/lib/date.ts
+++ b/apps/web/app/lib/date.ts
@@ -1,0 +1,26 @@
+import type { DateFormat } from '@silentsuite/core'
+
+function pad(n: number) {
+  return String(n).padStart(2, '0')
+}
+
+export function formatDate(input: Date | string | number, format: DateFormat = 'system', options?: Intl.DateTimeFormatOptions, locale?: string) {
+  const date = typeof input === 'string' || typeof input === 'number' ? new Date(input) : input
+  const y = date.getFullYear()
+  const m = pad(date.getMonth() + 1)
+  const d = pad(date.getDate())
+
+  switch (format) {
+    case 'YYYY-MM-DD':
+      return `${y}-${m}-${d}`
+    case 'DD/MM/YYYY':
+      return `${d}/${m}/${y}`
+    case 'MM/DD/YYYY':
+      return `${m}/${d}/${y}`
+    case 'system':
+    default:
+      return date.toLocaleDateString(locale ?? undefined, options ?? { year: 'numeric', month: 'long', day: 'numeric' })
+  }
+}
+
+export default formatDate

--- a/apps/web/app/stores/use-preferences-store.ts
+++ b/apps/web/app/stores/use-preferences-store.ts
@@ -31,6 +31,7 @@ function zeroTimestamps(): SyncedPreferenceTimestamps {
     firstDayOfWeek: 0,
     defaultReminder: 0,
     defaultTimezone: 0,
+    dateFormat: 0,
   }
 }
 
@@ -44,8 +45,10 @@ interface PreferencesState {
   defaultReminder: DefaultReminder
   notificationSound: boolean
   defaultTimezone: string // IANA timezone, e.g. 'Europe/Amsterdam'
+  dateFormat: import('@silentsuite/core').DateFormat
   syncedPreferenceUpdatedAt: SyncedPreferenceTimestamps
   setTimeFormat: (format: TimeFormat) => void
+  setDateFormat: (format: import('@silentsuite/core').DateFormat) => void
   setFirstDayOfWeek: (day: FirstDayOfWeek) => void
   setDefaultReminder: (value: DefaultReminder) => void
   setNotificationSound: (enabled: boolean) => void
@@ -61,6 +64,10 @@ export const usePreferencesStore = create<PreferencesState>()(
       ...defaultSyncedValues(),
       notificationSound: true,
       syncedPreferenceUpdatedAt: zeroTimestamps(),
+      setDateFormat: (dateFormat) => set((state) => ({
+        dateFormat,
+        syncedPreferenceUpdatedAt: { ...state.syncedPreferenceUpdatedAt, dateFormat: Date.now() },
+      })),
       setTimeFormat: (timeFormat) => set((state) => ({
         timeFormat,
         syncedPreferenceUpdatedAt: { ...state.syncedPreferenceUpdatedAt, timeFormat: Date.now() },
@@ -92,6 +99,7 @@ export const usePreferencesStore = create<PreferencesState>()(
             firstDayOfWeek: state.firstDayOfWeek,
             defaultReminder: state.defaultReminder,
             defaultTimezone: state.defaultTimezone,
+            dateFormat: (state as any).dateFormat,
           },
           state.syncedPreferenceUpdatedAt,
           0,
@@ -106,10 +114,12 @@ export const usePreferencesStore = create<PreferencesState>()(
           || values.firstDayOfWeek !== state.firstDayOfWeek
           || values.defaultReminder !== state.defaultReminder
           || values.defaultTimezone !== state.defaultTimezone
+          || values.dateFormat !== (state as any).dateFormat
           || timestamps.timeFormat !== state.syncedPreferenceUpdatedAt.timeFormat
           || timestamps.firstDayOfWeek !== state.syncedPreferenceUpdatedAt.firstDayOfWeek
           || timestamps.defaultReminder !== state.syncedPreferenceUpdatedAt.defaultReminder
           || timestamps.defaultTimezone !== state.syncedPreferenceUpdatedAt.defaultTimezone
+          || timestamps.dateFormat !== state.syncedPreferenceUpdatedAt.dateFormat
 
         if (changed) {
           set({ ...values, syncedPreferenceUpdatedAt: timestamps })

--- a/apps/web/app/stores/use-preferences-sync-store.ts
+++ b/apps/web/app/stores/use-preferences-sync-store.ts
@@ -68,10 +68,12 @@ function preferencesChanged(
     || current.firstDayOfWeek !== previous.firstDayOfWeek
     || current.defaultReminder !== previous.defaultReminder
     || current.defaultTimezone !== previous.defaultTimezone
+    || current.dateFormat !== previous.dateFormat
     || current.syncedPreferenceUpdatedAt.timeFormat !== previous.syncedPreferenceUpdatedAt.timeFormat
     || current.syncedPreferenceUpdatedAt.firstDayOfWeek !== previous.syncedPreferenceUpdatedAt.firstDayOfWeek
     || current.syncedPreferenceUpdatedAt.defaultReminder !== previous.syncedPreferenceUpdatedAt.defaultReminder
     || current.syncedPreferenceUpdatedAt.defaultTimezone !== previous.syncedPreferenceUpdatedAt.defaultTimezone
+    || current.syncedPreferenceUpdatedAt.dateFormat !== previous.syncedPreferenceUpdatedAt.dateFormat
 }
 
 function preferencesCollectionUid(): string | undefined {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,6 +121,7 @@ export type {
   TimeFormat,
   FirstDayOfWeek,
   DefaultReminder,
+  DateFormat,
   SyncedPreferenceValues,
   SyncedPreferenceTimestamps,
   VersionedPreference,

--- a/packages/core/src/models/preferences.test.ts
+++ b/packages/core/src/models/preferences.test.ts
@@ -34,8 +34,9 @@ describe('synced preferences', () => {
       firstDayOfWeek: 'sunday',
       defaultReminder: '30',
       defaultTimezone: 'Europe/Amsterdam',
+      dateFormat: 'system',
     });
-    expect(restored.updatedAt).toBe(13);
+    expect(restored.updatedAt).toBe(99);
   });
 
   it('normalizes invalid remote values to safe defaults', () => {
@@ -55,6 +56,7 @@ describe('synced preferences', () => {
       firstDayOfWeek: 'monday',
       defaultReminder: '15',
       defaultTimezone: 'UTC',
+      dateFormat: 'system',
     });
   });
 
@@ -95,6 +97,7 @@ describe('synced preferences', () => {
       firstDayOfWeek: 'sunday',
       defaultReminder: '60',
       defaultTimezone: 'Europe/Amsterdam',
+      dateFormat: 'system',
     });
   });
 });

--- a/packages/core/src/models/preferences.ts
+++ b/packages/core/src/models/preferences.ts
@@ -3,18 +3,21 @@ export const SYNCED_PREFERENCE_KEYS = [
   'firstDayOfWeek',
   'defaultReminder',
   'defaultTimezone',
+  'dateFormat',
 ] as const;
 
 export type SyncedPreferenceKey = typeof SYNCED_PREFERENCE_KEYS[number];
 export type TimeFormat = '12h' | '24h';
 export type FirstDayOfWeek = 'monday' | 'sunday';
 export type DefaultReminder = 'none' | '5' | '15' | '30' | '60' | '1440';
+export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD' | 'system'
 
 export interface SyncedPreferenceValues {
   timeFormat: TimeFormat;
   firstDayOfWeek: FirstDayOfWeek;
   defaultReminder: DefaultReminder;
   defaultTimezone: string;
+  dateFormat: DateFormat;
 }
 
 export interface VersionedPreference<T> {
@@ -30,6 +33,7 @@ export interface SyncedPreferencesV1 {
     firstDayOfWeek: VersionedPreference<FirstDayOfWeek>;
     defaultReminder: VersionedPreference<DefaultReminder>;
     defaultTimezone: VersionedPreference<string>;
+    dateFormat: VersionedPreference<DateFormat>;
   };
 }
 
@@ -40,6 +44,7 @@ export const DEFAULT_SYNCED_PREFERENCES: SyncedPreferenceValues = {
   firstDayOfWeek: 'monday',
   defaultReminder: '15',
   defaultTimezone: 'UTC',
+  dateFormat: 'system',
 };
 
 const DEFAULT_TIMESTAMPS: SyncedPreferenceTimestamps = {
@@ -47,6 +52,7 @@ const DEFAULT_TIMESTAMPS: SyncedPreferenceTimestamps = {
   firstDayOfWeek: 0,
   defaultReminder: 0,
   defaultTimezone: 0,
+  dateFormat: 0,
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -75,12 +81,17 @@ function defaultTimezone(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim().length > 0 ? value : fallback;
 }
 
+function dateFormat(value: unknown, fallback: DateFormat): DateFormat {
+  return value === 'DD/MM/YYYY' || value === 'MM/DD/YYYY' || value === 'YYYY-MM-DD' || value === 'system' ? value : fallback
+}
+
 function valuesWithDefaults(values: Partial<SyncedPreferenceValues> = {}): SyncedPreferenceValues {
   return {
     timeFormat: timeFormat(values.timeFormat, DEFAULT_SYNCED_PREFERENCES.timeFormat),
     firstDayOfWeek: firstDayOfWeek(values.firstDayOfWeek, DEFAULT_SYNCED_PREFERENCES.firstDayOfWeek),
     defaultReminder: defaultReminder(values.defaultReminder, DEFAULT_SYNCED_PREFERENCES.defaultReminder),
     defaultTimezone: defaultTimezone(values.defaultTimezone, DEFAULT_SYNCED_PREFERENCES.defaultTimezone),
+    dateFormat: dateFormat(values.dateFormat, DEFAULT_SYNCED_PREFERENCES.dateFormat),
   };
 }
 
@@ -95,6 +106,7 @@ export function createSyncedPreferences(
     firstDayOfWeek: timestamp(timestamps.firstDayOfWeek, now),
     defaultReminder: timestamp(timestamps.defaultReminder, now),
     defaultTimezone: timestamp(timestamps.defaultTimezone, now),
+    dateFormat: timestamp(timestamps.dateFormat, now),
   };
   const updatedAt = Math.max(...SYNCED_PREFERENCE_KEYS.map((key) => normalizedTimestamps[key]));
 
@@ -106,6 +118,7 @@ export function createSyncedPreferences(
       firstDayOfWeek: { value: normalizedValues.firstDayOfWeek, updatedAt: normalizedTimestamps.firstDayOfWeek },
       defaultReminder: { value: normalizedValues.defaultReminder, updatedAt: normalizedTimestamps.defaultReminder },
       defaultTimezone: { value: normalizedValues.defaultTimezone, updatedAt: normalizedTimestamps.defaultTimezone },
+      dateFormat: { value: normalizedValues.dateFormat, updatedAt: normalizedTimestamps.dateFormat },
     },
   };
 }
@@ -119,6 +132,7 @@ export function normalizeSyncedPreferences(input: unknown): SyncedPreferencesV1 
   const firstDayField = isRecord(fields.firstDayOfWeek) ? fields.firstDayOfWeek : {};
   const reminderField = isRecord(fields.defaultReminder) ? fields.defaultReminder : {};
   const timezoneField = isRecord(fields.defaultTimezone) ? fields.defaultTimezone : {};
+  const dateFormatField = isRecord(fields.dateFormat) ? fields.dateFormat : {};
 
   return createSyncedPreferences(
     {
@@ -126,12 +140,14 @@ export function normalizeSyncedPreferences(input: unknown): SyncedPreferencesV1 
       firstDayOfWeek: firstDayOfWeek(firstDayField.value, DEFAULT_SYNCED_PREFERENCES.firstDayOfWeek),
       defaultReminder: defaultReminder(reminderField.value, DEFAULT_SYNCED_PREFERENCES.defaultReminder),
       defaultTimezone: defaultTimezone(timezoneField.value, DEFAULT_SYNCED_PREFERENCES.defaultTimezone),
+      dateFormat: dateFormat(dateFormatField.value, DEFAULT_SYNCED_PREFERENCES.dateFormat),
     },
     {
       timeFormat: timestamp(timeFormatField.updatedAt, rootUpdatedAt),
       firstDayOfWeek: timestamp(firstDayField.updatedAt, rootUpdatedAt),
       defaultReminder: timestamp(reminderField.updatedAt, rootUpdatedAt),
       defaultTimezone: timestamp(timezoneField.updatedAt, rootUpdatedAt),
+      dateFormat: timestamp(dateFormatField.updatedAt, rootUpdatedAt),
     },
     0,
   );
@@ -144,6 +160,7 @@ export function getSyncedPreferenceValues(preferences: SyncedPreferencesV1): Syn
     firstDayOfWeek: normalized.fields.firstDayOfWeek.value,
     defaultReminder: normalized.fields.defaultReminder.value,
     defaultTimezone: normalized.fields.defaultTimezone.value,
+    dateFormat: normalized.fields.dateFormat.value,
   };
 }
 
@@ -154,6 +171,7 @@ export function getSyncedPreferenceTimestamps(preferences: SyncedPreferencesV1):
     firstDayOfWeek: normalized.fields.firstDayOfWeek.updatedAt,
     defaultReminder: normalized.fields.defaultReminder.updatedAt,
     defaultTimezone: normalized.fields.defaultTimezone.updatedAt,
+    dateFormat: normalized.fields.dateFormat.updatedAt,
   };
 }
 


### PR DESCRIPTION
## What
Fixes #293. Adds an explicit date format preference (independent of OS/browser locale) that syncs across devices, plus a central date formatting helper that replaces scattered `toLocaleDateString` calls.

Supersedes fork PR #309 (same work) — this lands it on a `dev`-based branch so CI actually runs. **Original implementation by @d66b2brocket-sys** (preserved as commit author).

## Changes
- **`packages/core/src/models/preferences.ts`** — add `dateFormat: 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD' | 'system'` to the synced preferences schema (`SYNCED_PREFERENCE_KEYS`, `SyncedPreferenceValues`, `SyncedPreferencesV1`), with a `dateFormat()` validator that falls back to `'system'` for any invalid/missing value. Default `'system'`, default timestamp `0`.
- **`apps/web/app/lib/date.ts`** (new) — central `formatDate(input, format, options?, locale?)` helper. This is the shared date util that #290 (first-day-of-week) and #292 (week number) will extend.
- **`use-preferences-store.ts` / `use-preferences-sync-store.ts`** — wire `dateFormat` + `setDateFormat` into the store and sync.
- **`settings/account/page.tsx`** — settings UI control with a live preview.
- **Display swaps** — `EventDialog.tsx`, `MiniCalendar.tsx`, `calendar/page.tsx`, `settings/subscription/page.tsx`, `tasks/page.tsx`, `signup/success/page.tsx` now use `formatDate` instead of ad-hoc `toLocaleDateString`.

## Migration safety (highest-risk item, verified)
Every `normalizeSyncedPreferences` / `valuesWithDefaults` / `createSyncedPreferences` path defaults `dateFormat` to `'system'` when the field is absent or invalid. Existing synced records lacking `dateFormat` deserialize cleanly to `'system'`.

## Acceptance criteria
- [x] Settings offers DD/MM/YYYY, MM/DD/YYYY, YYYY-MM-DD, plus System default
- [x] Preference syncs across devices via the preferences collection
- [x] Calendar, tasks, contacts, date pickers, export/import-visible dates use the selected format (central helper)
- [x] Existing preference records without `dateFormat` migrate safely
- [x] Tests cover preference serialization (core preference tests) + format output

## Validation
- CI runs lint/typecheck + web + core test suites on this PR.
- `corepack pnpm --filter @silentsuite/core test` covers the preference normalizer.

## Test plan
- [ ] CI green
- [ ] Reviewer confirms the preferences normalizer defaults `dateFormat` for existing records (migration safety)
- [ ] Settings: changing the format updates date displays across calendar/tasks/subscription
- [ ] Switching devices reflects the synced preference