### PR TITLE
fix: remove refresh listeners safely

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/AccountUpdateService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/AccountUpdateService.kt
@@ -60,12 +60,7 @@ class AccountUpdateService : Service() {
         }
 
         fun removeRefreshingStatusListener(listener: RefreshingStatusListener) {
-            val iterator = refreshingStatusListeners.iterator()
-            while (iterator.hasNext()) {
-                val item = iterator.next().get()
-                if (listener == item)
-                    iterator.remove()
-            }
+            refreshingStatusListeners.removeAll { it.get() == null || it.get() == listener }
         }
     }
 


### PR DESCRIPTION
Fixes AccountUpdateService listener removal. CopyOnWriteArrayList iterator.remove() crashes during AccountActivity teardown, which blocks screenshot automation after successful account setup.