### PR TITLE
fix(self-host): make server healthcheck tolerate SSL redirect

### DIFF
--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -55,7 +55,12 @@ services:
       - ./success.html:/app/etebase_server/templates/success.html:ro
       - ./etebase-server.ini:/etc/etebase-server/etebase-server.ini:ro
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:3735/')\""]
+      # Treat any non-5xx HTTP response as healthy. The server runs behind a
+      # TLS-terminating reverse proxy and Django's SECURE_SSL_REDIRECT (enabled
+      # when debug=false) 301-redirects this in-container plain-HTTP probe to
+      # https://, which urllib would follow and fail against the plaintext port.
+      # http.client does not follow redirects, so a 301 here still means "up".
+      test: ["CMD-SHELL", "python -c \"import http.client,sys; c=http.client.HTTPConnection('localhost',3735,timeout=5); c.request('GET','/'); sys.exit(0 if c.getresponse().status<500 else 1)\""]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
- Fixes the self-host server healthcheck so Django's HTTPS redirect no longer makes a running container look unhealthy.
- Replaces `urllib.request.urlopen(...)`, which follows the 301 redirect to `https://`, with `http.client.HTTPConnection`, which treats any non-5xx local HTTP response as healthy.
- Keeps genuine failures unhealthy: 5xx responses and connection-refused still exit non-zero.

## Root cause
Issue #323 matches a healthcheck regression after #285 enabled `SECURE_SSL_REDIRECT` by default in production-like self-host installs. The in-container probe hits `http://localhost:3735/`; Django returns 301 to HTTPS; `urllib` follows that redirect and then fails against the plaintext local port, marking the container unhealthy even though the server is up.

Fixes #323.

## Validation
- `python3` mock-server harness:
  - 200 OK: old=0, new=0
  - 301 HTTPS redirect: old=1, new=0
  - 500 error: old=1, new=1
  - connection refused: old=1, new=1
- `python3 -c "yaml.safe_load(...)"` parsed `self-host/docker-compose.yml` and verified the healthcheck command.
- `git diff --check origin/dev...HEAD`

## Notes
No reporter logs were attached to #323, so the root cause is based on repo/config evidence plus a local reproduction harness rather than the reporter's container logs.
