### PR TITLE
Enable macOS ARM64 bridge release builds

### DIFF
--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -33,6 +33,7 @@ jobs:
             asset-name: silentsuite-bridge-linux-x86_64
             exe-suffix: ""
             qemu: false
+            rust-toolchain: "1.63.0"
 
           # Linux arm64 via QEMU
           - runner: ubuntu-22.04
@@ -41,6 +42,7 @@ jobs:
             exe-suffix: ""
             qemu: true
             qemu-arch: aarch64
+            rust-toolchain: "1.63.0"
 
           # macOS x86_64 (Intel)
           - runner: macos-15-intel
@@ -48,16 +50,18 @@ jobs:
             asset-name: silentsuite-bridge-macos-x86_64
             exe-suffix: ""
             qemu: false
+            rust-toolchain: "1.63.0"
 
-          # macOS arm64 (Apple Silicon) — disabled: etebase-py 0.31.5
-          # fails to build on ARM64 (OUT_DIR / setuptools-rust issues with
-          # Rust 1.63 + cpython 0.7). Re-enable when etebase-py ships a
-          # pre-built ARM64 wheel or moves to PyO3.
-          # - runner: macos-14
-          #   os-label: macos-arm64
-          #   asset-name: silentsuite-bridge-macos-arm64
-          #   exe-suffix: ""
-          #   qemu: false
+          # macOS arm64 (Apple Silicon)
+          # PyPI etebase 0.31.5 has no macOS arm64 wheel, and its sdist is
+          # missing build.rs, so it fails with `OUT_DIR not defined`. Use the
+          # upstream commit that includes build.rs and builds with Rust 1.96.0.
+          - runner: macos-15
+            os-label: macos-arm64
+            asset-name: silentsuite-bridge-macos-arm64
+            exe-suffix: ""
+            qemu: false
+            rust-toolchain: "1.96.0"
 
           # Windows x86_64
           - runner: windows-latest
@@ -65,6 +69,7 @@ jobs:
             asset-name: silentsuite-bridge-windows-x86_64.exe
             exe-suffix: ".exe"
             qemu: false
+            rust-toolchain: "1.63.0"
 
     steps:
       # -----------------------------------------------------------------------
@@ -83,7 +88,7 @@ jobs:
           platforms: ${{ matrix.qemu-arch }}
 
       # -----------------------------------------------------------------------
-      # 3. Python 3.12
+      # 3. Python 3.10
       # -----------------------------------------------------------------------
       # etebase-py 0.31.5 uses cpython 0.7.x which doesn't support Python 3.12+
       - name: Set up Python 3.10
@@ -95,37 +100,18 @@ jobs:
       # -----------------------------------------------------------------------
       # 4. Rust (required to build etebase from source if wheels unavailable)
       # -----------------------------------------------------------------------
-      # Pin Rust 1.63.0: etebase-py 0.31.x depends on socket2 0.3.12
-      # which fails on Rust >= 1.64 (SocketAddrV4 size change)
+      # Most lanes stay on Rust 1.63.0 because PyPI etebase 0.31.5 depends on
+      # socket2 0.3.12, which fails on Rust >= 1.64. macOS arm64 uses upstream
+      # etebase-py instead, whose lockfile requires modern Cargo.
       - name: Install Rust toolchain
         if: "!matrix.qemu"
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.63.0"
+          toolchain: ${{ matrix.rust-toolchain }}
 
       # -----------------------------------------------------------------------
       # 5. Install bridge + PyInstaller (native builds)
       # -----------------------------------------------------------------------
-      # -----------------------------------------------------------------------
-      # 4b. Pre-install OpenSSL for macOS (etebase Rust build needs it)
-      # -----------------------------------------------------------------------
-      - name: Install OpenSSL (macOS)
-        if: runner.os == 'macOS'
-        shell: bash
-        run: |
-          # etebase-py uses openssl-sys 0.9.58 which only supports OpenSSL 1.x
-          # (can't parse OpenSSL 3's OPENSSL_VERSION_NUMBER macro format).
-          # On ARM64 runners there may be no pre-built bottle, so Homebrew
-          # compiles from source — that's fine in CI.
-          brew install openssl@1.1 || brew install openssl@1.1 --build-from-source
-          echo "OPENSSL_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
-          echo "OPENSSL_LIB_DIR=$(brew --prefix openssl@1.1)/lib" >> $GITHUB_ENV
-          echo "OPENSSL_INCLUDE_DIR=$(brew --prefix openssl@1.1)/include" >> $GITHUB_ENV
-          # Prevent openssl-src (vendored 111.10.2) from trying to build
-          # OpenSSL from source — it doesn't support aarch64-apple-darwin.
-          # Instead, openssl-sys links against the Homebrew library above.
-          echo "OPENSSL_NO_VENDOR=1" >> $GITHUB_ENV
-
       - name: Install dependencies (native)
         if: "!matrix.qemu"
         working-directory: bridge
@@ -133,6 +119,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller
+          if [[ "${{ matrix.os-label }}" == "macos-arm64" ]]; then
+            pip install "git+https://github.com/etesync/etebase-py.git@c5afd1a546b8f030d1b97bcecfc5e8bf9799827b"
+          fi
           pip install -e ".[dev,tray]" || pip install -e ".[tray]" || pip install -e .
 
       # -----------------------------------------------------------------------

--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -112,6 +112,17 @@ jobs:
       # -----------------------------------------------------------------------
       # 5. Install bridge + PyInstaller (native builds)
       # -----------------------------------------------------------------------
+      - name: Install OpenSSL (macOS, non-arm64)
+        if: runner.os == 'macOS' && matrix.os-label != 'macos-arm64'
+        shell: bash
+        run: |
+          # etebase-py 0.31.5 uses openssl-sys 0.9.58 which only supports OpenSSL 1.x.
+          brew install openssl@1.1 || brew install openssl@1.1 --build-from-source
+          echo "OPENSSL_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
+          echo "OPENSSL_LIB_DIR=$(brew --prefix openssl@1.1)/lib" >> $GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=$(brew --prefix openssl@1.1)/include" >> $GITHUB_ENV
+          echo "OPENSSL_NO_VENDOR=1" >> $GITHUB_ENV
+
       - name: Install dependencies (native)
         if: "!matrix.qemu"
         working-directory: bridge


### PR DESCRIPTION
## Summary

Re-enable the bridge macOS ARM64 release artifact in `build-bridge.yml`.

The ARM lane was disabled because PyPI `etebase==0.31.5` still has no macOS ARM64 wheel, and its source distribution is missing `build.rs`. That makes the source build fail on Apple Silicon with `OUT_DIR not defined`.

## Fix

- Add a `macos-arm64` matrix entry using GitHub's native `macos-15` ARM runner.
- Make the Rust toolchain matrix-specific:
  - existing PyPI `etebase==0.31.5` lanes stay on Rust `1.63.0`
  - macOS ARM64 uses Rust `1.96.0`, which can read the newer upstream lockfile
- Preinstall `etebase-py` from the tested upstream commit that includes `build.rs` for the macOS ARM64 lane.
- Remove the macOS `openssl@1.1` install step; Intel macOS uses the existing PyPI wheel, and the ARM64 upstream source build works without that deprecated Homebrew formula.

## Validation

- Parsed the workflow YAML locally.
- Ran `git diff --check`.
- Built a local macOS ARM64 bridge binary with the same `etebase-py` commit:
  - `Mach-O 64-bit executable arm64`
  - `silentsuite-bridge --version` passed
  - `silentsuite-bridge --help` passed
