### PR TITLE
test: cover self-host security route toggles

### DIFF
--- a/self-host/.env.example
+++ b/self-host/.env.example
@@ -26,9 +26,11 @@ SUPER_PASS=
 # the first admin to register). Flip to "true" once the admin is registered.
 ETEBASE_DISABLE_SIGNUP=false
 
-# One-time first-admin signup token. When set, the first account must sign up
-# with this token in the server URL query string:
-#   https://YOUR_DOMAIN/?bootstrap_token=YOUR_TOKEN
+# One-time first-admin signup token. install.sh auto-generates this value.
+# Manual installs should set a strong random token before first boot; leaving it
+# empty preserves the legacy open-first-signup behavior and does not protect the
+# first account from public races.
+# First signup server URL: https://YOUR_DOMAIN/?bootstrap_token=YOUR_TOKEN
 # After the first account exists, this token is no longer required.
 ETEBASE_BOOTSTRAP_ADMIN_TOKEN=
 

--- a/self-host/SELF-HOSTING.md
+++ b/self-host/SELF-HOSTING.md
@@ -231,9 +231,9 @@ https://sync.example.com/?bootstrap_token=YOUR_TOKEN
 
 This keeps a random visitor from racing you for the first account if they discover the server URL during setup. Once any user exists, the token is no longer required; you should still close signups immediately after creating your admin account. After that first browser signup, you can connect the mobile app with the normal server URL (`https://sync.example.com`).
 
-If you configure self-hosting manually instead of using `install.sh`, generate and set a strong `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` yourself before first boot. Leaving it empty preserves the old open-first-signup behavior for compatibility and does **not** protect the first account.
+If you configure self-hosting manually instead of using `install.sh`, generate and set a strong `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` yourself before first boot. Leaving it empty preserves the old open-first-signup behavior for compatibility and does **not** protect the first account from a public first-signup race.
 
-Because the bootstrap token is passed in the server URL, it may appear in local browser history or reverse-proxy access logs. Complete the first signup promptly; after the first app account exists, the token is ignored. If you suspect it was exposed before signup, rotate `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` in `.env` and recreate the server container before trying again.
+Because the bootstrap token is passed in the server URL, it may appear in local browser history, terminal scrollback, or reverse-proxy access logs. Complete the first signup promptly; after the first app account exists, the token is ignored. If you suspect it was exposed before signup, rotate `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` in `.env`, clear any leaked URL from logs/history where practical, and recreate the server container before trying again.
 
 Once your admin account is registered, close signups:
 

--- a/server/etebase_server/fastapi/test_self_host_security_routes.py
+++ b/server/etebase_server/fastapi/test_self_host_security_routes.py
@@ -1,0 +1,61 @@
+"""Focused tests for self-host security route exposure toggles."""
+
+from __future__ import annotations
+
+import importlib
+
+from fastapi.testclient import TestClient
+
+
+def test_fastapi_docs_routes_disabled_outside_debug(settings, tmp_path):
+    settings.DEBUG = False
+    settings.ALLOWED_HOSTS = ["testserver"]
+    settings.STATIC_ROOT = str(tmp_path / "static")
+    (tmp_path / "static").mkdir()
+
+    from etebase_server.fastapi.main import create_application
+
+    app = create_application()
+    route_paths = {getattr(route, "path", "") for route in app.routes}
+    client = TestClient(app)
+
+    for path in ("/openapi.json", "/docs", "/redoc"):
+        assert path not in route_paths
+        assert client.get(path).status_code == 404
+
+
+def test_fastapi_docs_routes_preserved_in_debug(settings, tmp_path):
+    settings.DEBUG = True
+    settings.ALLOWED_HOSTS = ["testserver"]
+    settings.STATIC_ROOT = str(tmp_path / "static")
+    (tmp_path / "static").mkdir()
+
+    from etebase_server.fastapi.main import create_application
+
+    app = create_application()
+    route_paths = {getattr(route, "path", "") for route in app.routes}
+    client = TestClient(app)
+
+    for path in ("/openapi.json", "/docs", "/redoc"):
+        assert path in route_paths
+        assert client.get(path).status_code == 200
+
+
+def _reload_urlpatterns_with_admin_disabled(settings, disabled: bool):
+    settings.ETEBASE_DISABLE_DJANGO_ADMIN = disabled
+
+    import etebase_server.urls as urls
+
+    return importlib.reload(urls).urlpatterns
+
+
+def test_django_admin_route_removed_when_disabled(settings):
+    urlpatterns = _reload_urlpatterns_with_admin_disabled(settings, True)
+
+    assert "admin/" not in {str(getattr(pattern, "pattern", "")) for pattern in urlpatterns}
+
+
+def test_django_admin_route_present_by_default(settings):
+    urlpatterns = _reload_urlpatterns_with_admin_disabled(settings, False)
+
+    assert "admin/" in {str(getattr(pattern, "pattern", "")) for pattern in urlpatterns}


### PR DESCRIPTION
## What

- adds focused regression tests for FastAPI docs/schema exposure:
  - `DEBUG=false` keeps `/openapi.json`, `/docs`, and `/redoc` absent/404
  - `DEBUG=true` preserves those dev routes
- adds focused regression tests for `ETEBASE_DISABLE_DJANGO_ADMIN` URL wiring:
  - true removes `admin/`
  - false keeps `admin/`
- strengthens self-host docs/comments for manual installs:
  - leaving `ETEBASE_BOOTSTRAP_ADMIN_TOKEN` empty preserves legacy open-first-signup behavior and does not protect the first account
  - query-string bootstrap URLs may leak via browser history, terminal scrollback, or reverse-proxy logs

## Validation
- `python3 -m py_compile server/etebase_server/fastapi/test_self_host_security_routes.py`
- `pytest server/etebase_server/fastapi/test_self_host_security_routes.py -q` → 4 passed

## Review status