### PR TITLE
fix: add kxml2 dep for androidTest R8 build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -188,6 +188,7 @@ dependencies {
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
     // UIAutomator for store screenshot capture instrumentation tests
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
+    androidTestImplementation 'net.sf.kxml:kxml2:2.3.0'
     testImplementation 'junit:junit:4.12'
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
 }

--- a/android/app/proguard-rules.txt
+++ b/android/app/proguard-rules.txt
@@ -71,3 +71,4 @@
 -dontwarn org.openjsse.javax.net.ssl.SSLParameters
 -dontwarn org.openjsse.javax.net.ssl.SSLSocket
 -dontwarn org.openjsse.net.ssl.OpenJSSE
+-dontwarn org.kxml2.**


### PR DESCRIPTION
R8 minification on debug androidTest fails with missing org.kxml2 classes. Add kxml2 dependency + proguard dontwarn rule.