### PR TITLE
Prioritize web calendar event loading

### DIFF
--- a/apps/web/app/lib/__tests__/calendar-loading.test.ts
+++ b/apps/web/app/lib/__tests__/calendar-loading.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { partitionCalendarItemsForFastPaint, type CalendarContentItem } from '../calendar-loading'
+
+function item(uid: string, content: string): CalendarContentItem {
+  return { uid, collectionUid: 'cal-1', content }
+}
+
+describe('partitionCalendarItemsForFastPaint', () => {
+  const now = new Date('2026-06-25T12:00:00Z')
+
+  it('loads current and future events before old history', () => {
+    const old = item('old', 'BEGIN:VEVENT\nDTSTART:20200101T090000Z\nDTEND:20200101T100000Z\nEND:VEVENT')
+    const recent = item('recent', 'BEGIN:VEVENT\nDTSTART:20260620T090000Z\nDTEND:20260620T100000Z\nEND:VEVENT')
+    const future = item('future', 'BEGIN:VEVENT\nDTSTART:20260701T090000Z\nDTEND:20260701T100000Z\nEND:VEVENT')
+
+    const { priority, backlog } = partitionCalendarItemsForFastPaint([old, recent, future], now)
+
+    expect(priority.map((event) => event.uid)).toEqual(['recent', 'future'])
+    expect(backlog.map((event) => event.uid)).toEqual(['old'])
+  })
+
+  it('keeps active recurring events in the fast path even if the master starts in the past', () => {
+    const activeRecurring = item(
+      'recurring-active',
+      'BEGIN:VEVENT\nDTSTART:20200101T090000Z\nDTEND:20200101T100000Z\nRRULE:FREQ=DAILY\nEND:VEVENT',
+    )
+    const endedRecurring = item(
+      'recurring-ended',
+      'BEGIN:VEVENT\nDTSTART:20200101T090000Z\nDTEND:20200101T100000Z\nRRULE:FREQ=DAILY;UNTIL=20200131T090000Z\nEND:VEVENT',
+    )
+
+    const { priority, backlog } = partitionCalendarItemsForFastPaint([endedRecurring, activeRecurring], now)
+
+    expect(priority.map((event) => event.uid)).toEqual(['recurring-active'])
+    expect(backlog.map((event) => event.uid)).toEqual(['recurring-ended'])
+  })
+
+  it('uses folded DTSTART/DTEND lines and TZID parameters when classifying events', () => {
+    const foldedFuture = item(
+      'folded-future',
+      'BEGIN:VEVENT\nDTSTART;TZID=America/New_York:20260701T090000\nDTEND;TZID=America/New_York:20260701T100000\nEND:VEVENT',
+    )
+    const foldedOld = item(
+      'folded-old',
+      'BEGIN:VEVENT\nDTSTART;VALUE=DATE:20200101\nDTEND;VALUE=DATE:\n 20200102\nEND:VEVENT',
+    )
+
+    const { priority, backlog } = partitionCalendarItemsForFastPaint([foldedOld, foldedFuture], now)
+
+    expect(priority.map((event) => event.uid)).toEqual(['folded-future'])
+    expect(backlog.map((event) => event.uid)).toEqual(['folded-old'])
+  })
+
+  it('keeps malformed events in the fast path so full deserialization can report them', () => {
+    const malformed = item('malformed', 'BEGIN:VEVENT\nSUMMARY:Missing DTSTART\nEND:VEVENT')
+
+    const { priority, backlog } = partitionCalendarItemsForFastPaint([malformed], now)
+
+    expect(priority.map((event) => event.uid)).toEqual(['malformed'])
+    expect(backlog).toEqual([])
+  })
+})

--- a/apps/web/app/lib/calendar-loading.ts
+++ b/apps/web/app/lib/calendar-loading.ts
@@ -1,0 +1,101 @@
+import { parseICalDateValue } from '@silentsuite/core'
+
+export interface CalendarContentItem {
+  uid: string
+  content: string
+  collectionUid: string
+}
+
+export interface CalendarItemPartitions<T extends CalendarContentItem> {
+  priority: T[]
+  backlog: T[]
+}
+
+const PRIORITY_PAST_DAYS = 30
+
+function unfoldICal(content: string): string {
+  return content.replace(/\r?\n[ \t]/g, '')
+}
+
+function getPropertyLine(content: string, name: string): string | null {
+  const unfolded = unfoldICal(content)
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const match = unfolded.match(new RegExp(`^${escapedName}(?:;[^:]*)?:.+$`, 'im'))
+  return match?.[0] ?? null
+}
+
+function getPropertyValue(content: string, name: string): string | null {
+  const line = getPropertyLine(content, name)
+  if (!line) return null
+  const colon = line.indexOf(':')
+  return colon === -1 ? null : line.slice(colon + 1).trim()
+}
+
+function getTzidFromLine(line: string | null): string | undefined {
+  if (!line) return undefined
+  const match = line.match(/(?:^|;)TZID=([^;:]+)/i)
+  return match?.[1]
+}
+
+function parseICalPropertyDate(content: string, name: string): Date | null {
+  const line = getPropertyLine(content, name)
+  if (!line) return null
+  const value = getPropertyValue(content, name)
+  if (!value) return null
+  try {
+    return parseICalDateValue(value, getTzidFromLine(line)).date
+  } catch {
+    return null
+  }
+}
+
+function rruleUntilDate(content: string): Date | null {
+  const rrule = getPropertyValue(content, 'RRULE')
+  const until = rrule?.match(/(?:^|;)UNTIL=([^;]+)/i)?.[1]
+  if (!until) return null
+  try {
+    return parseICalDateValue(until).date
+  } catch {
+    return null
+  }
+}
+
+function isPriorityCalendarItem(item: CalendarContentItem, now: Date): boolean {
+  const priorityStart = new Date(now)
+  priorityStart.setDate(priorityStart.getDate() - PRIORITY_PAST_DAYS)
+
+  const recurrenceRule = getPropertyValue(item.content, 'RRULE')
+  if (recurrenceRule) {
+    const until = rruleUntilDate(item.content)
+    return !until || until >= priorityStart
+  }
+
+  const endDate = parseICalPropertyDate(item.content, 'DTEND')
+  const startDate = parseICalPropertyDate(item.content, 'DTSTART')
+  const comparisonDate = endDate ?? startDate
+
+  // If a malformed/legacy item cannot be classified cheaply, keep it in the
+  // fast path so the full deserializer can decide without hiding it behind old
+  // history.
+  if (!comparisonDate) return true
+
+  return comparisonDate >= priorityStart
+}
+
+export function partitionCalendarItemsForFastPaint<T extends CalendarContentItem>(
+  items: T[],
+  now: Date = new Date(),
+): CalendarItemPartitions<T> {
+  const priority: T[] = []
+  const backlog: T[] = []
+
+  for (const item of items) {
+    if (isPriorityCalendarItem(item, now)) {
+      priority.push(item)
+    } else {
+      backlog.push(item)
+    }
+  }
+
+  return { priority, backlog }
+}

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -19,6 +19,17 @@ import {
   createSafeOperationalError,
   getSafeErrorDetails,
 } from '@/app/lib/privacy-safe-errors'
+import {
+  partitionCalendarItemsForFastPaint,
+  type CalendarContentItem,
+} from '@/app/lib/calendar-loading'
+import type { CalendarEvent } from '@silentsuite/core'
+
+const CALENDAR_DESERIALIZE_CHUNK_SIZE = 50
+
+function yieldToBrowser(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
 
 function reportSyncError(operation: string, err: unknown) {
   Sentry.captureException(createSafeOperationalError('sync-provider', operation), {
@@ -26,6 +37,54 @@ function reportSyncError(operation: string, err: unknown) {
     extra: getSafeErrorDetails(err),
   })
   logger.error(`[sync-provider] ${operation} failed`, getSafeErrorDetails(err))
+}
+
+async function deserializeCalendarItemsIncrementally(
+  items: CalendarContentItem[],
+  deserializeCalendarEvent: (content: string) => CalendarEvent,
+  source: 'cache' | 'server',
+): Promise<{ events: CalendarEvent[]; errors: unknown[] }> {
+  const { priority, backlog } = partitionCalendarItemsForFastPaint(items)
+  const allEvents: CalendarEvent[] = []
+  const errors: unknown[] = []
+
+  async function processGroup(group: CalendarContentItem[], groupName: 'priority' | 'backlog') {
+    for (let start = 0; start < group.length; start += CALENDAR_DESERIALIZE_CHUNK_SIZE) {
+      const chunk = group.slice(start, start + CALENDAR_DESERIALIZE_CHUNK_SIZE)
+      const chunkEvents: CalendarEvent[] = []
+
+      for (const item of chunk) {
+        try {
+          const event = deserializeCalendarEvent(item.content)
+          chunkEvents.push({ ...event, id: item.uid, calendarId: item.collectionUid })
+        } catch (err) {
+          errors.push(err)
+          logger.warn(`[sync-provider] Failed to deserialize ${source} calendar item`, getSafeErrorDetails(err))
+        }
+      }
+
+      if (chunkEvents.length > 0) {
+        allEvents.push(...chunkEvents)
+        useCalendarStore.getState().upsertFromRemote(chunkEvents)
+        logger.debug(
+          `[sync-provider] Loaded ${chunkEvents.length} ${source} calendar events from ${groupName} chunk`,
+        )
+      }
+
+      if (start + CALENDAR_DESERIALIZE_CHUNK_SIZE < group.length) {
+        await yieldToBrowser()
+      }
+    }
+  }
+
+  await processGroup(priority, 'priority')
+  await yieldToBrowser()
+  await processGroup(backlog, 'backlog')
+
+  // Final replace is still required: it preserves full-history search while
+  // dropping items that were deleted remotely after the previous local state.
+  useCalendarStore.getState().syncFromRemote(allEvents)
+  return { events: allEvents, errors }
 }
 
 /**
@@ -79,7 +138,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         await etebaseInitialize()
 
         // Now load items from each collection into the data stores
-        await loadItemsIntoStores()
+        const loadHadErrors = await loadItemsIntoStores()
 
         // Wire SyncEngine change events
         unsubChange = wireChangeHandler()
@@ -87,7 +146,13 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         // Wire SyncEngine status
         unsubStatus = wireStatusHandler()
 
-        setSyncStatus('synced')
+        if (loadHadErrors) {
+          setSyncStatus('error')
+          setError('Some synced items could not be loaded')
+        } else {
+          setSyncStatus('synced')
+          setError(null)
+        }
         setLastSynced(new Date())
       } catch (err) {
         reportSyncError('init', err)
@@ -143,12 +208,22 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
         if (eventItems.length > 0) {
           try {
-            const events = eventItems.map((it) => {
-              const event = core.deserializeCalendarEvent(it.content)
-              return { ...event, id: it.itemUid, calendarId: it.collectionUid }
-            })
-            useCalendarStore.getState().syncFromRemote(events)
-            logger.log(`[sync-provider] Hydrated ${events.length} events from cache`)
+            const { events, errors } = await deserializeCalendarItemsIncrementally(
+              eventItems.map((it) => ({
+                uid: it.itemUid,
+                content: it.content,
+                collectionUid: it.collectionUid,
+              })),
+              core.deserializeCalendarEvent,
+              'cache',
+            )
+            if (errors.length > 0) {
+              setSyncStatus('error')
+              setError('Some cached calendar events could not be loaded')
+              reportSyncError('hydrate cached calendar events', errors[0])
+            } else {
+              logger.log(`[sync-provider] Hydrated ${events.length} events from cache`)
+            }
           } catch (err) {
             logger.warn('[sync-provider] Failed to hydrate calendar events from cache', getSafeErrorDetails(err))
           }
@@ -158,9 +233,10 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       }
     }
 
-    async function loadItemsIntoStores() {
+    async function loadItemsIntoStores(): Promise<boolean> {
       const etebase = useEtebaseStore.getState()
       const cacheEnabled = isLocalCacheEnabled()
+      let hadErrors = false
 
       async function mirrorToCache(
         type: 'tasks' | 'contacts' | 'calendar',
@@ -181,6 +257,29 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         }
       }
 
+      // Load calendar events first so the calendar can paint before unrelated
+      // task/contact deserialization work on large accounts.
+      try {
+        const eventItems = await etebase.fetchAllItems('calendar')
+        if (eventItems.length > 0) {
+          const { deserializeCalendarEvent } = await import('@silentsuite/core')
+          const { events, errors } = await deserializeCalendarItemsIncrementally(
+            eventItems,
+            deserializeCalendarEvent,
+            'server',
+          )
+          logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
+          if (errors.length > 0) {
+            hadErrors = true
+            reportSyncError('load calendar event chunk', errors[0])
+          }
+          await mirrorToCache('calendar', eventItems)
+        }
+      } catch (err) {
+        hadErrors = true
+        reportSyncError('load calendar events', err)
+      }
+
       // Load tasks
       try {
         const taskItems = await etebase.fetchAllItems('tasks')
@@ -197,6 +296,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           await mirrorToCache('tasks', taskItems)
         }
       } catch (err) {
+        hadErrors = true
         reportSyncError('load tasks', err)
       }
 
@@ -214,24 +314,8 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           await mirrorToCache('contacts', contactItems)
         }
       } catch (err) {
+        hadErrors = true
         reportSyncError('load contacts', err)
-      }
-
-      // Load calendar events
-      try {
-        const eventItems = await etebase.fetchAllItems('calendar')
-        if (eventItems.length > 0) {
-          const { deserializeCalendarEvent } = await import('@silentsuite/core')
-          const events = eventItems.map((item) => {
-            const event = deserializeCalendarEvent(item.content)
-            return { ...event, id: item.uid, calendarId: item.collectionUid }
-          })
-          useCalendarStore.getState().syncFromRemote(events)
-          logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
-          await mirrorToCache('calendar', eventItems)
-        }
-      } catch (err) {
-        reportSyncError('load calendar events', err)
       }
 
       // Load and subscribe account-level preferences after the Etebase item
@@ -240,8 +324,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       try {
         await usePreferencesSyncStore.getState().initialize()
       } catch (err) {
+        hadErrors = true
         reportSyncError('initialize preferences sync', err)
       }
+
+      return hadErrors
     }
 
     function wireChangeHandler(): (() => void) | null {

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -60,6 +60,7 @@ interface CalendarActions {
   navigateToday: () => void
   importEvents: (newEvents: NewCalendarEvent[]) => Promise<number>
   syncFromRemote: (events: CalendarEvent[]) => void
+  upsertFromRemote: (events: CalendarEvent[]) => void
   setSearchQuery: (q: string) => void
   getFilteredEvents: () => CalendarEvent[]
 }
@@ -557,6 +558,26 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
 
   syncFromRemote: (remoteEvents: CalendarEvent[]) => {
     set({ events: remoteEvents, syncStatus: 'synced' })
+  },
+
+  upsertFromRemote: (remoteEvents: CalendarEvent[]) => {
+    if (remoteEvents.length === 0) return
+    set((state) => {
+      const nextEvents = [...state.events]
+      const indexById = new Map(nextEvents.map((event, index) => [event.id, index]))
+
+      for (const remoteEvent of remoteEvents) {
+        const index = indexById.get(remoteEvent.id)
+        if (index === undefined) {
+          indexById.set(remoteEvent.id, nextEvents.length)
+          nextEvents.push(remoteEvent)
+        } else {
+          nextEvents[index] = remoteEvent
+        }
+      }
+
+      return { events: nextEvents, syncStatus: 'syncing' }
+    })
   },
 
   setSearchQuery: (q: string) => set({ searchQuery: q }),


### PR DESCRIPTION
## Summary
- Load calendar items before unrelated task/contact collections during sync startup.
- Partition calendar items so current, future, recent, active recurring, and malformed items enter the fast path before old historical backlog.
- Deserialize calendar items in chunks, yielding between chunks and incrementally upserting events so users see visible events earlier on large accounts.
- Keep a final full sync replace to preserve deletion handling and full-history search after background backlog processing finishes.

Closes #374

## Validation
- `pnpm --filter @silentsuite/web test -- app/lib/__tests__/calendar-loading.test.ts` — passed (`32` files / `316` tests under current Vitest invocation).
- `pnpm --filter @silentsuite/web type-check` — passed after preparing worktree dependencies.
- `git diff --check` — passed.
