### PR TITLE
fix: close promotion security blockers

### DIFF
--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -6,14 +6,22 @@ on:
     branches: [main, dev]
     paths:
       - 'bridge/**'
+      - 'android/app/src/main/AndroidManifest.xml'
+      - 'android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt'
       - 'apps/docs/user-guide/apps/dav-bridge.md'
+      - 'tests/test_android_security_static.py'
+      - 'tests/test_release_versions_static.py'
       - 'tests/test_windows_installer_static.py'
       - '.github/workflows/test-bridge-windows.yml'
   pull_request:
     branches: [main, dev]
     paths:
       - 'bridge/**'
+      - 'android/app/src/main/AndroidManifest.xml'
+      - 'android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt'
       - 'apps/docs/user-guide/apps/dav-bridge.md'
+      - 'tests/test_android_security_static.py'
+      - 'tests/test_release_versions_static.py'
       - 'tests/test_windows_installer_static.py'
       - '.github/workflows/test-bridge-windows.yml'
 
@@ -37,7 +45,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pytest
-          python -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py -q
+          python -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py tests/test_android_security_static.py -q
 
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
@@ -12,6 +12,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 
+import io.silentsuite.sync.BuildConfig
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
 import io.silentsuite.sync.ui.BaseActivity
@@ -33,10 +34,10 @@ class LoginActivity : BaseActivity() {
 
         if (savedInstanceState == null) {
             // first call, show login screen directly (welcome dialog removed)
-            // Optional extras are used by screenshot instrumentation to prefill
-            // credentials without brittle keyboard/UIAutomator text entry.
-            val initialUsername = intent.getStringExtra(EXTRA_INITIAL_USERNAME)
-            val initialPassword = intent.getStringExtra(EXTRA_INITIAL_PASSWORD)
+            // Optional extras are only for debug screenshot instrumentation.
+            // Do not accept plaintext credential prefill extras in release builds.
+            val initialUsername = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_USERNAME) else null
+            val initialPassword = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_PASSWORD) else null
             supportFragmentManager.beginTransaction()
                     .replace(android.R.id.content, LoginCredentialsFragment.newInstance(initialUsername, initialPassword))
                     .commit()

--- a/bridge/install.ps1
+++ b/bridge/install.ps1
@@ -150,21 +150,28 @@ function Invoke-SilentSuiteBridgeInstall {
 
     # --- Verify SHA256 checksum ---
     $ChecksumAsset = $Release.assets | Where-Object { $_.name -eq "$AssetName.sha256" } | Select-Object -First 1
-    if ($ChecksumAsset) {
-        try {
-            $ExpectedLine = (Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -UseBasicParsing).Content.Trim()
-            $ExpectedHash = ($ExpectedLine -split '\s+')[0].ToUpper()
-            $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToUpper()
-            if ($ExpectedHash -ne $ActualHash) {
-                Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
-                Write-Err "Checksum mismatch! Expected $ExpectedHash, got $ActualHash"
-            }
-            Write-Ok "Checksum verified"
-        } catch {
-            Write-Warn "Could not verify checksum: $_"
+    if (-not $ChecksumAsset) {
+        Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+        Write-Err "No checksum asset found for $AssetName; refusing to install an unverified binary"
+    }
+
+    try {
+        $ExpectedLine = (Invoke-WebRequest -Uri $ChecksumAsset.browser_download_url -UseBasicParsing).Content.Trim()
+        $ExpectedHash = ($ExpectedLine -split '\s+')[0].ToUpper()
+        if ($ExpectedHash -notmatch '^[0-9A-F]{64}$') {
+            Write-Err "Invalid checksum content for $AssetName.sha256"
         }
+        $ActualHash = (Get-FileHash -Path $TmpFile -Algorithm SHA256).Hash.ToUpper()
+    } catch {
+        Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+        Write-Err "Could not verify checksum: $_"
+    }
+
+    if ($ExpectedHash -ne $ActualHash) {
+        Remove-Item $TmpFile -Force -ErrorAction SilentlyContinue
+        Write-Err "Checksum mismatch! Expected $ExpectedHash, got $ActualHash"
     } else {
-        Write-Warn "No checksum asset found for $AssetName"
+        Write-Ok "Checksum verified"
     }
 
     # --- Install binary ---

--- a/tests/test_android_security_static.py
+++ b/tests/test_android_security_static.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LOGIN_ACTIVITY = ROOT / "android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt"
+MANIFEST = ROOT / "android/app/src/main/AndroidManifest.xml"
+
+
+def test_login_activity_credential_prefill_extras_are_debug_only_and_not_exported():
+    activity = LOGIN_ACTIVITY.read_text(encoding="utf-8")
+    manifest = MANIFEST.read_text(encoding="utf-8")
+
+    assert "EXTRA_INITIAL_USERNAME" in activity
+    assert "EXTRA_INITIAL_PASSWORD" in activity
+    assert "BuildConfig.DEBUG" in activity
+    assert "if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_USERNAME) else null" in activity
+    assert "if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_PASSWORD) else null" in activity
+
+    login_decl = manifest[manifest.index('android:name=".ui.setup.LoginActivity"'):]
+    login_decl = login_decl[:login_decl.index("</activity>")]
+    assert 'android:exported="false"' in login_decl

--- a/tests/test_windows_installer_static.py
+++ b/tests/test_windows_installer_static.py
@@ -35,6 +35,30 @@ def test_windows_installer_has_top_level_error_log_and_interactive_pause():
     assert re.search(r"catch\s*\{", script, re.IGNORECASE)
 
 
+def test_windows_installer_fails_closed_on_checksum_mismatch():
+    script = read(INSTALLER)
+    checksum_block = script[script.index("# --- Verify SHA256 checksum ---"):script.index("# --- Install binary ---")]
+
+    assert "No checksum asset found" in checksum_block
+    assert "refusing to install an unverified binary" in checksum_block
+    assert "Invalid checksum content" in checksum_block
+    assert "Could not verify checksum" in checksum_block
+    assert "Write-Warn" not in checksum_block
+
+    mismatch_match = re.search(
+        r"if\s*\(\$ExpectedHash\s+-ne\s+\$ActualHash\)\s*\{(?P<body>.*?)\n\s*\}\s*else\s*\{(?P<else_body>.*?)\n\s*\}",
+        checksum_block,
+        re.DOTALL,
+    )
+    assert mismatch_match, "installer should explicitly compare expected and actual SHA256 hashes"
+    mismatch_body = mismatch_match.group("body")
+    else_body = mismatch_match.group("else_body")
+
+    assert "Remove-Item $TmpFile" in mismatch_body
+    assert "Write-Err" in mismatch_body
+    assert "Write-Ok \"Checksum verified\"" in else_body
+
+
 def test_bridge_docs_link_direct_windows_asset_and_visible_error_recovery():
     docs = read(DOCS)
 


### PR DESCRIPTION
## Summary
- make the Windows bridge installer fail closed when a downloaded checksum mismatches
- keep Android screenshot credential-prefill extras debug-only and assert LoginActivity is not exported
- wire the Android/static security guard into the Windows static regression workflow

## Test Plan
- `python -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py tests/test_android_security_static.py -q`
- attempted `./gradlew :app:compileDebugKotlin` locally; blocked by missing Android SDK/ANDROID_HOME in this environment

Unblocks dev→main promotion PR #363.
