### PR TITLE
fix(webapp): make subscription page text readable in light theme (#329)

### DIFF
--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -509,7 +509,7 @@ export default function SubscriptionPage() {
                             <button
                               onClick={() => handleCryptoCheckout(plan.id)}
                               disabled={cryptoCheckoutLoading || reactivating !== null}
-                              className="rounded-lg border border-amber-500/40 px-3 py-2 text-sm font-medium text-amber-600 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
+                              className="rounded-lg border border-amber-500/40 px-3 py-2 text-sm font-medium text-amber-700 dark:text-amber-400 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
                             >
                               {cryptoCheckoutLoading ? 'Opening...' : 'Pay crypto'}
                             </button>

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -11,7 +11,7 @@ const StripePaymentForm = dynamic(() => import('@/app/components/stripe-payment-
   loading: () => (
     <div className="flex flex-col items-center justify-center py-8">
       <div className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
-      <p className="mt-3 text-sm text-slate-400">Loading payment form...</p>
+      <p className="mt-3 text-sm text-[rgb(var(--muted))]">Loading payment form...</p>
     </div>
   ),
   ssr: false,
@@ -42,11 +42,11 @@ interface SubscriptionData {
 
 const STATUS_STYLES: Record<string, string> = {
   active: 'bg-[rgb(var(--primary))]/20 text-[rgb(var(--primary))]',
-  trialing: 'bg-amber-500/20 text-amber-400',
-  past_due: 'bg-red-500/20 text-red-400',
-  cancelled: 'bg-neutral-500/20 text-neutral-400',
-  expired: 'bg-neutral-500/20 text-neutral-400',
-  none: 'bg-neutral-500/20 text-neutral-400',
+  trialing: 'bg-amber-500/20 text-amber-700 dark:text-amber-400',
+  past_due: 'bg-red-500/20 text-red-700 dark:text-red-400',
+  cancelled: 'bg-neutral-500/20 text-neutral-600 dark:text-neutral-400',
+  expired: 'bg-neutral-500/20 text-neutral-600 dark:text-neutral-400',
+  none: 'bg-neutral-500/20 text-neutral-600 dark:text-neutral-400',
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -107,7 +107,7 @@ function CancelDialog({
           </Button>
           <Button
             size="sm"
-            className="border-red-500 bg-red-500/10 text-red-400 hover:bg-red-500/20"
+            className="border-red-500 bg-red-500/10 text-red-600 dark:text-red-400 hover:bg-red-500/20"
             onClick={onConfirm}
             disabled={cancelling}
           >
@@ -306,12 +306,12 @@ export default function SubscriptionPage() {
       {/* Trial banner */}
       {showTrialBanner && (
         <div className="flex items-center justify-between rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
-          <p className="text-sm text-amber-400">
+          <p className="text-sm text-amber-700 dark:text-amber-400">
             {data.trial.daysRemaining} day{data.trial.daysRemaining !== 1 ? 's' : ''} remaining in your trial
           </p>
           <button
             onClick={() => setBannerDismissed(true)}
-            className="text-amber-400 hover:text-amber-300 text-sm font-medium"
+            className="text-amber-700 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 text-sm font-medium"
           >
             Dismiss
           </button>
@@ -377,7 +377,7 @@ export default function SubscriptionPage() {
 
           {/* Cancel at period end notice */}
           {data.cancelAtPeriodEnd && !isCancelled && data.renewalDate && (
-            <p className="text-xs text-amber-400">
+            <p className="text-xs text-amber-700 dark:text-amber-400">
               Your subscription will be cancelled at the end of the current period ({formatDateStr(data.renewalDate)})
             </p>
           )}
@@ -394,7 +394,7 @@ export default function SubscriptionPage() {
             <Button
               variant="outline"
               size="sm"
-              className="border-red-500/30 text-red-400 hover:bg-red-500/10"
+              className="border-red-500/30 text-red-600 dark:text-red-400 hover:bg-red-500/10"
               onClick={() => setShowCancelDialog(true)}
             >
               Cancel subscription
@@ -477,9 +477,9 @@ export default function SubscriptionPage() {
                           </div>
                           <div>
                             <div className="flex items-center gap-2">
-                              <h3 className="font-medium text-white">{plan.name}</h3>
+                              <h3 className="font-medium text-[rgb(var(--foreground))]">{plan.name}</h3>
                               {'badge' in plan && plan.badge && (
-                                <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                                <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
                                   {plan.badge}
                                 </span>
                               )}
@@ -488,7 +488,7 @@ export default function SubscriptionPage() {
                           </div>
                         </div>
                         <div className="text-right">
-                          <span className="text-2xl font-bold text-white">&euro;{plan.price}</span>
+                          <span className="text-2xl font-bold text-[rgb(var(--foreground))]">&euro;{plan.price}</span>
                           <span className="text-sm text-[rgb(var(--muted))]">{plan.period}</span>
                         </div>
                       </div>
@@ -509,13 +509,13 @@ export default function SubscriptionPage() {
                             <button
                               onClick={() => handleCryptoCheckout(plan.id)}
                               disabled={cryptoCheckoutLoading || reactivating !== null}
-                              className="rounded-lg border border-amber-500/40 px-3 py-2 text-sm font-medium text-amber-300 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
+                              className="rounded-lg border border-amber-500/40 px-3 py-2 text-sm font-medium text-amber-600 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
                             >
                               {cryptoCheckoutLoading ? 'Opening...' : 'Pay crypto'}
                             </button>
                           </div>
                           {cryptoCheckoutError && (
-                            <p className="mt-2 text-xs text-red-400">{cryptoCheckoutError}</p>
+                            <p className="mt-2 text-xs text-red-600 dark:text-red-400">{cryptoCheckoutError}</p>
                           )}
                         </div>
                       )}
@@ -578,7 +578,7 @@ export default function SubscriptionPage() {
                       </p>
                     </div>
                     {changePlanError && (
-                      <p className="text-xs text-red-400">{changePlanError}</p>
+                      <p className="text-xs text-red-600 dark:text-red-400">{changePlanError}</p>
                     )}
                     <div className="flex gap-3 pt-2">
                       <Button
@@ -652,12 +652,12 @@ export default function SubscriptionPage() {
                             <div className="flex items-center gap-2">
                               <h3 className="font-medium text-[rgb(var(--foreground))]">{plan.name}</h3>
                               {isCurrent && (
-                                <span className="flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                                <span className="flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
                                   <Check className="h-3 w-3" /> Current
                                 </span>
                               )}
                               {'badge' in plan && plan.badge && !isCurrent && (
-                                <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-400">
+                                <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
                                   {plan.badge}
                                 </span>
                               )}
@@ -666,7 +666,7 @@ export default function SubscriptionPage() {
                           </div>
                         </div>
                         <div className="text-right shrink-0">
-                          <span className={`text-2xl font-bold ${isCurrent ? 'text-emerald-400' : 'text-[rgb(var(--foreground))]'}`}>
+                          <span className={`text-2xl font-bold ${isCurrent ? 'text-emerald-600 dark:text-emerald-400' : 'text-[rgb(var(--foreground))]'}`}>
                             &euro;{plan.price}
                           </span>
                           <span className="text-sm text-[rgb(var(--muted))]">{plan.period}</span>
@@ -700,7 +700,7 @@ export default function SubscriptionPage() {
       {/* Success toast */}
       {changePlanToast && (
         <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-2.5 shadow-lg backdrop-blur-sm">
-          <p className="text-sm font-medium text-emerald-400">{changePlanToast}</p>
+          <p className="text-sm font-medium text-emerald-600 dark:text-emerald-400">{changePlanToast}</p>
         </div>
       )}
     </div>

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -31,7 +31,7 @@ const StripePaymentForm = dynamic(() => import('@/app/components/stripe-payment-
   loading: () => (
     <div className="flex flex-col items-center justify-center py-8">
       <div className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
-      <p className="mt-3 text-sm text-slate-400">Loading payment form...</p>
+      <p className="mt-3 text-sm text-[rgb(var(--muted))]">Loading payment form...</p>
     </div>
   ),
   ssr: false,
@@ -199,7 +199,7 @@ function PriceDisplay({ interval }: { interval: BillingInterval }) {
   return (
     <span className="text-sm text-[rgb(var(--muted))]">
       Then <span className="font-semibold text-[rgb(var(--foreground))]">&euro;3.00/month</span> billed annually. Cancel anytime before day 30, no charge.
-      <span className="ml-1 text-xs font-medium text-emerald-400">Save 17%</span>
+      <span className="ml-1 text-xs font-medium text-emerald-600 dark:text-emerald-400">Save 17%</span>
     </span>
   )
 }
@@ -282,7 +282,7 @@ function StepCreateAccount({
             className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
           />
           {errors.email && (
-            <p id="signup-email-error" role="alert" className="text-xs text-red-400">{errors.email.message}</p>
+            <p id="signup-email-error" role="alert" className="text-xs text-red-600 dark:text-red-400">{errors.email.message}</p>
           )}
         </div>
 
@@ -302,7 +302,7 @@ function StepCreateAccount({
             className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
           />
           {errors.password && (
-            <p id="signup-password-error" role="alert" className="text-xs text-red-400">{errors.password.message}</p>
+            <p id="signup-password-error" role="alert" className="text-xs text-red-600 dark:text-red-400">{errors.password.message}</p>
           )}
           <PasswordStrength password={password} />
         </div>
@@ -323,7 +323,7 @@ function StepCreateAccount({
             className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
           />
           {errors.confirmPassword && (
-            <p id="signup-confirm-password-error" role="alert" className="text-xs text-red-400">
+            <p id="signup-confirm-password-error" role="alert" className="text-xs text-red-600 dark:text-red-400">
               {errors.confirmPassword.message}
             </p>
           )}
@@ -369,7 +369,7 @@ function StepCreateAccount({
 
         {submitError && (
           <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
-            <p className="text-sm text-red-400">{submitError}</p>
+            <p className="text-sm text-red-600 dark:text-red-400">{submitError}</p>
           </div>
         )}
 
@@ -532,7 +532,7 @@ function CryptoPaymentPanel({
           This Bitcoin invoice expired. Go back and start a new Bitcoin invoice.
         </div>
       ) : status === 'error' ? (
-        <div className="space-y-3 rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-400">
+        <div className="space-y-3 rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">
           <p>{error ?? 'Could not load Bitcoin payment details.'}</p>
           <Link href={session.checkoutUrl} onClick={handleExternalCheckout} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-red-500/30 bg-transparent px-4 py-2 text-sm font-medium text-red-700 shadow-sm transition-colors hover:bg-red-500/10 dark:text-red-200">
             Open in BTCPay instead
@@ -787,7 +787,7 @@ function StepChoosePlan({
 
         {(paymentMethodError || provisionError) && (
           <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
-            <p className="text-sm text-red-400">{paymentMethodError ?? provisionError}</p>
+            <p className="text-sm text-red-600 dark:text-red-400">{paymentMethodError ?? provisionError}</p>
           </div>
         )}
 
@@ -866,7 +866,7 @@ function StepChoosePlan({
             <p className="text-sm text-red-400">{provisionError}</p>
             <button
               onClick={onBack}
-              className="text-sm text-emerald-500 hover:text-emerald-400 transition-colors"
+              className="text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300 transition-colors"
             >
               Go back and try again
             </button>
@@ -953,7 +953,7 @@ function StepChoosePlan({
             <div className="flex-1">
               <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
                 <h3 className="text-xl sm:text-2xl font-bold text-[rgb(var(--foreground))] leading-tight">30-day free trial</h3>
-                <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400 uppercase tracking-wide">
+                <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase tracking-wide">
                   Recommended
                 </span>
               </div>
@@ -999,10 +999,10 @@ function StepChoosePlan({
       {/* Error display */}
       {provisionError && (
         <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
-          <p className="text-sm text-red-400">{provisionError}</p>
+          <p className="text-sm text-red-600 dark:text-red-400">{provisionError}</p>
           <button
             onClick={onClearError}
-            className="mt-2 text-xs text-red-400 hover:text-red-300 underline"
+            className="mt-2 text-xs text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 underline"
           >
             Dismiss
           </button>
@@ -1067,7 +1067,7 @@ function StepSelfHostSupport({ onNext }: { onNext: (choice: 'free' | 'support') 
       {/* Support option */}
       <div className="rounded-xl border border-amber-500/40 bg-amber-500/5 p-5 ring-1 ring-amber-500/20 flex flex-col relative overflow-hidden">
         <div className="absolute top-3 right-3">
-          <span className="rounded-full bg-amber-500/15 px-2.5 py-1 text-[11px] font-medium text-amber-400">
+          <span className="rounded-full bg-amber-500/15 px-2.5 py-1 text-[11px] font-medium text-amber-700 dark:text-amber-400">
             Optional
           </span>
         </div>
@@ -1156,7 +1156,7 @@ function StepAdminInfo({ serverUrl, onNext }: { serverUrl: string; onNext: () =>
             href={adminUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 text-sm font-medium text-emerald-500 hover:text-emerald-400 transition-colors"
+            className="flex items-center gap-2 text-sm font-medium text-emerald-600 hover:text-emerald-700 dark:text-emerald-500 dark:hover:text-emerald-400 transition-colors"
           >
             {adminUrl}
             <ExternalLink className="h-3.5 w-3.5" />

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -863,7 +863,7 @@ function StepChoosePlan({
           </div>
         ) : provisionError ? (
           <div className="space-y-4 text-center">
-            <p className="text-sm text-red-400">{provisionError}</p>
+            <p className="text-sm text-red-600 dark:text-red-400">{provisionError}</p>
             <button
               onClick={onBack}
               className="text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300 transition-colors"

--- a/apps/web/app/components/add-card-banner.tsx
+++ b/apps/web/app/components/add-card-banner.tsx
@@ -10,7 +10,7 @@ const StripePaymentForm = dynamic(() => import('./stripe-payment-form'), {
   loading: () => (
     <div className="flex flex-col items-center justify-center py-8">
       <div className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
-      <p className="mt-3 text-sm text-slate-400">Loading payment form...</p>
+      <p className="mt-3 text-sm text-[rgb(var(--muted))]">Loading payment form...</p>
     </div>
   ),
   ssr: false,
@@ -72,7 +72,7 @@ function PriceDisplay({ interval }: { interval: BillingInterval }) {
   return (
     <span className="text-sm font-medium text-[rgb(var(--foreground))]">
       &euro;36<span className="text-[rgb(var(--muted))]">/yr</span>
-      <span className="ml-1 text-xs text-emerald-500">(&euro;3/mo)</span>
+      <span className="ml-1 text-xs text-emerald-600 dark:text-emerald-500">(&euro;3/mo)</span>
     </span>
   )
 }
@@ -201,7 +201,7 @@ function AddCardModal({
 
             {error && (
               <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
-                <p className="text-sm text-red-400">{error}</p>
+                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
               </div>
             )}
 
@@ -276,7 +276,7 @@ export default function AddCardBanner({ daysRemaining, onCardAdded }: AddCardBan
         <div className="flex items-center gap-3">
           <Clock className="h-4 w-4 text-amber-400" />
           <div>
-            <p className="text-sm text-amber-400">
+            <p className="text-sm text-amber-700 dark:text-amber-400">
               {daysRemaining} day{daysRemaining !== 1 ? 's' : ''} left in your trial
             </p>
             <p className="text-xs text-[rgb(var(--muted))]">

--- a/apps/web/app/components/add-card-banner.tsx
+++ b/apps/web/app/components/add-card-banner.tsx
@@ -274,7 +274,7 @@ export default function AddCardBanner({ daysRemaining, onCardAdded }: AddCardBan
     <>
       <div className="flex items-center justify-between rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
         <div className="flex items-center gap-3">
-          <Clock className="h-4 w-4 text-amber-400" />
+          <Clock className="h-4 w-4 text-amber-700 dark:text-amber-400" />
           <div>
             <p className="text-sm text-amber-700 dark:text-amber-400">
               {daysRemaining} day{daysRemaining !== 1 ? 's' : ''} left in your trial


### PR DESCRIPTION
## Root cause

The subscription/reactivation page (`app.silentsuite.io/settings/subscription`) used dark-theme-only text colors that are invisible or low-contrast in light theme. The headline bug: the plan **name** and **price** were rendered with `text-white`, which disappears on a light card background in light theme — so a lapsed subscriber trying to reactivate could not read the plans.

Other offenders: `text-red-400` (error text), `text-amber-400` (trial/cancel notices), `text-emerald-400` (badges/success toast), `text-slate-400` (loading text) — all invisible/low-contrast on light backgrounds.

## Fix

Replaced hardcoded dark colors with theme-aware variants:
- `text-white` → `text-[rgb(var(--foreground))]` (plan name & price)
- `text-slate-400` → `text-[rgb(var(--muted))]` (loading text)
- `text-red-400` → `text-red-600 dark:text-red-400`
- `text-amber-400` → `text-amber-700 dark:text-amber-400`
- `text-emerald-400` → `text-emerald-600 dark:text-emerald-400`
- status pills (`text-neutral-400`/`text-amber-400`/`text-red-400`) → light+dark pairs

Applied across the subscription settings page, the signup choose-plan step, and the add-card banner (shared plan UI).

## Files changed
- `apps/web/app/(app)/settings/subscription/page.tsx` — plan name/price, status pills, trial/cancel notices, badges, error text, success toast
- `apps/web/app/(auth)/signup/page.tsx` — loading text, validation errors, plan badges, support/optional chips
- `apps/web/app/components/add-card-banner.tsx` — loading text, price display, error text, trial banner

## Validation
- Pure `className` string changes (no logic/type changes) — typecheck-safe.
- To run before merge: `pnpm --filter @silentsuite/web typecheck` + lint.
- **Visual verification needed on the deployed Cloudflare Pages preview in LIGHT theme** before merge: confirm the plan name, price, error text, trial banner, and reactivation success toast are all legible against the light background.

Closes #329