### PR TITLE
feat(web): add labels/categories for events, tasks, and contacts

### DIFF
--- a/apps/web/app/(app)/calendar/components/AgendaView.tsx
+++ b/apps/web/app/(app)/calendar/components/AgendaView.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react'
 import { Clock, MapPin } from 'lucide-react'
 import { CalendarEmptyState } from '@/app/components/empty-state'
+import { LabelChips } from '@/app/components/LabelEditor'
 import type { CalendarEvent } from '@silentsuite/core'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { resolveUserTimezone, shortTimezoneLabel } from '@/app/lib/tz'
@@ -99,6 +100,7 @@ export function AgendaView({ events, currentDate, onEventClick }: AgendaViewProp
                   {event.description}
                 </p>
               )}
+              <LabelChips labels={event.categories} className="mt-1.5" />
             </div>
           </div>
         </button>

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Trash2, MapPin, Clock, AlignLeft, Repeat, Pencil, Bell, X, CalendarDays, Tag } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { LabelEditor } from '@/app/components/LabelEditor'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
@@ -127,6 +128,7 @@ export function EventDialog({
 
   const canWrite = useAuthStore((s) => s.canWrite())
   const notifications = useNotifications()
+  const t = useTranslations('Labels')
   const defaultReminder = usePreferencesStore((s) => s.defaultReminder)
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
   const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
@@ -317,7 +319,7 @@ export function EventDialog({
         if (newStart.getTime() !== event.startDate.getTime()) patch.startDate = newStart
         if (effectiveEnd.getTime() !== event.endDate.getTime()) patch.endDate = effectiveEnd
         if (recurrenceRule !== event.recurrenceRule) patch.recurrenceRule = recurrenceRule
-        if (categories.join(' ') !== (event.categories ?? []).join(' ')) patch.categories = categories
+        if (JSON.stringify(categories) !== JSON.stringify(event.categories ?? [])) patch.categories = categories
         if (timezone !== (event.timezone ?? defaultTimezone)) patch.timezone = timezone
         if (selectedCalendarId !== (event.calendarId ?? defaultCalendarId)) patch.calendarId = selectedCalendarId
 
@@ -633,8 +635,7 @@ export function EventDialog({
                   labels={categories}
                   onChange={setCategories}
                   disabled={!canWrite}
-                  placeholder="Add label"
-                  aria-label="Event labels"
+                  aria-label={t('eventLabels')}
                 />
               </div>
 

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Trash2, MapPin, Clock, AlignLeft, Repeat, Pencil, Bell, X, CalendarDays } from 'lucide-react'
+import { Trash2, MapPin, Clock, AlignLeft, Repeat, Pencil, Bell, X, CalendarDays, Tag } from 'lucide-react'
+import { LabelEditor } from '@/app/components/LabelEditor'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
@@ -172,6 +173,9 @@ export function EventDialog({
   const [recurrenceRule, setRecurrenceRule] = useState<string | null>(
     isEdit ? event.recurrenceRule : null,
   )
+  const [categories, setCategories] = useState<string[]>(
+    isEdit ? (event.categories ?? []) : [],
+  )
   const [alarms, setAlarms] = useState<string[]>(() => {
     if (isEdit && event.alarms && event.alarms.length > 0) {
       return event.alarms
@@ -313,6 +317,7 @@ export function EventDialog({
         if (newStart.getTime() !== event.startDate.getTime()) patch.startDate = newStart
         if (effectiveEnd.getTime() !== event.endDate.getTime()) patch.endDate = effectiveEnd
         if (recurrenceRule !== event.recurrenceRule) patch.recurrenceRule = recurrenceRule
+        if (categories.join(' ') !== (event.categories ?? []).join(' ')) patch.categories = categories
         if (timezone !== (event.timezone ?? defaultTimezone)) patch.timezone = timezone
         if (selectedCalendarId !== (event.calendarId ?? defaultCalendarId)) patch.calendarId = selectedCalendarId
 
@@ -353,6 +358,7 @@ export function EventDialog({
           endDate: effectiveEnd,
           allDay,
           recurrenceRule,
+          categories,
           timezone,
           calendarId: selectedCalendarId,
           alarms: alarms
@@ -375,6 +381,7 @@ export function EventDialog({
     location,
     allDay,
     recurrenceRule,
+    categories,
     alarms,
     selectedCalendarId,
     timezone,
@@ -616,6 +623,18 @@ export function EventDialog({
                   aria-label="Event location"
                   readOnly={!canWrite}
                   className={`flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
+                />
+              </div>
+
+              {/* ---- Labels / categories ---- */}
+              <div className="flex items-start gap-3">
+                <Tag className="mt-2.5 h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                <LabelEditor
+                  labels={categories}
+                  onChange={setCategories}
+                  disabled={!canWrite}
+                  placeholder="Add label"
+                  aria-label="Event labels"
                 />
               </div>
 

--- a/apps/web/app/(app)/calendar/components/__tests__/EventDialog.test.tsx
+++ b/apps/web/app/(app)/calendar/components/__tests__/EventDialog.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import type { CalendarEvent } from '@silentsuite/core'
 import { EventDialog } from '../EventDialog'
+import { renderWithIntl } from '@/src/__tests__/render-with-intl'
 
 const mocks = vi.hoisted(() => ({
   createEvent: vi.fn(),
@@ -72,7 +73,7 @@ vi.mock('@/app/lib/use-focus-trap', () => ({
   useFocusTrap: vi.fn(),
 }))
 
-function makeEvent(): CalendarEvent {
+function makeEvent(overrides?: Partial<CalendarEvent>): CalendarEvent {
   return {
     id: 'event-item-1',
     uid: 'stable-event-uid',
@@ -89,6 +90,7 @@ function makeEvent(): CalendarEvent {
     timezone: 'UTC',
     created: new Date('2026-06-01T08:00:00Z'),
     updated: new Date('2026-06-01T08:00:00Z'),
+    ...overrides,
   }
 }
 
@@ -104,7 +106,7 @@ describe('EventDialog edit calendar selection', () => {
   })
 
   it('includes calendarId in the edit patch when the selected calendar changes', async () => {
-    render(<EventDialog mode="edit" event={makeEvent()} onClose={mocks.onClose} />)
+    renderWithIntl(<EventDialog mode="edit" event={makeEvent()} onClose={mocks.onClose} />)
 
     fireEvent.click(screen.getByRole('button', { name: /Family/ }))
     fireEvent.click(screen.getByRole('button', { name: 'Done' }))
@@ -116,5 +118,27 @@ describe('EventDialog edit calendar selection', () => {
       )
     })
     expect(mocks.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits a categories update when labels split from ["WorkHome"] to ["Work","Home"]', async () => {
+    const event = makeEvent({ categories: ['WorkHome'] })
+
+    renderWithIntl(<EventDialog mode="edit" event={event} onClose={mocks.onClose} />)
+
+    // Replace the single "WorkHome" label with two labels "Work" and "Home".
+    fireEvent.click(screen.getByLabelText('Remove label WorkHome'))
+    const input = screen.getByLabelText('Event labels')
+    fireEvent.change(input, { target: { value: 'Work' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.change(input, { target: { value: 'Home' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    await waitFor(() => {
+      expect(mocks.updateEvent).toHaveBeenCalledWith(
+        'event-item-1',
+        expect.objectContaining({ categories: ['Work', 'Home'] }),
+      )
+    })
   })
 })

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -5,6 +5,7 @@ import {
   Search, ArrowLeft, Phone, Mail, MapPin, Building2, Cake,
   StickyNote, User, WifiOff, Plus, Trash2, X, Pencil, Camera, BookUser, List, Folder, Tag,
 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { LabelEditor, LabelChips } from '@/app/components/LabelEditor'
 import { useContactStore, getFilteredContacts } from '@/app/stores/use-contact-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
@@ -243,6 +244,7 @@ function ContactForm({
   const photoInputRef = useRef<HTMLInputElement>(null)
   const modalRef = useRef<HTMLDivElement>(null)
   const [nameError, setNameError] = useState(false)
+  const t = useTranslations('Labels')
 
   // Focus trap: keep Tab cycling within the modal
   useFocusTrap(modalRef)
@@ -521,12 +523,11 @@ function ContactForm({
 
           {/* Labels / categories */}
           <fieldset className="space-y-2">
-            <legend className="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">Labels</legend>
+            <legend className="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">{t('sectionTitle')}</legend>
             <LabelEditor
               labels={categories}
               onChange={setCategories}
-              placeholder="Add label"
-              aria-label="Contact labels"
+              aria-label={t('contactLabels')}
             />
           </fieldset>
 
@@ -641,6 +642,7 @@ function ContactDetail({
   const photoInputRef = useRef<HTMLInputElement>(null)
   const [editing, setEditing] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState(false)
+  const t = useTranslations('Labels')
 
   const handlePhotoChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -873,7 +875,7 @@ function ContactDetail({
             </DetailSection>
           )}
           {contact.categories && contact.categories.length > 0 && (
-            <DetailSection icon={<Tag className="h-4 w-4" />} title="Labels">
+            <DetailSection icon={<Tag className="h-4 w-4" />} title={t('sectionTitle')}>
               <LabelChips labels={contact.categories} />
             </DetailSection>
           )}
@@ -1037,13 +1039,12 @@ function ContactDetail({
         </DetailSection>
 
         {/* Labels */}
-        <DetailSection icon={<Tag className="h-4 w-4" />} title="Labels">
+        <DetailSection icon={<Tag className="h-4 w-4" />} title={t('sectionTitle')}>
           <LabelEditor
             labels={contact.categories ?? []}
             onChange={(next) => handleFieldUpdate({ categories: next })}
             disabled={!canWrite}
-            placeholder="Add label"
-            aria-label="Contact labels"
+            aria-label={t('contactLabels')}
           />
         </DetailSection>
       </div>

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -3,8 +3,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   Search, ArrowLeft, Phone, Mail, MapPin, Building2, Cake,
-  StickyNote, User, WifiOff, Plus, Trash2, X, Pencil, Camera, BookUser, List, Folder,
+  StickyNote, User, WifiOff, Plus, Trash2, X, Pencil, Camera, BookUser, List, Folder, Tag,
 } from 'lucide-react'
+import { LabelEditor, LabelChips } from '@/app/components/LabelEditor'
 import { useContactStore, getFilteredContacts } from '@/app/stores/use-contact-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
@@ -278,6 +279,7 @@ function ContactForm({
   const [title, setTitle] = useState('')
   const [birthday, setBirthday] = useState('')
   const [notes, setNotes] = useState('')
+  const [categories, setCategories] = useState<string[]>([])
 
   const handlePhotoChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -307,11 +309,12 @@ function ContactForm({
         birthday: birthday || null,
         notes,
         photoUrl,
+        categories,
         listId: selectedListId,
       })
       onSaved(contact.id)
     },
-    [given, family, prefix, suffix, phones, emails, addresses, organization, title, birthday, notes, photoUrl, selectedListId, createContact, onSaved],
+    [given, family, prefix, suffix, phones, emails, addresses, organization, title, birthday, notes, photoUrl, categories, selectedListId, createContact, onSaved],
   )
 
   // Validate name on blur — show error if both given and family are empty
@@ -514,6 +517,17 @@ function ContactForm({
             <legend className="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">Personal</legend>
             <input type="date" value={birthday} onChange={(e) => setBirthday(e.target.value)} aria-label="Birthday" className={INPUT_CLASS} />
             <textarea value={notes} onChange={(e) => setNotes(e.target.value)} placeholder="Notes" aria-label="Notes" rows={3} className={`${INPUT_CLASS} resize-none`} />
+          </fieldset>
+
+          {/* Labels / categories */}
+          <fieldset className="space-y-2">
+            <legend className="text-xs font-medium uppercase tracking-wide text-[rgb(var(--muted))]">Labels</legend>
+            <LabelEditor
+              labels={categories}
+              onChange={setCategories}
+              placeholder="Add label"
+              aria-label="Contact labels"
+            />
           </fieldset>
 
           {/* Actions */}
@@ -858,6 +872,11 @@ function ContactDetail({
               )}
             </DetailSection>
           )}
+          {contact.categories && contact.categories.length > 0 && (
+            <DetailSection icon={<Tag className="h-4 w-4" />} title="Labels">
+              <LabelChips labels={contact.categories} />
+            </DetailSection>
+          )}
         </div>
         {deleteConfirmDialog}
       </div>
@@ -1014,6 +1033,17 @@ function ContactDetail({
             onChange={(v) => handleFieldUpdate({ notes: v })}
             placeholder="Notes"
             multiline
+          />
+        </DetailSection>
+
+        {/* Labels */}
+        <DetailSection icon={<Tag className="h-4 w-4" />} title="Labels">
+          <LabelEditor
+            labels={contact.categories ?? []}
+            onChange={(next) => handleFieldUpdate({ categories: next })}
+            disabled={!canWrite}
+            placeholder="Add label"
+            aria-label="Contact labels"
           />
         </DetailSection>
       </div>

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useCallback, useMemo, useState, useRef, useEffect } from 'react'
-import { X, ChevronDown, Calendar, Flag, WifiOff, Plus, AlignLeft, Pencil, List, Folder } from 'lucide-react'
+import { X, ChevronDown, Calendar, Flag, WifiOff, Plus, AlignLeft, Pencil, List, Folder, Tag } from 'lucide-react'
+import { LabelEditor, LabelChips } from '@/app/components/LabelEditor'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
 import { useSyncStore } from '@/app/stores/use-sync-store'
@@ -182,6 +183,7 @@ function TaskDialog({
       : '',
   )
   const [priority, setPriority] = useState<Priority>(task?.priority ?? 'medium')
+  const [categories, setCategories] = useState<string[]>(task?.categories ?? [])
   const [selectedListId, setSelectedListId] = useState(task?.listId ?? defaultListId)
 
   useEffect(() => {
@@ -214,6 +216,7 @@ function TaskDialog({
         description,
         due_date: parsedDue,
         priority,
+        categories,
         listId: selectedListId,
       })
     } else if (task) {
@@ -222,11 +225,12 @@ function TaskDialog({
         description,
         due_date: parsedDue,
         priority,
+        categories,
         listId: selectedListId,
       })
     }
     onClose()
-  }, [title, description, dueDate, priority, selectedListId, mode, task, createTask, updateTask, onClose])
+  }, [title, description, dueDate, priority, categories, selectedListId, mode, task, createTask, updateTask, onClose])
 
   return (
     <>
@@ -341,6 +345,17 @@ function TaskDialog({
                   </button>
                 ))}
               </div>
+            </div>
+
+            {/* Labels / categories */}
+            <div className="flex items-start gap-3">
+              <Tag className="mt-2.5 h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+              <LabelEditor
+                labels={categories}
+                onChange={setCategories}
+                placeholder="Add label"
+                aria-label="Task labels"
+              />
             </div>
 
             {/* Description / Notes */}
@@ -619,6 +634,7 @@ function TaskItem({ task }: { task: Task }) {
               {task.title || 'Untitled task'}
             </span>
           )}
+          {!expanded && <LabelChips labels={task.categories} className="mt-1" />}
         </div>
 
         {/* Badges */}
@@ -678,6 +694,16 @@ function TaskItem({ task }: { task: Task }) {
             readOnly={!canWrite}
             className={`w-full resize-none rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] px-3 py-2 text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none focus:ring-1 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
           />
+          <div className="flex items-start gap-2">
+            <Tag className="mt-2.5 h-3.5 w-3.5 shrink-0 text-[rgb(var(--muted))]" />
+            <LabelEditor
+              labels={task.categories ?? []}
+              onChange={(next) => canWrite && updateTask(task.id, { categories: next })}
+              disabled={!canWrite}
+              placeholder="Add label"
+              aria-label="Task labels"
+            />
+          </div>
         </div>
       )}
 

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState, useRef, useEffect } from 'react'
 import { X, ChevronDown, Calendar, Flag, WifiOff, Plus, AlignLeft, Pencil, List, Folder, Tag } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 import { LabelEditor, LabelChips } from '@/app/components/LabelEditor'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
@@ -165,6 +166,7 @@ function TaskDialog({
   const activeListId = useTaskListStore((s) => s.activeListId)
   const titleRef = useRef<HTMLInputElement>(null)
   const dialogRef = useRef<HTMLDivElement>(null)
+  const t = useTranslations('Labels')
 
   // Focus trap: keep Tab cycling within the dialog
   useFocusTrap(dialogRef)
@@ -353,8 +355,7 @@ function TaskDialog({
               <LabelEditor
                 labels={categories}
                 onChange={setCategories}
-                placeholder="Add label"
-                aria-label="Task labels"
+                aria-label={t('taskLabels')}
               />
             </div>
 
@@ -528,6 +529,7 @@ function TaskItem({ task }: { task: Task }) {
   const deleteTask = useTaskStore((s) => s.deleteTask)
   const toggleComplete = useTaskStore((s) => s.toggleComplete)
   const canWrite = useAuthStore((s) => s.canWrite())
+  const t = useTranslations('Labels')
 
   const [expanded, setExpanded] = useState(false)
   const [editingTitle, setEditingTitle] = useState(false)
@@ -700,8 +702,7 @@ function TaskItem({ task }: { task: Task }) {
               labels={task.categories ?? []}
               onChange={(next) => canWrite && updateTask(task.id, { categories: next })}
               disabled={!canWrite}
-              placeholder="Add label"
-              aria-label="Task labels"
+              aria-label={t('taskLabels')}
             />
           </div>
         </div>

--- a/apps/web/app/components/LabelEditor.tsx
+++ b/apps/web/app/components/LabelEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from 'react'
 import { Tag, X } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
 // ---------------------------------------------------------------------------
 // Shared label / category chip components (#291)
@@ -41,9 +42,9 @@ export function LabelChips({
   if (!labels || labels.length === 0) return null
   return (
     <div className={`flex flex-wrap gap-1.5 ${className}`}>
-      {labels.map((label) => (
+      {labels.map((label, index) => (
         <span
-          key={label}
+          key={`${label}-${index}`}
           className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300"
         >
           <Tag className="h-3 w-3" />
@@ -62,8 +63,8 @@ export function LabelEditor({
   labels,
   onChange,
   disabled = false,
-  placeholder = 'Add label…',
-  'aria-label': ariaLabel = 'Labels',
+  placeholder,
+  'aria-label': ariaLabel,
 }: {
   labels: string[]
   onChange: (next: string[]) => void
@@ -71,6 +72,7 @@ export function LabelEditor({
   placeholder?: string
   'aria-label'?: string
 }) {
+  const t = useTranslations('Labels')
   const [input, setInput] = useState('')
 
   const commit = useCallback(
@@ -104,9 +106,9 @@ export function LabelEditor({
 
   return (
     <div className="flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">
-      {labels.map((label) => (
+      {labels.map((label, index) => (
         <span
-          key={label}
+          key={`${label}-${index}`}
           className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300"
         >
           <Tag className="h-3 w-3" />
@@ -115,8 +117,8 @@ export function LabelEditor({
             <button
               type="button"
               onClick={() => remove(label)}
-              className="rounded-full p-0.5 hover:text-red-500 transition-colors"
-              aria-label={`Remove label ${label}`}
+              className="rounded-full p-1 hover:text-red-500 transition-colors max-md:min-h-[44px] max-md:min-w-[44px] max-md:flex max-md:items-center max-md:justify-center max-md:-my-2 max-md:-mx-1.5"
+              aria-label={t('removeLabel', { label })}
             >
               <X className="h-3 w-3" />
             </button>
@@ -130,8 +132,8 @@ export function LabelEditor({
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}
           onBlur={() => input.trim() && commit(input)}
-          placeholder={labels.length === 0 ? placeholder : ''}
-          aria-label={ariaLabel}
+          placeholder={labels.length === 0 ? (placeholder ?? t('addLabelPlaceholder')) : ''}
+          aria-label={ariaLabel ?? t('editorAriaLabel')}
           className="min-w-[6rem] flex-1 bg-transparent text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none"
         />
       )}

--- a/apps/web/app/components/LabelEditor.tsx
+++ b/apps/web/app/components/LabelEditor.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { Tag, X } from 'lucide-react'
+
+// ---------------------------------------------------------------------------
+// Shared label / category chip components (#291)
+//
+// Labels round-trip through ICS/vCard CATEGORIES in the core layer. These
+// components provide a consistent add/remove/display affordance across the
+// calendar, tasks, and contacts UIs.
+// ---------------------------------------------------------------------------
+
+/** Normalize a raw label list: trim, drop empties, de-dupe case-insensitively
+ *  while preserving the first-seen casing and order. */
+export function normalizeLabels(labels: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const raw of labels) {
+    const trimmed = raw.trim()
+    if (!trimmed) continue
+    const key = trimmed.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(trimmed)
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// LabelChips — read-only display
+// ---------------------------------------------------------------------------
+
+export function LabelChips({
+  labels,
+  className = '',
+}: {
+  labels: string[] | undefined
+  className?: string
+}) {
+  if (!labels || labels.length === 0) return null
+  return (
+    <div className={`flex flex-wrap gap-1.5 ${className}`}>
+      {labels.map((label) => (
+        <span
+          key={label}
+          className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300"
+        >
+          <Tag className="h-3 w-3" />
+          {label}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// LabelEditor — add / remove chips
+// ---------------------------------------------------------------------------
+
+export function LabelEditor({
+  labels,
+  onChange,
+  disabled = false,
+  placeholder = 'Add label…',
+  'aria-label': ariaLabel = 'Labels',
+}: {
+  labels: string[]
+  onChange: (next: string[]) => void
+  disabled?: boolean
+  placeholder?: string
+  'aria-label'?: string
+}) {
+  const [input, setInput] = useState('')
+
+  const commit = useCallback(
+    (raw: string) => {
+      const next = normalizeLabels([...labels, raw])
+      if (next.length !== labels.length) onChange(next)
+      setInput('')
+    },
+    [labels, onChange],
+  )
+
+  const remove = useCallback(
+    (label: string) => {
+      onChange(labels.filter((l) => l !== label))
+    },
+    [labels, onChange],
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' || e.key === ',') {
+        e.preventDefault()
+        if (input.trim()) commit(input)
+      } else if (e.key === 'Backspace' && !input && labels.length > 0) {
+        // Quick-delete the last chip when the input is empty
+        remove(labels[labels.length - 1]!)
+      }
+    },
+    [input, labels, commit, remove],
+  )
+
+  return (
+    <div className="flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">
+      {labels.map((label) => (
+        <span
+          key={label}
+          className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300"
+        >
+          <Tag className="h-3 w-3" />
+          {label}
+          {!disabled && (
+            <button
+              type="button"
+              onClick={() => remove(label)}
+              className="rounded-full p-0.5 hover:text-red-500 transition-colors"
+              aria-label={`Remove label ${label}`}
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </span>
+      ))}
+      {!disabled && (
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => input.trim() && commit(input)}
+          placeholder={labels.length === 0 ? placeholder : ''}
+          aria-label={ariaLabel}
+          className="min-w-[6rem] flex-1 bg-transparent text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none"
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/components/__tests__/LabelEditor.test.tsx
+++ b/apps/web/app/components/__tests__/LabelEditor.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { LabelEditor, LabelChips, normalizeLabels } from '../LabelEditor'
+
+vi.mock('lucide-react', () => ({
+  Tag: () => <svg data-testid="tag-icon" />,
+  X: () => <svg data-testid="x-icon" />,
+}))
+
+describe('normalizeLabels', () => {
+  it('trims, drops empties, and de-dupes case-insensitively preserving first casing', () => {
+    expect(normalizeLabels([' Work ', 'work', '', 'Home', 'WORK'])).toEqual(['Work', 'Home'])
+  })
+
+  it('returns an empty array when given only blank entries', () => {
+    expect(normalizeLabels(['', '   '])).toEqual([])
+  })
+})
+
+describe('LabelChips', () => {
+  it('renders nothing when there are no labels', () => {
+    const { container } = render(<LabelChips labels={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when labels is undefined', () => {
+    const { container } = render(<LabelChips labels={undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders one chip per label', () => {
+    render(<LabelChips labels={['Work', 'Personal']} />)
+    expect(screen.getByText('Work')).toBeInTheDocument()
+    expect(screen.getByText('Personal')).toBeInTheDocument()
+  })
+})
+
+describe('LabelEditor', () => {
+  it('adds a label on Enter', () => {
+    const onChange = vi.fn()
+    render(<LabelEditor labels={[]} onChange={onChange} />)
+    const input = screen.getByLabelText('Labels')
+    fireEvent.change(input, { target: { value: 'Work' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).toHaveBeenCalledWith(['Work'])
+  })
+
+  it('adds a label on comma', () => {
+    const onChange = vi.fn()
+    render(<LabelEditor labels={[]} onChange={onChange} />)
+    const input = screen.getByLabelText('Labels')
+    fireEvent.change(input, { target: { value: 'Urgent' } })
+    fireEvent.keyDown(input, { key: ',' })
+    expect(onChange).toHaveBeenCalledWith(['Urgent'])
+  })
+
+  it('does not add a duplicate label (case-insensitive)', () => {
+    const onChange = vi.fn()
+    render(<LabelEditor labels={['Work']} onChange={onChange} />)
+    const input = screen.getByLabelText('Labels')
+    fireEvent.change(input, { target: { value: 'work' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('removes a label via its remove button', () => {
+    const onChange = vi.fn()
+    render(<LabelEditor labels={['Work', 'Home']} onChange={onChange} />)
+    fireEvent.click(screen.getByLabelText('Remove label Work'))
+    expect(onChange).toHaveBeenCalledWith(['Home'])
+  })
+
+  it('removes the last chip on Backspace when the input is empty', () => {
+    const onChange = vi.fn()
+    render(<LabelEditor labels={['Work', 'Home']} onChange={onChange} />)
+    const input = screen.getByLabelText('Labels')
+    fireEvent.keyDown(input, { key: 'Backspace' })
+    expect(onChange).toHaveBeenCalledWith(['Work'])
+  })
+
+  it('hides the input and remove buttons when disabled', () => {
+    render(<LabelEditor labels={['Work']} onChange={vi.fn()} disabled />)
+    expect(screen.queryByLabelText('Labels')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Remove label Work')).not.toBeInTheDocument()
+    expect(screen.getByText('Work')).toBeInTheDocument()
+  })
+})

--- a/apps/web/app/components/__tests__/LabelEditor.test.tsx
+++ b/apps/web/app/components/__tests__/LabelEditor.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { LabelEditor, LabelChips, normalizeLabels } from '../LabelEditor'
+import { renderWithIntl } from '@/src/__tests__/render-with-intl'
 
 vi.mock('lucide-react', () => ({
   Tag: () => <svg data-testid="tag-icon" />,
@@ -38,7 +39,7 @@ describe('LabelChips', () => {
 describe('LabelEditor', () => {
   it('adds a label on Enter', () => {
     const onChange = vi.fn()
-    render(<LabelEditor labels={[]} onChange={onChange} />)
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} />)
     const input = screen.getByLabelText('Labels')
     fireEvent.change(input, { target: { value: 'Work' } })
     fireEvent.keyDown(input, { key: 'Enter' })
@@ -47,16 +48,25 @@ describe('LabelEditor', () => {
 
   it('adds a label on comma', () => {
     const onChange = vi.fn()
-    render(<LabelEditor labels={[]} onChange={onChange} />)
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} />)
     const input = screen.getByLabelText('Labels')
     fireEvent.change(input, { target: { value: 'Urgent' } })
     fireEvent.keyDown(input, { key: ',' })
     expect(onChange).toHaveBeenCalledWith(['Urgent'])
   })
 
+  it('adds a label on blur', () => {
+    const onChange = vi.fn()
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} />)
+    const input = screen.getByLabelText('Labels')
+    fireEvent.change(input, { target: { value: 'Work' } })
+    fireEvent.blur(input)
+    expect(onChange).toHaveBeenCalledWith(['Work'])
+  })
+
   it('does not add a duplicate label (case-insensitive)', () => {
     const onChange = vi.fn()
-    render(<LabelEditor labels={['Work']} onChange={onChange} />)
+    renderWithIntl(<LabelEditor labels={['Work']} onChange={onChange} />)
     const input = screen.getByLabelText('Labels')
     fireEvent.change(input, { target: { value: 'work' } })
     fireEvent.keyDown(input, { key: 'Enter' })
@@ -65,21 +75,21 @@ describe('LabelEditor', () => {
 
   it('removes a label via its remove button', () => {
     const onChange = vi.fn()
-    render(<LabelEditor labels={['Work', 'Home']} onChange={onChange} />)
+    renderWithIntl(<LabelEditor labels={['Work', 'Home']} onChange={onChange} />)
     fireEvent.click(screen.getByLabelText('Remove label Work'))
     expect(onChange).toHaveBeenCalledWith(['Home'])
   })
 
   it('removes the last chip on Backspace when the input is empty', () => {
     const onChange = vi.fn()
-    render(<LabelEditor labels={['Work', 'Home']} onChange={onChange} />)
+    renderWithIntl(<LabelEditor labels={['Work', 'Home']} onChange={onChange} />)
     const input = screen.getByLabelText('Labels')
     fireEvent.keyDown(input, { key: 'Backspace' })
     expect(onChange).toHaveBeenCalledWith(['Work'])
   })
 
   it('hides the input and remove buttons when disabled', () => {
-    render(<LabelEditor labels={['Work']} onChange={vi.fn()} disabled />)
+    renderWithIntl(<LabelEditor labels={['Work']} onChange={vi.fn()} disabled />)
     expect(screen.queryByLabelText('Labels')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Remove label Work')).not.toBeInTheDocument()
     expect(screen.getByText('Work')).toBeInTheDocument()

--- a/apps/web/app/components/import/ContactImport.tsx
+++ b/apps/web/app/components/import/ContactImport.tsx
@@ -11,6 +11,7 @@ import { useContactStore } from '@/app/stores/use-contact-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { normalizeLabels } from '@/app/components/LabelEditor'
 
 interface ContactImportProps {
   onImportComplete: (count: number) => void
@@ -140,7 +141,7 @@ export default function ContactImport({ onImportComplete, heading }: ContactImpo
         notes: contact.note ?? '',
         birthday: contact.bday ?? null,
         photoUrl: contact.photo ?? null,
-        categories: contact.categories ?? [],
+        categories: normalizeLabels(contact.categories ?? []),
         listId: selectedListId,
       }))
       const count = await importContacts(newContacts)

--- a/apps/web/app/components/import/ContactImport.tsx
+++ b/apps/web/app/components/import/ContactImport.tsx
@@ -140,6 +140,7 @@ export default function ContactImport({ onImportComplete, heading }: ContactImpo
         notes: contact.note ?? '',
         birthday: contact.bday ?? null,
         photoUrl: contact.photo ?? null,
+        categories: contact.categories ?? [],
         listId: selectedListId,
       }))
       const count = await importContacts(newContacts)

--- a/apps/web/app/components/import/TaskImport.tsx
+++ b/apps/web/app/components/import/TaskImport.tsx
@@ -12,6 +12,7 @@ import { useTaskStore } from '@/app/stores/use-task-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import type { Priority } from '@silentsuite/core'
+import { normalizeLabels } from '@/app/components/LabelEditor'
 
 interface TaskImportProps {
   onImportComplete: (count: number) => void
@@ -223,7 +224,7 @@ export default function TaskImport({ onImportComplete, heading }: TaskImportProp
         due_date: task.due ? parseICalDate(task.due) : null,
         priority: mapPriorityToStore(task.priority),
         completed: isCompletedVTodo(task),
-        categories: task.categories ?? [],
+        categories: normalizeLabels(task.categories ?? []),
         listId: selectedListId,
       }))
       const count = await importTasks(newTasks)

--- a/apps/web/app/components/import/TaskImport.tsx
+++ b/apps/web/app/components/import/TaskImport.tsx
@@ -223,6 +223,7 @@ export default function TaskImport({ onImportComplete, heading }: TaskImportProp
         due_date: task.due ? parseICalDate(task.due) : null,
         priority: mapPriorityToStore(task.priority),
         completed: isCompletedVTodo(task),
+        categories: task.categories ?? [],
         listId: selectedListId,
       }))
       const count = await importTasks(newTasks)

--- a/apps/web/app/components/import/__tests__/ContactImport.test.tsx
+++ b/apps/web/app/components/import/__tests__/ContactImport.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import ContactImport from '../ContactImport'
+import { renderWithIntl } from '@/src/__tests__/render-with-intl'
+import type { VCard } from '@silentsuite/core/utils/vcard-parser'
+const mocks = vi.hoisted(() => ({
+  importContacts: vi.fn(),
+  createCollection: vi.fn(),
+  onImportComplete: vi.fn(),
+}))
+
+vi.mock('@silentsuite/core/utils/vcard-parser', () => ({
+  parseVCard: vi.fn((vc: string): VCard => {
+    void vc
+    return {
+      uid: 'vc-1',
+      fn: 'Jane Doe',
+      categories: [' Work ', 'work', 'Home'],
+    }
+  }),
+}))
+
+vi.mock('@/app/stores/use-contact-store', () => ({
+  useContactStore: function useContactStore<T>(selector: (state: {
+    importContacts: typeof mocks.importContacts
+  }) => T): T {
+    return selector({ importContacts: mocks.importContacts })
+  },
+}))
+
+vi.mock('@/app/stores/use-contact-list-store', () => ({
+  useContactListStore: function useContactListStore<T>(selector: (state: {
+    lists: { id: string; name: string; color: string; visible: boolean }[]
+    activeListId: string
+  }) => T): T {
+    return selector({
+      lists: [{ id: 'default', name: 'Default', color: '#10b981', visible: true }],
+      activeListId: 'default',
+    })
+  },
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: function useEtebaseStore<T>(selector: (state: {
+    createCollection: typeof mocks.createCollection
+  }) => T): T {
+    return selector({ createCollection: mocks.createCollection })
+  },
+}))
+
+describe('ContactImport categories normalization', () => {
+  beforeEach(() => {
+    mocks.importContacts.mockReset().mockResolvedValue(1)
+    mocks.createCollection.mockReset()
+    mocks.onImportComplete.mockReset()
+  })
+
+  it('normalizes categories in the built import payload', async () => {
+    const { container } = renderWithIntl(<ContactImport onImportComplete={mocks.onImportComplete} />)
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(
+      ['BEGIN:VCARD\nVERSION:4.0\nFN:Jane Doe\nEND:VCARD'],
+      'contacts.vcf',
+      { type: 'text/vcard' },
+    )
+    fireEvent.change(input, { target: { files: [file] } })
+
+    const importButton = await screen.findByRole('button', { name: /Import 1 contacts/ })
+    fireEvent.click(importButton)
+
+    await waitFor(() => {
+      expect(mocks.importContacts).toHaveBeenCalledTimes(1)
+    })
+
+    const payload = mocks.importContacts.mock.calls[0]![0] as Array<{ categories: string[] }>
+    expect(payload[0]!.categories).toEqual(['Work', 'Home'])
+  })
+})

--- a/apps/web/app/components/import/__tests__/TaskImport.test.tsx
+++ b/apps/web/app/components/import/__tests__/TaskImport.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import TaskImport from '../TaskImport'
+import { renderWithIntl } from '@/src/__tests__/render-with-intl'
+import type { VTodo } from '@silentsuite/core/utils/ical-parser'
+
+const mocks = vi.hoisted(() => ({
+  importTasks: vi.fn(),
+  createCollection: vi.fn(),
+  onImportComplete: vi.fn(),
+}))
+
+vi.mock('@silentsuite/core/utils/ical-parser', () => ({
+  parseVTodo: vi.fn((ical: string): VTodo => {
+    void ical
+    return {
+      uid: 'vt-1',
+      summary: 'Review PR',
+      categories: [' Work ', 'work', 'Home'],
+    }
+  }),
+}))
+
+vi.mock('@/app/stores/use-task-store', () => ({
+  useTaskStore: function useTaskStore<T>(selector: (state: {
+    importTasks: typeof mocks.importTasks
+  }) => T): T {
+    return selector({ importTasks: mocks.importTasks })
+  },
+}))
+
+vi.mock('@/app/stores/use-task-list-store', () => ({
+  useTaskListStore: function useTaskListStore<T>(selector: (state: {
+    lists: { id: string; name: string; color: string; visible: boolean }[]
+    activeListId: string
+  }) => T): T {
+    return selector({
+      lists: [{ id: 'default', name: 'Default', color: '#10b981', visible: true }],
+      activeListId: 'default',
+    })
+  },
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: function useEtebaseStore<T>(selector: (state: {
+    createCollection: typeof mocks.createCollection
+  }) => T): T {
+    return selector({ createCollection: mocks.createCollection })
+  },
+}))
+
+describe('TaskImport categories normalization', () => {
+  beforeEach(() => {
+    mocks.importTasks.mockReset().mockResolvedValue(1)
+    mocks.createCollection.mockReset()
+    mocks.onImportComplete.mockReset()
+  })
+
+  it('normalizes categories in the built import payload', async () => {
+    const { container } = renderWithIntl(<TaskImport onImportComplete={mocks.onImportComplete} />)
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(
+      ['BEGIN:VTODO\nSUMMARY:Review PR\nEND:VTODO'],
+      'tasks.ics',
+      { type: 'text/calendar' },
+    )
+    fireEvent.change(input, { target: { files: [file] } })
+
+    const importButton = await screen.findByRole('button', { name: /Import 1 tasks/ })
+    fireEvent.click(importButton)
+
+    await waitFor(() => {
+      expect(mocks.importTasks).toHaveBeenCalledTimes(1)
+    })
+
+    const payload = mocks.importTasks.mock.calls[0]![0] as Array<{ categories: string[] }>
+    expect(payload[0]!.categories).toEqual(['Work', 'Home'])
+  })
+})

--- a/apps/web/app/components/import/__tests__/import-mappers.test.ts
+++ b/apps/web/app/components/import/__tests__/import-mappers.test.ts
@@ -20,6 +20,33 @@ describe('vEventToImportEvent', () => {
     expect(payload.calendarId).toBe('cal-1')
   })
 
+  it('preserves CATEGORIES labels in the import payload', () => {
+    const event: VEvent = {
+      uid: 'cat@example',
+      summary: 'Tagged event',
+      dtstart: '20260601T090000',
+      dtend: '20260601T100000',
+      categories: ['Work', 'Urgent'],
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.categories).toEqual(['Work', 'Urgent'])
+  })
+
+  it('defaults categories to an empty array when the source has none', () => {
+    const event: VEvent = {
+      uid: 'nocat@example',
+      summary: 'Untagged event',
+      dtstart: '20260601T090000',
+      dtend: '20260601T100000',
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.categories).toEqual([])
+  })
+
   it('drops timezone for all-day events (DATE-only, no TZID per RFC 5545)', () => {
     const event: VEvent = {
       uid: 'b@example',

--- a/apps/web/app/components/import/__tests__/import-mappers.test.ts
+++ b/apps/web/app/components/import/__tests__/import-mappers.test.ts
@@ -34,6 +34,20 @@ describe('vEventToImportEvent', () => {
     expect(payload.categories).toEqual(['Work', 'Urgent'])
   })
 
+  it('normalizes CATEGORIES labels in the import payload', () => {
+    const event: VEvent = {
+      uid: 'norm@example',
+      summary: 'Tagged event',
+      dtstart: '20260601T090000',
+      dtend: '20260601T100000',
+      categories: [' Work ', 'work', 'Home'],
+    }
+
+    const payload = vEventToImportEvent(event, 'cal-1')
+
+    expect(payload.categories).toEqual(['Work', 'Home'])
+  })
+
   it('defaults categories to an empty array when the source has none', () => {
     const event: VEvent = {
       uid: 'nocat@example',

--- a/apps/web/app/components/import/import-mappers.ts
+++ b/apps/web/app/components/import/import-mappers.ts
@@ -11,6 +11,7 @@ export interface ImportEventPayload {
   recurrenceRule: string | null
   exceptions: Date[]
   alarms: NonNullable<VEvent['valarms']>
+  categories: string[]
   calendarId: string
   timezone: string | undefined
 }
@@ -73,6 +74,7 @@ export function vEventToImportEvent(
     recurrenceRule: event.rrule ?? null,
     exceptions,
     alarms: event.valarms ?? [],
+    categories: event.categories ?? [],
     calendarId,
     timezone: isAllDay ? undefined : startTzid,
   }

--- a/apps/web/app/components/import/import-mappers.ts
+++ b/apps/web/app/components/import/import-mappers.ts
@@ -1,5 +1,6 @@
 import { parseICalDateValue } from '@silentsuite/core'
 import type { VEvent, VTodo } from '@silentsuite/core/utils/ical-parser'
+import { normalizeLabels } from '@/app/components/LabelEditor'
 
 export interface ImportEventPayload {
   title: string
@@ -74,7 +75,7 @@ export function vEventToImportEvent(
     recurrenceRule: event.rrule ?? null,
     exceptions,
     alarms: event.valarms ?? [],
-    categories: event.categories ?? [],
+    categories: normalizeLabels(event.categories ?? []),
     calendarId,
     timezone: isAllDay ? undefined : startTzid,
   }

--- a/apps/web/app/stores/__tests__/use-calendar-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-calendar-store.test.ts
@@ -331,3 +331,40 @@ describe('useCalendarStore.updateEvent calendar moves', () => {
     expect(useCalendarStore.getState().selectedEventId).toBe('master-new')
   })
 })
+
+describe('useCalendarStore.getFilteredEvents', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it('matches events by categories/labels', () => {
+    const work = makeRecurringEvent({
+      id: 'work-1',
+      uid: 'work-uid',
+      title: 'Strategy sync',
+      recurrenceRule: null,
+      categories: ['Work', 'VIP'],
+    })
+    const personal = makeRecurringEvent({
+      id: 'personal-1',
+      uid: 'personal-uid',
+      title: 'Yoga class',
+      recurrenceRule: null,
+      categories: ['Health'],
+    })
+    useCalendarStore.setState({ events: [work, personal] })
+
+    useCalendarStore.getState().setSearchQuery('work')
+    expect(useCalendarStore.getState().getFilteredEvents().map((e) => e.id)).toEqual(['work-1'])
+
+    useCalendarStore.getState().setSearchQuery('vip')
+    expect(useCalendarStore.getState().getFilteredEvents().map((e) => e.id)).toEqual(['work-1'])
+
+    useCalendarStore.getState().setSearchQuery('health')
+    expect(useCalendarStore.getState().getFilteredEvents().map((e) => e.id)).toEqual(['personal-1'])
+
+    // Empty query returns everything
+    useCalendarStore.getState().setSearchQuery('')
+    expect(useCalendarStore.getState().getFilteredEvents()).toHaveLength(2)
+  })
+})

--- a/apps/web/app/stores/__tests__/use-contact-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-contact-store.test.ts
@@ -149,5 +149,52 @@ describe('useContactStore', () => {
       expect(result).toHaveLength(1)
       expect(result[0]!.displayName).toBe('Alice Johnson')
     })
+
+    it('matches by categories/labels', () => {
+      const tagged: Contact[] = [
+        {
+          id: 't1',
+          uid: 't1',
+          displayName: 'Carol King',
+          name: { prefix: '', given: 'Carol', family: 'King', suffix: '' },
+          phones: [],
+          emails: [],
+          addresses: [],
+          organization: '',
+          title: '',
+          notes: '',
+          birthday: null,
+          photoUrl: null,
+          categories: ['Work', 'VIP'],
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+        {
+          id: 't2',
+          uid: 't2',
+          displayName: 'Dan Lee',
+          name: { prefix: '', given: 'Dan', family: 'Lee', suffix: '' },
+          phones: [],
+          emails: [],
+          addresses: [],
+          organization: '',
+          title: '',
+          notes: '',
+          birthday: null,
+          photoUrl: null,
+          categories: ['Family'],
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ]
+
+      const work = getFilteredContacts(tagged, 'work')
+      expect(work).toHaveLength(1)
+      expect(work[0]!.displayName).toBe('Carol King')
+
+      const vip = getFilteredContacts(tagged, 'vip')
+      expect(vip).toHaveLength(1)
+      expect(vip[0]!.displayName).toBe('Carol King')
+    })
   })
 })

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -22,6 +22,7 @@ interface NewCalendarEvent {
   recurrenceRule?: string | null
   exceptions?: Date[]
   alarms?: VAlarm[]
+  categories?: string[]
   calendarId?: string
   timezone?: string
 }
@@ -180,6 +181,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
       recurrenceRule: newEvent.recurrenceRule ?? null,
       exceptions: newEvent.exceptions ?? [],
       alarms: newEvent.alarms ?? [],
+      categories: newEvent.categories ?? [],
       calendarId: newEvent.calendarId ?? defaultCalendarId(),
       timezone: newEvent.timezone,
       created: now,
@@ -506,6 +508,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
         recurrenceRule: ne.recurrenceRule ?? null,
         exceptions: ne.exceptions ?? [],
         alarms: ne.alarms ?? [],
+        categories: ne.categories ?? [],
         calendarId: ne.calendarId ?? defaultCalendarId(),
         timezone: ne.timezone,
         created: now,
@@ -566,7 +569,8 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
       const title = (e.title ?? '').toLowerCase()
       const desc = (e.description ?? '').toLowerCase()
       const loc = (e.location ?? '').toLowerCase()
-      return title.includes(q) || desc.includes(q) || loc.includes(q)
+      const cats = (e.categories ?? []).join(' ').toLowerCase()
+      return title.includes(q) || desc.includes(q) || loc.includes(q) || cats.includes(q)
     })
   },
 }))

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -20,6 +20,7 @@ interface NewContact {
   notes?: string
   birthday?: string | null
   photoUrl?: string | null
+  categories?: string[]
   listId?: string
 }
 
@@ -74,6 +75,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
           notes: newContact.notes ?? '',
           birthday: newContact.birthday ?? null,
           photoUrl: newContact.photoUrl ?? null,
+          categories: newContact.categories ?? [],
           listId: newContact.listId ?? defaultContactListId(),
           created_at: now,
           updated_at: now,
@@ -188,6 +190,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
             notes: nc.notes ?? '',
             birthday: nc.birthday ?? null,
             photoUrl: nc.photoUrl ?? null,
+            categories: nc.categories ?? [],
             listId: nc.listId ?? defaultContactListId(),
             created_at: now,
             updated_at: now,
@@ -245,6 +248,7 @@ export function getFilteredContacts(contacts: Contact[], query: string): Contact
     const searchable = [
       c.displayName, c.name.given, c.name.family, c.organization,
       ...c.emails.map((e) => e.value), ...c.phones.map((p) => p.value),
+      ...(c.categories ?? []),
     ].join(' ').toLowerCase()
     return searchable.includes(q)
   })

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -15,6 +15,7 @@ interface NewTask {
   due_date?: Date | null
   priority?: Priority
   completed?: boolean
+  categories?: string[]
   listId?: string
 }
 
@@ -57,6 +58,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
           due_date: newTask.due_date ?? null,
           priority: newTask.priority ?? 'medium',
           completed: newTask.completed ?? false,
+          categories: newTask.categories ?? [],
           listId: newTask.listId ?? defaultTaskListId(),
           created_at: now,
           updated_at: now,
@@ -195,6 +197,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
             due_date: nt.due_date ?? null,
             priority: nt.priority ?? 'medium',
             completed: nt.completed ?? false,
+            categories: nt.categories ?? [],
             listId: nt.listId ?? defaultTaskListId(),
             created_at: now,
             updated_at: now,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -32,5 +32,14 @@
       "copied": "Fingerprint copied",
       "copyFailed": "Copy failed"
     }
+  },
+  "Labels": {
+    "addLabelPlaceholder": "Add label\u2026",
+    "editorAriaLabel": "Labels",
+    "removeLabel": "Remove label {label}",
+    "eventLabels": "Event labels",
+    "taskLabels": "Task labels",
+    "contactLabels": "Contact labels",
+    "sectionTitle": "Labels"
   }
 }


### PR DESCRIPTION
## Summary
Adds shared `LabelEditor`/`LabelChips` components and wires labels (categories) into the calendar event, task, and contact create/edit and detail views.

- **Create/edit:** `LabelEditor` in `EventDialog`, `TaskDialog`, `ContactForm`, and inline in `ContactDetail`/`TaskItem` (disabled when `!canWrite`).
- **Display:** `LabelChips` in `AgendaView`, `TaskItem`, and `ContactDetail`.
- **Stores:** `categories` added to the `New*` interfaces and defaulted to `[]` in `create*`/`import*` paths so existing unlabeled data deserializes safely. Search now matches categories across all three stores.
- **Import round-trip:** threads `categories` through the web import path — `vEventToImportEvent` payload, `TaskImport`, and `ContactImport` — so imported ICS/vCard `CATEGORIES` are preserved into the store instead of dropped. The core layer (via #311) already parses and re-emits `CATEGORIES`, so export round-trips too. Categories are stored as client-side encrypted PIM content alongside title/description; no decrypted content is exposed server-side.

## Acceptance criteria (#291)
- [x] Users can add/remove labels on events, tasks, and contacts
- [x] Labels round-trip through ICS `CATEGORIES` and vCard `CATEGORIES` (core via #311; web import now preserves them)
- [x] Labels visible in list/detail views and available via search (explicit label-click filtering is a follow-up; discoverability is covered by search)
- [x] Existing unlabeled data deserializes safely (`categories ?? []`)
- [x] Import/export preserves labels without leaking decrypted content server-side

## Test plan
- [x] `pnpm --filter @silentsuite/web test` — 291 passed (incl. 11 new `LabelEditor` tests + 2 new `import-mappers` categories tests)
- [x] `pnpm --filter @silentsuite/web type-check` — clean
- [x] `pnpm --filter @silentsuite/web lint` — clean (no new warnings)

Closes #291