### PR TITLE
Update Zapstore config for v0.3.0-beta release

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/silent-suite/silentsuite
-release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.2.0-beta/silentsuite-android-v0.2.0-beta.apk
+release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.3.0-beta/silentsuite-android-v0.3.0-beta.apk
 pubkey: npub1zuusadlzq6vehhaqhqpup0mhnx70q9cnf9hs48t79g6qn4wpg2eqsy8m35
 name: SilentSuite
 summary: Zero-knowledge calendar, contacts, and tasks sync for Android
@@ -20,10 +20,10 @@ tags:
   - sync
 license: GPL-3.0-only
 website: https://silentsuite.io
-icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/icon.png
+icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/icon.png
 images:
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-main.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-account.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-create-calendar.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-view-collection.png
-release_notes: android/fastlane/metadata/android/en-US/changelogs/6.txt
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-add-account.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-sync-overview.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-navigation-drawer.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-encryption-fingerprint.png
+release_notes: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/changelogs/8.txt


### PR DESCRIPTION
Point `zapstore.yaml` at the v0.3.0-beta Android release asset, icon, screenshots, and changelog.

- `release_source`: v0.3.0-beta APK
- `icon`/`images`: v0.3.0-beta tag URLs (also fixes stale screenshot filenames that referenced non-existent `1-main.png`/`2-account.png`/`3-create-calendar.png`/`4-view-collection.png`; the real files are `1-add-account.png`/`2-sync-overview.png`/`3-navigation-drawer.png`/`4-encryption-fingerprint.png`)
- `release_notes`: changelogs/8.txt (absolute raw URL)

The Zapstore release for `io.silentsuite.android@0.3.0-beta` was published to `wss://relay.zapstore.dev` via `zsp` (NIP-46 bunker signing) and confirmed up-to-date. App page: https://zapstore.dev/apps/io.silentsuite.android

No code changes; metadata-only.