### PR TITLE
fix(webapp): show full title for short calendar events (#331)

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -680,6 +680,44 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     }
   }, [sxEvents, eventsPlugin])
 
+  // #331: Reveal the full title on short/clipped calendar events.
+  // Schedule-X clips event text with `overflow: hidden`, so a short event's
+  // title can be unreadable. The DOM still holds the full text, so mirror it
+  // into a native `title` tooltip on each event element so hovering shows the
+  // complete title (and time). A MutationObserver keeps titles in sync across
+  // re-renders, sync updates, and view switches.
+  useEffect(() => {
+    const root = document.querySelector('.sx-silentsuite-calendar')
+    if (!root) return
+
+    const selector = '.sx__time-grid-event, .sx__month-grid-event, .sx__day-grid-event'
+    const applyAll = () => {
+      root.querySelectorAll(selector).forEach((el) => {
+        const text = (el.textContent || '').replace(/\s+/g, ' ').trim()
+        if (text && el.getAttribute('title') !== text) {
+          el.setAttribute('title', text)
+        }
+      })
+    }
+
+    let raf = 0
+    const schedule = () => {
+      if (raf) return
+      raf = requestAnimationFrame(() => {
+        raf = 0
+        applyAll()
+      })
+    }
+
+    applyAll()
+    const observer = new MutationObserver(schedule)
+    observer.observe(root, { childList: true, subtree: true })
+    return () => {
+      if (raf) cancelAnimationFrame(raf)
+      observer.disconnect()
+    }
+  }, [sxEvents, currentView])
+
   /** Find the time grid scrollable container and calculate time from Y */
   const getTimeFromY = useCallback(
     (clientY: number, gridEl: HTMLElement): number => {


### PR DESCRIPTION
## Root cause

Schedule-X renders time-grid events with `overflow: hidden` on `.sx__time-grid-event` (`apps/web/app/globals.css:260`). For a short (~15-30 min) event the block is too small to show the full title, so the text is clipped — and there was no way to see the complete title.

## Fix

The DOM still holds the full title text (CSS clipping is visual only). Mirror each event element's `textContent` into a native `title` tooltip so hovering a clipped event reveals the complete title (and time). A debounced `MutationObserver` keeps the tooltips in sync across re-renders, background sync updates, and view switches.

```tsx
useEffect(() => {
  const root = document.querySelector('.sx-silentsuite-calendar')
  if (!root) return
  const selector = '.sx__time-grid-event, .sx__month-grid-event, .sx__day-grid-event'
  // ... set title = trimmed textContent on each event element, debounced via rAF
}, [sxEvents, currentView])
```

This is the least-invasive fix that works with Schedule-X's default rendering (no custom event component, no styling regression). Applies to time-grid (week/day), month-grid, and all-day events.

## Files changed
- `apps/web/app/(app)/calendar/components/CalendarGrid.tsx` — add a `useEffect` that sets native `title` tooltips on rendered event elements, kept in sync via a debounced `MutationObserver`

## Validation
- `pnpm --filter @silentsuite/web exec tsc --noEmit` passes (exit 0).
- **Visual verification needed on the deployed Cloudflare Pages preview before merge**: create a short (~15-30 min) event with a longish title in week/day view and confirm hovering reveals the full title; also confirm long events and month view are unaffected.

Closes #331