### PR TITLE
fix(webapp): lay out overlapping calendar events side-by-side (#330)

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -515,6 +515,13 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     weekOptions: {
       gridHeight: 800,
       eventWidth: 95,
+      // Concurrent (overlapping) events — e.g. from different collections — must
+      // render in side-by-side columns instead of stacking on top of each other.
+      // Schedule-X defaults eventOverlap to true, which paints each event at full
+      // eventWidth and lets them visually hide one another. Setting it to false
+      // makes Schedule-X divide the day column among concurrent events so both
+      // are visible. See issue #330.
+      eventOverlap: false,
     },
     plugins: [eventsPlugin],
     callbacks: {


### PR DESCRIPTION
## Root cause

The webapp calendar uses Schedule-X v4.3.1. Schedule-X **defaults `weekOptions.eventOverlap` to `true`** (verified: `core.umd.js:5351`), which paints each concurrent event at the full `eventWidth` (95) and lets them visually overlap. Its `getWidthRule` (`core.umd.js:1464`) only divides the day-column width among concurrent events when `eventOverlap` is `false`. So events from different collections that share a time slot were stacking on top of each other instead of rendering side-by-side.

## Fix

One-line config change: set `eventOverlap: false` in `weekOptions` so Schedule-X lays out concurrent events in side-by-side columns (standard calendar behavior).

```ts
weekOptions: {
  gridHeight: 800,
  eventWidth: 95,
  eventOverlap: false,  // concurrent events render side-by-side, not stacked
},
```

Verified `eventOverlap: boolean` is a valid `WeekOptions` field in the installed `@schedule-x/calendar@4.3.1` type definitions (`core.d.ts:1008`, `weekOptions?: Partial<WeekOptions>` at `core.d.ts:1080`).

## Files changed
- `apps/web/app/(app)/calendar/components/CalendarGrid.tsx` — add `eventOverlap: false` to `weekOptions`

## Validation
- Type-safe: `eventOverlap: boolean` is a valid `WeekOptions` field; `weekOptions` accepts `Partial<WeekOptions>`.
- To run before merge: `pnpm --filter @silentsuite/web typecheck` + lint.
- **Visual verification needed on the deployed Cloudflare Pages preview before merge**: create two events from different calendar collections with overlapping time slots in week/day view and confirm they render side-by-side rather than overlapping.

Closes #330