### PR TITLE
Add structured web task details

### DIFF
--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useMemo, useState, useRef, useEffect } from 'react'
-import { X, ChevronDown, Calendar, Flag, WifiOff, Plus, AlignLeft, Pencil, List, Folder, Tag } from 'lucide-react'
+import { X, ChevronDown, Calendar, Flag, WifiOff, Plus, AlignLeft, Pencil, List, Folder, Tag, MapPin, Link, BarChart3, CircleDot } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { LabelEditor, LabelChips } from '@/app/components/LabelEditor'
 import { useTaskStore } from '@/app/stores/use-task-store'
@@ -15,7 +15,7 @@ import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
 import { TasksEmptyState } from '@/app/components/empty-state'
 import { ConfirmDialog } from '@/app/components/confirm-dialog'
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
-import type { Task, Priority } from '@silentsuite/core'
+import type { Task, TaskStatus, Priority } from '@silentsuite/core'
 
 // ── Priority config ──
 
@@ -47,6 +47,15 @@ const PRIORITY_LABELS: Record<Priority, string> = {
   urgent: 'Urgent',
 }
 
+const STATUS_LABELS: Record<TaskStatus, string> = {
+  'needs-action': 'Needs action',
+  'in-process': 'In progress',
+  completed: 'Completed',
+  cancelled: 'Cancelled',
+}
+
+const STATUS_OPTIONS: TaskStatus[] = ['needs-action', 'in-process', 'completed', 'cancelled']
+
 // ── Helpers ──
 
 function formatDueDate(date: Date): string {
@@ -72,6 +81,23 @@ function dueDateColor(date: Date): string {
   if (diffDays < 0) return 'text-red-400'
   if (diffDays === 0) return 'text-amber-400'
   return 'text-[rgb(var(--muted))]'
+}
+
+function dateInputValue(date: Date | null | undefined): string {
+  return date
+    ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+    : ''
+}
+
+function parseDateInput(value: string): Date | null {
+  if (!value) return null
+  const [y, m, d] = value.split('-').map(Number)
+  return new Date(y!, m! - 1, d!)
+}
+
+function normalizeTaskProgress(status: TaskStatus, percent: number): { completed: boolean; percent_complete: number } {
+  if (status === 'completed') return { completed: true, percent_complete: 100 }
+  return { completed: false, percent_complete: Math.max(0, Math.min(99, Math.round(percent))) }
 }
 
 function sortTasks(tasks: Task[]): Task[] {
@@ -179,12 +205,13 @@ function TaskDialog({
 
   const [title, setTitle] = useState(task?.title ?? '')
   const [description, setDescription] = useState(task?.description ?? '')
-  const [dueDate, setDueDate] = useState<string>(
-    task?.due_date
-      ? `${task.due_date.getFullYear()}-${String(task.due_date.getMonth() + 1).padStart(2, '0')}-${String(task.due_date.getDate()).padStart(2, '0')}`
-      : '',
-  )
+  const [startDate, setStartDate] = useState<string>(dateInputValue(task?.start_date))
+  const [dueDate, setDueDate] = useState<string>(dateInputValue(task?.due_date))
   const [priority, setPriority] = useState<Priority>(task?.priority ?? 'medium')
+  const [status, setStatus] = useState<TaskStatus>(task?.status ?? (task?.completed ? 'completed' : 'needs-action'))
+  const [percentComplete, setPercentComplete] = useState(task?.percent_complete ?? (task?.completed ? 100 : 0))
+  const [location, setLocation] = useState(task?.location ?? '')
+  const [url, setUrl] = useState(task?.url ?? '')
   const [categories, setCategories] = useState<string[]>(task?.categories ?? [])
   const [selectedListId, setSelectedListId] = useState(task?.listId ?? defaultListId)
 
@@ -205,19 +232,21 @@ function TaskDialog({
     const trimmed = title.trim()
     if (!trimmed) return
 
-    const parsedDue = dueDate
-      ? (() => {
-          const [y, m, d] = dueDate.split('-').map(Number)
-          return new Date(y!, m! - 1, d!)
-        })()
-      : null
+    const parsedStart = parseDateInput(startDate)
+    const parsedDue = parseDateInput(dueDate)
+    const progress = normalizeTaskProgress(status, percentComplete)
 
     if (mode === 'create') {
       createTask({
         title: trimmed,
         description,
+        start_date: parsedStart,
         due_date: parsedDue,
         priority,
+        status,
+        ...progress,
+        location,
+        url,
         categories,
         listId: selectedListId,
       })
@@ -225,14 +254,19 @@ function TaskDialog({
       updateTask(task.id, {
         title: trimmed,
         description,
+        start_date: parsedStart,
         due_date: parsedDue,
         priority,
+        status,
+        ...progress,
+        location,
+        url,
         categories,
         listId: selectedListId,
       })
     }
     onClose()
-  }, [title, description, dueDate, priority, categories, selectedListId, mode, task, createTask, updateTask, onClose])
+  }, [title, description, startDate, dueDate, priority, status, percentComplete, location, url, categories, selectedListId, mode, task, createTask, updateTask, onClose])
 
   return (
     <>
@@ -277,29 +311,95 @@ function TaskDialog({
               className="w-full text-base font-medium bg-transparent text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none border-b border-[rgb(var(--border))] pb-2"
             />
 
-            {/* Due date */}
-            <div className="flex items-center gap-3">
-              <Calendar className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
-              <div className="flex items-center gap-2">
-                <span className="text-sm text-[rgb(var(--muted))]">Due date</span>
+            {/* Dates */}
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="flex items-center gap-3">
+                <Calendar className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                <span className="sr-only">Start date</span>
+                <div className="flex flex-1 items-center gap-2">
+                  <span className="text-sm text-[rgb(var(--muted))]">Start</span>
+                  <input
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => setStartDate(e.target.value)}
+                    aria-label="Start date"
+                    className="min-w-0 flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  />
+                </div>
+              </label>
+              <label className="flex items-center gap-3">
+                <Calendar className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                <span className="sr-only">Due date</span>
+                <div className="flex flex-1 items-center gap-2">
+                  <span className="text-sm text-[rgb(var(--muted))]">Due</span>
+                  <input
+                    type="date"
+                    value={dueDate}
+                    onChange={(e) => setDueDate(e.target.value)}
+                    aria-label="Due date"
+                    className="min-w-0 flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  />
+                </div>
+              </label>
+            </div>
+
+            {/* Status and progress */}
+            <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+              <label className="flex items-center gap-3">
+                <CircleDot className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                <span className="sr-only">Task status</span>
+                <select
+                  value={status}
+                  onChange={(e) => setStatus(e.target.value as TaskStatus)}
+                  aria-label="Task status"
+                  className="w-full rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                >
+                  {STATUS_OPTIONS.map((option) => (
+                    <option key={option} value={option}>{STATUS_LABELS[option]}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex items-center gap-2">
+                <BarChart3 className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                <span className="text-sm text-[rgb(var(--muted))]">Progress</span>
                 <input
-                  type="date"
-                  value={dueDate}
-                  onChange={(e) => setDueDate(e.target.value)}
-                  aria-label="Due date"
-                  className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={percentComplete}
+                  onChange={(e) => setPercentComplete(Number(e.target.value))}
+                  aria-label="Percent complete"
+                  className="w-20 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-sm text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
                 />
-                {dueDate && (
-                  <button
-                    type="button"
-                    onClick={() => setDueDate('')}
-                    className="rounded p-1 text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors"
-                    aria-label="Clear due date"
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                )}
-              </div>
+              </label>
+            </div>
+
+            {/* Location and URL */}
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="flex items-center gap-3">
+                <MapPin className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                <span className="sr-only">Location</span>
+                <input
+                  type="text"
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                  placeholder="Location"
+                  aria-label="Location"
+                  className="min-w-0 flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                />
+              </label>
+              <label className="flex items-center gap-3">
+                <Link className="h-4 w-4 shrink-0 text-[rgb(var(--muted))]" />
+                <span className="sr-only">URL</span>
+                <input
+                  type="url"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  placeholder="URL"
+                  aria-label="URL"
+                  className="min-w-0 flex-1 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                />
+              </label>
             </div>
 
             {/* Priority */}

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { create } from 'zustand'
-import type { Task, Priority, SyncStatus } from '@silentsuite/core'
+import type { Task, TaskStatus, Priority, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
@@ -12,9 +12,14 @@ import { useTaskListStore } from '@/app/stores/use-task-list-store'
 interface NewTask {
   title: string
   description?: string
+  start_date?: Date | null
   due_date?: Date | null
   priority?: Priority
   completed?: boolean
+  status?: TaskStatus
+  percent_complete?: number
+  location?: string
+  url?: string
   categories?: string[]
   listId?: string
 }
@@ -55,9 +60,14 @@ export const useTaskStore = create<TaskState & TaskActions>()(
           uid: tempId,
           title: newTask.title,
           description: newTask.description ?? '',
+          start_date: newTask.start_date ?? null,
           due_date: newTask.due_date ?? null,
           priority: newTask.priority ?? 'medium',
           completed: newTask.completed ?? false,
+          status: newTask.status ?? (newTask.completed ? 'completed' : 'needs-action'),
+          percent_complete: newTask.percent_complete ?? (newTask.completed ? 100 : 0),
+          location: newTask.location ?? '',
+          url: newTask.url ?? '',
           categories: newTask.categories ?? [],
           listId: newTask.listId ?? defaultTaskListId(),
           created_at: now,
@@ -156,7 +166,14 @@ export const useTaskStore = create<TaskState & TaskActions>()(
         if (index === -1) return
 
         const task = tasks[index]!
-        const updated = { ...task, completed: !task.completed, updated_at: new Date() }
+        const nextCompleted = !task.completed
+        const updated = {
+          ...task,
+          completed: nextCompleted,
+          status: nextCompleted ? 'completed' as const : 'needs-action' as const,
+          percent_complete: nextCompleted ? 100 : 0,
+          updated_at: new Date(),
+        }
         const next = [...tasks]
         next[index] = updated
         set({ tasks: next })
@@ -194,9 +211,14 @@ export const useTaskStore = create<TaskState & TaskActions>()(
             uid: tempId,
             title: nt.title,
             description: nt.description ?? '',
+            start_date: nt.start_date ?? null,
             due_date: nt.due_date ?? null,
             priority: nt.priority ?? 'medium',
             completed: nt.completed ?? false,
+            status: nt.status ?? (nt.completed ? 'completed' : 'needs-action'),
+            percent_complete: nt.percent_complete ?? (nt.completed ? 100 : 0),
+            location: nt.location ?? '',
+            url: nt.url ?? '',
             categories: nt.categories ?? [],
             listId: nt.listId ?? defaultTaskListId(),
             created_at: now,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,7 +89,7 @@ export {
   serializeTask,
   deserializeTask,
 } from './models/task.js';
-export type { Task } from './models/task.js';
+export type { Task, TaskStatus } from './models/task.js';
 
 // Contact model
 export {

--- a/packages/core/src/models/task.test.ts
+++ b/packages/core/src/models/task.test.ts
@@ -132,6 +132,42 @@ describe('toVTodo / fromVTodo roundtrip', () => {
     expect(restored.id).toBe('my-id');
     expect(restored.uid).toBe('my-id');
   });
+  it('roundtrips structured task.org-style fields through VTODO', () => {
+    const original = makeFullTask({
+      start_date: new Date(2026, 2, 18, 0, 0, 0),
+      due_date: new Date(2026, 2, 20, 0, 0, 0),
+      status: 'in-process',
+      percent_complete: 45,
+      location: 'Office',
+      url: 'https://example.com/tasks/1',
+    });
+    const ical = toVTodo(original);
+
+    expect(ical).toContain('DTSTART;VALUE=DATE:20260318');
+    expect(ical).toContain('DUE;VALUE=DATE:20260320');
+    expect(ical).toContain('STATUS:IN-PROCESS');
+    expect(ical).toContain('PERCENT-COMPLETE:45');
+    expect(ical).toContain('LOCATION:Office');
+    expect(ical).toContain('URL:https://example.com/tasks/1');
+
+    const restored = fromVTodo(ical);
+    expect(restored.start_date!.getFullYear()).toBe(2026);
+    expect(restored.start_date!.getMonth()).toBe(2);
+    expect(restored.start_date!.getDate()).toBe(18);
+    expect(restored.status).toBe('in-process');
+    expect(restored.percent_complete).toBe(45);
+    expect(restored.location).toBe('Office');
+    expect(restored.url).toBe('https://example.com/tasks/1');
+    expect(restored.completed).toBe(false);
+  });
+
+  it('serializes cancelled tasks and clamps incomplete percent complete', () => {
+    const task = makeFullTask({ status: 'cancelled', percent_complete: 125, completed: false });
+    const vtodo = toVTodo(task);
+
+    expect(vtodo).toContain('STATUS:CANCELLED');
+    expect(vtodo).toContain('PERCENT-COMPLETE:100');
+  });
 });
 
 // ── Priority mapping ──

--- a/packages/core/src/models/task.ts
+++ b/packages/core/src/models/task.ts
@@ -2,14 +2,25 @@ import { parseVTodo, generateVTodo } from '../utils/ical-parser.js';
 import type { VTodo } from '../utils/ical-parser.js';
 import type { Priority } from './types.js';
 
+export type TaskStatus = 'needs-action' | 'in-process' | 'completed' | 'cancelled';
+
 export interface Task {
   id: string;
   uid: string;
   title: string;
   description: string;
+  start_date?: Date | null;
   due_date: Date | null;
   priority: Priority;
   completed: boolean;
+  /** RFC 5545 VTODO STATUS. `completed` remains for legacy callers and is kept in sync. */
+  status?: TaskStatus;
+  /** RFC 5545 PERCENT-COMPLETE, clamped to 0-100. */
+  percent_complete?: number;
+  /** RFC 5545 LOCATION for clients that support task places/contexts. */
+  location?: string;
+  /** RFC 5545 URL for the task's canonical link/reference. */
+  url?: string;
   /** User-defined labels/categories for grouping and filtering.
    *  Round-tripped via the ICS CATEGORIES property (comma-separated).
    *  Optional so existing callers keep compiling; deserialize paths default to []. */
@@ -32,6 +43,20 @@ const ICAL_TO_PRIORITY: Record<number, Priority> = {
   2: 'high',
   5: 'medium',
   9: 'low',
+};
+
+const TASK_STATUS_TO_ICAL: Record<TaskStatus, string> = {
+  'needs-action': 'NEEDS-ACTION',
+  'in-process': 'IN-PROCESS',
+  completed: 'COMPLETED',
+  cancelled: 'CANCELLED',
+};
+
+const ICAL_TO_TASK_STATUS: Record<string, TaskStatus> = {
+  'NEEDS-ACTION': 'needs-action',
+  'IN-PROCESS': 'in-process',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled',
 };
 
 function icalPriorityToModel(value: number | undefined): Priority {
@@ -93,6 +118,23 @@ function isDateOnly(value: string): boolean {
   return value.replace(/[^0-9TZ]/g, '').length <= 8;
 }
 
+function statusToICal(task: Task): string {
+  if (task.completed) return 'COMPLETED';
+  return TASK_STATUS_TO_ICAL[task.status ?? 'needs-action'];
+}
+
+function icalStatusToModel(value: string | undefined, completed: boolean): TaskStatus {
+  if (completed) return 'completed';
+  if (!value) return 'needs-action';
+  return ICAL_TO_TASK_STATUS[value.toUpperCase()] ?? 'needs-action';
+}
+
+function normalizePercent(value: number | undefined, completed: boolean): number {
+  if (completed) return 100;
+  if (value === undefined || Number.isNaN(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
 /**
  * Convert a Task to an iCalendar VTODO string.
  */
@@ -102,12 +144,24 @@ export function toVTodo(task: Task): string {
     summary: task.title || undefined,
     description: task.description || undefined,
     priority: PRIORITY_TO_ICAL[task.priority],
-    status: task.completed ? 'COMPLETED' : 'NEEDS-ACTION',
-    percentComplete: task.completed ? 100 : 0,
+    status: statusToICal(task),
+    percentComplete: normalizePercent(task.percent_complete, task.completed),
+    location: task.location || undefined,
+    url: task.url || undefined,
     categories: task.categories && task.categories.length > 0 ? task.categories : undefined,
     created: formatICalUtcDateTime(task.created_at),
     lastModified: formatICalUtcDateTime(task.updated_at),
   };
+
+  if (task.start_date) {
+    const startDateOnly = task.start_date.getHours() === 0
+      && task.start_date.getMinutes() === 0
+      && task.start_date.getSeconds() === 0;
+    vtodo.dtstart = startDateOnly ? formatICalDate(task.start_date) : formatICalDateTime(task.start_date);
+    if (startDateOnly) {
+      vtodo.dtstartParams = { VALUE: 'DATE' };
+    }
+  }
 
   if (task.due_date) {
     const dueDateOnly = task.due_date.getHours() === 0
@@ -137,15 +191,21 @@ export function fromVTodo(vtodoStr: string): Task {
   const completed = vtodo.status?.toUpperCase() === 'COMPLETED'
     || vtodo.percentComplete === 100
     || (vtodo.status === undefined && vtodo.completed !== undefined);
+  const status = icalStatusToModel(vtodo.status, completed);
 
   return {
     id: vtodo.uid,
     uid: vtodo.uid,
     title: vtodo.summary ?? '',
     description: vtodo.description ?? '',
+    start_date: vtodo.dtstart ? parseICalDateValue(vtodo.dtstart) : null,
     due_date,
     priority: icalPriorityToModel(vtodo.priority),
     completed,
+    status,
+    percent_complete: normalizePercent(vtodo.percentComplete, completed),
+    location: vtodo.location ?? '',
+    url: vtodo.url ?? '',
     // Preserve CATEGORIES for round-trip; default to [] for legacy records
     categories: vtodo.categories ?? [],
     created_at: vtodo.created ? parseICalDateValue(vtodo.created) : now,

--- a/packages/core/src/utils/ical-parser.ts
+++ b/packages/core/src/utils/ical-parser.ts
@@ -32,6 +32,8 @@ export interface VTodo {
   uid: string;
   summary?: string;
   description?: string;
+  dtstart?: string;
+  dtstartParams?: Record<string, string>;
   due?: string;
   dueParams?: Record<string, string>;
   priority?: number;
@@ -40,6 +42,8 @@ export interface VTodo {
   created?: string;
   lastModified?: string;
   percentComplete?: number;
+  location?: string;
+  url?: string;
   /** CATEGORIES (RFC 5545) — comma-separated user labels */
   categories?: string[];
 }
@@ -433,6 +437,12 @@ export function parseVTodo(ical: string): VTodo {
       case 'DESCRIPTION':
         todo.description = unescapeText(prop.value);
         break;
+      case 'DTSTART':
+        todo.dtstart = prop.value;
+        if (Object.keys(prop.params).length > 0) {
+          todo.dtstartParams = prop.params;
+        }
+        break;
       case 'DUE':
         todo.due = prop.value;
         if (Object.keys(prop.params).length > 0) {
@@ -456,6 +466,12 @@ export function parseVTodo(ical: string): VTodo {
         break;
       case 'PERCENT-COMPLETE':
         todo.percentComplete = parseInt(prop.value, 10);
+        break;
+      case 'LOCATION':
+        todo.location = unescapeText(prop.value);
+        break;
+      case 'URL':
+        todo.url = prop.value;
         break;
       case 'CATEGORIES':
         todo.categories = splitCommaValues(prop.value).map((c) => c.trim()).filter((c) => c.length > 0);
@@ -486,6 +502,17 @@ export function generateVTodo(todo: VTodo): string {
   if (todo.summary) lines.push(foldLine(`SUMMARY:${escapeText(todo.summary)}`));
   if (todo.description) lines.push(foldLine(`DESCRIPTION:${escapeText(todo.description)}`));
 
+  if (todo.dtstart) {
+    if (todo.dtstartParams && Object.keys(todo.dtstartParams).length > 0) {
+      const paramStr = Object.entries(todo.dtstartParams)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(';');
+      lines.push(foldLine(`DTSTART;${paramStr}:${todo.dtstart}`));
+    } else {
+      lines.push(foldLine(`DTSTART:${todo.dtstart}`));
+    }
+  }
+
   if (todo.due) {
     if (todo.dueParams && Object.keys(todo.dueParams).length > 0) {
       const paramStr = Object.entries(todo.dueParams)
@@ -503,6 +530,8 @@ export function generateVTodo(todo: VTodo): string {
   if (todo.created) lines.push(foldLine(`CREATED:${todo.created}`));
   if (todo.lastModified) lines.push(foldLine(`LAST-MODIFIED:${todo.lastModified}`));
   if (todo.percentComplete !== undefined) lines.push(foldLine(`PERCENT-COMPLETE:${todo.percentComplete}`));
+  if (todo.location) lines.push(foldLine(`LOCATION:${escapeText(todo.location)}`));
+  if (todo.url) lines.push(foldLine(`URL:${todo.url}`));
   if (todo.categories && todo.categories.length > 0) {
     lines.push(foldLine(`CATEGORIES:${todo.categories.map(escapeText).join(',')}`));
   }


### PR DESCRIPTION
## Summary
- Add structured task detail fields inspired by task.org: start date, RFC 5545 status, percent complete, location, and URL.
- Persist the new fields through the web task store and task create/edit dialog.
- Extend core VTODO parsing/generation for `DTSTART`, `STATUS`, `PERCENT-COMPLETE`, `LOCATION`, and `URL` while preserving existing completion behavior.

Closes #377

## Validation
- `pnpm --filter @silentsuite/core test -- src/models/task.test.ts src/utils/ical-parser.test.ts` — passed (`12` files / `273` tests under current Vitest invocation).
- `pnpm --filter @silentsuite/web type-check` — passed.
- `git diff --check` — passed.

## Deferred
- Recurrence/reminders/subtasks/attachments are intentionally deferred; this PR lands a first interoperable VTODO-backed slice.
