### PR TITLE
Promote self-host healthcheck fix to main

### DIFF
--- a/self-host/docker-compose.yml
+++ b/self-host/docker-compose.yml
@@ -55,7 +55,12 @@ services:
       - ./success.html:/app/etebase_server/templates/success.html:ro
       - ./etebase-server.ini:/etc/etebase-server/etebase-server.ini:ro
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:3735/')\""]
+      # Treat any non-5xx HTTP response as healthy. The server runs behind a
+      # TLS-terminating reverse proxy and Django's SECURE_SSL_REDIRECT (enabled
+      # when debug=false) 301-redirects this in-container plain-HTTP probe to
+      # https://, which urllib would follow and fail against the plaintext port.
+      # http.client does not follow redirects, so a 301 here still means "up".
+      test: ["CMD-SHELL", "python -c \"import http.client,sys; c=http.client.HTTPConnection('localhost',3735,timeout=5); c.request('GET','/'); sys.exit(0 if c.getresponse().status<500 else 1)\""]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary
Promotes the self-host healthcheck fix from dev to main.

Included change:
- #326: `fix(self-host): make server healthcheck tolerate SSL redirect`

## Why
Self-host containers could be marked permanently unhealthy because the Docker healthcheck followed Django's production HTTPS redirect from the in-container plaintext HTTP probe. The fix treats the expected 301 redirect as evidence the app is up while still failing on 5xx responses and down/refused server cases.

## Validation already completed on dev
- PR #326 CI: Dependency Audit, Lint and Type Check, Tests, Build Web App all passed.
- Local mock healthcheck harness: 200 healthy, 301 fixed to healthy, 500 unhealthy, connection refused unhealthy.
- YAML parse of `self-host/docker-compose.yml` succeeded.
- `git diff --check origin/dev...HEAD` passed.

## Promotion notes
This is a self-host compose change only. It does not change hosted production server code, but promoting to main is needed for release/mainline self-host artifacts.
