### PR TITLE
chore(release): promote v0.3.0-beta to main

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
 
-        versionCode 7
-        versionName "0.2.2-beta"
+        versionCode 8
+        versionName "0.3.0-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,9 @@
+SilentSuite v0.3.0-beta
+
+- Added encrypted sharing invitation/member management support.
+- Added labels/categories for events, tasks, and contacts.
+- Added pull-to-refresh manual sync on Android collection and account screens.
+- Improved Android .vcf contact import reliability with privacy-safe failure counts.
+- Polished Android status bar, toolbar icons, dark-theme icon tints, and login screen.
+- Added calendar search, date/week preferences, per-collection export, and mobile web collection management.
+- Hardened offline queue privacy, Android signing workflows, bridge, server, and self-hosting.

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,9 @@
+SilentSuite v0.3.0-beta
+
+- Added encrypted sharing invitation/member management support.
+- Added labels/categories for events, tasks, and contacts.
+- Added pull-to-refresh manual sync on Android collection and account screens.
+- Improved Android .vcf contact import reliability with privacy-safe failure counts.
+- Polished Android status bar, toolbar icons, dark-theme icon tints, and login screen.
+- Added calendar search, date/week preferences, per-collection export, and mobile web collection management.
+- Hardened offline queue privacy, Android signing workflows, bridge, server, and self-hosting.


### PR DESCRIPTION
## Summary
- Promote `dev` release metadata for SilentSuite v0.3.0-beta to `main`.
- Bumps Android version metadata to `versionCode 8` / `versionName "0.3.0-beta"`.
- Adds matching Fastlane changelogs in both Android metadata roots.

## Verification
- PR #324 to `dev` passed CI: Android unsigned build, lint/type check, tests, dependency audit, and web build succeeded.

## Release follow-up
After this lands on `main`, create and push the `v0.3.0-beta` tag, create the draft release notes, wait for Android and bridge tag workflows, verify assets, then publish the release.