### PR TITLE
security: harden self-host bootstrap exposure

### DIFF
--- a/self-host/.env.example
+++ b/self-host/.env.example
@@ -25,3 +25,13 @@ SUPER_PASS=
 # Open registration toggle. "false" allows new signups (default; needed for
 # the first admin to register). Flip to "true" once the admin is registered.
 ETEBASE_DISABLE_SIGNUP=false
+
+# One-time first-admin signup token. When set, the first account must sign up
+# with this token in the server URL query string:
+#   https://YOUR_DOMAIN/?bootstrap_token=YOUR_TOKEN
+# After the first account exists, this token is no longer required.
+ETEBASE_BOOTSTRAP_ADMIN_TOKEN=
+
+# Disable the advanced Django /admin/ panel entirely. Most self-hosters should
+# leave this true and manage SilentSuite through the app.
+ETEBASE_DISABLE_DJANGO_ADMIN=true

--- a/self-host/SELF-HOSTING.md
+++ b/self-host/SELF-HOSTING.md
@@ -214,15 +214,26 @@ not already include them:
 
 Once your server is running and your reverse proxy is configured:
 
-1. Open [app.silentsuite.io](https://app.silentsuite.io) or the SilentSuite mobile app
+1. Open [app.silentsuite.io](https://app.silentsuite.io) in a browser for the first signup
 2. On the signup page, expand **Advanced Settings**
-3. Enter `https://sync.example.com` (your domain) as the server URL
+3. Enter the one-time first-admin URL printed by the installer as the server URL:
+   `https://sync.example.com/?bootstrap_token=YOUR_TOKEN`
 4. Create your account and start syncing
 5. **Run `./close-signups.sh`** from your install directory — see below.
 
 ## Closing Open Signups
 
-The server ships with `ETEBASE_DISABLE_SIGNUP=false` so your first account can be created from the SilentSuite app. **The window between server-up and admin-registered is unsafe** — anyone who reaches your server URL during that gap can grab an account.
+The server ships with `ETEBASE_DISABLE_SIGNUP=false` so your first account can be created from the SilentSuite app. The installer also generates `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` in `.env`; while the server has zero users, the first signup must include that token in the server URL query string:
+
+```text
+https://sync.example.com/?bootstrap_token=YOUR_TOKEN
+```
+
+This keeps a random visitor from racing you for the first account if they discover the server URL during setup. Once any user exists, the token is no longer required; you should still close signups immediately after creating your admin account. After that first browser signup, you can connect the mobile app with the normal server URL (`https://sync.example.com`).
+
+If you configure self-hosting manually instead of using `install.sh`, generate and set a strong `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` yourself before first boot. Leaving it empty preserves the old open-first-signup behavior for compatibility and does **not** protect the first account.
+
+Because the bootstrap token is passed in the server URL, it may appear in local browser history or reverse-proxy access logs. Complete the first signup promptly; after the first app account exists, the token is ignored. If you suspect it was exposed before signup, rotate `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` in `.env` and recreate the server container before trying again.
 
 Once your admin account is registered, close signups:
 
@@ -255,7 +266,7 @@ Within a single pinned release, `./update.sh` re-pulls the pinned images and rec
 
 ## Admin Panel
 
-Access the admin panel at `https://your-domain/admin/` using the credentials from `.env`.
+The advanced Django admin panel is disabled by default in self-host installs (`ETEBASE_DISABLE_DJANGO_ADMIN=true`) because normal operators do not need it exposed on the public sync domain. If you need it for recovery or advanced maintenance, set `ETEBASE_DISABLE_DJANGO_ADMIN=false` in `.env`, recreate the server container, and protect `/admin/` with your reverse proxy or Cloudflare Access before exposing it.
 
 ## Backup and Restore
 

--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -43,6 +43,11 @@ services:
       # Open registration toggle. "true" blocks new signups (use after the
       # operator's admin account is registered). Default "false" allows signup.
       ETEBASE_DISABLE_SIGNUP: ${ETEBASE_DISABLE_SIGNUP:-false}
+      # One-time first-admin signup token. When set, the first signup must use
+      # https://YOUR_DOMAIN/?bootstrap_token=TOKEN as the server URL.
+      ETEBASE_BOOTSTRAP_ADMIN_TOKEN: ${ETEBASE_BOOTSTRAP_ADMIN_TOKEN:-}
+      # Hide the advanced Django admin panel unless explicitly re-enabled.
+      ETEBASE_DISABLE_DJANGO_ADMIN: ${ETEBASE_DISABLE_DJANGO_ADMIN:-true}
       # Only these reverse proxy IPs may set X-Forwarded-* headers.
       TRUSTED_PROXY_IPS: ${TRUSTED_PROXY_IPS:-127.0.0.1}
     volumes:

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -238,6 +238,7 @@ echo ""
 echo "Generating secure passwords..."
 DATABASE_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=')
 SUPER_PASS=$(openssl rand -base64 16 | tr -d '/+=')
+BOOTSTRAP_ADMIN_TOKEN=$(openssl rand -base64 32 | tr -d '/+=')
 
 # ── Write .env ─────────────────────────────────────────────────────────
 
@@ -267,6 +268,14 @@ SUPER_PASS=$SUPER_PASS
 # Open registration toggle. "false" allows new signups (default; needed for
 # the first admin to register). Flip to "true" once the admin is registered.
 ETEBASE_DISABLE_SIGNUP=false
+
+# One-time first-admin signup token. Use this only for the first signup by
+# entering https://$DOMAIN/?bootstrap_token=$BOOTSTRAP_ADMIN_TOKEN as the
+# server URL in the app. After the first account exists, the token is ignored.
+ETEBASE_BOOTSTRAP_ADMIN_TOKEN=$BOOTSTRAP_ADMIN_TOKEN
+
+# Hide the advanced Django /admin/ panel unless explicitly re-enabled.
+ETEBASE_DISABLE_DJANGO_ADMIN=true
 EOF
 
 chmod 600 .env
@@ -405,9 +414,10 @@ echo ""
 echo "  2. Point your DNS A record for $DOMAIN"
 echo "     to this server's public IP."
 echo ""
-echo "  3. Open https://app.silentsuite.io (or the mobile app)"
+echo "  3. Open https://app.silentsuite.io in a browser"
 echo "  4. On the signup page, expand 'Advanced Settings'"
-echo "  5. Enter https://$DOMAIN as the server URL"
+echo "  5. Enter this one-time first-admin server URL:"
+echo "       https://$DOMAIN/?bootstrap_token=$BOOTSTRAP_ADMIN_TOKEN"
 echo "  6. Create your account — you'll be the admin!"
 echo "  7. Immediately run ./close-signups.sh to block further registration."
 echo ""
@@ -441,10 +451,14 @@ ${C_RED}┌───────────────────────
 │  SECURITY: open registration is currently ENABLED.                  │
 └─────────────────────────────────────────────────────────────────────┘${C_RESET}
 
-  Anyone who reaches https://$DOMAIN/ before you do can grab an account
-  on this server. To stop that:
+  First signup is protected by a one-time bootstrap token generated into
+  your local .env file. Use this server URL for your first signup:
 
-    ${C_YELLOW}1. Sign up your own account at https://$DOMAIN/ now (step 6 above).${C_RESET}
+    ${C_YELLOW}https://$DOMAIN/?bootstrap_token=$BOOTSTRAP_ADMIN_TOKEN${C_RESET}
+
+  After your admin account exists, close general registration:
+
+    ${C_YELLOW}1. Sign up your own account now (step 6 above).${C_RESET}
     ${C_YELLOW}2. Run ${C_RESET}./close-signups.sh${C_YELLOW} from this directory.${C_RESET}
 
   ./close-signups.sh sets ETEBASE_DISABLE_SIGNUP=true in .env and recreates

--- a/server/etebase_server/fastapi/main.py
+++ b/server/etebase_server/fastapi/main.py
@@ -23,6 +23,9 @@ def create_application(prefix="", middlewares=[]):
     app = FastAPI(
         title="Etebase",
         description="The Etebase server API documentation",
+        openapi_url="/openapi.json" if settings.DEBUG else None,
+        docs_url="/docs" if settings.DEBUG else None,
+        redoc_url="/redoc" if settings.DEBUG else None,
         externalDocs={
             "url": "https://docs.etebase.com",
             "description": "Docs about the API specifications and clients.",

--- a/server/etebase_server/fastapi/routers/authentication.py
+++ b/server/etebase_server/fastapi/routers/authentication.py
@@ -1,3 +1,4 @@
+import hmac
 import logging
 import typing as t
 from datetime import datetime
@@ -234,6 +235,16 @@ def dashboard_url(request: Request, user: UserType = Depends(get_authenticated_u
 def signup_save(data: SignupIn, request: Request) -> UserType:
     user_data = data.user
     with transaction.atomic():
+        bootstrap_token = settings.ETEBASE_BOOTSTRAP_ADMIN_TOKEN
+        if bootstrap_token and not models.UserInfo.objects.exists():
+            supplied_token = request.query_params.get("bootstrap_token", "")
+            if not hmac.compare_digest(bootstrap_token.encode("utf-8"), supplied_token.encode("utf-8")):
+                raise HttpError(
+                    "bootstrap_token_required",
+                    "A valid bootstrap token is required for the first account on this server.",
+                    status.HTTP_403_FORBIDDEN,
+                )
+
         try:
             user_queryset = get_user_queryset(User.objects.all(), CallbackContext(request.path_params))
             instance = user_queryset.get(**{User.USERNAME_FIELD: user_data.username.lower()})

--- a/server/etebase_server/fastapi/test_authentication.py
+++ b/server/etebase_server/fastapi/test_authentication.py
@@ -27,6 +27,7 @@ from etebase_server.fastapi.conftest import (
     msgpack_post,
     perform_login,
 )
+from etebase_server.myauth.models import get_typed_user_model
 
 
 @pytest.mark.django_db(transaction=True)
@@ -170,14 +171,17 @@ class TestLogin:
 
 @pytest.mark.django_db(transaction=True)
 class TestSignup:
-    def test_signup_creates_a_new_user(self, auth_client, login_pubkey, encryption_pubkey, user_salt):
-        body = {
-            "user": {"username": "test_user_new", "email": "new@example.com"},
+    def _signup_body(self, username, email, login_pubkey, encryption_pubkey, user_salt):
+        return {
+            "user": {"username": username, "email": email},
             "salt": user_salt,
             "loginPubkey": login_pubkey,
             "pubkey": encryption_pubkey,
             "encryptedContent": b"\x00" * 64,
         }
+
+    def test_signup_creates_a_new_user(self, auth_client, login_pubkey, encryption_pubkey, user_salt):
+        body = self._signup_body("test_user_new", "new@example.com", login_pubkey, encryption_pubkey, user_salt)
 
         response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
 
@@ -193,13 +197,7 @@ class TestSignup:
         self, auth_client, user_factory, login_pubkey, encryption_pubkey, user_salt
     ):
         user_factory(username="test_user_alice")
-        body = {
-            "user": {"username": "test_user_alice", "email": "alice@example.com"},
-            "salt": user_salt,
-            "loginPubkey": login_pubkey,
-            "pubkey": encryption_pubkey,
-            "encryptedContent": b"\x00" * 64,
-        }
+        body = self._signup_body("test_user_alice", "alice@example.com", login_pubkey, encryption_pubkey, user_salt)
 
         response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
 
@@ -209,13 +207,7 @@ class TestSignup:
     def test_signup_unexpected_creation_error_returns_safe_detail(
         self, auth_client, login_pubkey, encryption_pubkey, user_salt
     ):
-        body = {
-            "user": {"username": "test_user_error", "email": "error@example.com"},
-            "salt": user_salt,
-            "loginPubkey": login_pubkey,
-            "pubkey": encryption_pubkey,
-            "encryptedContent": b"\x00" * 64,
-        }
+        body = self._signup_body("test_user_error", "error@example.com", login_pubkey, encryption_pubkey, user_salt)
 
         with patch(
             "etebase_server.fastapi.routers.authentication.create_user",
@@ -228,6 +220,63 @@ class TestSignup:
         assert decoded["code"] == "generic"
         assert decoded["detail"] == "An error occurred during signup. Please try again."
         assert "raw database hostname secret" not in decoded["detail"]
+
+    @override_settings(ETEBASE_BOOTSTRAP_ADMIN_TOKEN="bootstrap-secret")
+    def test_first_signup_requires_bootstrap_token_when_configured(
+        self, auth_client, login_pubkey, encryption_pubkey, user_salt
+    ):
+        body = self._signup_body("test_user_bootstrap", "bootstrap@example.com", login_pubkey, encryption_pubkey, user_salt)
+
+        missing_response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
+        wrong_response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/?bootstrap_token=wrong", body)
+        unicode_wrong_response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/?bootstrap_token=ünïcödé", body)
+
+        user_model = get_typed_user_model()
+        assert missing_response.status_code == 403
+        assert wrong_response.status_code == 403
+        assert unicode_wrong_response.status_code == 403
+        assert decode_response(missing_response)["code"] == "bootstrap_token_required"
+        assert decode_response(wrong_response)["code"] == "bootstrap_token_required"
+        assert decode_response(unicode_wrong_response)["code"] == "bootstrap_token_required"
+        assert not user_model.objects.filter(username="test_user_bootstrap").exists()
+
+    @override_settings(ETEBASE_BOOTSTRAP_ADMIN_TOKEN="bootstrap-secret")
+    def test_first_signup_accepts_valid_bootstrap_token(
+        self, auth_client, login_pubkey, encryption_pubkey, user_salt
+    ):
+        body = self._signup_body("test_user_bootstrap", "bootstrap@example.com", login_pubkey, encryption_pubkey, user_salt)
+
+        response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/?bootstrap_token=bootstrap-secret", body)
+
+        assert response.status_code in (200, 201)
+        assert decode_response(response)["user"]["username"] == "test_user_bootstrap"
+
+    @override_settings(ETEBASE_BOOTSTRAP_ADMIN_TOKEN="bootstrap-secret")
+    def test_bootstrap_token_still_required_when_only_django_superuser_exists(
+        self, auth_client, user_factory, login_pubkey, encryption_pubkey, user_salt
+    ):
+        user_factory(username="admin", email="admin@example.com", with_userinfo=False)
+        body = self._signup_body("test_user_bootstrap", "bootstrap@example.com", login_pubkey, encryption_pubkey, user_salt)
+
+        missing_response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
+        token_response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/?bootstrap_token=bootstrap-secret", body)
+
+        assert missing_response.status_code == 403
+        assert decode_response(missing_response)["code"] == "bootstrap_token_required"
+        assert token_response.status_code in (200, 201)
+        assert decode_response(token_response)["user"]["username"] == "test_user_bootstrap"
+
+    @override_settings(ETEBASE_BOOTSTRAP_ADMIN_TOKEN="bootstrap-secret")
+    def test_bootstrap_token_not_required_after_first_app_user_exists(
+        self, auth_client, user_factory, login_pubkey, encryption_pubkey, user_salt
+    ):
+        user_factory(username="existing_user", email="existing@example.com")
+        body = self._signup_body("second_user", "second@example.com", login_pubkey, encryption_pubkey, user_salt)
+
+        response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
+
+        assert response.status_code in (200, 201)
+        assert decode_response(response)["user"]["username"] == "second_user"
 
 
 @pytest.mark.django_db(transaction=True)

--- a/server/etebase_server/settings.py
+++ b/server/etebase_server/settings.py
@@ -15,6 +15,13 @@ import os
 
 from .utils import get_secret_from_file
 
+
+def env_flag(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in ("true", "1", "yes")
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 SOURCE_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(SOURCE_DIR)
@@ -33,6 +40,8 @@ SECRET_FILE = os.path.join(BASE_DIR, "secret.txt")
 DEBUG = os.environ.get('ETEBASE_DEBUG', 'false').lower() == 'true'
 
 ALLOWED_HOSTS = []
+ETEBASE_DISABLE_DJANGO_ADMIN = env_flag("ETEBASE_DISABLE_DJANGO_ADMIN")
+ETEBASE_BOOTSTRAP_ADMIN_TOKEN = os.environ.get("ETEBASE_BOOTSTRAP_ADMIN_TOKEN", "")
 
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
@@ -209,7 +218,7 @@ if "DJANGO_MEDIA_ROOT" in os.environ:
 # Self-host operators flip this on (via close-signups.sh) once their admin
 # is registered. Replaces the etebase-server.ini-only path so the toggle is
 # runtime-driven without an image rebuild.
-if os.environ.get("ETEBASE_DISABLE_SIGNUP", "").lower() in ("true", "1", "yes"):
+if env_flag("ETEBASE_DISABLE_SIGNUP"):
     ETEBASE_CREATE_USER_FUNC = "etebase_server.django.utils.create_user_blocked"
 
 # Make an `etebase_server_settings` module available to override settings.

--- a/server/etebase_server/urls.py
+++ b/server/etebase_server/urls.py
@@ -1,8 +1,11 @@
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path
 from django.views.generic import TemplateView
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
     path("", TemplateView.as_view(template_name="success.html")),
 ]
+
+if not settings.ETEBASE_DISABLE_DJANGO_ADMIN:
+    urlpatterns.insert(0, path("admin/", admin.site.urls))


### PR DESCRIPTION
## Summary
- Require a one-time bootstrap token for the first SilentSuite app account when `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` is configured.
- Disable FastAPI `/openapi.json`, `/docs`, and `/redoc` outside `DEBUG`.
- Allow self-host installs to disable Django `/admin/`, defaulting to disabled in compose/install output.
- Update self-host install/docs to generate and use a browser-only first-admin bootstrap URL, then close signups.

Closes #287

## Verification
- `python3 -m py_compile server/etebase_server/settings.py server/etebase_server/urls.py server/etebase_server/fastapi/main.py server/etebase_server/fastapi/routers/authentication.py server/etebase_server/fastapi/test_authentication.py`
- `bash -n self-host/install.sh self-host/close-signups.sh`
- `python -m ruff check etebase_server/settings.py etebase_server/urls.py etebase_server/fastapi/main.py etebase_server/fastapi/routers/authentication.py etebase_server/fastapi/test_authentication.py`
- `python -m pytest etebase_server/fastapi/test_authentication.py -q` → 20 passed
- Runtime check: production hides FastAPI docs/OpenAPI; `ETEBASE_DISABLE_DJANGO_ADMIN=true` omits `/admin/`; DEBUG/admin-enabled settings keep expected routes.

## Reviews