### PR TITLE
fix: sanitize screenshot args and robust login tap

### DIFF
--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -214,7 +214,9 @@ public class StoreScreenshotsTest {
         }
         UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), 1000);
         if (!loggedIn || emailField != null) {
-            throw new AssertionError("Cannot capture " + screenName + ": login did not complete");
+            throw new AssertionError("Cannot capture " + screenName + ": login did not complete (credentials present="
+                    + (testEmail != null && !testEmail.isEmpty() && testPassword != null && !testPassword.isEmpty())
+                    + ", currentPackage=" + device.getCurrentPackageName() + ")");
         }
     }
 
@@ -243,7 +245,14 @@ public class StoreScreenshotsTest {
         }
 
         fillLoginFields();
-        tapRes("login");
+        device.pressBack(); // hide keyboard so the bottom login button is clickable
+        sleep(500);
+        if (!tapRes("login") && !tapText("LOG IN") && !tapText("Log In")) {
+            // Fallback for MaterialButton instances that expose neither stable
+            // resource id nor text to UiAutomator on API 35.
+            device.click(device.getDisplayWidth() / 2, device.getDisplayHeight() - 115);
+            sleep(1000);
+        }
 
         // Wait for the server login/encryption flow to advance.
         sleep(5000);

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -86,8 +86,8 @@ public class StoreScreenshotsTest {
             captureDir.mkdirs();
         }
 
-        testEmail = args.getString("testEmail", null);
-        testPassword = args.getString("testPassword", null);
+        testEmail = cleanArg(args.getString("testEmail", null));
+        testPassword = cleanArg(args.getString("testPassword", null));
 
         launchApp();
     }
@@ -127,6 +127,20 @@ public class StoreScreenshotsTest {
             throw new AssertionError("Failed to save screenshot: " + out.getAbsolutePath());
         }
         SystemClock.sleep(400);
+    }
+
+    private static String cleanArg(String value) {
+        if (value == null) {
+            return null;
+        }
+        value = value.trim();
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        if (value.length() >= 2 && value.startsWith("'") && value.endsWith("'")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     private void sleep(long ms) {


### PR DESCRIPTION
Fix screenshot CI login automation by cleaning quoted instrumentation args, hiding the keyboard before tapping LOG IN, and adding robust fallback tapping/fail-fast diagnostics.