### PR TITLE
fix: fail screenshot provisioning loudly

### DIFF
--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/ScreenshotAccountProvisioner.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/ScreenshotAccountProvisioner.kt
@@ -23,7 +23,7 @@ object ScreenshotAccountProvisioner {
     @JvmStatic
     fun ensureAccount(context: Context, email: String?, password: String?): Boolean {
         if (email.isNullOrBlank() || password.isNullOrBlank()) {
-            return false
+            throw IllegalStateException("Screenshot account credentials missing")
         }
 
         val accountManager = AccountManager.get(context)
@@ -35,12 +35,12 @@ object ScreenshotAccountProvisioner {
 
         val config = BaseConfigurationFinder(context, LoginCredentials(null, email, password)).findInitialConfiguration()
         if (config.isFailed || config.etebaseSession.isNullOrBlank()) {
-            return false
+            throw IllegalStateException("Screenshot Etebase login/config failed: " + (config.error?.javaClass?.name ?: "empty session"))
         }
 
         val account = Account(config.userName, App.accountType)
         if (!accountManager.addAccountExplicitly(account, null, null)) {
-            return false
+            throw IllegalStateException("Screenshot Android account creation failed")
         }
 
         AccountSettings.setUserData(accountManager, account, config.url, config.userName)

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -328,54 +328,10 @@ public class StoreScreenshotsTest {
         }
 
         Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        if (ScreenshotAccountProvisioner.ensureAccount(targetContext, testEmail, testPassword)) {
-            loggedIn = true;
-            launchApp();
-            sleep(5000);
-            return;
-        }
-
-        // Fallback to the visual login path if programmatic setup fails.
-        launchPrefilledLogin();
-
-        if (!isLoginScreen()) {
-            return;
-        }
-
-        fillLoginFields();
-        espressoLoginFallback();
-        device.pressBack(); // hide keyboard so the bottom login button is clickable
-        sleep(500);
-        if (!tapRes("login") && !tapText("LOG IN") && !tapText("Log In")) {
-            device.click(device.getDisplayWidth() / 2, device.getDisplayHeight() - 115);
-            sleep(1000);
-        }
-
-        long deadline = SystemClock.uptimeMillis() + 30000;
-        while (SystemClock.uptimeMillis() < deadline && isLoginScreen()) {
-            sleep(1000);
-        }
-
-        // Handle the encryption password prompt if it appears.
-        UiObject2 encLabel = device.wait(Until.findObject(By.textContains("Encryption Password")), 2000);
-        if (encLabel != null) {
-            List<UiObject2> editTexts = device.findObjects(By.clazz("android.widget.EditText"));
-            if (!editTexts.isEmpty()) {
-                UiObject2 encPass = editTexts.get(editTexts.size() - 1);
-                encPass.click();
-                sleep(300);
-                encPass.setText(testPassword);
-                sleep(300);
-            }
-            device.pressBack();
-            sleep(500);
-            if (!tapText("Finish")) {
-                tapText("FINISH");
-            }
-            sleep(5000);
-        }
-
-        loggedIn = PACKAGE.equals(device.getCurrentPackageName()) && !isLoginScreen();
+        ScreenshotAccountProvisioner.ensureAccount(targetContext, testEmail, testPassword);
+        loggedIn = true;
+        launchApp();
+        sleep(5000);
     }
 
     /**


### PR DESCRIPTION
Makes screenshot account provisioning fail with a non-secret reason instead of silently falling back to repeated Add account screenshots.