### PR TITLE
fix: exact R8 dontwarn for kxml2 service loader class

### DIFF
--- a/android/app/proguard-rules.txt
+++ b/android/app/proguard-rules.txt
@@ -73,3 +73,4 @@
 -dontwarn org.openjsse.net.ssl.OpenJSSE
 -dontwarn org.kxml2.**
 -dontwarn org.xmlpull.**
+-dontwarn org.kxml2.io.KXmlParser,org.kxml2.io.KXmlSerializer


### PR DESCRIPTION
Add exact comma-separated class name to proguard rules for R8 full mode.