### PR TITLE
fix: harden Windows bridge installer

### DIFF
--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -1,0 +1,113 @@
+name: Test Bridge (Windows)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'bridge/**'
+      - 'apps/docs/user-guide/apps/dav-bridge.md'
+      - 'tests/test_windows_installer_static.py'
+      - '.github/workflows/test-bridge-windows.yml'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'bridge/**'
+      - 'apps/docs/user-guide/apps/dav-bridge.md'
+      - 'tests/test_windows_installer_static.py'
+      - '.github/workflows/test-bridge-windows.yml'
+
+jobs:
+  installer:
+    name: Installer and docs checks
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Run static installer/docs regression tests
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pytest tests/test_windows_installer_static.py -q
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
+
+      - name: Analyze PowerShell installer
+        shell: pwsh
+        run: |
+          $results = Invoke-ScriptAnalyzer -Path bridge/install.ps1 -Severity Error
+          $results | Format-Table -AutoSize
+          if ($results) { throw "PSScriptAnalyzer found errors in bridge/install.ps1" }
+
+      - name: Assert installer failures do not exit parent PowerShell
+        shell: pwsh
+        run: |
+          $script = Get-Content bridge/install.ps1 -Raw
+          $tokens = $null
+          $errors = $null
+          $ast = [System.Management.Automation.Language.Parser]::ParseInput($script, [ref]$tokens, [ref]$errors)
+          if ($errors.Count -gt 0) {
+            $errors | Format-List
+            throw "PowerShell parser errors in bridge/install.ps1"
+          }
+
+          $writeErr = $ast.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Write-Err'
+          }, $true)
+          if (-not $writeErr) { throw "Write-Err helper not found" }
+
+          $exitStatements = $writeErr.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.ExitStatementAst]
+          }, $true)
+          if ($exitStatements.Count -gt 0) {
+            throw "Write-Err must not call exit because irm ... | iex would close the user's terminal"
+          }
+
+  smoke:
+    name: Bridge CLI smoke test
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: "1.63.0"
+
+      - name: Install bridge package
+        working-directory: bridge
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" || pip install -e .
+
+      - name: silentsuite-bridge --version
+        shell: pwsh
+        run: silentsuite-bridge --version
+
+      - name: silentsuite-bridge --help
+        shell: pwsh
+        run: silentsuite-bridge --help

--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -29,19 +29,41 @@ The bridge exposes every SilentSuite calendar, task list, and address book as it
 
 ## Install
 
+### Windows
+
+Download the current Windows bridge binary directly:
+
+- [Download SilentSuite Bridge for Windows x86_64](https://github.com/silent-suite/silentsuite/releases/latest/download/silentsuite-bridge-windows-x86_64.exe)
+- [Windows SHA256 checksum](https://github.com/silent-suite/silentsuite/releases/latest/download/silentsuite-bridge-windows-x86_64.exe.sha256)
+
+Save the file in Downloads. You can either keep the release file name or rename it to `silentsuite-bridge.exe`, then run it from an already-open PowerShell or Windows Terminal window so any first-run errors stay visible:
+
+```powershell
+cd $env:USERPROFILE\Downloads
+.\silentsuite-bridge-windows-x86_64.exe --version
+.\silentsuite-bridge-windows-x86_64.exe --login
+```
+
+If you renamed the file, use `./silentsuite-bridge.exe` instead.
+
+If Windows SmartScreen appears, choose **More info** and only continue if the publisher/file name matches the SilentSuite release you downloaded.
+
 ### Installer Status
 
-Bridge installer scripts are not yet published as stable `main`/release-tagged endpoints. Until they are, download bridge binaries from the [GitHub releases](https://github.com/silent-suite/silentsuite/releases) page instead of piping an installer URL into your shell.
+Bridge installer scripts are being hardened. If you use a PowerShell installer command, run it from an already-open PowerShell or Windows Terminal window, not from the Run dialog or by double-clicking a `.ps1` file.
 
 ::: warning
 Do not run installer commands from the public `dev` branch. Those scripts may contain unreleased changes and are not part of the stable docs flow.
 :::
 
-When stable installers are published, they will:
-1. Download the correct binary for your OS and architecture
-2. Install it to `~/.local/bin/`
-3. Optionally set up auto-start
-4. Open the bridge dashboard for first-time login
+If a PowerShell window closes before you can read the error, reopen PowerShell and run the diagnostic form instead. It downloads the installer to a temporary file and runs it with `-File`, so failures stay visible and are also written to `%LOCALAPPDATA%\SilentSuite\install.log`.
+
+```powershell
+irm https://raw.githubusercontent.com/silent-suite/silentsuite/main/bridge/install.ps1 -OutFile $env:TEMP\silentsuite-bridge-install.ps1
+powershell -ExecutionPolicy Bypass -File $env:TEMP\silentsuite-bridge-install.ps1
+```
+
+All downloads are also available from the [GitHub releases](https://github.com/silent-suite/silentsuite/releases) page.
 
 ## First-Time Setup
 

--- a/bridge/install.ps1
+++ b/bridge/install.ps1
@@ -1,7 +1,11 @@
 # SilentSuite Bridge — Windows PowerShell installer
 #
 # Usage:
-#   irm silentsuite.io/bridge/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/silent-suite/silentsuite/main/bridge/install.ps1 | iex
+#
+# Safer diagnostic usage if a one-liner fails:
+#   irm https://raw.githubusercontent.com/silent-suite/silentsuite/main/bridge/install.ps1 -OutFile $env:TEMP\silentsuite-bridge-install.ps1
+#   powershell -ExecutionPolicy Bypass -File $env:TEMP\silentsuite-bridge-install.ps1
 #
 # This script:
 # 1. Detects architecture (x86_64 only)
@@ -12,6 +16,7 @@
 #
 # License: AGPL-3.0
 
+$PreviousErrorActionPreference = $ErrorActionPreference
 $ErrorActionPreference = "Stop"
 
 # --- Configuration ---
@@ -19,137 +24,207 @@ $Repo = "silent-suite/silentsuite"
 $BinaryName = "silentsuite-bridge"
 $InstallDir = if ($env:SILENTSUITE_INSTALL_DIR) { $env:SILENTSUITE_INSTALL_DIR } else { "$env:LOCALAPPDATA\SilentSuite" }
 $ExePath = "$InstallDir\$BinaryName.exe"
+$InstallLog = Join-Path $InstallDir "install.log"
 
 # --- Helpers ---
-function Write-Step($msg)  { Write-Host "`n  $msg" -ForegroundColor White }
-function Write-Ok($msg)    { Write-Host "  ✓ $msg" -ForegroundColor Green }
-function Write-Warn($msg)  { Write-Host "  ! $msg" -ForegroundColor Yellow }
-function Write-Err($msg)   { Write-Host "  ✗ $msg" -ForegroundColor Red; exit 1 }
-
-# --- Detect architecture ---
-$Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-if ($Arch -ne "X64") {
-    Write-Err "Unsupported architecture: $Arch. Only x86_64 is supported."
-}
-
-# --- Banner ---
-Write-Host ""
-Write-Host "  SilentSuite Bridge" -ForegroundColor White
-Write-Host "  E2EE CalDAV/CardDAV sync for your desktop apps"
-
-# --- Check for existing installation ---
-if (Test-Path $ExePath) {
+function Write-InstallLog($msg) {
     try {
-        $CurrentVersion = & $ExePath --version 2>&1 | Select-Object -First 1
-        Write-Step "Existing installation detected"
-        Write-Ok "Current version: $CurrentVersion"
-        Write-Ok "Upgrading..."
-    } catch {
-        Write-Warn "Existing binary found but could not read version"
-    }
-}
-
-# --- Download latest release ---
-# Fetches the releases list (sorted newest-first) and walks until we find one
-# that carries the bridge asset. Umbrella releases (e.g. v0.1.0-beta) won't
-# have bridge binaries, so we skip past them to the most recent release that
-# actually has a bridge asset (bridge-vX.Y.Z prefix going forward, or the
-# legacy vX.Y.Z-bridge suffix).
-Write-Step "Downloading latest release..."
-$AssetName = "$BinaryName-windows-x86_64.exe"
-$ReleaseUrl = "https://api.github.com/repos/$Repo/releases?per_page=100"
-
-try {
-    $Releases = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
-} catch {
-    Write-Err "Failed to fetch release info from GitHub: $_"
-}
-
-$Release = $null
-$Asset = $null
-foreach ($r in $Releases) {
-    $candidate = $r.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
-    if ($candidate) {
-        $Release = $r
-        $Asset = $candidate
-        break
-    }
-}
-if (-not $Asset) {
-    Write-Err "No asset found matching $AssetName across recent releases. Check https://github.com/$Repo/releases"
-}
-
-# Create install directory
-if (-not (Test-Path $InstallDir)) {
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-}
-
-$TmpFile = Join-Path $env:TEMP "silentsuite-bridge-download.exe"
-try {
-    Invoke-WebRequest -Uri $Asset.browser_download_url -OutFile $TmpFile -UseBasicParsing
-    Write-Ok "Downloaded $AssetName"
-} catch {
-    Write-Err "Download failed: $_"
-}
-
-# --- Verify SHA256 checksum ---
-$ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "$AssetName.sha256" } | Select-Object -First 1
-if ($ChecksumAsset) {
-    try {
-        $ExpectedLine = (Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -UseBasicParsing).Content.Trim()
-        $ExpectedHash = ($ExpectedLine -split '\s+')[0].ToUpper()
-        $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToUpper()
-        if ($ExpectedHash -ne $ActualHash) {
-            Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
-            Write-Err "Checksum mismatch! Expected $ExpectedHash, got $ActualHash"
+        if (-not (Test-Path $InstallDir)) {
+            New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
         }
-        Write-Ok "Checksum verified"
+        $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        Add-Content -Path $InstallLog -Value "[$Timestamp] $msg" -Encoding UTF8
     } catch {
-        Write-Warn "Could not verify checksum: $_"
+        # Logging must never hide the installer error the user needs to see.
     }
 }
 
-# --- Install binary ---
-Move-Item -Path $TmpFile -Destination $ExePath -Force
-Write-Ok "Installed to $ExePath"
+function Write-Step($msg)  { Write-Host "`n  $msg" -ForegroundColor White; Write-InstallLog "STEP $msg" }
+function Write-Ok($msg)    { Write-Host "  ✓ $msg" -ForegroundColor Green; Write-InstallLog "OK $msg" }
+function Write-Warn($msg)  { Write-Host "  ! $msg" -ForegroundColor Yellow; Write-InstallLog "WARN $msg" }
+function Write-Err($msg)   { Write-Host "  ✗ $msg" -ForegroundColor Red; Write-InstallLog "ERROR $msg"; throw $msg }
 
-# --- Add to user PATH ---
-$UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-if ($UserPath -notlike "*$InstallDir*") {
-    [Environment]::SetEnvironmentVariable("PATH", "$InstallDir;$UserPath", "User")
-    Write-Ok "Added $InstallDir to user PATH"
-} else {
-    Write-Ok "$InstallDir already in PATH"
+function Wait-BeforeCloseIfInteractive {
+    if ($env:CI) { return }
+    if (-not [Environment]::UserInteractive) { return }
+
+    try {
+        Write-Host ""
+        Read-Host "Press Enter to close"
+    } catch {
+        # Some non-interactive hosts still report as interactive. Ignore pause failures.
+    }
 }
-$env:PATH = "$InstallDir;$env:PATH"
 
-# --- Auto-start ---
-Write-Step "Setting up auto-start..."
+function Get-GitHubErrorHint($errorRecord) {
+    $statusCode = $null
+    try {
+        $statusCode = [int]$errorRecord.Exception.Response.StatusCode
+    } catch {
+        $statusCode = $null
+    }
+
+    if ($statusCode -eq 403) {
+        return "GitHub refused the release lookup, possibly because the unauthenticated API rate limit was reached. Download manually from https://github.com/$Repo/releases/latest or retry later."
+    }
+    if ($statusCode -eq 404) {
+        return "GitHub did not return release metadata. Check https://github.com/$Repo/releases/latest for current downloads."
+    }
+    return "Check https://github.com/$Repo/releases/latest for manual downloads."
+}
+
+function Invoke-SilentSuiteBridgeInstall {
+    # --- Detect architecture ---
+    $Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    if ($Arch -ne "X64") {
+        Write-Err "Unsupported architecture: $Arch. Only x86_64 is supported."
+    }
+
+    # --- Banner ---
+    Write-Host ""
+    Write-Host "  SilentSuite Bridge" -ForegroundColor White
+    Write-Host "  E2EE CalDAV/CardDAV sync for your desktop apps"
+    Write-InstallLog "Installer started"
+
+    # --- Check for existing installation ---
+    if (Test-Path $ExePath) {
+        try {
+            $CurrentVersion = & $ExePath --version 2>&1 | Select-Object -First 1
+            Write-Step "Existing installation detected"
+            Write-Ok "Current version: $CurrentVersion"
+            Write-Ok "Upgrading..."
+        } catch {
+            Write-Warn "Existing binary found but could not read version"
+        }
+    }
+
+    # --- Download latest release ---
+    Write-Step "Downloading latest release..."
+    $AssetName = "$BinaryName-windows-x86_64.exe"
+    $ReleaseUrl = "https://api.github.com/repos/$Repo/releases/latest"
+
+    try {
+        $Release = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
+    } catch {
+        $Hint = Get-GitHubErrorHint $_
+        Write-Err "Failed to fetch latest release info from GitHub: $_. $Hint"
+    }
+
+    $Asset = $Release.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+    if (-not $Asset) {
+        # Fallback for the unlikely case where the newest umbrella release has no bridge asset.
+        $ReleaseListUrl = "https://api.github.com/repos/$Repo/releases?per_page=25"
+        try {
+            $Releases = Invoke-RestMethod -Uri $ReleaseListUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
+        } catch {
+            $Hint = Get-GitHubErrorHint $_
+            Write-Err "Latest release did not contain $AssetName and fallback release lookup failed: $_. $Hint"
+        }
+
+        foreach ($r in $Releases) {
+            $candidate = $r.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+            if ($candidate) {
+                $Release = $r
+                $Asset = $candidate
+                break
+            }
+        }
+    }
+
+    if (-not $Asset) {
+        Write-Err "No asset found matching $AssetName across recent releases. Download manually from https://github.com/$Repo/releases/latest"
+    }
+
+    # Create install directory
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    $TmpFile = Join-Path $env:TEMP "silentsuite-bridge-download.exe"
+    try {
+        Invoke-WebRequest -Uri $Asset.browser_download_url -OutFile $TmpFile -UseBasicParsing
+        Write-Ok "Downloaded $AssetName from $($Release.tag_name)"
+    } catch {
+        Write-Err "Download failed: $_. Try downloading manually from https://github.com/$Repo/releases/latest"
+    }
+
+    # --- Verify SHA256 checksum ---
+    $ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "$AssetName.sha256" } | Select-Object -First 1
+    if ($ChecksumAsset) {
+        try {
+            $ExpectedLine = (Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -UseBasicParsing).Content.Trim()
+            $ExpectedHash = ($ExpectedLine -split '\s+')[0].ToUpper()
+            $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToUpper()
+            if ($ExpectedHash -ne $ActualHash) {
+                Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+                Write-Err "Checksum mismatch! Expected $ExpectedHash, got $ActualHash"
+            }
+            Write-Ok "Checksum verified"
+        } catch {
+            Write-Warn "Could not verify checksum: $_"
+        }
+    } else {
+        Write-Warn "No checksum asset found for $AssetName"
+    }
+
+    # --- Install binary ---
+    Move-Item -Path $TmpFile -Destination $ExePath -Force
+    Write-Ok "Installed to $ExePath"
+
+    # --- Add to user PATH ---
+    $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    if ($UserPath -notlike "*$InstallDir*") {
+        [Environment]::SetEnvironmentVariable("PATH", "$InstallDir;$UserPath", "User")
+        Write-Ok "Added $InstallDir to user PATH"
+    } else {
+        Write-Ok "$InstallDir already in PATH"
+    }
+    $env:PATH = "$InstallDir;$env:PATH"
+
+    # --- Auto-start ---
+    Write-Step "Setting up auto-start..."
+    try {
+        & $ExePath --install-autostart 2>&1 | Out-Null
+        Write-Ok "Auto-start configured"
+    } catch {
+        Write-Warn "Could not set up auto-start (run later: $BinaryName --install-autostart)"
+    }
+
+    # --- Login ---
+    Write-Step "Launching login..."
+    Write-Host "  Opening your browser to sign in."
+    Write-Host "  After login, the bridge runs in the background.`n"
+    try {
+        & $ExePath --login
+        Start-Process -FilePath $ExePath -ArgumentList "--no-tray" -WindowStyle Hidden
+        Start-Sleep -Seconds 2
+        Write-Ok "Bridge is running! Dashboard: http://localhost:37358/"
+    } catch {
+        Write-Warn "Login did not complete. Run later: $BinaryName --login"
+    }
+
+    # --- Done ---
+    Write-Step "Setup complete!"
+    Write-Host ""
+    Write-Host "  Bridge installed." -ForegroundColor Green
+    Write-Host "  Dashboard: " -NoNewline; Write-Host "http://localhost:37358/" -ForegroundColor Cyan
+    Write-Host "  Log in:    " -NoNewline; Write-Host "$BinaryName --login" -ForegroundColor Cyan
+    Write-Host "  Log file:  " -NoNewline; Write-Host "$InstallLog" -ForegroundColor Cyan
+    Write-Host "  Full docs: " -NoNewline; Write-Host "https://docs.silentsuite.io/bridge" -ForegroundColor Cyan
+    Write-Host ""
+}
+
 try {
-    & $ExePath --install-autostart 2>&1 | Out-Null
-    Write-Ok "Auto-start configured"
+    Invoke-SilentSuiteBridgeInstall
 } catch {
-    Write-Warn "Could not set up auto-start (run later: $BinaryName --install-autostart)"
+    Write-Host ""
+    Write-Host "  SilentSuite Bridge install failed." -ForegroundColor Red
+    Write-Host "  Error: $_" -ForegroundColor Red
+    Write-Host "  Log file: $InstallLog" -ForegroundColor Yellow
+    Write-Host "  Manual download: https://github.com/$Repo/releases/latest/download/silentsuite-bridge-windows-x86_64.exe" -ForegroundColor Cyan
+    Write-InstallLog "Install failed: $_"
+    Wait-BeforeCloseIfInteractive
+    throw
+} finally {
+    $ErrorActionPreference = $PreviousErrorActionPreference
 }
-
-# --- Login ---
-Write-Step "Launching login..."
-Write-Host "  Opening your browser to sign in."
-Write-Host "  After login, the bridge runs in the background.`n"
-try {
-    & $ExePath --login
-    Start-Process -FilePath $ExePath -ArgumentList "--no-tray" -WindowStyle Hidden
-    Start-Sleep -Seconds 2
-    Write-Ok "Bridge is running! Dashboard: http://localhost:37358/.web/"
-} catch {
-    Write-Warn "Login did not complete. Run later: $BinaryName --login"
-}
-
-# --- Done ---
-Write-Step "Setup complete!"
-Write-Host ""
-Write-Host "  Bridge installed." -ForegroundColor Green
-Write-Host "  Dashboard: " -NoNewline; Write-Host "http://localhost:37358/.web/" -ForegroundColor Cyan
-Write-Host "  Log in:    " -NoNewline; Write-Host "$BinaryName --login" -ForegroundColor Cyan
-Write-Host "  Full docs: " -NoNewline; Write-Host "https://docs.silentsuite.io/bridge" -ForegroundColor Cyan
-Write-Host ""

--- a/tests/test_windows_installer_static.py
+++ b/tests/test_windows_installer_static.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "bridge" / "install.ps1"
+DOCS = ROOT / "apps" / "docs" / "user-guide" / "apps" / "dav-bridge.md"
+WINDOWS_WORKFLOW = ROOT / ".github" / "workflows" / "test-bridge-windows.yml"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_windows_installer_error_helper_does_not_exit_parent_powershell():
+    script = read(INSTALLER)
+    helper_match = re.search(r"function\s+Write-Err\s*\([^)]*\)\s*\{(?P<body>.*?)\n\}", script, re.DOTALL)
+    assert helper_match, "installer should define a Write-Err helper"
+    helper_body = helper_match.group("body")
+
+    assert not re.search(r"\bexit\b", helper_body, re.IGNORECASE), (
+        "Write-Err must not call exit; under `irm ... | iex` that can close the user's PowerShell window"
+    )
+    assert re.search(r"\bthrow\b", helper_body, re.IGNORECASE), (
+        "Write-Err should throw so failures are visible without terminating the parent host"
+    )
+
+
+def test_windows_installer_has_top_level_error_log_and_interactive_pause():
+    script = read(INSTALLER)
+
+    assert "$InstallLog" in script
+    assert "%LOCALAPPDATA%" in script or "$env:LOCALAPPDATA" in script
+    assert "Press Enter to close" in script
+    assert re.search(r"try\s*\{", script, re.IGNORECASE)
+    assert re.search(r"catch\s*\{", script, re.IGNORECASE)
+
+
+def test_bridge_docs_link_direct_windows_asset_and_visible_error_recovery():
+    docs = read(DOCS)
+
+    assert "silentsuite-bridge-windows-x86_64.exe" in docs
+    assert "silentsuite-bridge-windows-x86_64.exe.sha256" in docs
+    assert "already-open PowerShell" in docs or "already-open Windows Terminal" in docs
+    assert "-OutFile" in docs and "-File" in docs
+
+
+def test_windows_github_actions_workflow_covers_installer_and_binary_smoke_tests():
+    workflow = read(WINDOWS_WORKFLOW)
+
+    assert "windows-latest" in workflow
+    assert "install.ps1" in workflow
+    assert "PSScriptAnalyzer" in workflow
+    assert "Write-Err" in workflow
+    assert "silentsuite-bridge --version" in workflow or "silentsuite-bridge.exe --version" in workflow


### PR DESCRIPTION
## Summary
- Adds direct Windows bridge download links and visible-error recovery instructions to the user guide.
- Hardens `bridge/install.ps1` so failure paths throw/log instead of calling `exit 1` from `irm ... | iex` and closing the user's PowerShell window.
- Adds a Windows GitHub Actions workflow for installer/docs regression checks, PowerShell AST/script analysis, and bridge CLI smoke tests.

## Test Plan
- [x] `/tmp/ss-bridge-installer-venv/bin/python -m pytest tests/test_windows_installer_static.py -q`
- [x] `pnpm --filter @silentsuite/docs build`
- [x] `python3` YAML parse for `.github/workflows/test-bridge-windows.yml`
- [x] `git diff --check`
- [ ] GitHub Actions Windows workflow on PR

Closes #353
