### PR TITLE
Add configurable calendar day bounds

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -199,8 +199,12 @@ function snapTo30Min(date: Date): Date {
   return snapped
 }
 
-const DAY_START_HOUR = 6
-const DAY_END_HOUR = 22
+const DEFAULT_DAY_START_HOUR = 0
+const DEFAULT_DAY_END_HOUR = 24
+
+function formatDayBoundary(hour: number): string {
+  return `${String(hour).padStart(2, '0')}:00`
+}
 
 /** Find the display event under the cursor by matching click coordinates to day column + time */
 function findEventAtPosition(
@@ -294,6 +298,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const defaultTimezone = usePreferencesStore((s) => s.defaultTimezone)
   const userTz = useMemo(() => resolveUserTimezone(defaultTimezone), [defaultTimezone])
   const firstDayOfWeek = usePreferencesStore((s) => s.firstDayOfWeek)
+  const dayStartHour = usePreferencesStore((s) => s.dayStartHour ?? DEFAULT_DAY_START_HOUR)
+  const dayEndHour = usePreferencesStore((s) => s.dayEndHour ?? DEFAULT_DAY_END_HOUR)
   // Schedule-X WeekDay enum: MONDAY = 1 … SUNDAY = 7 (not 0-indexed).
   const sxFirstDayOfWeek = firstDayOfWeek === 'sunday' ? 7 : 1
 
@@ -474,6 +480,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const initialTimezoneRef = useRef(userTz)
   // Capture initial first-day-of-week for Schedule-X config (changes pushed via signal below)
   const initialFirstDayRef = useRef(sxFirstDayOfWeek)
+  const initialDayBoundariesRef = useRef({ start: formatDayBoundary(dayStartHour), end: formatDayBoundary(dayEndHour) })
 
   // Memoize the event click handler
   const handleEventClick = useCallback(
@@ -510,7 +517,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     locale: initialLocaleRef.current,
     // Derived from the firstDayOfWeek preference; live changes pushed via signal below.
     firstDayOfWeek: initialFirstDayRef.current,
-    dayBoundaries: { start: '06:00', end: '22:00' },
+    dayBoundaries: initialDayBoundariesRef.current,
     timezone: initialTimezoneRef.current,
     weekOptions: {
       gridHeight: 800,
@@ -562,6 +569,21 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       // Schedule-X internals may not be ready
     }
   }, [calendar, sxFirstDayOfWeek])
+
+  // Push day-boundary preference changes into Schedule-X and our drag/select math.
+  useEffect(() => {
+    if (!calendar) return
+    try {
+      const app = (calendar as any).$app
+      const boundariesSignal = app?.config?.dayBoundaries
+      const next = { start: formatDayBoundary(dayStartHour), end: formatDayBoundary(dayEndHour) }
+      if (boundariesSignal) {
+        boundariesSignal.value = next
+      }
+    } catch {
+      // Schedule-X internals may not be ready
+    }
+  }, [calendar, dayStartHour, dayEndHour])
 
   // Sync view AND date changes from store → Schedule-X via internal API.
   // CalendarApp has NO public navigation methods. We access the private $app
@@ -730,9 +752,9 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     (clientY: number, gridEl: HTMLElement): number => {
       const rect = gridEl.getBoundingClientRect()
       const relativeY = clientY - rect.top + gridEl.scrollTop
-      const totalHours = DAY_END_HOUR - DAY_START_HOUR
+      const totalHours = dayEndHour - dayStartHour
       const pixelsPerHour = gridEl.scrollHeight / totalHours
-      return DAY_START_HOUR + relativeY / pixelsPerHour
+      return dayStartHour + relativeY / pixelsPerHour
     },
     [],
   )
@@ -789,18 +811,18 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       const snappedHour = Math.round(hour * 2) / 2
 
       const durationHours = dragMoveStartRef.current.duration / (60 * 60 * 1000)
-      const maxStartHour = DAY_END_HOUR - durationHours
-      const clampedHour = Math.max(DAY_START_HOUR, Math.min(snappedHour, maxStartHour))
+      const maxStartHour = dayEndHour - durationHours
+      const clampedHour = Math.max(dayStartHour, Math.min(snappedHour, maxStartHour))
       const clampedStart = buildDateFromHour(dayInfo.date, clampedHour)
       const clampedEnd = new Date(clampedStart.getTime() + dragMoveStartRef.current.duration)
 
-      const totalHours = DAY_END_HOUR - DAY_START_HOUR
+      const totalHours = dayEndHour - dayStartHour
       const pixelsPerHour = gridEl.scrollHeight / totalHours
       const gridRect = gridEl.getBoundingClientRect()
       const wrapperRect = wrapper.getBoundingClientRect()
 
       const topY =
-        (clampedHour - DAY_START_HOUR) * pixelsPerHour -
+        (clampedHour - dayStartHour) * pixelsPerHour -
         gridEl.scrollTop +
         gridRect.top -
         wrapperRect.top
@@ -863,8 +885,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       const hour = getTimeFromY(clientY, gridEl)
       const snappedHour = Math.round(hour * 2) / 2
       const durationHours = moveStart.duration / (60 * 60 * 1000)
-      const maxStartHour = DAY_END_HOUR - durationHours
-      const clampedHour = Math.max(DAY_START_HOUR, Math.min(snappedHour, maxStartHour))
+      const maxStartHour = dayEndHour - durationHours
+      const clampedHour = Math.max(dayStartHour, Math.min(snappedHour, maxStartHour))
       const newStart = buildDateFromHour(dayInfo.date, clampedHour)
       const newEnd = new Date(newStart.getTime() + moveStart.duration)
 
@@ -1028,12 +1050,12 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         const origStartHour =
           origStart.getHours() + origStart.getMinutes() / 60
         const minEndHour = origStartHour + 0.5 // 30 min minimum
-        const clampedEndHour = Math.max(minEndHour, Math.min(snappedHour, DAY_END_HOUR))
+        const clampedEndHour = Math.max(minEndHour, Math.min(snappedHour, dayEndHour))
 
         const newEnd = buildDateFromHour(origStart, clampedEndHour)
 
         // Compute ghost overlay
-        const totalHours = DAY_END_HOUR - DAY_START_HOUR
+        const totalHours = dayEndHour - dayStartHour
         const pixelsPerHour = gridEl.scrollHeight / totalHours
         const gridRect = gridEl.getBoundingClientRect()
         const wrapperRect = wrapper.getBoundingClientRect()
@@ -1063,7 +1085,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         if (!dayInfo) return
 
         const topY =
-          (origStartHour - DAY_START_HOUR) * pixelsPerHour -
+          (origStartHour - dayStartHour) * pixelsPerHour -
           gridEl.scrollTop +
           gridRect.top -
           wrapperRect.top
@@ -1194,13 +1216,13 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       const snappedEnd = snapHour(Math.max(startHour, endHour))
 
       // Convert snapped hours back to pixel positions
-      const totalHours = DAY_END_HOUR - DAY_START_HOUR
+      const totalHours = dayEndHour - dayStartHour
       const pixelsPerHour = gridEl.scrollHeight / totalHours
       const gridRect = gridEl.getBoundingClientRect()
       const wrapperRect = wrapper.getBoundingClientRect()
 
-      const snappedTopY = (snappedStart - DAY_START_HOUR) * pixelsPerHour - gridEl.scrollTop + gridRect.top - wrapperRect.top
-      const snappedBottomY = (snappedEnd - DAY_START_HOUR) * pixelsPerHour - gridEl.scrollTop + gridRect.top - wrapperRect.top
+      const snappedTopY = (snappedStart - dayStartHour) * pixelsPerHour - gridEl.scrollTop + gridRect.top - wrapperRect.top
+      const snappedBottomY = (snappedEnd - dayStartHour) * pixelsPerHour - gridEl.scrollTop + gridRect.top - wrapperRect.top
 
       const colRect = dragStartRef.current.dayColRect
       if (!colRect) return
@@ -1253,7 +1275,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         const origStart = resizeStart.originalStart
         const origStartHour = origStart.getHours() + origStart.getMinutes() / 60
         const minEndHour = origStartHour + 0.5
-        const clampedEndHour = Math.max(minEndHour, Math.min(snappedHour, DAY_END_HOUR))
+        const clampedEndHour = Math.max(minEndHour, Math.min(snappedHour, dayEndHour))
         const newEnd = buildDateFromHour(origStart, clampedEndHour)
 
         if (newEnd.getTime() !== resizeStart.originalEnd.getTime()) {

--- a/apps/web/app/(app)/settings/account/page.tsx
+++ b/apps/web/app/(app)/settings/account/page.tsx
@@ -6,7 +6,7 @@ import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { formatDate } from '@/app/lib/date'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
-import type { DefaultReminder } from '@silentsuite/core'
+import type { DayBoundaryHour, DefaultReminder } from '@silentsuite/core'
 
 interface AccountDetails {
   id: string
@@ -27,12 +27,17 @@ export default function AccountPage() {
   const notificationSound = usePreferencesStore((s) => s.notificationSound)
   const defaultTimezone = usePreferencesStore((s) => s.defaultTimezone)
   const dateFormat = usePreferencesStore((s) => s.dateFormat)
+  const dayStartHour = usePreferencesStore((s) => s.dayStartHour)
+  const dayEndHour = usePreferencesStore((s) => s.dayEndHour)
   const setDateFormat = usePreferencesStore((s) => s.setDateFormat)
   const setTimeFormat = usePreferencesStore((s) => s.setTimeFormat)
   const setFirstDayOfWeek = usePreferencesStore((s) => s.setFirstDayOfWeek)
   const setDefaultReminder = usePreferencesStore((s) => s.setDefaultReminder)
   const setNotificationSound = usePreferencesStore((s) => s.setNotificationSound)
   const setDefaultTimezone = usePreferencesStore((s) => s.setDefaultTimezone)
+  const setDayBounds = usePreferencesStore((s) => s.setDayBounds)
+
+  const hourOptions = useMemo(() => Array.from({ length: 25 }, (_, hour) => hour as DayBoundaryHour), [])
 
   const allTimezones = useMemo(() => {
     try {
@@ -178,6 +183,42 @@ export default function AccountPage() {
                     Sunday
                   </button>
                 </div>
+              </div>
+
+              {/* Visible Day Bounds */}
+              <div className="space-y-2">
+                <p className="text-xs text-[rgb(var(--muted))]">Visible calendar day</p>
+                <div className="grid grid-cols-2 gap-2">
+                  <label className="space-y-1 text-xs text-[rgb(var(--muted))]">
+                    <span>Start</span>
+                    <select
+                      value={dayStartHour}
+                      onChange={(e) => setDayBounds(Number(e.target.value) as DayBoundaryHour, dayEndHour)}
+                      className="w-full rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                    >
+                      {hourOptions.slice(0, 24).map((hour) => (
+                        <option key={hour} value={hour} disabled={hour >= dayEndHour}>
+                          {String(hour).padStart(2, '0')}:00
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="space-y-1 text-xs text-[rgb(var(--muted))]">
+                    <span>End</span>
+                    <select
+                      value={dayEndHour}
+                      onChange={(e) => setDayBounds(dayStartHour, Number(e.target.value) as DayBoundaryHour)}
+                      className="w-full rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                    >
+                      {hourOptions.slice(1).map((hour) => (
+                        <option key={hour} value={hour} disabled={hour <= dayStartHour}>
+                          {String(hour).padStart(2, '0')}:00
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+                <p className="text-xs text-[rgb(var(--muted))]">Default is the full 00:00–24:00 day.</p>
               </div>
 
               {/* Default Reminder */}

--- a/apps/web/app/stores/use-preferences-store.ts
+++ b/apps/web/app/stores/use-preferences-store.ts
@@ -6,6 +6,7 @@ import {
   getSyncedPreferenceTimestamps,
   getSyncedPreferenceValues,
   mergeSyncedPreferences,
+  type DayBoundaryHour,
   type DefaultReminder,
   type FirstDayOfWeek,
   type SyncedPreferencesV1,
@@ -32,6 +33,8 @@ function zeroTimestamps(): SyncedPreferenceTimestamps {
     defaultReminder: 0,
     defaultTimezone: 0,
     dateFormat: 0,
+    dayStartHour: 0,
+    dayEndHour: 0,
   }
 }
 
@@ -46,9 +49,12 @@ interface PreferencesState {
   notificationSound: boolean
   defaultTimezone: string // IANA timezone, e.g. 'Europe/Amsterdam'
   dateFormat: import('@silentsuite/core').DateFormat
+  dayStartHour: DayBoundaryHour
+  dayEndHour: DayBoundaryHour
   syncedPreferenceUpdatedAt: SyncedPreferenceTimestamps
   setTimeFormat: (format: TimeFormat) => void
   setDateFormat: (format: import('@silentsuite/core').DateFormat) => void
+  setDayBounds: (start: DayBoundaryHour, end: DayBoundaryHour) => void
   setFirstDayOfWeek: (day: FirstDayOfWeek) => void
   setDefaultReminder: (value: DefaultReminder) => void
   setNotificationSound: (enabled: boolean) => void
@@ -72,6 +78,19 @@ export const usePreferencesStore = create<PreferencesState>()(
         timeFormat,
         syncedPreferenceUpdatedAt: { ...state.syncedPreferenceUpdatedAt, timeFormat: Date.now() },
       })),
+      setDayBounds: (start, end) => set((state) => {
+        const { dayStartHour, dayEndHour } = normalizeValues({ dayStartHour: start, dayEndHour: end })
+        const now = Date.now()
+        return {
+          dayStartHour,
+          dayEndHour,
+          syncedPreferenceUpdatedAt: {
+            ...state.syncedPreferenceUpdatedAt,
+            dayStartHour: now,
+            dayEndHour: now,
+          },
+        }
+      }),
       setFirstDayOfWeek: (firstDayOfWeek) => set((state) => ({
         firstDayOfWeek,
         syncedPreferenceUpdatedAt: { ...state.syncedPreferenceUpdatedAt, firstDayOfWeek: Date.now() },
@@ -100,6 +119,8 @@ export const usePreferencesStore = create<PreferencesState>()(
             defaultReminder: state.defaultReminder,
             defaultTimezone: state.defaultTimezone,
             dateFormat: (state as any).dateFormat,
+            dayStartHour: state.dayStartHour,
+            dayEndHour: state.dayEndHour,
           },
           state.syncedPreferenceUpdatedAt,
           0,
@@ -115,11 +136,15 @@ export const usePreferencesStore = create<PreferencesState>()(
           || values.defaultReminder !== state.defaultReminder
           || values.defaultTimezone !== state.defaultTimezone
           || values.dateFormat !== (state as any).dateFormat
+          || values.dayStartHour !== state.dayStartHour
+          || values.dayEndHour !== state.dayEndHour
           || timestamps.timeFormat !== state.syncedPreferenceUpdatedAt.timeFormat
           || timestamps.firstDayOfWeek !== state.syncedPreferenceUpdatedAt.firstDayOfWeek
           || timestamps.defaultReminder !== state.syncedPreferenceUpdatedAt.defaultReminder
           || timestamps.defaultTimezone !== state.syncedPreferenceUpdatedAt.defaultTimezone
           || timestamps.dateFormat !== state.syncedPreferenceUpdatedAt.dateFormat
+          || timestamps.dayStartHour !== state.syncedPreferenceUpdatedAt.dayStartHour
+          || timestamps.dayEndHour !== state.syncedPreferenceUpdatedAt.dayEndHour
 
         if (changed) {
           set({ ...values, syncedPreferenceUpdatedAt: timestamps })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,6 +122,7 @@ export type {
   FirstDayOfWeek,
   DefaultReminder,
   DateFormat,
+  DayBoundaryHour,
   SyncedPreferenceValues,
   SyncedPreferenceTimestamps,
   VersionedPreference,

--- a/packages/core/src/models/preferences.test.ts
+++ b/packages/core/src/models/preferences.test.ts
@@ -21,6 +21,8 @@ describe('synced preferences', () => {
         firstDayOfWeek: 11,
         defaultReminder: 12,
         defaultTimezone: 13,
+        dayStartHour: 14,
+        dayEndHour: 15,
       },
       99,
     );
@@ -35,6 +37,8 @@ describe('synced preferences', () => {
       defaultReminder: '30',
       defaultTimezone: 'Europe/Amsterdam',
       dateFormat: 'system',
+      dayStartHour: 0,
+      dayEndHour: 24,
     });
     expect(restored.updatedAt).toBe(99);
   });
@@ -57,7 +61,18 @@ describe('synced preferences', () => {
       defaultReminder: '15',
       defaultTimezone: 'UTC',
       dateFormat: 'system',
+      dayStartHour: 0,
+      dayEndHour: 24,
     });
+  });
+
+
+  it('accepts valid day bounds and falls back when start is not before end', () => {
+    const valid = createSyncedPreferences({ dayStartHour: 7, dayEndHour: 19 }, {}, 42);
+    expect(getSyncedPreferenceValues(valid)).toMatchObject({ dayStartHour: 7, dayEndHour: 19 });
+
+    const invalid = createSyncedPreferences({ dayStartHour: 22, dayEndHour: 6 }, {}, 42);
+    expect(getSyncedPreferenceValues(invalid)).toMatchObject({ dayStartHour: 0, dayEndHour: 24 });
   });
 
   it('merges by newest timestamp per field', () => {
@@ -98,6 +113,8 @@ describe('synced preferences', () => {
       defaultReminder: '60',
       defaultTimezone: 'Europe/Amsterdam',
       dateFormat: 'system',
+      dayStartHour: 0,
+      dayEndHour: 24,
     });
   });
 });

--- a/packages/core/src/models/preferences.ts
+++ b/packages/core/src/models/preferences.ts
@@ -4,6 +4,8 @@ export const SYNCED_PREFERENCE_KEYS = [
   'defaultReminder',
   'defaultTimezone',
   'dateFormat',
+  'dayStartHour',
+  'dayEndHour',
 ] as const;
 
 export type SyncedPreferenceKey = typeof SYNCED_PREFERENCE_KEYS[number];
@@ -11,6 +13,7 @@ export type TimeFormat = '12h' | '24h';
 export type FirstDayOfWeek = 'monday' | 'sunday';
 export type DefaultReminder = 'none' | '5' | '15' | '30' | '60' | '1440';
 export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD' | 'system'
+export type DayBoundaryHour = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24;
 
 export interface SyncedPreferenceValues {
   timeFormat: TimeFormat;
@@ -18,6 +21,8 @@ export interface SyncedPreferenceValues {
   defaultReminder: DefaultReminder;
   defaultTimezone: string;
   dateFormat: DateFormat;
+  dayStartHour: DayBoundaryHour;
+  dayEndHour: DayBoundaryHour;
 }
 
 export interface VersionedPreference<T> {
@@ -34,6 +39,8 @@ export interface SyncedPreferencesV1 {
     defaultReminder: VersionedPreference<DefaultReminder>;
     defaultTimezone: VersionedPreference<string>;
     dateFormat: VersionedPreference<DateFormat>;
+    dayStartHour: VersionedPreference<DayBoundaryHour>;
+    dayEndHour: VersionedPreference<DayBoundaryHour>;
   };
 }
 
@@ -45,6 +52,8 @@ export const DEFAULT_SYNCED_PREFERENCES: SyncedPreferenceValues = {
   defaultReminder: '15',
   defaultTimezone: 'UTC',
   dateFormat: 'system',
+  dayStartHour: 0,
+  dayEndHour: 24,
 };
 
 const DEFAULT_TIMESTAMPS: SyncedPreferenceTimestamps = {
@@ -53,6 +62,8 @@ const DEFAULT_TIMESTAMPS: SyncedPreferenceTimestamps = {
   defaultReminder: 0,
   defaultTimezone: 0,
   dateFormat: 0,
+  dayStartHour: 0,
+  dayEndHour: 0,
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -85,13 +96,32 @@ function dateFormat(value: unknown, fallback: DateFormat): DateFormat {
   return value === 'DD/MM/YYYY' || value === 'MM/DD/YYYY' || value === 'YYYY-MM-DD' || value === 'system' ? value : fallback
 }
 
+function dayBoundaryHour(value: unknown, fallback: DayBoundaryHour): DayBoundaryHour {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 24
+    ? value as DayBoundaryHour
+    : fallback;
+}
+
+function normalizeDayBounds(start: DayBoundaryHour, end: DayBoundaryHour): { dayStartHour: DayBoundaryHour; dayEndHour: DayBoundaryHour } {
+  if (start < end) return { dayStartHour: start, dayEndHour: end };
+  return {
+    dayStartHour: DEFAULT_SYNCED_PREFERENCES.dayStartHour,
+    dayEndHour: DEFAULT_SYNCED_PREFERENCES.dayEndHour,
+  };
+}
+
 function valuesWithDefaults(values: Partial<SyncedPreferenceValues> = {}): SyncedPreferenceValues {
+  const dayBounds = normalizeDayBounds(
+    dayBoundaryHour(values.dayStartHour, DEFAULT_SYNCED_PREFERENCES.dayStartHour),
+    dayBoundaryHour(values.dayEndHour, DEFAULT_SYNCED_PREFERENCES.dayEndHour),
+  );
   return {
     timeFormat: timeFormat(values.timeFormat, DEFAULT_SYNCED_PREFERENCES.timeFormat),
     firstDayOfWeek: firstDayOfWeek(values.firstDayOfWeek, DEFAULT_SYNCED_PREFERENCES.firstDayOfWeek),
     defaultReminder: defaultReminder(values.defaultReminder, DEFAULT_SYNCED_PREFERENCES.defaultReminder),
     defaultTimezone: defaultTimezone(values.defaultTimezone, DEFAULT_SYNCED_PREFERENCES.defaultTimezone),
     dateFormat: dateFormat(values.dateFormat, DEFAULT_SYNCED_PREFERENCES.dateFormat),
+    ...dayBounds,
   };
 }
 
@@ -107,6 +137,8 @@ export function createSyncedPreferences(
     defaultReminder: timestamp(timestamps.defaultReminder, now),
     defaultTimezone: timestamp(timestamps.defaultTimezone, now),
     dateFormat: timestamp(timestamps.dateFormat, now),
+    dayStartHour: timestamp(timestamps.dayStartHour, now),
+    dayEndHour: timestamp(timestamps.dayEndHour, now),
   };
   const updatedAt = Math.max(...SYNCED_PREFERENCE_KEYS.map((key) => normalizedTimestamps[key]));
 
@@ -119,6 +151,8 @@ export function createSyncedPreferences(
       defaultReminder: { value: normalizedValues.defaultReminder, updatedAt: normalizedTimestamps.defaultReminder },
       defaultTimezone: { value: normalizedValues.defaultTimezone, updatedAt: normalizedTimestamps.defaultTimezone },
       dateFormat: { value: normalizedValues.dateFormat, updatedAt: normalizedTimestamps.dateFormat },
+      dayStartHour: { value: normalizedValues.dayStartHour, updatedAt: normalizedTimestamps.dayStartHour },
+      dayEndHour: { value: normalizedValues.dayEndHour, updatedAt: normalizedTimestamps.dayEndHour },
     },
   };
 }
@@ -133,6 +167,8 @@ export function normalizeSyncedPreferences(input: unknown): SyncedPreferencesV1 
   const reminderField = isRecord(fields.defaultReminder) ? fields.defaultReminder : {};
   const timezoneField = isRecord(fields.defaultTimezone) ? fields.defaultTimezone : {};
   const dateFormatField = isRecord(fields.dateFormat) ? fields.dateFormat : {};
+  const dayStartHourField = isRecord(fields.dayStartHour) ? fields.dayStartHour : {};
+  const dayEndHourField = isRecord(fields.dayEndHour) ? fields.dayEndHour : {};
 
   return createSyncedPreferences(
     {
@@ -141,6 +177,10 @@ export function normalizeSyncedPreferences(input: unknown): SyncedPreferencesV1 
       defaultReminder: defaultReminder(reminderField.value, DEFAULT_SYNCED_PREFERENCES.defaultReminder),
       defaultTimezone: defaultTimezone(timezoneField.value, DEFAULT_SYNCED_PREFERENCES.defaultTimezone),
       dateFormat: dateFormat(dateFormatField.value, DEFAULT_SYNCED_PREFERENCES.dateFormat),
+      ...normalizeDayBounds(
+        dayBoundaryHour(dayStartHourField.value, DEFAULT_SYNCED_PREFERENCES.dayStartHour),
+        dayBoundaryHour(dayEndHourField.value, DEFAULT_SYNCED_PREFERENCES.dayEndHour),
+      ),
     },
     {
       timeFormat: timestamp(timeFormatField.updatedAt, rootUpdatedAt),
@@ -148,6 +188,8 @@ export function normalizeSyncedPreferences(input: unknown): SyncedPreferencesV1 
       defaultReminder: timestamp(reminderField.updatedAt, rootUpdatedAt),
       defaultTimezone: timestamp(timezoneField.updatedAt, rootUpdatedAt),
       dateFormat: timestamp(dateFormatField.updatedAt, rootUpdatedAt),
+      dayStartHour: timestamp(dayStartHourField.updatedAt, rootUpdatedAt),
+      dayEndHour: timestamp(dayEndHourField.updatedAt, rootUpdatedAt),
     },
     0,
   );
@@ -161,6 +203,8 @@ export function getSyncedPreferenceValues(preferences: SyncedPreferencesV1): Syn
     defaultReminder: normalized.fields.defaultReminder.value,
     defaultTimezone: normalized.fields.defaultTimezone.value,
     dateFormat: normalized.fields.dateFormat.value,
+    dayStartHour: normalized.fields.dayStartHour.value,
+    dayEndHour: normalized.fields.dayEndHour.value,
   };
 }
 
@@ -172,6 +216,8 @@ export function getSyncedPreferenceTimestamps(preferences: SyncedPreferencesV1):
     defaultReminder: normalized.fields.defaultReminder.updatedAt,
     defaultTimezone: normalized.fields.defaultTimezone.updatedAt,
     dateFormat: normalized.fields.dateFormat.updatedAt,
+    dayStartHour: normalized.fields.dayStartHour.updatedAt,
+    dayEndHour: normalized.fields.dayEndHour.updatedAt,
   };
 }
 


### PR DESCRIPTION
## Summary
- Change the default visible calendar day from 06:00-22:00 to the full 00:00-24:00 range.
- Add synced day-bound preferences (`dayStartHour`, `dayEndHour`) with validation and safe fallback for invalid bounds.
- Wire CalendarGrid Schedule-X day boundaries and drag/select math to the configured bounds.
- Add Settings > Account controls for selecting the visible calendar day start and end.

Closes #376

## Validation
- `pnpm --filter @silentsuite/core test -- src/models/preferences.test.ts` — passed (`12` files / `272` tests under current Vitest invocation).
- `pnpm --filter @silentsuite/web type-check` — passed.
- `git diff --check` — passed.

## Notes
- This PR is intentionally separate from #375 so month multi-day rendering can land independently from preference/schema changes.
