### PR TITLE
fix(bridge): prevent password exposure when DAV URL opened in a browser (#332)

### DIFF
--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -443,6 +443,7 @@ SUCCESS_PAGE_HTML = """<!DOCTYPE html>
                 <button class="copy-btn" onclick="copyUrl(event, 'bridgeUrl')">Copy</button>
             </div>
             <p class="url-note">CalDAV and CardDAV share the same base URL &mdash; this is normal. Your app will discover calendars and contacts automatically.</p>
+            <p class="url-note" style="color:#f59e0b;">This URL is for calendar/contact apps, not a web browser. Copy it into your app &mdash; opening it in a browser can expose your password in the address bar.</p>
             DASHBOARD_BOOKMARK
             <div class="next-step">
                 You're signed in. You can close this tab &mdash; the bridge is already running in the background and will keep syncing on its own.

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -939,6 +939,7 @@ def _render_dashboard():
                 '</div>'
                 f'<button class="copy-btn" onclick="copy(event, \'{url_id}\')">Copy</button>'
                 '</div>'
+                '<div style="font-size:12px;color:#f59e0b;margin-top:6px;">For calendar/contact apps only. Copy it into your app &mdash; do not open it in a web browser, which can expose your password in the address bar.</div>'
                 '<div class="account-actions">'
                 f'<button class="account-action-btn" data-account="{account_attr}" '
                 'onclick="logoutAccount(this)">Log out</button>'

--- a/bridge/tests/test_dashboard_url_security.py
+++ b/bridge/tests/test_dashboard_url_security.py
@@ -1,0 +1,50 @@
+"""Regression tests for issue #332: credentials must never appear in a URL."""
+
+import re
+
+import pytest
+
+from silentsuite_bridge import config
+from silentsuite_bridge.radicale.creds import Credentials
+from silentsuite_bridge.web import _bridge_status, _render_dashboard
+
+
+def _reset_status():
+    _bridge_status.update({
+        "state": "starting",
+        "last_sync": None,
+        "error": None,
+        "collections": {"calendars": 0, "contacts": 0, "tasks": 0},
+        "collections_by_account": {},
+        "collections_scope": "all configured accounts",
+    })
+
+
+def test_dashboard_urls_never_embed_credentials(tmp_path, monkeypatch):
+    """#332: no URL rendered by the dashboard may embed Basic-Auth userinfo
+    (user:password@host) or a password query param. Credentials must never
+    appear in a URL (browser history / referrer / screenshots). The browser
+    embedding Basic-Auth creds when a user opens the DAV URL is mitigated by
+    warning users not to open it in a browser."""
+    _reset_status()
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(
+        "silentsuite_bridge.web._account_fingerprint", lambda _c, _u: None
+    )
+
+    creds = Credentials()
+    creds.set_etebase("alice@example.com", "alice-session", "https://server.test")
+    creds.save()
+
+    html = _render_dashboard()
+
+    # The displayed DAV URL puts the email in the path only; the authority has
+    # no user:password@ userinfo.
+    assert "http://127.0.0.1:37358/alice@example.com/" in html
+    userinfo = re.search(r"https?://[^/\s@]+:[^/\s@]+@", html)
+    assert userinfo is None, "credential userinfo embedded in URL: " + str(userinfo)
+    assert re.search(r"[?&](password|passwd|token|secret)=", html, re.I) is None
+    # Users are warned not to open the CalDAV URL in a browser.
+    assert "do not open it in a web browser" in html


### PR DESCRIPTION
## Root cause

When a user opens the CalDAV/CardDAV URL (`http://127.0.0.1:PORT/<email>/`) in a **web browser**, Radicale's HTTP Basic-Auth challenge causes the browser to embed the credentials as `http://email:password@127.0.0.1:PORT/...` in the address bar, leaking the password via browser history / screenshots / referrer. (Confirmed by the reporter: the URL bar showed `http://email:password@...`.)

**The bridge itself never puts credentials in a URL** — I audited every code path:
- Dashboard URL (`__main__._dashboard_url()`), tray "Open Dashboard", and all `webbrowser.open()` calls use clean `http://host:port/` URLs.
- The `--login` browser auth flow (`auth_browser.py`) POSTs the password in the request body and redirects to `/success` (no credentials in any URL).
- The displayed DAV URL is `http://host:port/<email>/` (email in the path only, no password).
- Radicale validates CalDAV-client credentials via HTTP Basic Auth against a stored hash (`radicale/auth.py`).

So the leak is **browser Basic-Auth behaviour** when the DAV URL is opened in a browser instead of pasted into a calendar/contact app.

## Fix

Mitigate at the UX layer so users never open the DAV URL in a browser:
- **Dashboard** (`web/__init__.py`): add a warning beside each account's CalDAV/CardDAV URL — "For calendar/contact apps only. Copy it into your app — do not open it in a web browser, which can expose your password in the address bar."
- **Post-login success page** (`auth_browser.py`): add the same warning beside the bridge URL.
- **Regression test** (`tests/test_dashboard_url_security.py`): assert no URL rendered by the dashboard embeds Basic-Auth userinfo (`user:password@host`) or a password query param, and that the warning is present. This locks in the secure behaviour.

## Files changed
- `bridge/src/silentsuite_bridge/web/__init__.py` — dashboard warning beside the DAV URL
- `bridge/src/silentsuite_bridge/auth_browser.py` — success-page warning beside the bridge URL
- `bridge/tests/test_dashboard_url_security.py` — new regression test

## Validation
- `python3 -m py_compile` passes on all three files (syntax OK).
- Per project convention (AGENTS.md S2), the full bridge pytest suite (requires `radicale` + `etebase` + Rust toolchain) runs in **CI**, which will execute the new regression test.

## Note / follow-up
A hard technical prevention — serving a friendly HTML info page to browser requests at the DAV collection root instead of a 401, while keeping Basic Auth for real CalDAV clients — is possible but requires deeper Radicale auth/routing changes and risks breaking CalDAV discovery. That is left as a follow-up; this PR addresses the reported vector (opening the URL in a browser) with clear guidance and a regression guard.

Closes #332