### PR TITLE
fix: provision screenshot account programmatically

### DIFF
--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/ScreenshotAccountProvisioner.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/ScreenshotAccountProvisioner.kt
@@ -1,0 +1,56 @@
+package io.silentsuite.screenshots
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Context
+import android.content.ContentResolver
+import android.provider.CalendarContract
+import io.silentsuite.sync.AccountSettings
+import io.silentsuite.sync.App
+import io.silentsuite.sync.Constants
+import io.silentsuite.sync.ui.ActiveAccountManager
+import io.silentsuite.sync.ui.setup.BaseConfigurationFinder
+import io.silentsuite.sync.ui.setup.LoginCredentials
+
+/**
+ * Deterministic account setup for store screenshot instrumentation.
+ *
+ * This runs only from androidTest. It avoids brittle keyboard/UIAutomator login
+ * entry by using the same Etebase configuration finder and AccountSettings path
+ * as the normal login flow.
+ */
+object ScreenshotAccountProvisioner {
+    @JvmStatic
+    fun ensureAccount(context: Context, email: String?, password: String?): Boolean {
+        if (email.isNullOrBlank() || password.isNullOrBlank()) {
+            return false
+        }
+
+        val accountManager = AccountManager.get(context)
+        val existing = accountManager.getAccountsByType(App.accountType).firstOrNull { it.name == email }
+        if (existing != null) {
+            ActiveAccountManager.setActiveAccount(context, existing)
+            return true
+        }
+
+        val config = BaseConfigurationFinder(context, LoginCredentials(null, email, password)).findInitialConfiguration()
+        if (config.isFailed || config.etebaseSession.isNullOrBlank()) {
+            return false
+        }
+
+        val account = Account(config.userName, App.accountType)
+        if (!accountManager.addAccountExplicitly(account, null, null)) {
+            return false
+        }
+
+        AccountSettings.setUserData(accountManager, account, config.url, config.userName)
+        val settings = AccountSettings(context, account)
+        settings.etebaseSession = config.etebaseSession
+        settings.setSyncInterval(App.addressBooksAuthority, Constants.DEFAULT_SYNC_INTERVAL.toLong())
+        settings.setSyncInterval(CalendarContract.AUTHORITY, Constants.DEFAULT_SYNC_INTERVAL.toLong())
+        ContentResolver.setIsSyncable(account, App.addressBooksAuthority, 1)
+        ContentResolver.setIsSyncable(account, CalendarContract.AUTHORITY, 1)
+        ActiveAccountManager.setActiveAccount(context, account)
+        return true
+    }
+}

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -327,26 +327,30 @@ public class StoreScreenshotsTest {
             return; // no credentials, skip login
         }
 
+        Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        if (ScreenshotAccountProvisioner.ensureAccount(targetContext, testEmail, testPassword)) {
+            loggedIn = true;
+            launchApp();
+            sleep(5000);
+            return;
+        }
+
+        // Fallback to the visual login path if programmatic setup fails.
         launchPrefilledLogin();
 
         if (!isLoginScreen()) {
             return;
         }
 
-        // LoginActivity prefilled the credentials via optional extras. The fallback
-        // entry methods remain as backup if a future app version drops prefill.
         fillLoginFields();
         espressoLoginFallback();
         device.pressBack(); // hide keyboard so the bottom login button is clickable
         sleep(500);
         if (!tapRes("login") && !tapText("LOG IN") && !tapText("Log In")) {
-            // Fallback for MaterialButton instances that expose neither stable
-            // resource id nor text to UIAutomator on API 35.
             device.click(device.getDisplayWidth() / 2, device.getDisplayHeight() - 115);
             sleep(1000);
         }
 
-        // Wait for the server login/encryption flow to advance off the login screen.
         long deadline = SystemClock.uptimeMillis() + 30000;
         while (SystemClock.uptimeMillis() < deadline && isLoginScreen()) {
             sleep(1000);


### PR DESCRIPTION
Creates the screenshot demo account from androidTest using the app's own Etebase/BaseConfigurationFinder and AccountSettings path before post-login captures, with the visual login flow retained as fallback.