### PR TITLE
fix: upgrade androidTest deps to fix instrumentation test crash

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -180,17 +180,14 @@ dependencies {
     implementation project(':ical4android')
     implementation project(':vcard4android')
     // for tests
-    androidTestImplementation('androidx.test:runner:1.1.0-alpha4') {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
-    androidTestImplementation('androidx.test:rules:1.1.0-alpha4') {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
-    androidTestImplementation 'junit:junit:4.12'
+    androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
     // UIAutomator for store screenshot capture instrumentation tests
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
     androidTestImplementation 'net.sf.kxml:kxml2:2.3.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
 }

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -42,7 +42,7 @@ import org.junit.runners.MethodSorters;
 
 import java.io.File;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;


### PR DESCRIPTION
Upgrade androidx.test:runner and rules from 1.1.0-alpha4 (2018) to 1.6.x (2024) to resolve a version conflict with uiautomator:2.3.0 that crashed the instrumentation test on launch. Fix the InstrumentationRegistry import path. Add ext:junit. Upgrade junit to 4.13.2.