### PR TITLE
Show timed multi-day events across month days

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -13,11 +13,10 @@ import { useCalendarStore, type CalendarView } from '@/app/stores/use-calendar-s
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
-import { expandRecurrence } from '@silentsuite/core'
 import type { CalendarEvent, DateRange, FirstDayOfWeek } from '@silentsuite/core'
 import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
 import { startOfWeek, endOfWeek } from '@/app/lib/date'
-import { isMultiDayTimedRange, toAllDayEndPlainDate, toTimedMonthEndPlainDate } from '../lib/all-day'
+import { expandEventsForRange, toScheduleXEvents, type DisplayEvent } from '../lib/calendar-grid-events'
 
 import '@schedule-x/theme-default/dist/index.css'
 
@@ -46,23 +45,6 @@ function toScheduleXDateTime(date: Date, tz: string): Temporal.ZonedDateTime {
   return Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO(tz)
 }
 
-/** Expanded event used for display — may be a recurring instance */
-interface DisplayEvent {
-  id: string
-  /** The master event id (for recurring instances, this differs from id) */
-  masterId: string
-  title: string
-  description: string
-  location: string
-  startDate: Date
-  endDate: Date
-  allDay: boolean
-  isRecurring: boolean
-  /** The specific occurrence date for this instance */
-  instanceDate: Date
-  calendarId?: string
-}
-
 /** Get the visible date range for the current view, honoring the first-day preference */
 function getViewRange(currentDate: Date, view: CalendarView, firstDay: FirstDayOfWeek): DateRange {
   const d = new Date(currentDate)
@@ -83,97 +65,6 @@ function getViewRange(currentDate: Date, view: CalendarView, firstDay: FirstDayO
       return { start, end }
     }
   }
-}
-
-/** Expand recurring events into individual display events for the visible range */
-function expandEventsForRange(
-  events: CalendarEvent[],
-  range: DateRange,
-): DisplayEvent[] {
-  const result: DisplayEvent[] = []
-
-  for (const event of events) {
-    if (!event.recurrenceRule) {
-      // Non-recurring: include if it overlaps the range. For all-day events,
-      // endDate is iCal-exclusive (next-day midnight) so use strict `>` to avoid
-      // matching events whose visual last day is just before range.start.
-      const overlapsRangeStart = event.allDay
-        ? event.endDate > range.start
-        : event.endDate >= range.start
-      if (overlapsRangeStart && event.startDate <= range.end) {
-        result.push({
-          id: event.id,
-          masterId: event.id,
-          title: event.title,
-          description: event.description,
-          location: event.location,
-          startDate: event.startDate,
-          endDate: event.endDate,
-          allDay: event.allDay,
-          isRecurring: false,
-          instanceDate: event.startDate,
-          calendarId: event.calendarId,
-        })
-      }
-    } else {
-      // Recurring: expand occurrences
-      const duration = event.endDate.getTime() - event.startDate.getTime()
-      const occurrences = expandRecurrence(
-        event.recurrenceRule,
-        event.startDate,
-        range,
-        event.exceptions,
-      )
-
-      for (const occDate of occurrences) {
-        const occEnd = new Date(occDate.getTime() + duration)
-        result.push({
-          id: `${event.id}__${occDate.getTime()}`,
-          masterId: event.id,
-          title: event.title,
-          description: event.description,
-          location: event.location,
-          startDate: occDate,
-          endDate: occEnd,
-          allDay: event.allDay,
-          isRecurring: true,
-          instanceDate: occDate,
-          calendarId: event.calendarId,
-        })
-      }
-    }
-  }
-
-  return result
-}
-
-function toScheduleXEvents(
-  displayEvents: DisplayEvent[],
-  calendarColors: Map<string, string>,
-  userTz: string,
-  currentView: CalendarView,
-): CalendarEventExternal[] {
-  return displayEvents.map((e) => {
-    const color = calendarColors.get(e.calendarId ?? 'default') ?? '#10b981'
-    const renderAsMonthBar = currentView === 'month' && !e.allDay && isMultiDayTimedRange(e.startDate, e.endDate)
-    return {
-      id: e.id,
-      title: e.isRecurring ? `↻ ${e.title}` : e.title,
-      start: e.allDay || renderAsMonthBar ? toPlainDate(e.startDate) : toScheduleXDateTime(e.startDate, userTz),
-      end: e.allDay
-        ? toAllDayEndPlainDate(e.startDate, e.endDate)
-        : renderAsMonthBar
-          ? toTimedMonthEndPlainDate(e.startDate, e.endDate)
-        : toScheduleXDateTime(e.endDate, userTz),
-      description: e.description || undefined,
-      location: e.location || undefined,
-      calendarId: e.calendarId ?? 'default',
-      _options: {
-        additionalClasses: [`sx-cal-color-${(e.calendarId ?? 'default').replace(/[^a-zA-Z0-9_-]/g, '_')}`],
-      },
-      _color: color,
-    }
-  })
 }
 
 /** Convert a Temporal.ZonedDateTime to a JS Date */
@@ -327,7 +218,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   displayEventMapRef.current = displayEventMap
 
   const sxEvents = useMemo(
-    () => toScheduleXEvents(displayEvents, calendarColors, userTz, currentView),
+    () => toScheduleXEvents(displayEvents, calendarColors, userTz, currentView, toScheduleXDateTime),
     [displayEvents, calendarColors, userTz, currentView],
   )
 

--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { toScheduleXEvents, type DisplayEvent } from '../calendar-grid-events'
+
+function displayEvent(overrides: Partial<DisplayEvent> = {}): DisplayEvent {
+  const startDate = new Date('2026-06-25T22:00:00Z')
+  const endDate = new Date('2026-06-27T01:00:00Z')
+  return {
+    id: 'event-1',
+    masterId: 'event-1',
+    title: 'Multi-day trip',
+    description: '',
+    location: '',
+    startDate,
+    endDate,
+    allDay: false,
+    isRecurring: false,
+    instanceDate: startDate,
+    calendarId: 'cal-1',
+    ...overrides,
+  }
+}
+
+function zdt(date: Date): Temporal.ZonedDateTime {
+  return Temporal.Instant.fromEpochMilliseconds(date.getTime()).toZonedDateTimeISO('UTC')
+}
+
+describe('toScheduleXEvents', () => {
+  it('splits timed multi-day events into one month-view segment per affected day', () => {
+    const events = toScheduleXEvents(
+      [displayEvent()],
+      new Map([['cal-1', '#10b981']]),
+      'UTC',
+      'month',
+      zdt,
+    )
+
+    expect(events).toHaveLength(3)
+    expect(events.map((event) => String(event.start))).toEqual([
+      '2026-06-25',
+      '2026-06-26',
+      '2026-06-27',
+    ])
+    expect(events.map((event) => String(event.end))).toEqual([
+      '2026-06-25',
+      '2026-06-26',
+      '2026-06-27',
+    ])
+    expect(events.map((event) => event.id)).toEqual([
+      'event-1__day_2026-06-25',
+      'event-1__day_2026-06-26',
+      'event-1__day_2026-06-27',
+    ])
+  })
+
+  it('keeps timed multi-day events as a single timed event outside month view', () => {
+    const events = toScheduleXEvents(
+      [displayEvent()],
+      new Map([['cal-1', '#10b981']]),
+      'UTC',
+      'week',
+      zdt,
+    )
+
+    expect(events).toHaveLength(1)
+    expect(events[0]!.id).toBe('event-1')
+    expect(String(events[0]!.start)).toContain('2026-06-25')
+    expect(String(events[0]!.end)).toContain('2026-06-27')
+  })
+
+  it('keeps all-day multi-day events as one Schedule-X date range', () => {
+    const event = displayEvent({
+      allDay: true,
+      startDate: new Date('2026-06-25T00:00:00Z'),
+      endDate: new Date('2026-06-28T00:00:00Z'),
+    })
+
+    const events = toScheduleXEvents(
+      [event],
+      new Map([['cal-1', '#10b981']]),
+      'UTC',
+      'month',
+      zdt,
+    )
+
+    expect(events).toHaveLength(1)
+    expect(String(events[0]!.start)).toBe('2026-06-25')
+    expect(String(events[0]!.end)).toBe('2026-06-27')
+  })
+})

--- a/apps/web/app/(app)/calendar/lib/calendar-grid-events.ts
+++ b/apps/web/app/(app)/calendar/lib/calendar-grid-events.ts
@@ -1,0 +1,137 @@
+import type { CalendarEventExternal } from '@schedule-x/calendar'
+import { expandRecurrence } from '@silentsuite/core'
+import type { CalendarEvent, DateRange } from '@silentsuite/core'
+import { dateToPlainDate, isMultiDayTimedRange, toAllDayEndPlainDate, toTimedMonthEndPlainDate } from './all-day'
+
+/** Expanded event used for display — may be a recurring instance */
+export interface DisplayEvent {
+  id: string
+  /** The master event id (for recurring instances, this differs from id) */
+  masterId: string
+  title: string
+  description: string
+  location: string
+  startDate: Date
+  endDate: Date
+  allDay: boolean
+  isRecurring: boolean
+  /** The specific occurrence date for this instance */
+  instanceDate: Date
+  calendarId?: string
+}
+
+type CalendarGridView = 'week' | 'month'
+
+/** Expand recurring events into individual display events for the visible range */
+export function expandEventsForRange(
+  events: CalendarEvent[],
+  range: DateRange,
+): DisplayEvent[] {
+  const result: DisplayEvent[] = []
+
+  for (const event of events) {
+    if (!event.recurrenceRule) {
+      // Non-recurring: include if it overlaps the range. For all-day events,
+      // endDate is iCal-exclusive (next-day midnight) so use strict `>` to avoid
+      // matching events whose visual last day is just before range.start.
+      const overlapsRangeStart = event.allDay
+        ? event.endDate > range.start
+        : event.endDate >= range.start
+      if (overlapsRangeStart && event.startDate <= range.end) {
+        result.push({
+          id: event.id,
+          masterId: event.id,
+          title: event.title,
+          description: event.description,
+          location: event.location,
+          startDate: event.startDate,
+          endDate: event.endDate,
+          allDay: event.allDay,
+          isRecurring: false,
+          instanceDate: event.startDate,
+          calendarId: event.calendarId,
+        })
+      }
+    } else {
+      // Recurring: expand occurrences
+      const duration = event.endDate.getTime() - event.startDate.getTime()
+      const occurrences = expandRecurrence(
+        event.recurrenceRule,
+        event.startDate,
+        range,
+        event.exceptions,
+      )
+
+      for (const occDate of occurrences) {
+        const occEnd = new Date(occDate.getTime() + duration)
+        result.push({
+          id: `${event.id}__${occDate.getTime()}`,
+          masterId: event.id,
+          title: event.title,
+          description: event.description,
+          location: event.location,
+          startDate: occDate,
+          endDate: occEnd,
+          allDay: event.allDay,
+          isRecurring: true,
+          instanceDate: occDate,
+          calendarId: event.calendarId,
+        })
+      }
+    }
+  }
+
+  return result
+}
+
+function splitMonthTimedEvent(e: DisplayEvent): DisplayEvent[] {
+  const segments: DisplayEvent[] = []
+  const endPlainDate = toTimedMonthEndPlainDate(e.startDate, e.endDate)
+  let day = dateToPlainDate(e.startDate)
+
+  while (Temporal.PlainDate.compare(day, endPlainDate) <= 0) {
+    const segmentDate = new Date(day.year, day.month - 1, day.day, e.startDate.getHours(), e.startDate.getMinutes(), e.startDate.getSeconds(), e.startDate.getMilliseconds())
+    segments.push({
+      ...e,
+      id: `${e.id}__day_${day.toString()}`,
+      startDate: segmentDate,
+      endDate: segmentDate,
+    })
+    day = day.add({ days: 1 })
+  }
+
+  return segments
+}
+
+export function toScheduleXEvents(
+  displayEvents: DisplayEvent[],
+  calendarColors: Map<string, string>,
+  userTz: string,
+  currentView: CalendarGridView,
+  toScheduleXDateTime: (date: Date, tz: string) => Temporal.ZonedDateTime,
+): CalendarEventExternal[] {
+  const eventsForView = currentView === 'month'
+    ? displayEvents.flatMap((e) => (!e.allDay && isMultiDayTimedRange(e.startDate, e.endDate) ? splitMonthTimedEvent(e) : [e]))
+    : displayEvents
+
+  return eventsForView.map((e) => {
+    const color = calendarColors.get(e.calendarId ?? 'default') ?? '#10b981'
+    return {
+      id: e.id,
+      title: e.isRecurring ? `↻ ${e.title}` : e.title,
+      start: e.allDay ? dateToPlainDate(e.startDate) : currentView === 'month' && e.id.includes('__day_') ? dateToPlainDate(e.startDate) : toScheduleXDateTime(e.startDate, userTz),
+      end: e.allDay
+        ? toAllDayEndPlainDate(e.startDate, e.endDate)
+        : currentView === 'month' && e.id.includes('__day_')
+          ? dateToPlainDate(e.startDate)
+          : toScheduleXDateTime(e.endDate, userTz),
+      description: e.description || undefined,
+      location: e.location || undefined,
+      calendarId: e.calendarId ?? 'default',
+      _options: {
+        additionalClasses: [`sx-cal-color-${(e.calendarId ?? 'default').replace(/[^a-zA-Z0-9_-]/g, '_')}`],
+      },
+      _color: color,
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- Extract calendar grid event expansion/conversion into a testable helper module.
- Split timed multi-day events into one month-view segment per affected day so they are visible across the full span.
- Keep all-day multi-day events as Schedule-X date ranges and keep week view timed behavior unchanged.

Closes #375

## Validation
- `pnpm --filter @silentsuite/web test -- 'app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts'` — passed (`32` files / `315` tests under current Vitest invocation).
- `pnpm --filter @silentsuite/web type-check` — passed.
- `git diff --check` — passed.

## Notes
- This PR intentionally scopes to #375. Configurable 00:00-24:00 day bounds remain in #376 for a separate PR because that touches preferences UI, Schedule-X config, and drag/select math.
