### PR TITLE
Promote dev to main

### DIFF
--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -23,6 +23,11 @@ jobs:
   build:
     name: Build (${{ matrix.os-label }})
     runs-on: ${{ matrix.runner }}
+    # On a tag push, stamp the release version into the binary from the tag.
+    # The spec file (silentsuite-bridge.spec) reads this and freezes it into
+    # _version.py. Empty on non-tag builds, which fall back to pyproject.
+    env:
+      SILENTSUITE_BRIDGE_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +162,19 @@ jobs:
         run: |
           BINARY="dist/silentsuite-bridge${{ matrix.exe-suffix }}"
           echo "--- Smoke test: $BINARY --version ---"
-          "$BINARY" --version
+          OUT="$(env -u SILENTSUITE_BRIDGE_VERSION "$BINARY" --version)"
+          echo "$OUT"
+          EXPECTED_VERSION="${SILENTSUITE_BRIDGE_VERSION#v}"
+          if [[ -n "$EXPECTED_VERSION" && "$OUT" != *"$EXPECTED_VERSION"* ]]; then
+            echo "ERROR: bridge did not report release version $EXPECTED_VERSION" >&2
+            exit 1
+          fi
+          case "$OUT" in
+            *0.1.0*)
+              echo "ERROR: bridge reported the stale 0.1.0 version" >&2
+              exit 1
+              ;;
+          esac
           echo "Smoke test passed."
 
       # -----------------------------------------------------------------------
@@ -171,6 +188,7 @@ jobs:
           options: >-
             --platform linux/arm64
             -v ${{ github.workspace }}:/workspace
+            -e SILENTSUITE_BRIDGE_VERSION=${{ env.SILENTSUITE_BRIDGE_VERSION }}
           run: |
             set -e
             echo "=== Installing system deps ==="
@@ -190,7 +208,19 @@ jobs:
               --distpath dist/ \
               --workpath build/
             echo "=== Smoke test ==="
-            dist/silentsuite-bridge --version
+            OUT="$(env -u SILENTSUITE_BRIDGE_VERSION dist/silentsuite-bridge --version)"
+            echo "$OUT"
+            EXPECTED_VERSION="${SILENTSUITE_BRIDGE_VERSION#v}"
+            if [ -n "$EXPECTED_VERSION" ] && ! printf '%s' "$OUT" | grep -F "$EXPECTED_VERSION" >/dev/null; then
+              echo "ERROR: bridge did not report release version $EXPECTED_VERSION" >&2
+              exit 1
+            fi
+            case "$OUT" in
+              *0.1.0*)
+                echo "ERROR: bridge reported the stale 0.1.0 version" >&2
+                exit 1
+                ;;
+            esac
             echo "=== Rename + checksum (inside container to avoid permission issues) ==="
             mv dist/silentsuite-bridge dist/${{ matrix.asset-name }}
             sha256sum dist/${{ matrix.asset-name }} > dist/${{ matrix.asset-name }}.sha256

--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest
-          python -m pytest tests/test_windows_installer_static.py -q
+          python -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py -q
 
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -6,14 +6,22 @@ on:
     branches: [main, dev]
     paths:
       - 'bridge/**'
+      - 'android/app/src/main/AndroidManifest.xml'
+      - 'android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt'
       - 'apps/docs/user-guide/apps/dav-bridge.md'
+      - 'tests/test_android_security_static.py'
+      - 'tests/test_release_versions_static.py'
       - 'tests/test_windows_installer_static.py'
       - '.github/workflows/test-bridge-windows.yml'
   pull_request:
     branches: [main, dev]
     paths:
       - 'bridge/**'
+      - 'android/app/src/main/AndroidManifest.xml'
+      - 'android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt'
       - 'apps/docs/user-guide/apps/dav-bridge.md'
+      - 'tests/test_android_security_static.py'
+      - 'tests/test_release_versions_static.py'
       - 'tests/test_windows_installer_static.py'
       - '.github/workflows/test-bridge-windows.yml'
 
@@ -37,7 +45,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest
-          python -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py -q
+          python -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py tests/test_android_security_static.py -q
 
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -1,0 +1,113 @@
+name: Test Bridge (Windows)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, dev]
+    paths:
+      - 'bridge/**'
+      - 'apps/docs/user-guide/apps/dav-bridge.md'
+      - 'tests/test_windows_installer_static.py'
+      - '.github/workflows/test-bridge-windows.yml'
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'bridge/**'
+      - 'apps/docs/user-guide/apps/dav-bridge.md'
+      - 'tests/test_windows_installer_static.py'
+      - '.github/workflows/test-bridge-windows.yml'
+
+jobs:
+  installer:
+    name: Installer and docs checks
+    runs-on: windows-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Run static installer/docs regression tests
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+          python -m pytest tests/test_windows_installer_static.py -q
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
+
+      - name: Analyze PowerShell installer
+        shell: pwsh
+        run: |
+          $results = Invoke-ScriptAnalyzer -Path bridge/install.ps1 -Severity Error
+          $results | Format-Table -AutoSize
+          if ($results) { throw "PSScriptAnalyzer found errors in bridge/install.ps1" }
+
+      - name: Assert installer failures do not exit parent PowerShell
+        shell: pwsh
+        run: |
+          $script = Get-Content bridge/install.ps1 -Raw
+          $tokens = $null
+          $errors = $null
+          $ast = [System.Management.Automation.Language.Parser]::ParseInput($script, [ref]$tokens, [ref]$errors)
+          if ($errors.Count -gt 0) {
+            $errors | Format-List
+            throw "PowerShell parser errors in bridge/install.ps1"
+          }
+
+          $writeErr = $ast.Find({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq 'Write-Err'
+          }, $true)
+          if (-not $writeErr) { throw "Write-Err helper not found" }
+
+          $exitStatements = $writeErr.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.ExitStatementAst]
+          }, $true)
+          if ($exitStatements.Count -gt 0) {
+            throw "Write-Err must not call exit because irm ... | iex would close the user's terminal"
+          }
+
+  smoke:
+    name: Bridge CLI smoke test
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.10"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: "1.63.0"
+
+      - name: Install bridge package
+        working-directory: bridge
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" || pip install -e .
+
+      - name: silentsuite-bridge --version
+        shell: pwsh
+        run: silentsuite-bridge --version
+
+      - name: silentsuite-bridge --help
+        shell: pwsh
+        run: silentsuite-bridge --help

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -187,6 +187,7 @@ dependencies {
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
     // UIAutomator for store screenshot capture instrumentation tests
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     androidTestImplementation 'net.sf.kxml:kxml2:2.3.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -30,6 +30,8 @@
 
 package io.silentsuite.screenshots;
 
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.SystemClock;
 
@@ -95,18 +97,26 @@ public class StoreScreenshotsTest {
     }
 
     private static void launchApp() {
-        try {
-            InstrumentationRegistry.getInstrumentation()
-                    .getUiAutomation()
-                    .executeShellCommand("monkey -p " + PACKAGE + " -c android.intent.category.LAUNCHER 1");
-        } catch (Exception e) {
-            // Shell command may throw if the process is transitioning; ignore
+        Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Intent intent = targetContext.getPackageManager().getLaunchIntentForPackage(PACKAGE);
+        if (intent == null) {
+            throw new AssertionError("No launch intent for " + PACKAGE);
         }
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        targetContext.startActivity(intent);
         device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT);
         SystemClock.sleep(2000);
     }
 
     private void capture(String name) {
+        String currentPackage = device.getCurrentPackageName();
+        if (!PACKAGE.equals(currentPackage)) {
+            launchApp();
+            currentPackage = device.getCurrentPackageName();
+        }
+        if (!PACKAGE.equals(currentPackage)) {
+            throw new AssertionError("Cannot capture " + name + ": current package is " + currentPackage);
+        }
         if (!captureDir.exists()) {
             captureDir.mkdirs();
         }

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -32,6 +32,7 @@ package io.silentsuite.screenshots;
 
 import android.content.Context;
 import android.content.Intent;
+import android.widget.EditText;
 import android.os.Bundle;
 import android.os.SystemClock;
 
@@ -49,6 +50,15 @@ import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.Until;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.withHint;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.allOf;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class StoreScreenshotsTest {
@@ -157,6 +167,21 @@ public class StoreScreenshotsTest {
                     .executeShellCommand(command)
                     .close();
         } catch (Exception ignored) {
+        }
+    }
+
+    private void espressoLoginFallback() {
+        try {
+            onView(allOf(isAssignableFrom(EditText.class), withHint("Email")))
+                    .perform(replaceText(testEmail), closeSoftKeyboard());
+            sleep(300);
+            onView(allOf(isAssignableFrom(EditText.class), withHint("Password")))
+                    .perform(replaceText(testPassword), closeSoftKeyboard());
+            sleep(300);
+            onView(withId(io.silentsuite.sync.R.id.login)).perform(click());
+            sleep(1000);
+        } catch (Throwable ignored) {
+            // Fall back to UIAutomator/coordinate automation below.
         }
     }
 
@@ -302,6 +327,7 @@ public class StoreScreenshotsTest {
         }
 
         fillLoginFields();
+        espressoLoginFallback();
         coordinateLoginFallback();
         device.pressBack(); // hide keyboard so the bottom login button is clickable
         sleep(500);

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.io.File;
+import java.util.List;
 
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.uiautomator.By;
@@ -162,6 +163,47 @@ public class StoreScreenshotsTest {
         return false;
     }
 
+    private boolean tapRes(String resId) {
+        UiObject2 obj = device.wait(Until.findObject(By.res(PACKAGE, resId)), NAV_TIMEOUT);
+        if (obj != null) {
+            obj.click();
+            sleep(1000);
+            return true;
+        }
+        return false;
+    }
+
+    private void fillLoginFields() {
+        UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), NAV_TIMEOUT);
+        if (emailField != null) {
+            emailField.click();
+            sleep(300);
+            emailField.setText(testEmail);
+            sleep(300);
+        }
+
+        // The password input itself is the second EditText inside a TextInputLayout
+        // (R.id.url_password belongs to the layout), so address EditText widgets.
+        List<UiObject2> editTexts = device.findObjects(By.clazz("android.widget.EditText"));
+        if (editTexts.size() >= 2) {
+            UiObject2 passField = editTexts.get(1);
+            passField.click();
+            sleep(300);
+            passField.setText(testPassword);
+            sleep(300);
+        }
+    }
+
+    private void requireLoggedIn(String screenName) {
+        if (!loggedIn) {
+            tryLogin();
+        }
+        UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), 1000);
+        if (!loggedIn || emailField != null) {
+            throw new AssertionError("Cannot capture " + screenName + ": login did not complete");
+        }
+    }
+
     /**
      * Attempt to log in with the test account credentials (if provided).
      * Types email + password into the login fields and taps Log In.
@@ -172,10 +214,10 @@ public class StoreScreenshotsTest {
             return; // no credentials, skip login
         }
 
-        // Make sure we are on the login screen
+        launchApp();
+
         UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), NAV_TIMEOUT);
         if (emailField == null) {
-            // Maybe we are already logged in, or need to reach login
             tapText("Get Started");
             sleep(1000);
             tapText("Add account");
@@ -183,47 +225,34 @@ public class StoreScreenshotsTest {
             emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), NAV_TIMEOUT);
         }
         if (emailField == null) {
-            return; // cannot reach login
+            return;
         }
 
-        // Type email
-        emailField.click();
-        sleep(300);
-        emailField.setText(testEmail);
-        sleep(300);
+        fillLoginFields();
+        tapRes("login");
 
-        // Type password
-        UiObject2 passField = device.wait(Until.findObject(By.res(PACKAGE, "url_password")), NAV_TIMEOUT);
-        if (passField != null) {
-            passField.click();
-            sleep(300);
-            passField.setText(testPassword);
-            sleep(300);
-        }
+        // Wait for the server login/encryption flow to advance.
+        sleep(5000);
 
-        // Tap Log In
-        tapText("Log In");
-
-        // Wait for the collections/accounts screen to appear (login success)
-        // The encryption password step may appear; if so, the test password is also
-        // the encryption password, so handle it.
-        sleep(3000);
-
-        // Handle the encryption password prompt if it appears
-        UiObject2 encPass = device.wait(Until.findObject(By.res(PACKAGE, "url_password")), 3000);
+        // Handle the encryption password prompt if it appears.
         UiObject2 encLabel = device.wait(Until.findObject(By.textContains("Encryption Password")), 2000);
-        if (encLabel != null && encPass != null) {
-            encPass.click();
-            sleep(300);
-            encPass.setText(testPassword);
-            sleep(300);
+        if (encLabel != null) {
+            List<UiObject2> editTexts = device.findObjects(By.clazz("android.widget.EditText"));
+            if (!editTexts.isEmpty()) {
+                UiObject2 encPass = editTexts.get(editTexts.size() - 1);
+                encPass.click();
+                sleep(300);
+                encPass.setText(testPassword);
+                sleep(300);
+            }
             tapText("Finish");
-            sleep(3000);
+            tapText("FINISH");
+            sleep(5000);
         }
 
-        // Check if we landed on the accounts/collections screen
-        UiObject2 collections = device.wait(Until.findObject(By.textContains("SilentSuite")), 5000);
-        loggedIn = collections != null;
+        // Successful login leaves the LoginActivity and no longer shows the email field.
+        UiObject2 stillLogin = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), 1000);
+        loggedIn = stillLogin == null && PACKAGE.equals(device.getCurrentPackageName());
     }
 
     /**
@@ -278,9 +307,7 @@ public class StoreScreenshotsTest {
      */
     @Test
     public void test03_collections() {
-        if (!loggedIn) {
-            tryLogin();
-        }
+        requireLoggedIn("collections");
         launchApp(); // relaunch to land on accounts/collections
         sleep(2000);
         capture("3-collections");
@@ -291,9 +318,7 @@ public class StoreScreenshotsTest {
      */
     @Test
     public void test04_fingerprint() {
-        if (!loggedIn) {
-            tryLogin();
-        }
+        requireLoggedIn("fingerprint");
         // Open the account overflow menu and tap "Verify encryption fingerprint"
         tapDescContains("More");
         sleep(800);
@@ -309,9 +334,7 @@ public class StoreScreenshotsTest {
      */
     @Test
     public void test05_sharing_members() {
-        if (!loggedIn) {
-            tryLogin();
-        }
+        requireLoggedIn("sharing members");
         // Tap the first collection to open its detail, then Manage Members
         UiObject2 collection = device.wait(Until.findObject(By.textContains("Calendar")), NAV_TIMEOUT);
         if (collection == null) {
@@ -335,9 +358,7 @@ public class StoreScreenshotsTest {
      */
     @Test
     public void test06_invitations() {
-        if (!loggedIn) {
-            tryLogin();
-        }
+        requireLoggedIn("invitations");
         // Open navigation drawer
         device.pressBack();
         sleep(500);
@@ -363,9 +384,7 @@ public class StoreScreenshotsTest {
      */
     @Test
     public void test07_collection_detail() {
-        if (!loggedIn) {
-            tryLogin();
-        }
+        requireLoggedIn("collection detail");
         launchApp();
         sleep(2000);
         UiObject2 collection = device.wait(Until.findObject(By.textContains("Calendar")), NAV_TIMEOUT);
@@ -386,9 +405,7 @@ public class StoreScreenshotsTest {
      */
     @Test
     public void test08_import() {
-        if (!loggedIn) {
-            tryLogin();
-        }
+        requireLoggedIn("import");
         tapDescContains("More");
         sleep(800);
         tapText("Import");

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -187,23 +187,38 @@ public class StoreScreenshotsTest {
         return false;
     }
 
+    private boolean isLoginScreen() {
+        return device.hasObject(By.textContains("Add account"))
+                || device.hasObject(By.text("LOG IN"))
+                || device.hasObject(By.text("Log In"))
+                || (device.hasObject(By.textContains("Email")) && device.hasObject(By.textContains("Password")));
+    }
+
     private void fillLoginFields() {
+        // Prefer visible EditText widgets. Material TextInputLayout resource IDs are
+        // not reliably exposed to UIAutomator on API 35, but the child EditTexts are.
+        List<UiObject2> editTexts = device.findObjects(By.clazz("android.widget.EditText"));
+        if (editTexts.size() >= 2) {
+            UiObject2 emailField = editTexts.get(0);
+            emailField.click();
+            sleep(300);
+            emailField.setText(testEmail);
+            sleep(300);
+
+            UiObject2 passField = editTexts.get(1);
+            passField.click();
+            sleep(300);
+            passField.setText(testPassword);
+            sleep(300);
+            return;
+        }
+
+        // Fallback for devices that expose the email field by resource id.
         UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), NAV_TIMEOUT);
         if (emailField != null) {
             emailField.click();
             sleep(300);
             emailField.setText(testEmail);
-            sleep(300);
-        }
-
-        // The password input itself is the second EditText inside a TextInputLayout
-        // (R.id.url_password belongs to the layout), so address EditText widgets.
-        List<UiObject2> editTexts = device.findObjects(By.clazz("android.widget.EditText"));
-        if (editTexts.size() >= 2) {
-            UiObject2 passField = editTexts.get(1);
-            passField.click();
-            sleep(300);
-            passField.setText(testPassword);
             sleep(300);
         }
     }
@@ -212,11 +227,11 @@ public class StoreScreenshotsTest {
         if (!loggedIn) {
             tryLogin();
         }
-        UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), 1000);
-        if (!loggedIn || emailField != null) {
+        if (!loggedIn || isLoginScreen()) {
             throw new AssertionError("Cannot capture " + screenName + ": login did not complete (credentials present="
                     + (testEmail != null && !testEmail.isEmpty() && testPassword != null && !testPassword.isEmpty())
-                    + ", currentPackage=" + device.getCurrentPackageName() + ")");
+                    + ", currentPackage=" + device.getCurrentPackageName()
+                    + ", loginScreen=" + isLoginScreen() + ")");
         }
     }
 
@@ -232,15 +247,14 @@ public class StoreScreenshotsTest {
 
         launchApp();
 
-        UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), NAV_TIMEOUT);
-        if (emailField == null) {
+        // If we are not already on the login screen, try to navigate there.
+        if (!isLoginScreen()) {
             tapText("Get Started");
             sleep(1000);
             tapText("Add account");
             sleep(1000);
-            emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), NAV_TIMEOUT);
         }
-        if (emailField == null) {
+        if (!isLoginScreen()) {
             return;
         }
 
@@ -249,13 +263,16 @@ public class StoreScreenshotsTest {
         sleep(500);
         if (!tapRes("login") && !tapText("LOG IN") && !tapText("Log In")) {
             // Fallback for MaterialButton instances that expose neither stable
-            // resource id nor text to UiAutomator on API 35.
+            // resource id nor text to UIAutomator on API 35.
             device.click(device.getDisplayWidth() / 2, device.getDisplayHeight() - 115);
             sleep(1000);
         }
 
-        // Wait for the server login/encryption flow to advance.
-        sleep(5000);
+        // Wait for the server login/encryption flow to advance off the login screen.
+        long deadline = SystemClock.uptimeMillis() + 30000;
+        while (SystemClock.uptimeMillis() < deadline && isLoginScreen()) {
+            sleep(1000);
+        }
 
         // Handle the encryption password prompt if it appears.
         UiObject2 encLabel = device.wait(Until.findObject(By.textContains("Encryption Password")), 2000);
@@ -268,14 +285,15 @@ public class StoreScreenshotsTest {
                 encPass.setText(testPassword);
                 sleep(300);
             }
-            tapText("Finish");
-            tapText("FINISH");
+            device.pressBack();
+            sleep(500);
+            if (!tapText("Finish")) {
+                tapText("FINISH");
+            }
             sleep(5000);
         }
 
-        // Successful login leaves the LoginActivity and no longer shows the email field.
-        UiObject2 stillLogin = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), 1000);
-        loggedIn = stillLogin == null && PACKAGE.equals(device.getCurrentPackageName());
+        loggedIn = PACKAGE.equals(device.getCurrentPackageName()) && !isLoginScreen();
     }
 
     /**

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -214,7 +214,9 @@ public class StoreScreenshotsTest {
         }
         UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), 1000);
         if (!loggedIn || emailField != null) {
-            throw new AssertionError("Cannot capture " + screenName + ": login did not complete");
+            throw new AssertionError("Cannot capture " + screenName + ": login did not complete (credentials present="
+                    + (testEmail != null && !testEmail.isEmpty() && testPassword != null && !testPassword.isEmpty())
+                    + ", currentPackage=" + device.getCurrentPackageName() + ")");
         }
     }
 
@@ -243,7 +245,14 @@ public class StoreScreenshotsTest {
         }
 
         fillLoginFields();
-        tapRes("login");
+        device.pressBack(); // hide keyboard so the bottom login button is clickable
+        sleep(500);
+        if (!tapRes("login") && !tapText("LOG IN") && !tapText("Log In")) {
+            // Fallback for MaterialButton instances that expose neither stable
+            // resource id nor text to UiAutomator on API 35.
+            device.click(device.getDisplayWidth() / 2, device.getDisplayHeight() - 115);
+            sleep(1000);
+        }
 
         // Wait for the server login/encryption flow to advance.
         sleep(5000);

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -51,6 +51,8 @@ import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.Until;
 
+import io.silentsuite.sync.ui.setup.LoginActivity;
+
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
@@ -114,6 +116,17 @@ public class StoreScreenshotsTest {
             throw new AssertionError("No launch intent for " + PACKAGE);
         }
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        targetContext.startActivity(intent);
+        device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT);
+        SystemClock.sleep(2000);
+    }
+
+    private static void launchPrefilledLogin() {
+        Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Intent intent = new Intent(targetContext, LoginActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.putExtra(LoginActivity.EXTRA_INITIAL_USERNAME, testEmail);
+        intent.putExtra(LoginActivity.EXTRA_INITIAL_PASSWORD, testPassword);
         targetContext.startActivity(intent);
         device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT);
         SystemClock.sleep(2000);
@@ -313,22 +326,16 @@ public class StoreScreenshotsTest {
             return; // no credentials, skip login
         }
 
-        launchApp();
+        launchPrefilledLogin();
 
-        // If we are not already on the login screen, try to navigate there.
-        if (!isLoginScreen()) {
-            tapText("Get Started");
-            sleep(1000);
-            tapText("Add account");
-            sleep(1000);
-        }
         if (!isLoginScreen()) {
             return;
         }
 
+        // LoginActivity prefilled the credentials via optional extras. The fallback
+        // entry methods remain as backup if a future app version drops prefill.
         fillLoginFields();
         espressoLoginFallback();
-        coordinateLoginFallback();
         device.pressBack(); // hide keyboard so the bottom login button is clickable
         sleep(500);
         if (!tapRes("login") && !tapText("LOG IN") && !tapText("Log In")) {

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -143,6 +143,49 @@ public class StoreScreenshotsTest {
         return value;
     }
 
+    private static String shellTextArg(String value) {
+        // Android's input text command treats %s as a space. The screenshot
+        // credentials do not contain spaces, but keep this safe and shell-quoted.
+        String escaped = value.replace("'", "'\''").replace(" ", "%s");
+        return "'" + escaped + "'";
+    }
+
+    private static void shellCommand(String command) {
+        try {
+            InstrumentationRegistry.getInstrumentation()
+                    .getUiAutomation()
+                    .executeShellCommand(command)
+                    .close();
+        } catch (Exception ignored) {
+        }
+    }
+
+    private void coordinateLoginFallback() {
+        // Last-resort automation for API 35 where Material TextInput nodes are
+        // visible but not reliably exposed by resource id or text selector.
+        int w = device.getDisplayWidth();
+        int h = device.getDisplayHeight();
+        int emailY = Math.round(h * 0.315f);
+        int passwordY = Math.round(h * 0.395f);
+        int loginY = h - 75;
+
+        device.click(w / 2, emailY);
+        sleep(300);
+        shellCommand("input text " + shellTextArg(testEmail));
+        sleep(300);
+
+        device.click(w / 2, passwordY);
+        sleep(300);
+        shellCommand("input text " + shellTextArg(testPassword));
+        sleep(300);
+
+        device.pressBack();
+        sleep(500);
+        device.click(w / 2, loginY);
+        sleep(1000);
+    }
+
+
     private void sleep(long ms) {
         SystemClock.sleep(ms);
     }
@@ -259,6 +302,7 @@ public class StoreScreenshotsTest {
         }
 
         fillLoginFields();
+        coordinateLoginFallback();
         device.pressBack(); // hide keyboard so the bottom login button is clickable
         sleep(500);
         if (!tapRes("login") && !tapText("LOG IN") && !tapText("Log In")) {

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -86,8 +86,8 @@ public class StoreScreenshotsTest {
             captureDir.mkdirs();
         }
 
-        testEmail = args.getString("testEmail", null);
-        testPassword = args.getString("testPassword", null);
+        testEmail = cleanArg(args.getString("testEmail", null));
+        testPassword = cleanArg(args.getString("testPassword", null));
 
         launchApp();
     }
@@ -127,6 +127,20 @@ public class StoreScreenshotsTest {
             throw new AssertionError("Failed to save screenshot: " + out.getAbsolutePath());
         }
         SystemClock.sleep(400);
+    }
+
+    private static String cleanArg(String value) {
+        if (value == null) {
+            return null;
+        }
+        value = value.trim();
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        if (value.length() >= 2 && value.startsWith("'") && value.endsWith("'")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     private void sleep(long ms) {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
@@ -23,15 +23,24 @@ import io.silentsuite.sync.ui.WebViewActivity
  */
 class LoginActivity : BaseActivity() {
 
+    companion object {
+        const val EXTRA_INITIAL_USERNAME = "io.silentsuite.sync.extra.INITIAL_USERNAME"
+        const val EXTRA_INITIAL_PASSWORD = "io.silentsuite.sync.extra.INITIAL_PASSWORD"
+    }
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (savedInstanceState == null)
-        // first call, show login screen directly (welcome dialog removed)
+        if (savedInstanceState == null) {
+            // first call, show login screen directly (welcome dialog removed)
+            // Optional extras are used by screenshot instrumentation to prefill
+            // credentials without brittle keyboard/UIAutomator text entry.
+            val initialUsername = intent.getStringExtra(EXTRA_INITIAL_USERNAME)
+            val initialPassword = intent.getStringExtra(EXTRA_INITIAL_PASSWORD)
             supportFragmentManager.beginTransaction()
-                    .replace(android.R.id.content, LoginCredentialsFragment())
+                    .replace(android.R.id.content, LoginCredentialsFragment.newInstance(initialUsername, initialPassword))
                     .commit()
+        }
 
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
@@ -12,6 +12,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 
+import io.silentsuite.sync.BuildConfig
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
 import io.silentsuite.sync.ui.BaseActivity
@@ -33,10 +34,10 @@ class LoginActivity : BaseActivity() {
 
         if (savedInstanceState == null) {
             // first call, show login screen directly (welcome dialog removed)
-            // Optional extras are used by screenshot instrumentation to prefill
-            // credentials without brittle keyboard/UIAutomator text entry.
-            val initialUsername = intent.getStringExtra(EXTRA_INITIAL_USERNAME)
-            val initialPassword = intent.getStringExtra(EXTRA_INITIAL_PASSWORD)
+            // Optional extras are only for debug screenshot instrumentation.
+            // Do not accept plaintext credential prefill extras in release builds.
+            val initialUsername = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_USERNAME) else null
+            val initialPassword = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_PASSWORD) else null
             supportFragmentManager.beginTransaction()
                     .replace(android.R.id.content, LoginCredentialsFragment.newInstance(initialUsername, initialPassword))
                     .commit()

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/docs",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -29,19 +29,41 @@ The bridge exposes every SilentSuite calendar, task list, and address book as it
 
 ## Install
 
+### Windows
+
+Download the current Windows bridge binary directly:
+
+- [Download SilentSuite Bridge for Windows x86_64](https://github.com/silent-suite/silentsuite/releases/latest/download/silentsuite-bridge-windows-x86_64.exe)
+- [Windows SHA256 checksum](https://github.com/silent-suite/silentsuite/releases/latest/download/silentsuite-bridge-windows-x86_64.exe.sha256)
+
+Save the file in Downloads. You can either keep the release file name or rename it to `silentsuite-bridge.exe`, then run it from an already-open PowerShell or Windows Terminal window so any first-run errors stay visible:
+
+```powershell
+cd $env:USERPROFILE\Downloads
+.\silentsuite-bridge-windows-x86_64.exe --version
+.\silentsuite-bridge-windows-x86_64.exe --login
+```
+
+If you renamed the file, use `./silentsuite-bridge.exe` instead.
+
+If Windows SmartScreen appears, choose **More info** and only continue if the publisher/file name matches the SilentSuite release you downloaded.
+
 ### Installer Status
 
-Bridge installer scripts are not yet published as stable `main`/release-tagged endpoints. Until they are, download bridge binaries from the [GitHub releases](https://github.com/silent-suite/silentsuite/releases) page instead of piping an installer URL into your shell.
+Bridge installer scripts are being hardened. If you use a PowerShell installer command, run it from an already-open PowerShell or Windows Terminal window, not from the Run dialog or by double-clicking a `.ps1` file.
 
 ::: warning
 Do not run installer commands from the public `dev` branch. Those scripts may contain unreleased changes and are not part of the stable docs flow.
 :::
 
-When stable installers are published, they will:
-1. Download the correct binary for your OS and architecture
-2. Install it to `~/.local/bin/`
-3. Optionally set up auto-start
-4. Open the bridge dashboard for first-time login
+If a PowerShell window closes before you can read the error, reopen PowerShell and run the diagnostic form instead. It downloads the installer to a temporary file and runs it with `-File`, so failures stay visible and are also written to `%LOCALAPPDATA%\SilentSuite\install.log`.
+
+```powershell
+irm https://raw.githubusercontent.com/silent-suite/silentsuite/main/bridge/install.ps1 -OutFile $env:TEMP\silentsuite-bridge-install.ps1
+powershell -ExecutionPolicy Bypass -File $env:TEMP\silentsuite-bridge-install.ps1
+```
+
+All downloads are also available from the [GitHub releases](https://github.com/silent-suite/silentsuite/releases) page.
 
 ## First-Time Setup
 

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -18,6 +18,7 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { normalizeServerUrl } from '@/app/stores/use-etebase-store'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { BILLING_API_URL } from '@/app/lib/config'
+import { DISPLAY_VERSION } from '@/app/lib/constants'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
 import { StepCreateVault } from './components/step-create-vault'
@@ -1580,7 +1581,7 @@ export default function SignupPage() {
       </div>
       {/* Build version indicator */}
       <div className="fixed bottom-2 left-2 text-[10px] text-slate-600 font-mono select-none pointer-events-none">
-        v0.3.0
+        v{DISPLAY_VERSION}
       </div>
     </div>
   )

--- a/apps/web/app/lib/constants.ts
+++ b/apps/web/app/lib/constants.ts
@@ -5,6 +5,14 @@
  * are easy to find / change in one place.
  */
 
+// ── Display version ─────────────────────────────────────────────────────
+/**
+ * Human-facing build version shown in the UI (e.g. the signup page badge).
+ * Update this on release so displayed versions don't go stale. Keep in sync
+ * with the current release tag.
+ */
+export const DISPLAY_VERSION = '0.3.0-beta'
+
 // ── Time unit multipliers (ms) ──────────────────────────────────────────
 export const MS_PER_SECOND = 1_000
 export const MS_PER_MINUTE = 60 * MS_PER_SECOND

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/web",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",

--- a/bridge/.gitignore
+++ b/bridge/.gitignore
@@ -31,6 +31,9 @@ htpasswd
 *.spec
 !silentsuite-bridge.spec
 
+# Generated at build time from the release tag (see silentsuite-bridge.spec)
+src/silentsuite_bridge/_version.py
+
 # OS
 .DS_Store
 Thumbs.db

--- a/bridge/install.ps1
+++ b/bridge/install.ps1
@@ -150,21 +150,28 @@ function Invoke-SilentSuiteBridgeInstall {
 
     # --- Verify SHA256 checksum ---
     $ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "$AssetName.sha256" } | Select-Object -First 1
-    if ($ChecksumAsset) {
-        try {
-            $ExpectedLine = (Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -UseBasicParsing).Content.Trim()
-            $ExpectedHash = ($ExpectedLine -split '\s+')[0].ToUpper()
-            $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToUpper()
-            if ($ExpectedHash -ne $ActualHash) {
-                Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
-                Write-Err "Checksum mismatch! Expected $ExpectedHash, got $ActualHash"
-            }
-            Write-Ok "Checksum verified"
-        } catch {
-            Write-Warn "Could not verify checksum: $_"
+    if (-not $ChecksumAsset) {
+        Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+        Write-Err "No checksum asset found for $AssetName; refusing to install an unverified binary"
+    }
+
+    try {
+        $ExpectedLine = (Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -UseBasicParsing).Content.Trim()
+        $ExpectedHash = ($ExpectedLine -split '\s+')[0].ToUpper()
+        if ($ExpectedHash -notmatch '^[0-9A-F]{64}$') {
+            Write-Err "Invalid checksum content for $AssetName.sha256"
         }
+        $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToUpper()
+    } catch {
+        Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+        Write-Err "Could not verify checksum: $_"
+    }
+
+    if ($ExpectedHash -ne $ActualHash) {
+        Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+        Write-Err "Checksum mismatch! Expected $ExpectedHash, got $ActualHash"
     } else {
-        Write-Warn "No checksum asset found for $AssetName"
+        Write-Ok "Checksum verified"
     }
 
     # --- Install binary ---

--- a/bridge/install.ps1
+++ b/bridge/install.ps1
@@ -1,7 +1,11 @@
 # SilentSuite Bridge — Windows PowerShell installer
 #
 # Usage:
-#   irm silentsuite.io/bridge/install.ps1 | iex
+#   irm https://raw.githubusercontent.com/silent-suite/silentsuite/main/bridge/install.ps1 | iex
+#
+# Safer diagnostic usage if a one-liner fails:
+#   irm https://raw.githubusercontent.com/silent-suite/silentsuite/main/bridge/install.ps1 -OutFile $env:TEMP\silentsuite-bridge-install.ps1
+#   powershell -ExecutionPolicy Bypass -File $env:TEMP\silentsuite-bridge-install.ps1
 #
 # This script:
 # 1. Detects architecture (x86_64 only)
@@ -12,6 +16,7 @@
 #
 # License: AGPL-3.0
 
+$PreviousErrorActionPreference = $ErrorActionPreference
 $ErrorActionPreference = "Stop"
 
 # --- Configuration ---
@@ -19,137 +24,207 @@ $Repo = "silent-suite/silentsuite"
 $BinaryName = "silentsuite-bridge"
 $InstallDir = if ($env:SILENTSUITE_INSTALL_DIR) { $env:SILENTSUITE_INSTALL_DIR } else { "$env:LOCALAPPDATA\SilentSuite" }
 $ExePath = "$InstallDir\$BinaryName.exe"
+$InstallLog = Join-Path $InstallDir "install.log"
 
 # --- Helpers ---
-function Write-Step($msg)  { Write-Host "`n  $msg" -ForegroundColor White }
-function Write-Ok($msg)    { Write-Host "  ✓ $msg" -ForegroundColor Green }
-function Write-Warn($msg)  { Write-Host "  ! $msg" -ForegroundColor Yellow }
-function Write-Err($msg)   { Write-Host "  ✗ $msg" -ForegroundColor Red; exit 1 }
-
-# --- Detect architecture ---
-$Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
-if ($Arch -ne "X64") {
-    Write-Err "Unsupported architecture: $Arch. Only x86_64 is supported."
-}
-
-# --- Banner ---
-Write-Host ""
-Write-Host "  SilentSuite Bridge" -ForegroundColor White
-Write-Host "  E2EE CalDAV/CardDAV sync for your desktop apps"
-
-# --- Check for existing installation ---
-if (Test-Path $ExePath) {
+function Write-InstallLog($msg) {
     try {
-        $CurrentVersion = & $ExePath --version 2>&1 | Select-Object -First 1
-        Write-Step "Existing installation detected"
-        Write-Ok "Current version: $CurrentVersion"
-        Write-Ok "Upgrading..."
-    } catch {
-        Write-Warn "Existing binary found but could not read version"
-    }
-}
-
-# --- Download latest release ---
-# Fetches the releases list (sorted newest-first) and walks until we find one
-# that carries the bridge asset. Umbrella releases (e.g. v0.1.0-beta) won't
-# have bridge binaries, so we skip past them to the most recent release that
-# actually has a bridge asset (bridge-vX.Y.Z prefix going forward, or the
-# legacy vX.Y.Z-bridge suffix).
-Write-Step "Downloading latest release..."
-$AssetName = "$BinaryName-windows-x86_64.exe"
-$ReleaseUrl = "https://api.github.com/repos/$Repo/releases?per_page=100"
-
-try {
-    $Releases = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
-} catch {
-    Write-Err "Failed to fetch release info from GitHub: $_"
-}
-
-$Release = $null
-$Asset = $null
-foreach ($r in $Releases) {
-    $candidate = $r.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
-    if ($candidate) {
-        $Release = $r
-        $Asset = $candidate
-        break
-    }
-}
-if (-not $Asset) {
-    Write-Err "No asset found matching $AssetName across recent releases. Check https://github.com/$Repo/releases"
-}
-
-# Create install directory
-if (-not (Test-Path $InstallDir)) {
-    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-}
-
-$TmpFile = Join-Path $env:TEMP "silentsuite-bridge-download.exe"
-try {
-    Invoke-WebRequest -Uri $Asset.browser_download_url -OutFile $TmpFile -UseBasicParsing
-    Write-Ok "Downloaded $AssetName"
-} catch {
-    Write-Err "Download failed: $_"
-}
-
-# --- Verify SHA256 checksum ---
-$ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "$AssetName.sha256" } | Select-Object -First 1
-if ($ChecksumAsset) {
-    try {
-        $ExpectedLine = (Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -UseBasicParsing).Content.Trim()
-        $ExpectedHash = ($ExpectedLine -split '\s+')[0].ToUpper()
-        $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToUpper()
-        if ($ExpectedHash -ne $ActualHash) {
-            Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
-            Write-Err "Checksum mismatch! Expected $ExpectedHash, got $ActualHash"
+        if (-not (Test-Path $InstallDir)) {
+            New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
         }
-        Write-Ok "Checksum verified"
+        $Timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+        Add-Content -Path $InstallLog -Value "[$Timestamp] $msg" -Encoding UTF8
     } catch {
-        Write-Warn "Could not verify checksum: $_"
+        # Logging must never hide the installer error the user needs to see.
     }
 }
 
-# --- Install binary ---
-Move-Item -Path $TmpFile -Destination $ExePath -Force
-Write-Ok "Installed to $ExePath"
+function Write-Step($msg)  { Write-Host "`n  $msg" -ForegroundColor White; Write-InstallLog "STEP $msg" }
+function Write-Ok($msg)    { Write-Host "  ✓ $msg" -ForegroundColor Green; Write-InstallLog "OK $msg" }
+function Write-Warn($msg)  { Write-Host "  ! $msg" -ForegroundColor Yellow; Write-InstallLog "WARN $msg" }
+function Write-Err($msg)   { Write-Host "  ✗ $msg" -ForegroundColor Red; Write-InstallLog "ERROR $msg"; throw $msg }
 
-# --- Add to user PATH ---
-$UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-if ($UserPath -notlike "*$InstallDir*") {
-    [Environment]::SetEnvironmentVariable("PATH", "$InstallDir;$UserPath", "User")
-    Write-Ok "Added $InstallDir to user PATH"
-} else {
-    Write-Ok "$InstallDir already in PATH"
+function Wait-BeforeCloseIfInteractive {
+    if ($env:CI) { return }
+    if (-not [Environment]::UserInteractive) { return }
+
+    try {
+        Write-Host ""
+        Read-Host "Press Enter to close"
+    } catch {
+        # Some non-interactive hosts still report as interactive. Ignore pause failures.
+    }
 }
-$env:PATH = "$InstallDir;$env:PATH"
 
-# --- Auto-start ---
-Write-Step "Setting up auto-start..."
+function Get-GitHubErrorHint($errorRecord) {
+    $statusCode = $null
+    try {
+        $statusCode = [int]$errorRecord.Exception.Response.StatusCode
+    } catch {
+        $statusCode = $null
+    }
+
+    if ($statusCode -eq 403) {
+        return "GitHub refused the release lookup, possibly because the unauthenticated API rate limit was reached. Download manually from https://github.com/$Repo/releases/latest or retry later."
+    }
+    if ($statusCode -eq 404) {
+        return "GitHub did not return release metadata. Check https://github.com/$Repo/releases/latest for current downloads."
+    }
+    return "Check https://github.com/$Repo/releases/latest for manual downloads."
+}
+
+function Invoke-SilentSuiteBridgeInstall {
+    # --- Detect architecture ---
+    $Arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    if ($Arch -ne "X64") {
+        Write-Err "Unsupported architecture: $Arch. Only x86_64 is supported."
+    }
+
+    # --- Banner ---
+    Write-Host ""
+    Write-Host "  SilentSuite Bridge" -ForegroundColor White
+    Write-Host "  E2EE CalDAV/CardDAV sync for your desktop apps"
+    Write-InstallLog "Installer started"
+
+    # --- Check for existing installation ---
+    if (Test-Path $ExePath) {
+        try {
+            $CurrentVersion = & $ExePath --version 2>&1 | Select-Object -First 1
+            Write-Step "Existing installation detected"
+            Write-Ok "Current version: $CurrentVersion"
+            Write-Ok "Upgrading..."
+        } catch {
+            Write-Warn "Existing binary found but could not read version"
+        }
+    }
+
+    # --- Download latest release ---
+    Write-Step "Downloading latest release..."
+    $AssetName = "$BinaryName-windows-x86_64.exe"
+    $ReleaseUrl = "https://api.github.com/repos/$Repo/releases/latest"
+
+    try {
+        $Release = Invoke-RestMethod -Uri $ReleaseUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
+    } catch {
+        $Hint = Get-GitHubErrorHint $_
+        Write-Err "Failed to fetch latest release info from GitHub: $_. $Hint"
+    }
+
+    $Asset = $Release.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+    if (-not $Asset) {
+        # Fallback for the unlikely case where the newest umbrella release has no bridge asset.
+        $ReleaseListUrl = "https://api.github.com/repos/$Repo/releases?per_page=25"
+        try {
+            $Releases = Invoke-RestMethod -Uri $ReleaseListUrl -Headers @{ "User-Agent" = "SilentSuite-Installer" }
+        } catch {
+            $Hint = Get-GitHubErrorHint $_
+            Write-Err "Latest release did not contain $AssetName and fallback release lookup failed: $_. $Hint"
+        }
+
+        foreach ($r in $Releases) {
+            $candidate = $r.assets | Where-Object { $_.name -eq $AssetName } | Select-Object -First 1
+            if ($candidate) {
+                $Release = $r
+                $Asset = $candidate
+                break
+            }
+        }
+    }
+
+    if (-not $Asset) {
+        Write-Err "No asset found matching $AssetName across recent releases. Download manually from https://github.com/$Repo/releases/latest"
+    }
+
+    # Create install directory
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+
+    $TmpFile = Join-Path $env:TEMP "silentsuite-bridge-download.exe"
+    try {
+        Invoke-WebRequest -Uri $Asset.browser_download_url -OutFile $TmpFile -UseBasicParsing
+        Write-Ok "Downloaded $AssetName from $($Release.tag_name)"
+    } catch {
+        Write-Err "Download failed: $_. Try downloading manually from https://github.com/$Repo/releases/latest"
+    }
+
+    # --- Verify SHA256 checksum ---
+    $ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "$AssetName.sha256" } | Select-Object -First 1
+    if ($ChecksumAsset) {
+        try {
+            $ExpectedLine = (Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -UseBasicParsing).Content.Trim()
+            $ExpectedHash = ($ExpectedLine -split '\s+')[0].ToUpper()
+            $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToUpper()
+            if ($ExpectedHash -ne $ActualHash) {
+                Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+                Write-Err "Checksum mismatch! Expected $ExpectedHash, got $ActualHash"
+            }
+            Write-Ok "Checksum verified"
+        } catch {
+            Write-Warn "Could not verify checksum: $_"
+        }
+    } else {
+        Write-Warn "No checksum asset found for $AssetName"
+    }
+
+    # --- Install binary ---
+    Move-Item -Path $TmpFile -Destination $ExePath -Force
+    Write-Ok "Installed to $ExePath"
+
+    # --- Add to user PATH ---
+    $UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    if ($UserPath -notlike "*$InstallDir*") {
+        [Environment]::SetEnvironmentVariable("PATH", "$InstallDir;$UserPath", "User")
+        Write-Ok "Added $InstallDir to user PATH"
+    } else {
+        Write-Ok "$InstallDir already in PATH"
+    }
+    $env:PATH = "$InstallDir;$env:PATH"
+
+    # --- Auto-start ---
+    Write-Step "Setting up auto-start..."
+    try {
+        & $ExePath --install-autostart 2>&1 | Out-Null
+        Write-Ok "Auto-start configured"
+    } catch {
+        Write-Warn "Could not set up auto-start (run later: $BinaryName --install-autostart)"
+    }
+
+    # --- Login ---
+    Write-Step "Launching login..."
+    Write-Host "  Opening your browser to sign in."
+    Write-Host "  After login, the bridge runs in the background.`n"
+    try {
+        & $ExePath --login
+        Start-Process -FilePath $ExePath -ArgumentList "--no-tray" -WindowStyle Hidden
+        Start-Sleep -Seconds 2
+        Write-Ok "Bridge is running! Dashboard: http://localhost:37358/"
+    } catch {
+        Write-Warn "Login did not complete. Run later: $BinaryName --login"
+    }
+
+    # --- Done ---
+    Write-Step "Setup complete!"
+    Write-Host ""
+    Write-Host "  Bridge installed." -ForegroundColor Green
+    Write-Host "  Dashboard: " -NoNewline; Write-Host "http://localhost:37358/" -ForegroundColor Cyan
+    Write-Host "  Log in:    " -NoNewline; Write-Host "$BinaryName --login" -ForegroundColor Cyan
+    Write-Host "  Log file:  " -NoNewline; Write-Host "$InstallLog" -ForegroundColor Cyan
+    Write-Host "  Full docs: " -NoNewline; Write-Host "https://docs.silentsuite.io/bridge" -ForegroundColor Cyan
+    Write-Host ""
+}
+
 try {
-    & $ExePath --install-autostart 2>&1 | Out-Null
-    Write-Ok "Auto-start configured"
+    Invoke-SilentSuiteBridgeInstall
 } catch {
-    Write-Warn "Could not set up auto-start (run later: $BinaryName --install-autostart)"
+    Write-Host ""
+    Write-Host "  SilentSuite Bridge install failed." -ForegroundColor Red
+    Write-Host "  Error: $_" -ForegroundColor Red
+    Write-Host "  Log file: $InstallLog" -ForegroundColor Yellow
+    Write-Host "  Manual download: https://github.com/$Repo/releases/latest/download/silentsuite-bridge-windows-x86_64.exe" -ForegroundColor Cyan
+    Write-InstallLog "Install failed: $_"
+    Wait-BeforeCloseIfInteractive
+    throw
+} finally {
+    $ErrorActionPreference = $PreviousErrorActionPreference
 }
-
-# --- Login ---
-Write-Step "Launching login..."
-Write-Host "  Opening your browser to sign in."
-Write-Host "  After login, the bridge runs in the background.`n"
-try {
-    & $ExePath --login
-    Start-Process -FilePath $ExePath -ArgumentList "--no-tray" -WindowStyle Hidden
-    Start-Sleep -Seconds 2
-    Write-Ok "Bridge is running! Dashboard: http://localhost:37358/.web/"
-} catch {
-    Write-Warn "Login did not complete. Run later: $BinaryName --login"
-}
-
-# --- Done ---
-Write-Step "Setup complete!"
-Write-Host ""
-Write-Host "  Bridge installed." -ForegroundColor Green
-Write-Host "  Dashboard: " -NoNewline; Write-Host "http://localhost:37358/.web/" -ForegroundColor Cyan
-Write-Host "  Log in:    " -NoNewline; Write-Host "$BinaryName --login" -ForegroundColor Cyan
-Write-Host "  Full docs: " -NoNewline; Write-Host "https://docs.silentsuite.io/bridge" -ForegroundColor Cyan
-Write-Host ""

--- a/bridge/pyproject.toml
+++ b/bridge/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "silentsuite-bridge"
-version = "0.1.0"
+version = "0.3.0-beta"
 description = "SilentSuite Bridge — Local E2EE CalDAV/CardDAV sync daemon"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/bridge/silentsuite-bridge.spec
+++ b/bridge/silentsuite-bridge.spec
@@ -12,10 +12,49 @@
 import os
 import sys
 import glob
+import re
 from pathlib import Path
 import importlib.util
 
 from PyInstaller.utils.hooks import copy_metadata
+
+
+# ---------------------------------------------------------------------------
+# Release version stamping
+# ---------------------------------------------------------------------------
+# PyInstaller binaries do not ship Python package metadata, so a frozen build
+# cannot read its version from importlib.metadata. To make `--version` report
+# the released version, we freeze it into _version.py at build time. The source
+# is, in order of preference:
+#   1. SILENTSUITE_BRIDGE_VERSION  (set explicitly by CI tag builds)
+#   2. GITHUB_REF_NAME             (the pushed git tag, e.g. "v0.3.0-beta")
+# When neither is set (local dev build), _version.py is left absent and the
+# package falls back to importlib.metadata / pyproject.toml.
+def stamp_version():
+    spec_dir = Path(globals().get("SPECPATH", os.getcwd()))
+    target = spec_dir / "src" / "silentsuite_bridge" / "_version.py"
+    raw = os.environ.get("SILENTSUITE_BRIDGE_VERSION", "").strip()
+    if not raw:
+        ref = os.environ.get("GITHUB_REF_NAME", "").strip()
+        # Only treat the ref as a version when it looks like a release tag.
+        if ref.startswith("v") and any(ch.isdigit() for ch in ref):
+            raw = ref
+    if not raw:
+        if target.exists() and "Generated at build time from the release tag" in target.read_text(encoding="utf-8"):
+            target.unlink()
+            print(f"[spec] Removed stale generated version stamp: {target}")
+        return
+    version = raw.lstrip("v")
+    if not re.match(r"^\d+\.\d+\.\d+(?:[-.][A-Za-z0-9][A-Za-z0-9.-]*)?$", version):
+        raise SystemExit(f"Invalid SILENTSUITE_BRIDGE_VERSION/GITHUB_REF_NAME for Python stamp: {raw!r}")
+    target.write_text(
+        '# Generated at build time from the release tag. Do not edit or commit.\n'
+        f'VERSION = {version!r}\n'
+    )
+    print(f"[spec] Stamped bridge version: {version} -> {target}")
+
+
+stamp_version()
 
 
 def safe_copy_metadata(package_name):

--- a/bridge/src/silentsuite_bridge/__init__.py
+++ b/bridge/src/silentsuite_bridge/__init__.py
@@ -7,6 +7,49 @@ endpoints on localhost for use with any standard PIM client.
 License: AGPL-3.0-only
 """
 
-__version__ = "0.1.0"
+import os
+from importlib import metadata as _metadata
+
+# Kept in sync with pyproject.toml [project].version. Used only as a
+# last-resort fallback when neither a build stamp nor package metadata is
+# available (e.g. running straight from source without an editable install).
+_FALLBACK_VERSION = "0.3.0-beta"
+
+
+def _resolve_version() -> str:
+    """Resolve the bridge version, preferring a release-build stamp.
+
+    Resolution order:
+      1. ``SILENTSUITE_BRIDGE_VERSION`` env var — explicit runtime/build
+         override (CI tag builds set this; see silentsuite-bridge.spec).
+      2. ``_version.py`` — written at build time from the git tag and frozen
+         into the PyInstaller binary, which does not ship package metadata.
+      3. ``_FALLBACK_VERSION`` — the exact human-facing release string. This is
+         preferred over package metadata because Python normalizes
+         ``0.3.0-beta`` to ``0.3.0b0`` in installed metadata.
+      4. ``importlib.metadata`` — final fallback for unusual packaged installs.
+    """
+    override = os.environ.get("SILENTSUITE_BRIDGE_VERSION", "").strip()
+    if override:
+        return override.lstrip("v")
+
+    try:
+        from ._version import VERSION as _stamped  # type: ignore[attr-defined]
+
+        if _stamped:
+            return str(_stamped).lstrip("v")
+    except Exception:
+        pass
+
+    if _FALLBACK_VERSION:
+        return _FALLBACK_VERSION
+
+    try:
+        return _metadata.version("silentsuite-bridge")
+    except _metadata.PackageNotFoundError:
+        return "0.0.0-dev"
+
+
+__version__ = _resolve_version()
 __author__ = "SilentSuite"
 __license__ = "AGPL-3.0-only"

--- a/bridge/tests/test_version.py
+++ b/bridge/tests/test_version.py
@@ -1,0 +1,64 @@
+"""Version reporting tests.
+
+Guards against the stale-version regression where `silentsuite-bridge
+--version` reported 0.1.0 long after the project had moved on (the binary was
+never re-stamped from the release tag). These tests keep the package version,
+the pyproject version, and the CLI/env override path in agreement.
+"""
+
+import importlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import silentsuite_bridge
+
+BRIDGE_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _pyproject_version() -> str:
+    pyproject = (BRIDGE_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    assert match, "bridge/pyproject.toml should declare [project].version"
+    return match.group(1)
+
+
+def test_version_is_not_stale_placeholder():
+    """The long-lived 0.1.0 placeholder must never resurface."""
+    assert silentsuite_bridge.__version__ != "0.1.0"
+
+
+def test_version_looks_like_a_release():
+    """Version must be a plausible semver-ish string (e.g. 0.3.0-beta)."""
+    assert re.match(r"^\d+\.\d+\.\d+", silentsuite_bridge.__version__)
+
+
+def test_fallback_matches_pyproject():
+    """The hardcoded fallback must track pyproject so source runs aren't stale."""
+    assert silentsuite_bridge._FALLBACK_VERSION == _pyproject_version()
+
+
+def test_env_override_takes_precedence(monkeypatch):
+    """Release builds stamp the version via the env override; honour it and
+    strip a leading 'v' so a raw git tag works."""
+    monkeypatch.setenv("SILENTSUITE_BRIDGE_VERSION", "v9.9.9-rc1")
+    reloaded = importlib.reload(silentsuite_bridge)
+    try:
+        assert reloaded.__version__ == "9.9.9-rc1"
+    finally:
+        monkeypatch.delenv("SILENTSUITE_BRIDGE_VERSION", raising=False)
+        importlib.reload(silentsuite_bridge)
+
+
+def test_cli_version_output_matches_package():
+    """`python -m silentsuite_bridge --version` must echo the package version."""
+    result = subprocess.run(
+        [sys.executable, "-m", "silentsuite_bridge", "--version"],
+        capture_output=True,
+        text=True,
+        cwd=str(BRIDGE_ROOT / "src"),
+    )
+    assert result.returncode == 0, result.stderr
+    assert silentsuite_bridge.__version__ in result.stdout
+    assert "0.1.0" not in result.stdout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silentsuite",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "author": "SilentSuite <info@silentsuite.io>",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/config",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "files": [
     "typescript",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/core",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/ui",
-  "version": "0.1.0",
+  "version": "0.3.0-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/tests/test_android_security_static.py
+++ b/tests/test_android_security_static.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOGIN_ACTIVITY = ROOT / "android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt"
+MANIFEST = ROOT / "android/app/src/main/AndroidManifest.xml"
+
+
+def test_login_activity_credential_prefill_extras_are_debug_only_and_not_exported():
+    activity = LOGIN_ACTIVITY.read_text(encoding="utf-8")
+    manifest = MANIFEST.read_text(encoding="utf-8")
+
+    assert "EXTRA_INITIAL_USERNAME" in activity
+    assert "EXTRA_INITIAL_PASSWORD" in activity
+    assert "BuildConfig.DEBUG" in activity
+    assert "if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_USERNAME) else null" in activity
+    assert "if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_PASSWORD) else null" in activity
+
+    login_decl = manifest[manifest.index('android:name=".ui.setup.LoginActivity"'):]
+    login_decl = login_decl[:login_decl.index("</activity>")]
+    assert 'android:exported="false"' in login_decl

--- a/tests/test_release_versions_static.py
+++ b/tests/test_release_versions_static.py
@@ -1,0 +1,67 @@
+"""Static release-version consistency checks.
+
+These tests guard against stale user-visible versions across the bridge, web
+workspace packages, and Android metadata. They intentionally avoid archived
+prototype code under _archive/.
+"""
+
+from pathlib import Path
+import json
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+CURRENT_RELEASE_VERSION = "0.3.0-beta"
+
+PACKAGE_JSON_PATHS = [
+    "package.json",
+    "apps/web/package.json",
+    "apps/docs/package.json",
+    "packages/core/package.json",
+    "packages/ui/package.json",
+    "packages/config/package.json",
+]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_workspace_package_versions_match_current_release():
+    for rel in PACKAGE_JSON_PATHS:
+        package = json.loads(read(rel))
+        assert package["version"] == CURRENT_RELEASE_VERSION, rel
+
+
+def test_bridge_pyproject_version_matches_current_release():
+    pyproject = read("bridge/pyproject.toml")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    assert match, "bridge/pyproject.toml should declare [project].version"
+    assert match.group(1) == CURRENT_RELEASE_VERSION
+
+
+def test_web_signup_uses_named_display_version_constant():
+    constants = read("apps/web/app/lib/constants.ts")
+    signup = read("apps/web/app/(auth)/signup/page.tsx")
+
+    assert f"DISPLAY_VERSION = '{CURRENT_RELEASE_VERSION}'" in constants
+    assert "import { DISPLAY_VERSION }" in signup
+    assert "v{DISPLAY_VERSION}" in signup
+    assert "v0.3.0" not in signup
+
+
+def test_android_version_name_matches_current_release():
+    gradle = read("android/app/build.gradle")
+    match = re.search(r'versionName\s+"([^"]+)"', gradle)
+    assert match, "android/app/build.gradle should declare versionName"
+    assert match.group(1) == CURRENT_RELEASE_VERSION
+
+
+def test_bridge_release_workflow_validates_frozen_version_without_runtime_env_override():
+    workflow = read(".github/workflows/build-bridge.yml")
+    spec = read("bridge/silentsuite-bridge.spec")
+
+    assert "env -u SILENTSUITE_BRIDGE_VERSION" in workflow
+    assert "SPECPATH" in spec
+    assert "Removed stale generated version stamp" in spec
+    assert "target.unlink()" in spec
+    assert "VERSION = {version!r}" in spec

--- a/tests/test_windows_installer_static.py
+++ b/tests/test_windows_installer_static.py
@@ -35,6 +35,30 @@ def test_windows_installer_has_top_level_error_log_and_interactive_pause():
     assert re.search(r"catch\s*\{", script, re.IGNORECASE)
 
 
+def test_windows_installer_fails_closed_on_checksum_mismatch():
+    script = read(INSTALLER)
+    checksum_block = script[script.index("# --- Verify SHA256 checksum ---"):script.index("# --- Install binary ---")]
+
+    assert "No checksum asset found" in checksum_block
+    assert "refusing to install an unverified binary" in checksum_block
+    assert "Invalid checksum content" in checksum_block
+    assert "Could not verify checksum" in checksum_block
+    assert "Write-Warn" not in checksum_block
+
+    mismatch_match = re.search(
+        r"if\s*\(\$ExpectedHash\s+-ne\s+\$ActualHash\)\s*\{(?P<body>.*?)\n\s*\}\s*else\s*\{(?P<else_body>.*?)\n\s*\}",
+        checksum_block,
+        re.DOTALL,
+    )
+    assert mismatch_match, "installer should explicitly compare expected and actual SHA256 hashes"
+    mismatch_body = mismatch_match.group("body")
+    else_body = mismatch_match.group("else_body")
+
+    assert "Remove-Item $TmpFile" in mismatch_body
+    assert "Write-Err" in mismatch_body
+    assert "Write-Ok \"Checksum verified\"" in else_body
+
+
 def test_bridge_docs_link_direct_windows_asset_and_visible_error_recovery():
     docs = read(DOCS)
 

--- a/tests/test_windows_installer_static.py
+++ b/tests/test_windows_installer_static.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "bridge" / "install.ps1"
+DOCS = ROOT / "apps" / "docs" / "user-guide" / "apps" / "dav-bridge.md"
+WINDOWS_WORKFLOW = ROOT / ".github" / "workflows" / "test-bridge-windows.yml"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_windows_installer_error_helper_does_not_exit_parent_powershell():
+    script = read(INSTALLER)
+    helper_match = re.search(r"function\s+Write-Err\s*\([^)]*\)\s*\{(?P<body>.*?)\n\}", script, re.DOTALL)
+    assert helper_match, "installer should define a Write-Err helper"
+    helper_body = helper_match.group("body")
+
+    assert not re.search(r"\bexit\b", helper_body, re.IGNORECASE), (
+        "Write-Err must not call exit; under `irm ... | iex` that can close the user's PowerShell window"
+    )
+    assert re.search(r"\bthrow\b", helper_body, re.IGNORECASE), (
+        "Write-Err should throw so failures are visible without terminating the parent host"
+    )
+
+
+def test_windows_installer_has_top_level_error_log_and_interactive_pause():
+    script = read(INSTALLER)
+
+    assert "$InstallLog" in script
+    assert "%LOCALAPPDATA%" in script or "$env:LOCALAPPDATA" in script
+    assert "Press Enter to close" in script
+    assert re.search(r"try\s*\{", script, re.IGNORECASE)
+    assert re.search(r"catch\s*\{", script, re.IGNORECASE)
+
+
+def test_bridge_docs_link_direct_windows_asset_and_visible_error_recovery():
+    docs = read(DOCS)
+
+    assert "silentsuite-bridge-windows-x86_64.exe" in docs
+    assert "silentsuite-bridge-windows-x86_64.exe.sha256" in docs
+    assert "already-open PowerShell" in docs or "already-open Windows Terminal" in docs
+    assert "-OutFile" in docs and "-File" in docs
+
+
+def test_windows_github_actions_workflow_covers_installer_and_binary_smoke_tests():
+    workflow = read(WINDOWS_WORKFLOW)
+
+    assert "windows-latest" in workflow
+    assert "install.ps1" in workflow
+    assert "PSScriptAnalyzer" in workflow
+    assert "Write-Err" in workflow
+    assert "silentsuite-bridge --version" in workflow or "silentsuite-bridge.exe --version" in workflow


### PR DESCRIPTION
## Summary
Promote current `dev` to `main` after the Windows bridge install/version fixes, promotion security blocker fixes, and recent screenshot/Android test robustness fixes.

Base: `a01de638558c10ea4de1a35b5d9a4a216678e747`  
Head: `4856e6fa2fcf8c56528e2d360d84263e2a4538ad`

## Included highlights
- Windows bridge installer hardening and direct docs/download path
- Bridge binary version stamping from release tags; stale `0.1.0` regression guards
- Windows installer checksum verification now fails closed instead of warning through
- Web signup display version moved to a named constant and aligned to `0.3.0-beta`
- Workspace package metadata aligned to `0.3.0-beta`
- Android screenshot credential prefill restricted to debug builds and guarded by static test
- Android/screenshot instrumentation robustness fixes currently on `dev`

## Gates
- [ ] PR checks green
- [ ] Main post-merge workflows green
- [ ] Production smoke checks