### PR TITLE
fix: synchronize release version surfaces

### DIFF
--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -23,6 +23,11 @@ jobs:
   build:
     name: Build (${{ matrix.os-label }})
     runs-on: ${{ matrix.runner }}
+    # On a tag push, stamp the release version into the binary from the tag.
+    # The spec file (silentsuite-bridge.spec) reads this and freezes it into
+    # _version.py. Empty on non-tag builds, which fall back to pyproject.
+    env:
+      SILENTSUITE_BRIDGE_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +162,19 @@ jobs:
         run: |
           BINARY="dist/silentsuite-bridge${{ matrix.exe-suffix }}"
           echo "--- Smoke test: $BINARY --version ---"
-          "$BINARY" --version
+          OUT="$(env -u SILENTSUITE_BRIDGE_VERSION "$BINARY" --version)"
+          echo "$OUT"
+          EXPECTED_VERSION="${SILENTSUITE_BRIDGE_VERSION#v}"
+          if [[ -n "$EXPECTED_VERSION" && "$OUT" != *"$EXPECTED_VERSION"* ]]; then
+            echo "ERROR: bridge did not report release version $EXPECTED_VERSION" >&2
+            exit 1
+          fi
+          case "$OUT" in
+            *0.1.0*)
+              echo "ERROR: bridge reported the stale 0.1.0 version" >&2
+              exit 1
+              ;;
+          esac
           echo "Smoke test passed."
 
       # -----------------------------------------------------------------------
@@ -171,6 +188,7 @@ jobs:
           options: >-
             --platform linux/arm64
             -v ${{ github.workspace }}:/workspace
+            -e SILENTSUITE_BRIDGE_VERSION=${{ env.SILENTSUITE_BRIDGE_VERSION }}
           run: |
             set -e
             echo "=== Installing system deps ==="
@@ -190,7 +208,19 @@ jobs:
               --distpath dist/ \
               --workpath build/
             echo "=== Smoke test ==="
-            dist/silentsuite-bridge --version
+            OUT="$(env -u SILENTSUITE_BRIDGE_VERSION dist/silentsuite-bridge --version)"
+            echo "$OUT"
+            EXPECTED_VERSION="${SILENTSUITE_BRIDGE_VERSION#v}"
+            if [ -n "$EXPECTED_VERSION" ] && ! printf '%s' "$OUT" | grep -F "$EXPECTED_VERSION" >/dev/null; then
+              echo "ERROR: bridge did not report release version $EXPECTED_VERSION" >&2
+              exit 1
+            fi
+            case "$OUT" in
+              *0.1.0*)
+                echo "ERROR: bridge reported the stale 0.1.0 version" >&2
+                exit 1
+                ;;
+            esac
             echo "=== Rename + checksum (inside container to avoid permission issues) ==="
             mv dist/silentsuite-bridge dist/${{ matrix.asset-name }}
             sha256sum dist/${{ matrix.asset-name }} > dist/${{ matrix.asset-name }}.sha256

--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest
-          python -m pytest tests/test_windows_installer_static.py -q
+          python -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py -q
 
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/docs",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -18,6 +18,7 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { normalizeServerUrl } from '@/app/stores/use-etebase-store'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { BILLING_API_URL } from '@/app/lib/config'
+import { DISPLAY_VERSION } from '@/app/lib/constants'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
 import { StepCreateVault } from './components/step-create-vault'
@@ -1580,7 +1581,7 @@ export default function SignupPage() {
       </div>
       {/* Build version indicator */}
       <div className="fixed bottom-2 left-2 text-[10px] text-slate-600 font-mono select-none pointer-events-none">
-        v0.3.0
+        v{DISPLAY_VERSION}
       </div>
     </div>
   )

--- a/apps/web/app/lib/constants.ts
+++ b/apps/web/app/lib/constants.ts
@@ -5,6 +5,14 @@
  * are easy to find / change in one place.
  */
 
+// ── Display version ─────────────────────────────────────────────────────
+/**
+ * Human-facing build version shown in the UI (e.g. the signup page badge).
+ * Update this on release so displayed versions don't go stale. Keep in sync
+ * with the current release tag.
+ */
+export const DISPLAY_VERSION = '0.3.0-beta'
+
 // ── Time unit multipliers (ms) ──────────────────────────────────────────
 export const MS_PER_SECOND = 1_000
 export const MS_PER_MINUTE = 60 * MS_PER_SECOND

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/web",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",

--- a/bridge/.gitignore
+++ b/bridge/.gitignore
@@ -31,6 +31,9 @@ htpasswd
 *.spec
 !silentsuite-bridge.spec
 
+# Generated at build time from the release tag (see silentsuite-bridge.spec)
+src/silentsuite_bridge/_version.py
+
 # OS
 .DS_Store
 Thumbs.db

--- a/bridge/pyproject.toml
+++ b/bridge/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "silentsuite-bridge"
-version = "0.1.0"
+version = "0.3.0-beta"
 description = "SilentSuite Bridge — Local E2EE CalDAV/CardDAV sync daemon"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/bridge/silentsuite-bridge.spec
+++ b/bridge/silentsuite-bridge.spec
@@ -12,10 +12,49 @@
 import os
 import sys
 import glob
+import re
 from pathlib import Path
 import importlib.util
 
 from PyInstaller.utils.hooks import copy_metadata
+
+
+# ---------------------------------------------------------------------------
+# Release version stamping
+# ---------------------------------------------------------------------------
+# PyInstaller binaries do not ship Python package metadata, so a frozen build
+# cannot read its version from importlib.metadata. To make `--version` report
+# the released version, we freeze it into _version.py at build time. The source
+# is, in order of preference:
+#   1. SILENTSUITE_BRIDGE_VERSION  (set explicitly by CI tag builds)
+#   2. GITHUB_REF_NAME             (the pushed git tag, e.g. "v0.3.0-beta")
+# When neither is set (local dev build), _version.py is left absent and the
+# package falls back to importlib.metadata / pyproject.toml.
+def stamp_version():
+    spec_dir = Path(globals().get("SPECPATH", os.getcwd()))
+    target = spec_dir / "src" / "silentsuite_bridge" / "_version.py"
+    raw = os.environ.get("SILENTSUITE_BRIDGE_VERSION", "").strip()
+    if not raw:
+        ref = os.environ.get("GITHUB_REF_NAME", "").strip()
+        # Only treat the ref as a version when it looks like a release tag.
+        if ref.startswith("v") and any(ch.isdigit() for ch in ref):
+            raw = ref
+    if not raw:
+        if target.exists() and "Generated at build time from the release tag" in target.read_text(encoding="utf-8"):
+            target.unlink()
+            print(f"[spec] Removed stale generated version stamp: {target}")
+        return
+    version = raw.lstrip("v")
+    if not re.match(r"^\d+\.\d+\.\d+(?:[-.][A-Za-z0-9][A-Za-z0-9.-]*)?$", version):
+        raise SystemExit(f"Invalid SILENTSUITE_BRIDGE_VERSION/GITHUB_REF_NAME for Python stamp: {raw!r}")
+    target.write_text(
+        '# Generated at build time from the release tag. Do not edit or commit.\n'
+        f'VERSION = {version!r}\n'
+    )
+    print(f"[spec] Stamped bridge version: {version} -> {target}")
+
+
+stamp_version()
 
 
 def safe_copy_metadata(package_name):

--- a/bridge/src/silentsuite_bridge/__init__.py
+++ b/bridge/src/silentsuite_bridge/__init__.py
@@ -7,6 +7,49 @@ endpoints on localhost for use with any standard PIM client.
 License: AGPL-3.0-only
 """
 
-__version__ = "0.1.0"
+import os
+from importlib import metadata as _metadata
+
+# Kept in sync with pyproject.toml [project].version. Used only as a
+# last-resort fallback when neither a build stamp nor package metadata is
+# available (e.g. running straight from source without an editable install).
+_FALLBACK_VERSION = "0.3.0-beta"
+
+
+def _resolve_version() -> str:
+    """Resolve the bridge version, preferring a release-build stamp.
+
+    Resolution order:
+      1. ``SILENTSUITE_BRIDGE_VERSION`` env var — explicit runtime/build
+         override (CI tag builds set this; see silentsuite-bridge.spec).
+      2. ``_version.py`` — written at build time from the git tag and frozen
+         into the PyInstaller binary, which does not ship package metadata.
+      3. ``_FALLBACK_VERSION`` — the exact human-facing release string. This is
+         preferred over package metadata because Python normalizes
+         ``0.3.0-beta`` to ``0.3.0b0`` in installed metadata.
+      4. ``importlib.metadata`` — final fallback for unusual packaged installs.
+    """
+    override = os.environ.get("SILENTSUITE_BRIDGE_VERSION", "").strip()
+    if override:
+        return override.lstrip("v")
+
+    try:
+        from ._version import VERSION as _stamped  # type: ignore[attr-defined]
+
+        if _stamped:
+            return str(_stamped).lstrip("v")
+    except Exception:
+        pass
+
+    if _FALLBACK_VERSION:
+        return _FALLBACK_VERSION
+
+    try:
+        return _metadata.version("silentsuite-bridge")
+    except _metadata.PackageNotFoundError:
+        return "0.0.0-dev"
+
+
+__version__ = _resolve_version()
 __author__ = "SilentSuite"
 __license__ = "AGPL-3.0-only"

--- a/bridge/tests/test_version.py
+++ b/bridge/tests/test_version.py
@@ -1,0 +1,64 @@
+"""Version reporting tests.
+
+Guards against the stale-version regression where `silentsuite-bridge
+--version` reported 0.1.0 long after the project had moved on (the binary was
+never re-stamped from the release tag). These tests keep the package version,
+the pyproject version, and the CLI/env override path in agreement.
+"""
+
+import importlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import silentsuite_bridge
+
+BRIDGE_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject_version() -> str:
+    pyproject = (BRIDGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    assert match, "bridge/pyproject.toml should declare [project].version"
+    return match.group(1)
+
+
+def test_version_is_not_stale_placeholder():
+    """The long-lived 0.1.0 placeholder must never resurface."""
+    assert silentsuite_bridge.__version__ != "0.1.0"
+
+
+def test_version_looks_like_a_release():
+    """Version must be a plausible semver-ish string (e.g. 0.3.0-beta)."""
+    assert re.match(r"^\d+\.\d+\.\d+", silentsuite_bridge.__version__)
+
+
+def test_fallback_matches_pyproject():
+    """The hardcoded fallback must track pyproject so source runs aren't stale."""
+    assert silentsuite_bridge._FALLBACK_VERSION == _pyproject_version()
+
+
+def test_env_override_takes_precedence(monkeypatch):
+    """Release builds stamp the version via the env override; honour it and
+    strip a leading 'v' so a raw git tag works."""
+    monkeypatch.setenv("SILENTSUITE_BRIDGE_VERSION", "v9.9.9-rc1")
+    reloaded = importlib.reload(silentsuite_bridge)
+    try:
+        assert reloaded.__version__ == "9.9.9-rc1"
+    finally:
+        monkeypatch.delenv("SILENTSUITE_BRIDGE_VERSION", raising=False)
+        importlib.reload(silentsuite_bridge)
+
+
+def test_cli_version_output_matches_package():
+    """`python -m silentsuite_bridge --version` must echo the package version."""
+    result = subprocess.run(
+        [sys.executable, "-m", "silentsuite_bridge", "--version"],
+        capture_output=True,
+        text=True,
+        cwd=str(BRIDGE_ROOT / "src"),
+    )
+    assert result.returncode == 0, result.stderr
+    assert silentsuite_bridge.__version__ in result.stdout
+    assert "0.1.0" not in result.stdout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silentsuite",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "author": "SilentSuite <info@silentsuite.io>",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/config",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "files": [
     "typescript",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/core",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/ui",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/tests/test_release_versions_static.py
+++ b/tests/test_release_versions_static.py
@@ -1,0 +1,67 @@
+"""Static release-version consistency checks.
+
+These tests guard against stale user-visible versions across the bridge, web
+workspace packages, and Android metadata. They intentionally avoid archived
+prototype code under _archive/.
+"""
+
+from pathlib import Path
+import json
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+CURRENT_RELEASE_VERSION = "0.3.0-beta"
+
+PACKAGE_JSON_PATHS = [
+    "package.json",
+    "apps/web/package.json",
+    "apps/docs/package.json",
+    "packages/core/package.json",
+    "packages/ui/package.json",
+    "packages/config/package.json",
+]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_workspace_package_versions_match_current_release():
+    for rel in PACKAGE_JSON_PATHS:
+        package = json.loads(read(rel))
+        assert package["version"] == CURRENT_RELEASE_VERSION, rel
+
+
+def test_bridge_pyproject_version_matches_current_release():
+    pyproject = read("bridge/pyproject.toml")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    assert match, "bridge/pyproject.toml should declare [project].version"
+    assert match.group(1) == CURRENT_RELEASE_VERSION
+
+
+def test_web_signup_uses_named_display_version_constant():
+    constants = read("apps/web/app/lib/constants.ts")
+    signup = read("apps/web/app/(auth)/signup/page.tsx")
+
+    assert f"DISPLAY_VERSION = '{CURRENT_RELEASE_VERSION}'" in constants
+    assert "import { DISPLAY_VERSION }" in signup
+    assert "v{DISPLAY_VERSION}" in signup
+    assert "v0.3.0" not in signup
+
+
+def test_android_version_name_matches_current_release():
+    gradle = read("android/app/build.gradle")
+    match = re.search(r'versionName\s+"([^"]+)"', gradle)
+    assert match, "android/app/build.gradle should declare versionName"
+    assert match.group(1) == CURRENT_RELEASE_VERSION
+
+
+def test_bridge_release_workflow_validates_frozen_version_without_runtime_env_override():
+    workflow = read(".github/workflows/build-bridge.yml")
+    spec = read("bridge/silentsuite-bridge.spec")
+
+    assert "env -u SILENTSUITE_BRIDGE_VERSION" in workflow
+    assert "SPECPATH" in spec
+    assert "Removed stale generated version stamp" in spec
+    assert "target.unlink()" in spec
+    assert "VERSION = {version!r}" in spec


### PR DESCRIPTION
## Summary
- fixes bridge version reporting so `silentsuite-bridge --version` no longer reports stale `0.1.0`
- stamps PyInstaller bridge binaries from release tags via `SILENTSUITE_BRIDGE_VERSION`
- updates web signup version display to use a named constant
- aligns private workspace package metadata with `0.3.0-beta`
- adds static regression checks for bridge/web/Android release-version surfaces

## Test Plan
- `python -m pytest tests/test_release_versions_static.py -q`
- `PYTHONPATH=bridge/src python -m pytest tests/test_release_versions_static.py tests/test_windows_installer_static.py bridge/tests/test_version.py -q`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web test -- --runInBand`

Closes #222
Closes #202
