### PR TITLE
fix: disable R8 full mode for androidTest build

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2048M
+android.enableR8.fullMode=false


### PR DESCRIPTION
R8 full mode fails on missing transitive annotation classes from androidx.test. Switch to compat mode.