### PR TITLE
fix(bridge): bind Add Account button via addEventListener so showLoginPanel is defined (#333)

### DIFF
--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -552,7 +552,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
     </style>
 </head>
 <body>
-    <script>window.SILENTSUITE_DASHBOARD_CSRF = '{{CSRF_TOKEN}}';</script>
+    <script>window.SILENTSUITE_DASHBOARD_CSRF = {{CSRF_TOKEN}};</script>
     <div class="container">
         <h1>SilentSuite Bridge</h1>
         <div class="version">v{{VERSION}}</div>
@@ -579,7 +579,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
             <div class="url-section">
                 <div class="section-title-row">
                     <h3>Configured Accounts</h3>
-                    <button id="addAccountBtn" class="account-action-btn primary" onclick="showLoginPanel()">Add / Re-authenticate Account</button>
+                    <button id="addAccountBtn" class="account-action-btn primary">Add / Re-authenticate Account</button>
                 </div>
                 <div id="accountActionStatus" class="account-action-status" role="status"></div>
                 <div id="dashboardLoginPanel" class="login-panel {{LOGIN_PANEL_CLASS}}" data-required="{{LOGIN_REQUIRED}}">
@@ -621,6 +621,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
         <script>
             (function() {
                 var sel = document.getElementById('syncInterval');
+                if (!sel) return;
                 sel.value = '{{SYNC_INTERVAL}}';
                 // fallback if value doesn't match any option
                 if (sel.selectedIndex === -1) sel.value = '900';
@@ -771,6 +772,14 @@ DASHBOARD_HTML = """<!DOCTYPE html>
             }
             pollProgress();
             setInterval(pollProgress, 2000);
+            // Bind the 'Add / Re-authenticate Account' button via addEventListener
+            // rather than an inline onclick, so the handler does not depend on
+            // inline-onclick resolving a global function (the failure mode behind
+            // 'showLoginPanel is not defined at HTMLButtonElement.onclick'). #333.
+            (function() {
+                var addAccountBtn = document.getElementById('addAccountBtn');
+                if (addAccountBtn) addAccountBtn.addEventListener('click', showLoginPanel);
+            })();
         </script>
 
         <div class="status-card log-section">
@@ -964,7 +973,9 @@ def _render_dashboard():
     page = page.replace("{{COLLECTIONS}}", esc(col_text))
     page = page.replace("{{ACCOUNT_LIST}}", account_html)
     page = page.replace("{{SYNC_LOG}}", log_html)
-    page = page.replace("{{CSRF_TOKEN}}", esc(_dashboard_csrf_token))
+    # JSON-encode the CSRF token so it is always a valid JS string literal
+    # (defence-in-depth: no dependency on the token charset for JS-safety).
+    page = page.replace("{{CSRF_TOKEN}}", json.dumps(_dashboard_csrf_token))
     page = page.replace("{{LOGIN_PANEL_CLASS}}", login_panel_class)
     page = page.replace("{{LOGIN_REQUIRED}}", login_required)
     page = page.replace("{{LOGIN_TITLE}}", esc(login_title))

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -200,6 +200,21 @@ def test_render_dashboard_escapes_account_action_attributes(tmp_path, monkeypatc
     assert "removeAccount('" not in html
 
 
+def test_add_account_button_bound_via_add_event_listener(tmp_path, monkeypatch):
+    """#333: the Add/Re-authenticate button must not rely on an inline onclick
+    resolving a global showLoginPanel function - bind via addEventListener."""
+    _reset_status()
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+
+    html = _render_dashboard()
+
+    assert 'onclick="showLoginPanel()"' not in html
+    assert "addEventListener('click', showLoginPanel)" in html
+    # CSRF must be injected as a JSON string literal (no surrounding single quotes
+    # in the template) so it is always valid JS.
+    assert "window.SILENTSUITE_DASHBOARD_CSRF = {{CSRF_TOKEN}}" not in html
+
+
 def test_forget_account_status_removes_one_accounts_counts():
     _reset_status()
     update_status(


### PR DESCRIPTION
## Root cause / failure class

Clicking **"Add / Re-authenticate Account"** on the bridge dashboard threw:
```
Uncaught ReferenceError: showLoginPanel is not defined
    at HTMLButtonElement.onclick
```

The button used an inline `onclick="showLoginPanel()"` that depends on inline-onclick resolving a **global** function. Inline-onclick global resolution is the classic failure mode behind `ReferenceError: X is not defined at HTMLButtonElement.onclick` — it breaks when script execution is interrupted before the function is established, or under browser scoping/CSP quirks, leaving the click dead and the login panel never opening.

## Fix

Make the binding robust and remove the fragile inline-onclick dependency:

1. **Bind `#addAccountBtn` via `addEventListener`** at the end of the dashboard `<script>` instead of an inline `onclick`. The handler no longer depends on inline-onclick global resolution.
2. **Guard the `syncInterval` IIFE** with a null-check (`if (!sel) return;`) so a missing element can never halt the script before the function/binding are established.
3. **JSON-encode the CSRF token** (`json.dumps`) so the injected `window.SILENTSUITE_DASHBOARD_CSRF` value is always a valid JS string literal regardless of token content (defence-in-depth; previously relied on the token charset being JS-safe inside single quotes).

## Files changed
- `bridge/src/silentsuite_bridge/web/__init__.py` — remove inline onclick, add addEventListener binding, guard IIFE, JSON-encode CSRF
- `bridge/tests/test_web_dashboard.py` — new regression test asserting the button is bound via `addEventListener('click', showLoginPanel)` and not via inline `onclick`

## Validation
- `python3 -m py_compile` passes on both changed files (syntax OK).
- Per project convention (AGENTS.md S2), the full bridge pytest suite (requires `radicale` + `etebase` + Rust toolchain) runs in **CI**, which will execute the new regression test.
- The exact macOS trigger could not be reproduced headlessly on `ss` (no macOS). **Please verify on macOS** with the new build that clicking "Add / Re-authenticate Account" opens the login panel without a console error.

## Note
The other inline `onclick` handlers (`logoutAccount`, `removeAccount`, `toggleFingerprint`, `copy`) were left as-is to keep this PR focused on the reported bug; they can be migrated to `addEventListener` in a follow-up if desired.

Closes #333