### PR TITLE
feat(calendar): honor week start preference

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -14,8 +14,9 @@ import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { expandRecurrence } from '@silentsuite/core'
-import type { CalendarEvent, DateRange } from '@silentsuite/core'
+import type { CalendarEvent, DateRange, FirstDayOfWeek } from '@silentsuite/core'
 import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
+import { startOfWeek, endOfWeek } from '@/app/lib/date'
 import { isMultiDayTimedRange, toAllDayEndPlainDate, toTimedMonthEndPlainDate } from '../lib/all-day'
 
 import '@schedule-x/theme-default/dist/index.css'
@@ -62,27 +63,23 @@ interface DisplayEvent {
   calendarId?: string
 }
 
-/** Get the visible date range for the current view */
-function getViewRange(currentDate: Date, view: CalendarView): DateRange {
+/** Get the visible date range for the current view, honoring the first-day preference */
+function getViewRange(currentDate: Date, view: CalendarView, firstDay: FirstDayOfWeek): DateRange {
   const d = new Date(currentDate)
   switch (view) {
     case 'week': {
-      const day = d.getDay()
-      const mondayOffset = day === 0 ? -6 : 1 - day
-      const start = new Date(d.getFullYear(), d.getMonth(), d.getDate() + mondayOffset)
+      const start = startOfWeek(d, firstDay)
       const end = new Date(start)
       end.setDate(start.getDate() + 6)
       end.setHours(23, 59, 59, 999)
       return { start, end }
     }
     case 'month': {
-      const start = new Date(d.getFullYear(), d.getMonth(), 1)
-      const end = new Date(d.getFullYear(), d.getMonth() + 1, 0, 23, 59, 59, 999)
+      const monthStart = new Date(d.getFullYear(), d.getMonth(), 1)
+      const monthEnd = new Date(d.getFullYear(), d.getMonth() + 1, 0, 23, 59, 59, 999)
       // Extend to cover partial weeks at start/end of month
-      const startDay = start.getDay()
-      start.setDate(start.getDate() - (startDay === 0 ? 6 : startDay - 1))
-      const endDay = end.getDay()
-      if (endDay !== 0) end.setDate(end.getDate() + (7 - endDay))
+      const start = startOfWeek(monthStart, firstDay)
+      const end = endOfWeek(monthEnd, firstDay)
       return { start, end }
     }
   }
@@ -296,6 +293,9 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const use12h = timeFormat !== '24h'
   const defaultTimezone = usePreferencesStore((s) => s.defaultTimezone)
   const userTz = useMemo(() => resolveUserTimezone(defaultTimezone), [defaultTimezone])
+  const firstDayOfWeek = usePreferencesStore((s) => s.firstDayOfWeek)
+  // Schedule-X WeekDay enum: MONDAY = 1 … SUNDAY = 7 (not 0-indexed).
+  const sxFirstDayOfWeek = firstDayOfWeek === 'sunday' ? 7 : 1
 
   const lastClickPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
 
@@ -312,7 +312,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const [eventsPlugin] = useState(() => createEventsServicePlugin())
 
   // Expand recurring events for the visible range
-  const viewRange = useMemo(() => getViewRange(currentDate, currentView), [currentDate, currentView])
+  const viewRange = useMemo(() => getViewRange(currentDate, currentView, firstDayOfWeek), [currentDate, currentView, firstDayOfWeek])
   const displayEvents = useMemo(() => expandEventsForRange(events, viewRange), [events, viewRange])
 
   // Keep a ref map to look up display events by schedule-x id
@@ -472,6 +472,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const initialLocaleRef = useRef(timeFormat === '24h' ? 'en-GB' : 'en-US')
   // Capture initial timezone for Schedule-X config (changes are pushed via signal below)
   const initialTimezoneRef = useRef(userTz)
+  // Capture initial first-day-of-week for Schedule-X config (changes pushed via signal below)
+  const initialFirstDayRef = useRef(sxFirstDayOfWeek)
 
   // Memoize the event click handler
   const handleEventClick = useCallback(
@@ -506,7 +508,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     defaultView: initialViewRef.current,
     isDark: resolvedTheme === 'dark',
     locale: initialLocaleRef.current,
-    firstDayOfWeek: 1, // Monday — must match getViewRange() and formatDateRange()
+    // Derived from the firstDayOfWeek preference; live changes pushed via signal below.
+    firstDayOfWeek: initialFirstDayRef.current,
     dayBoundaries: { start: '06:00', end: '22:00' },
     timezone: initialTimezoneRef.current,
     weekOptions: {
@@ -535,6 +538,23 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       // Schedule-X internals may not be ready
     }
   }, [calendar, userTz])
+
+  // Push first-day-of-week changes to the Schedule-X config signal so the grid
+  // AND the date picker re-render when the user updates the preference in
+  // Settings — without a full page reload. config.firstDayOfWeek is shared
+  // between the calendar and its date picker, so this fixes both at once.
+  useEffect(() => {
+    if (!calendar) return
+    try {
+      const app = (calendar as any).$app
+      const fdowSignal = app?.config?.firstDayOfWeek
+      if (fdowSignal && fdowSignal.value !== sxFirstDayOfWeek) {
+        fdowSignal.value = sxFirstDayOfWeek
+      }
+    } catch {
+      // Schedule-X internals may not be ready
+    }
+  }, [calendar, sxFirstDayOfWeek])
 
   // Sync view AND date changes from store → Schedule-X via internal API.
   // CalendarApp has NO public navigation methods. We access the private $app
@@ -609,7 +629,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
 
         // Compare with the store's expected range for the current view
         const storeState = useCalendarStore.getState()
-        const storeRange = getViewRange(storeState.currentDate, storeState.currentView)
+        const currentFirstDay = usePreferencesStore.getState().firstDayOfWeek
+        const storeRange = getViewRange(storeState.currentDate, storeState.currentView, currentFirstDay)
 
         // Allow 1-day tolerance (month views may extend into adjacent months)
         const startDiff = Math.abs(sxRangeStart.getTime() - storeRange.start.getTime())

--- a/apps/web/app/(app)/calendar/components/MiniCalendar.tsx
+++ b/apps/web/app/(app)/calendar/components/MiniCalendar.tsx
@@ -7,9 +7,8 @@ import { expandRecurrence, type CalendarEvent } from '@silentsuite/core'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
-import { formatDate } from '@/app/lib/date'
+import { formatDate, weekStartIndex, weekdayLabels } from '@/app/lib/date'
 
-const WEEKDAY_LABELS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
 const FALLBACK_CALENDAR_COLOR = '#10b981'
 const MAX_DOTS_PER_DAY = 4
 
@@ -106,6 +105,8 @@ export function MiniCalendar() {
 
   const today = useMemo(() => new Date(), [])
   const dateFormat = usePreferencesStore((s) => s.dateFormat)
+  const firstDayOfWeek = usePreferencesStore((s) => s.firstDayOfWeek)
+  const weekdays = useMemo(() => weekdayLabels(firstDayOfWeek), [firstDayOfWeek])
 
   const handleDayClick = useCallback(
     (date: Date) => {
@@ -138,9 +139,9 @@ export function MiniCalendar() {
 
   const days = useMemo((): DayCell[] => {
     const firstOfMonth = new Date(miniYear, miniMonth, 1)
-    // Monday = 0, Sunday = 6
-    let startDow = firstOfMonth.getDay() - 1
-    if (startDow < 0) startDow = 6
+    // Number of leading cells from the previous month, honoring the first-day
+    // preference (0 when the month starts on the configured first day).
+    const startDow = (firstOfMonth.getDay() - weekStartIndex(firstDayOfWeek) + 7) % 7
 
     const cellDates: { date: Date; inCurrentMonth: boolean }[] = []
 
@@ -189,7 +190,7 @@ export function MiniCalendar() {
       isSelected: isSameDay(cell.date, currentDate),
       eventDotColors: dotsByDay.get(dateKey(cell.date)) ?? [],
     }))
-  }, [miniYear, miniMonth, currentDate, events, today, calendarColors, visibleCalendarIds])
+  }, [miniYear, miniMonth, currentDate, events, today, calendarColors, visibleCalendarIds, firstDayOfWeek])
 
   const monthLabel = formatDate(new Date(miniYear, miniMonth), 'system', { month: 'long', year: 'numeric' })
 
@@ -222,7 +223,7 @@ export function MiniCalendar() {
 
       {/* Weekday headers */}
       <div className="grid grid-cols-7 mb-1">
-        {WEEKDAY_LABELS.map((label) => (
+        {weekdays.map((label) => (
           <div key={label} className="text-center text-[10px] font-medium text-[rgb(var(--muted))]">
             {label}
           </div>

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useMemo, useState } from 'react'
 import { ChevronLeft, ChevronRight, Plus, Folder, Search as SearchIcon } from 'lucide-react'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
-import { formatDate } from '@/app/lib/date'
+import { formatDate, startOfWeek, getWeekNumber } from '@/app/lib/date'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
@@ -28,31 +28,33 @@ function snapTo30Min(date: Date): Date {
   return snapped
 }
 
-function formatDateRange(date: Date, view: 'week' | 'month', dateFormat: import('@silentsuite/core').DateFormat): string {
+function formatDateRange(
+  date: Date,
+  view: 'week' | 'month',
+  dateFormat: import('@silentsuite/core').DateFormat,
+  firstDay: import('@silentsuite/core').FirstDayOfWeek,
+): string {
   const opts: Intl.DateTimeFormatOptions = { month: 'long', year: 'numeric' }
 
   if (view === 'month') {
     return formatDate(date, dateFormat, opts)
   }
 
-  // Week view: find Monday of the week
-  const day = date.getDay()
-  const mondayOffset = day === 0 ? -6 : 1 - day
-  const monday = new Date(date)
-  monday.setDate(date.getDate() + mondayOffset)
-  const sunday = new Date(monday)
-  sunday.setDate(monday.getDate() + 6)
+  // Week view: derive the week start/end from the first-day preference
+  const weekStart = startOfWeek(date, firstDay)
+  const weekEnd = new Date(weekStart)
+  weekEnd.setDate(weekStart.getDate() + 6)
 
-  const startMonth = formatDate(monday, 'system', { month: 'long' })
-  const endMonth = formatDate(sunday, 'system', { month: 'long' })
+  const startMonth = formatDate(weekStart, 'system', { month: 'long' })
+  const endMonth = formatDate(weekEnd, 'system', { month: 'long' })
 
-  if (monday.getMonth() === sunday.getMonth()) {
-    return `${startMonth} ${monday.getDate()}–${sunday.getDate()}, ${monday.getFullYear()}`
+  if (weekStart.getMonth() === weekEnd.getMonth()) {
+    return `${startMonth} ${weekStart.getDate()}–${weekEnd.getDate()}, ${weekStart.getFullYear()}`
   }
-  if (monday.getFullYear() === sunday.getFullYear()) {
-    return `${startMonth} ${monday.getDate()} – ${endMonth} ${sunday.getDate()}, ${monday.getFullYear()}`
+  if (weekStart.getFullYear() === weekEnd.getFullYear()) {
+    return `${startMonth} ${weekStart.getDate()} – ${endMonth} ${weekEnd.getDate()}, ${weekStart.getFullYear()}`
   }
-  return `${startMonth} ${monday.getDate()}, ${monday.getFullYear()} – ${endMonth} ${sunday.getDate()}, ${sunday.getFullYear()}`
+  return `${startMonth} ${weekStart.getDate()}, ${weekStart.getFullYear()} – ${endMonth} ${weekEnd.getDate()}, ${weekEnd.getFullYear()}`
 }
 
 function CalendarSkeleton() {
@@ -102,14 +104,23 @@ export default function CalendarPage() {
   const setSelectedEvent = useCalendarStore((s) => s.setSelectedEvent)
   const calendars = useCalendarListStore((s) => s.calendars)
   const dateFormat = usePreferencesStore((s) => s.dateFormat)
+  const firstDayOfWeek = usePreferencesStore((s) => s.firstDayOfWeek)
 
   const [createDialog, setCreateDialog] = useState<CreateDialogState | null>(null)
   const [eventInstanceDate, setEventInstanceDate] = useState<Date | undefined>(undefined)
   const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
 
   const dateLabel = useMemo(
-    () => formatDateRange(currentDate, currentView, dateFormat),
-    [currentDate, currentView, dateFormat],
+    () => formatDateRange(currentDate, currentView, dateFormat, firstDayOfWeek),
+    [currentDate, currentView, dateFormat, firstDayOfWeek],
+  )
+
+  // Active calendar-week indicator (#292). Shown in week view; respects the
+  // first-day-of-week preference (ISO-8601 for Monday-start). Updates as the
+  // user navigates because it derives from currentDate.
+  const weekNumber = useMemo(
+    () => (currentView === 'week' ? getWeekNumber(currentDate, firstDayOfWeek) : null),
+    [currentView, currentDate, firstDayOfWeek],
   )
 
   const visibleCalendarIds = useMemo(
@@ -195,6 +206,14 @@ export default function CalendarPage() {
             <ChevronRight className="h-5 w-5" />
           </button>
           <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">{dateLabel}</h2>
+          {weekNumber !== null && (
+            <span
+              className="rounded-md bg-[rgb(var(--surface))] px-2 py-0.5 text-xs font-medium text-[rgb(var(--muted))]"
+              title="Calendar week"
+            >
+              Week {weekNumber}
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <CalendarViewSwitcher />
@@ -251,7 +270,17 @@ export default function CalendarPage() {
             <Folder className="h-5 w-5" />
           </button>
         </div>
-        <h2 className="text-base font-semibold text-[rgb(var(--foreground))] px-1">{dateLabel}</h2>
+        <div className="flex items-center gap-2 px-1">
+          <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">{dateLabel}</h2>
+          {weekNumber !== null && (
+            <span
+              className="rounded-md bg-[rgb(var(--surface))] px-2 py-0.5 text-xs font-medium text-[rgb(var(--muted))]"
+              title="Calendar week"
+            >
+              Week {weekNumber}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Content */}

--- a/apps/web/app/lib/__tests__/date.test.ts
+++ b/apps/web/app/lib/__tests__/date.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  endOfWeek,
+  getWeekNumber,
+  startOfWeek,
+  weekdayLabels,
+  weekStartIndex,
+} from '../date'
+
+function ymd(date: Date): string {
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${date.getFullYear()}-${m}-${d}`
+}
+
+describe('weekStartIndex', () => {
+  it('maps the preference to a JS getDay() index', () => {
+    expect(weekStartIndex('monday')).toBe(1)
+    expect(weekStartIndex('sunday')).toBe(0)
+  })
+})
+
+describe('weekdayLabels', () => {
+  it('orders labels from Monday for monday-start', () => {
+    expect(weekdayLabels('monday')).toEqual(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'])
+  })
+
+  it('orders labels from Sunday for sunday-start', () => {
+    expect(weekdayLabels('sunday')).toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'])
+  })
+})
+
+describe('startOfWeek', () => {
+  // 2026-06-20 is a Saturday.
+  const saturday = new Date(2026, 5, 20, 14, 30)
+
+  it('returns the Monday of the week for monday-start', () => {
+    const start = startOfWeek(saturday, 'monday')
+    expect(ymd(start)).toBe('2026-06-15') // Monday
+    expect(start.getHours()).toBe(0)
+  })
+
+  it('returns the Sunday of the week for sunday-start', () => {
+    const start = startOfWeek(saturday, 'sunday')
+    expect(ymd(start)).toBe('2026-06-14') // Sunday
+  })
+
+  it('is idempotent on the first day itself', () => {
+    const monday = new Date(2026, 5, 15)
+    expect(ymd(startOfWeek(monday, 'monday'))).toBe('2026-06-15')
+    const sunday = new Date(2026, 5, 14)
+    expect(ymd(startOfWeek(sunday, 'sunday'))).toBe('2026-06-14')
+  })
+})
+
+describe('endOfWeek', () => {
+  const saturday = new Date(2026, 5, 20, 14, 30)
+
+  it('returns the Sunday end-of-day for monday-start', () => {
+    const end = endOfWeek(saturday, 'monday')
+    expect(ymd(end)).toBe('2026-06-21') // Sunday
+    expect(end.getHours()).toBe(23)
+    expect(end.getMinutes()).toBe(59)
+  })
+
+  it('returns the Saturday end-of-day for sunday-start', () => {
+    const end = endOfWeek(saturday, 'sunday')
+    expect(ymd(end)).toBe('2026-06-20') // Saturday
+    expect(end.getHours()).toBe(23)
+  })
+})
+
+describe('getWeekNumber (monday-start = ISO-8601)', () => {
+  it('week containing the first Thursday is week 1', () => {
+    // 2026-01-01 is a Thursday → ISO 2026-W01.
+    expect(getWeekNumber(new Date(2026, 0, 1), 'monday')).toBe(1)
+  })
+
+  it('late-December dates can belong to week 1 of the next year', () => {
+    // 2024-12-30 (Monday) → ISO 2025-W01.
+    expect(getWeekNumber(new Date(2024, 11, 30), 'monday')).toBe(1)
+  })
+
+  it('early-January dates can belong to the last week of the previous year', () => {
+    // 2023-01-01 (Sunday) → ISO 2022-W52.
+    expect(getWeekNumber(new Date(2023, 0, 1), 'monday')).toBe(52)
+  })
+
+  it('computes a mid-year week number', () => {
+    // Week of Mon 2026-06-15 → ISO week 25.
+    expect(getWeekNumber(new Date(2026, 5, 20), 'monday')).toBe(25)
+    expect(getWeekNumber(new Date(2026, 5, 15), 'monday')).toBe(25)
+  })
+
+  it('gives every day in the same week the same number', () => {
+    const numbers = new Set<number>()
+    for (let day = 15; day <= 21; day++) {
+      numbers.add(getWeekNumber(new Date(2026, 5, day), 'monday'))
+    }
+    expect(numbers).toEqual(new Set([25]))
+  })
+})
+
+describe('getWeekNumber (sunday-start convention)', () => {
+  it('numbers by the week-numbering year of the week Wednesday (4th day)', () => {
+    // For sunday-start, the week Sun 2025-12-28 – Sat 2026-01-03 has its
+    // Wednesday (2025-12-31) in 2025, so week 1 of 2026 starts Sun 2026-01-04.
+    // The week of Sat 2026-06-20 (starting Sun 2026-06-14) is therefore week 24.
+    expect(getWeekNumber(new Date(2026, 5, 20), 'sunday')).toBe(24)
+    expect(getWeekNumber(new Date(2026, 5, 14), 'sunday')).toBe(24)
+  })
+
+  it('gives every day in the same sunday-start week the same number', () => {
+    const numbers = new Set<number>()
+    for (let day = 14; day <= 20; day++) {
+      numbers.add(getWeekNumber(new Date(2026, 5, day), 'sunday'))
+    }
+    expect(numbers).toEqual(new Set([24]))
+  })
+})

--- a/apps/web/app/lib/date.ts
+++ b/apps/web/app/lib/date.ts
@@ -1,7 +1,81 @@
-import type { DateFormat } from '@silentsuite/core'
+import type { DateFormat, FirstDayOfWeek } from '@silentsuite/core'
 
 function pad(n: number) {
   return String(n).padStart(2, '0')
+}
+
+/**
+ * JS `Date.getDay()` index (0 = Sunday … 6 = Saturday) of the configured first
+ * day of the week. Monday-start → 1, Sunday-start → 0.
+ */
+export function weekStartIndex(firstDay: FirstDayOfWeek): number {
+  return firstDay === 'sunday' ? 0 : 1
+}
+
+/**
+ * Start-of-day `Date` for the week containing `date`, honoring the first-day
+ * preference. The returned date is at local midnight.
+ */
+export function startOfWeek(date: Date, firstDay: FirstDayOfWeek): Date {
+  const startIdx = weekStartIndex(firstDay)
+  const diff = (date.getDay() - startIdx + 7) % 7
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - diff)
+}
+
+/**
+ * End-of-day `Date` (23:59:59.999) for the last day of the week containing
+ * `date`, honoring the first-day preference.
+ */
+export function endOfWeek(date: Date, firstDay: FirstDayOfWeek): Date {
+  const start = startOfWeek(date, firstDay)
+  const end = new Date(start)
+  end.setDate(start.getDate() + 6)
+  end.setHours(23, 59, 59, 999)
+  return end
+}
+
+const WEEKDAY_SHORT = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const
+
+/**
+ * Two-letter weekday labels ordered starting from the configured first day.
+ * Monday-start → `['Mo','Tu',…,'Su']`; Sunday-start → `['Su','Mo',…,'Sa']`.
+ */
+export function weekdayLabels(firstDay: FirstDayOfWeek): string[] {
+  const startIdx = weekStartIndex(firstDay)
+  return Array.from({ length: 7 }, (_, i) => WEEKDAY_SHORT[(startIdx + i) % 7]!)
+}
+
+/**
+ * Calendar week number for `date`, honoring the first-day preference.
+ *
+ * For Monday-start this is exactly ISO-8601: weeks run Monday–Sunday and the
+ * week-numbering year is the year containing that week's Thursday (its 4th day),
+ * so week 1 is the week containing the year's first Thursday.
+ *
+ * Sunday-start uses the same algorithm generalized: weeks run Sunday–Saturday
+ * and a week belongs to the year containing its Wednesday (the 4th day of a
+ * Sunday-start week). This keeps numbering stable and ~aligned with ISO while
+ * matching the user's chosen week boundaries. It is NOT the ISO standard, which
+ * is only defined for Monday-start weeks.
+ */
+export function getWeekNumber(date: Date, firstDay: FirstDayOfWeek): number {
+  const weekStart = startOfWeek(date, firstDay)
+  // The 4th day of the week (Thursday for Monday-start, Wednesday for
+  // Sunday-start) determines the week-numbering year.
+  const anchor = new Date(weekStart)
+  anchor.setDate(anchor.getDate() + 3)
+  const weekYear = anchor.getFullYear()
+
+  // Locate the start of week 1: the first week whose anchor falls in weekYear.
+  const firstWeekStart = startOfWeek(new Date(weekYear, 0, 1), firstDay)
+  const firstAnchor = new Date(firstWeekStart)
+  firstAnchor.setDate(firstAnchor.getDate() + 3)
+  const week1Start = firstAnchor.getFullYear() === weekYear
+    ? firstWeekStart
+    : new Date(firstWeekStart.getFullYear(), firstWeekStart.getMonth(), firstWeekStart.getDate() + 7)
+
+  const diffMs = weekStart.getTime() - week1Start.getTime()
+  return Math.round(diffMs / (7 * 24 * 60 * 60 * 1000)) + 1
 }
 
 export function formatDate(input: Date | string | number, format: DateFormat = 'system', options?: Intl.DateTimeFormatOptions, locale?: string) {


### PR DESCRIPTION
## Summary
- apply the synced first-day-of-week preference to Schedule-X calendar range math, mini calendar labels/grid, and calendar date labels
- add documented shared week helpers, including ISO Monday week numbers and a documented Sunday-start convention
- show the active week number in week view on desktop and mobile calendar headers

Closes #290.
Closes #292.

## Validation
- `corepack pnpm --filter @silentsuite/web test -- apps/web/app/lib/__tests__/date.test.ts` — passed (27 files / 293 tests)
- `corepack pnpm --filter @silentsuite/web type-check` — passed
- `corepack pnpm --filter @silentsuite/web lint` — passed with existing warnings
- `corepack pnpm --filter @silentsuite/web build` — passed with existing Sentry/standalone trace warnings