### PR TITLE
fix: guard account service unbind race

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -692,8 +692,15 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         override fun onCleared() {
             davService?.removeRefreshingStatusListener(this)
             if (serviceBound) {
-                context.unbindService(this)
-                serviceBound = false
+                try {
+                    context.unbindService(this)
+                } catch (e: IllegalArgumentException) {
+                    // The service connection can be reported as connected while Android
+                    // has already dropped the registration during fast activity teardown.
+                    Logger.log.fine("Account update service was already unbound")
+                } finally {
+                    serviceBound = false
+                }
             }
 
             if (syncStatusListener != null) {


### PR DESCRIPTION
Hardens AccountActivity teardown by catching the expected Android unbindService race when a service connection was already dropped during fast lifecycle changes.