### PR TITLE
fix: apply proguard rules to androidTest R8 build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,6 +30,7 @@ android {
         debug {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            testProguardFile 'proguard-rules.txt'
 
             /*
              * To override the server's url (for example when developing),
@@ -46,6 +47,7 @@ android {
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            testProguardFile 'proguard-rules.txt'
             buildConfigField 'String', 'DEBUG_REMOTE_URL', 'null'
 
             // Configure Kotlin compiler optimisations for releases

--- a/android/app/proguard-rules.txt
+++ b/android/app/proguard-rules.txt
@@ -72,3 +72,4 @@
 -dontwarn org.openjsse.javax.net.ssl.SSLSocket
 -dontwarn org.openjsse.net.ssl.OpenJSSE
 -dontwarn org.kxml2.**
+-dontwarn org.xmlpull.**


### PR DESCRIPTION
Add testProguardFile so -dontwarn rules suppress kxml2/xmlpull missing class errors in the androidTest R8 step.