### PR TITLE
fix: use stable login field ids for screenshot automation

### DIFF
--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -124,7 +124,7 @@ public class StoreScreenshotsTest {
     private static void launchPrefilledLogin() {
         Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         Intent intent = new Intent(targetContext, LoginActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         intent.putExtra(LoginActivity.EXTRA_INITIAL_USERNAME, testEmail);
         intent.putExtra(LoginActivity.EXTRA_INITIAL_PASSWORD, testPassword);
         targetContext.startActivity(intent);
@@ -188,7 +188,7 @@ public class StoreScreenshotsTest {
             onView(allOf(isAssignableFrom(EditText.class), withHint("Email")))
                     .perform(replaceText(testEmail), closeSoftKeyboard());
             sleep(300);
-            onView(allOf(isAssignableFrom(EditText.class), withHint("Password")))
+            onView(withId(io.silentsuite.sync.R.id.login_password))
                     .perform(replaceText(testPassword), closeSoftKeyboard());
             sleep(300);
             onView(withId(io.silentsuite.sync.R.id.login)).perform(click());
@@ -278,28 +278,29 @@ public class StoreScreenshotsTest {
     private void fillLoginFields() {
         // Prefer visible EditText widgets. Material TextInputLayout resource IDs are
         // not reliably exposed to UIAutomator on API 35, but the child EditTexts are.
-        List<UiObject2> editTexts = device.findObjects(By.clazz("android.widget.EditText"));
-        if (editTexts.size() >= 2) {
-            UiObject2 emailField = editTexts.get(0);
-            emailField.click();
+        UiObject2 emailById = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), 1500);
+        if (emailById != null) {
+            emailById.click();
             sleep(300);
-            emailField.setText(testEmail);
+            emailById.setText(testEmail);
             sleep(300);
+        }
 
-            UiObject2 passField = editTexts.get(1);
-            passField.click();
+        UiObject2 passById = device.wait(Until.findObject(By.res(PACKAGE, "login_password")), 1500);
+        if (passById != null) {
+            passById.click();
             sleep(300);
-            passField.setText(testPassword);
+            passById.setText(testPassword);
             sleep(300);
             return;
         }
 
-        // Fallback for devices that expose the email field by resource id.
-        UiObject2 emailField = device.wait(Until.findObject(By.res(PACKAGE, "user_name")), NAV_TIMEOUT);
-        if (emailField != null) {
-            emailField.click();
+        List<UiObject2> editTexts = device.findObjects(By.clazz("android.widget.EditText"));
+        if (editTexts.size() >= 2) {
+            UiObject2 passField = editTexts.get(1);
+            passField.click();
             sleep(300);
-            emailField.setText(testEmail);
+            passField.setText(testPassword);
             sleep(300);
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
@@ -8,6 +8,7 @@
 
 package io.silentsuite.sync.ui.setup
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -33,16 +34,25 @@ class LoginActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         if (savedInstanceState == null) {
-            // first call, show login screen directly (welcome dialog removed)
-            // Optional extras are only for debug screenshot instrumentation.
-            // Do not accept plaintext credential prefill extras in release builds.
-            val initialUsername = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_USERNAME) else null
-            val initialPassword = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_PASSWORD) else null
-            supportFragmentManager.beginTransaction()
-                    .replace(android.R.id.content, LoginCredentialsFragment.newInstance(initialUsername, initialPassword))
-                    .commit()
+            showLoginFragment(intent)
         }
 
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        showLoginFragment(intent)
+    }
+
+    private fun showLoginFragment(intent: Intent) {
+        // Optional extras are only for debug screenshot instrumentation.
+        // Do not accept plaintext credential prefill extras in release builds.
+        val initialUsername = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_USERNAME) else null
+        val initialPassword = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_PASSWORD) else null
+        supportFragmentManager.beginTransaction()
+                .replace(android.R.id.content, LoginCredentialsFragment.newInstance(initialUsername, initialPassword))
+                .commit()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/android/app/src/main/res/layout/login_credentials_fragment.xml
+++ b/android/app/src/main/res/layout/login_credentials_fragment.xml
@@ -100,6 +100,7 @@
                 app:boxStrokeWidth="1dp"
                 app:boxStrokeWidthFocused="2dp">
                 <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/login_password"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:fontFamily="monospace"


### PR DESCRIPTION
Adds a stable id for the password input and makes screenshot instrumentation launch a fresh prefilled LoginActivity before tapping Log In. This should stop the CI screenshots from staying on empty Add account screens.