### PR TITLE
Add web label color selection

### DIFF
--- a/apps/web/app/components/LabelEditor.tsx
+++ b/apps/web/app/components/LabelEditor.tsx
@@ -1,8 +1,13 @@
 'use client'
 
-import { useCallback, useState } from 'react'
-import { Tag, X } from 'lucide-react'
+import { useCallback, useRef, useState, type FormEvent } from 'react'
+import { Palette, Tag, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import {
+  getLabelColor,
+  labelTextColor,
+  useLabelColorStore,
+} from '@/app/stores/use-label-color-store'
 
 // ---------------------------------------------------------------------------
 // Shared label / category chip components (#291)
@@ -43,15 +48,73 @@ export function LabelChips({
   return (
     <div className={`flex flex-wrap gap-1.5 ${className}`}>
       {labels.map((label, index) => (
-        <span
+        <LabelChip
           key={`${label}-${index}`}
-          className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300"
-        >
-          <Tag className="h-3 w-3" />
-          {label}
-        </span>
+          label={label}
+        />
       ))}
     </div>
+  )
+}
+
+function LabelChip({
+  label,
+  disabled = false,
+  onRemove,
+  changeColorLabel,
+  removeLabel,
+}: {
+  label: string
+  disabled?: boolean
+  onRemove?: () => void
+  changeColorLabel?: string
+  removeLabel?: string
+}) {
+  const colors = useLabelColorStore((state) => state.colors)
+  const setLabelColor = useLabelColorStore((state) => state.setLabelColor)
+  const colorInputRef = useRef<HTMLInputElement>(null)
+  const color = getLabelColor(label, colors)
+  const handleColorInput = useCallback((event: FormEvent<HTMLInputElement>) => {
+    setLabelColor(label, event.currentTarget.value)
+  }, [label, setLabelColor])
+
+  return (
+    <span
+      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium shadow-sm ring-1 ring-black/5"
+      style={{ backgroundColor: color, color: labelTextColor(color) }}
+    >
+      <Tag className="h-3 w-3" />
+      {label}
+      {onRemove && !disabled && (
+        <>
+          <button
+            type="button"
+            onClick={() => colorInputRef.current?.click()}
+            className="rounded-full p-1 transition-colors hover:bg-black/10 focus:outline-none focus:ring-1 focus:ring-white/80 max-md:min-h-[44px] max-md:min-w-[44px] max-md:flex max-md:items-center max-md:justify-center max-md:-my-2 max-md:-mx-1.5"
+            aria-label={changeColorLabel}
+          >
+            <Palette className="h-3 w-3" />
+          </button>
+          <input
+            ref={colorInputRef}
+            type="color"
+            value={color}
+            onInput={handleColorInput}
+            onChange={handleColorInput}
+            className="sr-only"
+            aria-label={changeColorLabel}
+          />
+          <button
+            type="button"
+            onClick={onRemove}
+            className="rounded-full p-1 transition-colors hover:bg-black/10 focus:outline-none focus:ring-1 focus:ring-white/80 max-md:min-h-[44px] max-md:min-w-[44px] max-md:flex max-md:items-center max-md:justify-center max-md:-my-2 max-md:-mx-1.5"
+            aria-label={removeLabel}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </>
+      )}
+    </span>
   )
 }
 
@@ -107,23 +170,14 @@ export function LabelEditor({
   return (
     <div className="flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">
       {labels.map((label, index) => (
-        <span
+        <LabelChip
           key={`${label}-${index}`}
-          className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300"
-        >
-          <Tag className="h-3 w-3" />
-          {label}
-          {!disabled && (
-            <button
-              type="button"
-              onClick={() => remove(label)}
-              className="rounded-full p-1 hover:text-red-500 transition-colors max-md:min-h-[44px] max-md:min-w-[44px] max-md:flex max-md:items-center max-md:justify-center max-md:-my-2 max-md:-mx-1.5"
-              aria-label={t('removeLabel', { label })}
-            >
-              <X className="h-3 w-3" />
-            </button>
-          )}
-        </span>
+          label={label}
+          disabled={disabled}
+          onRemove={() => remove(label)}
+          changeColorLabel={t('changeLabelColor', { label })}
+          removeLabel={t('removeLabel', { label })}
+        />
       ))}
       {!disabled && (
         <input

--- a/apps/web/app/components/__tests__/LabelEditor.test.tsx
+++ b/apps/web/app/components/__tests__/LabelEditor.test.tsx
@@ -1,12 +1,19 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { LabelEditor, LabelChips, normalizeLabels } from '../LabelEditor'
 import { renderWithIntl } from '@/src/__tests__/render-with-intl'
+import { getLabelColor, labelTextColor, useLabelColorStore } from '@/app/stores/use-label-color-store'
 
 vi.mock('lucide-react', () => ({
+  Palette: () => <svg data-testid="palette-icon" />,
   Tag: () => <svg data-testid="tag-icon" />,
   X: () => <svg data-testid="x-icon" />,
 }))
+
+beforeEach(() => {
+  useLabelColorStore.setState({ colors: {} })
+  localStorage.clear()
+})
 
 describe('normalizeLabels', () => {
   it('trims, drops empties, and de-dupes case-insensitively preserving first casing', () => {
@@ -33,6 +40,26 @@ describe('LabelChips', () => {
     render(<LabelChips labels={['Work', 'Personal']} />)
     expect(screen.getByText('Work')).toBeInTheDocument()
     expect(screen.getByText('Personal')).toBeInTheDocument()
+  })
+
+  it('uses deterministic colors for labels without stored metadata', () => {
+    render(<LabelChips labels={['Work']} />)
+    const color = getLabelColor('Work')
+
+    expect(screen.getByText('Work').closest('span')).toHaveStyle({
+      backgroundColor: color,
+      color: labelTextColor(color),
+    })
+  })
+
+  it('uses user-selected colors from the label color store', () => {
+    useLabelColorStore.getState().setLabelColor('Work', '#ef4444')
+    render(<LabelChips labels={['Work']} />)
+
+    expect(screen.getByText('Work').closest('span')).toHaveStyle({
+      backgroundColor: '#ef4444',
+      color: '#ffffff',
+    })
   })
 })
 
@@ -78,6 +105,22 @@ describe('LabelEditor', () => {
     renderWithIntl(<LabelEditor labels={['Work', 'Home']} onChange={onChange} />)
     fireEvent.click(screen.getByLabelText('Remove label Work'))
     expect(onChange).toHaveBeenCalledWith(['Home'])
+  })
+
+  it('lets users choose and persist a label color without changing label names', () => {
+    const onChange = vi.fn()
+    renderWithIntl(<LabelEditor labels={['Work']} onChange={onChange} />)
+    const colorInput = screen.getAllByLabelText('Change label Work color')
+      .find((element): element is HTMLInputElement => element instanceof HTMLInputElement)!
+
+    fireEvent.input(colorInput, { target: { value: '#3b82f6' } })
+
+    expect(useLabelColorStore.getState().colors.work).toBe('#3b82f6')
+    expect(screen.getByText('Work').closest('span')).toHaveStyle({
+      backgroundColor: '#3b82f6',
+      color: '#ffffff',
+    })
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it('removes the last chip on Backspace when the input is empty', () => {

--- a/apps/web/app/stores/use-label-color-store.ts
+++ b/apps/web/app/stores/use-label-color-store.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export const LABEL_COLOR_PALETTE = [
+  '#10b981', // emerald
+  '#3b82f6', // blue
+  '#f59e0b', // amber
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#ec4899', // pink
+  '#06b6d4', // cyan
+  '#f97316', // orange
+]
+
+export type LabelColorMap = Record<string, string>
+
+interface LabelColorState {
+  colors: LabelColorMap
+  setLabelColor: (label: string, color: string) => void
+  removeLabelColor: (label: string) => void
+}
+
+function labelKey(label: string): string {
+  return label.trim().toLowerCase()
+}
+
+export function normalizeLabelColor(color: string): string | null {
+  const trimmed = color.trim()
+  return /^#[0-9a-fA-F]{6}$/.test(trimmed) ? trimmed.toLowerCase() : null
+}
+
+export function defaultLabelColor(label: string): string {
+  const key = labelKey(label)
+  let hash = 0
+  for (let index = 0; index < key.length; index += 1) {
+    hash = ((hash << 5) - hash + key.charCodeAt(index)) | 0
+  }
+  return LABEL_COLOR_PALETTE[Math.abs(hash) % LABEL_COLOR_PALETTE.length]!
+}
+
+export function getLabelColor(label: string, colors: LabelColorMap = {}): string {
+  const key = labelKey(label)
+  const stored = key ? normalizeLabelColor(colors[key] ?? '') : null
+  return stored ?? defaultLabelColor(label)
+}
+
+export function labelTextColor(color: string): '#0f172a' | '#ffffff' {
+  const normalized = normalizeLabelColor(color) ?? LABEL_COLOR_PALETTE[0]!
+  const red = Number.parseInt(normalized.slice(1, 3), 16)
+  const green = Number.parseInt(normalized.slice(3, 5), 16)
+  const blue = Number.parseInt(normalized.slice(5, 7), 16)
+  const luminance = (0.299 * red + 0.587 * green + 0.114 * blue) / 255
+  return luminance > 0.62 ? '#0f172a' : '#ffffff'
+}
+
+export const useLabelColorStore = create<LabelColorState>()(
+  persist(
+    (set) => ({
+      colors: {},
+      setLabelColor: (label, color) => {
+        const key = labelKey(label)
+        const normalized = normalizeLabelColor(color)
+        if (!key || !normalized) return
+        set((state) => ({
+          colors: {
+            ...state.colors,
+            [key]: normalized,
+          },
+        }))
+      },
+      removeLabelColor: (label) => {
+        const key = labelKey(label)
+        if (!key) return
+        set((state) => {
+          const { [key]: _removed, ...colors } = state.colors
+          return { colors }
+        })
+      },
+    }),
+    {
+      name: 'silentsuite-label-colors',
+    },
+  ),
+)

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -36,6 +36,7 @@
   "Labels": {
     "addLabelPlaceholder": "Add label\u2026",
     "editorAriaLabel": "Labels",
+    "changeLabelColor": "Change label {label} color",
     "removeLabel": "Remove label {label}",
     "eventLabels": "Event labels",
     "taskLabels": "Task labels",


### PR DESCRIPTION
## Summary
- Add a persisted client-side label color store keyed by normalized label names.
- Render event/task/contact label chips with deterministic fallback colors and readable text contrast.
- Add a native color picker affordance in the shared label editor without changing the synced label/category strings.

Closes #372

## Validation
- `pnpm --filter @silentsuite/web test -- app/components/__tests__/LabelEditor.test.tsx` — passed (`31` files / `315` tests after rebasing onto current `dev`).
- `pnpm --filter @silentsuite/web type-check` — passed.
- `git diff --check` — passed.

## Notes
- Label color metadata stays local in `silentsuite-label-colors`; synced ICS/vCard `CATEGORIES` values remain plain strings so import/export compatibility is preserved.
