### PR TITLE
Fix blank calendar after day-boundary updates

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -17,6 +17,10 @@ import type { CalendarEvent, DateRange, FirstDayOfWeek } from '@silentsuite/core
 import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
 import { startOfWeek, endOfWeek } from '@/app/lib/date'
 import { expandEventsForRange, toScheduleXEvents, type DisplayEvent } from '../lib/calendar-grid-events'
+import {
+  toScheduleXDayBoundariesExternal,
+  toScheduleXDayBoundariesInternal,
+} from '../lib/calendar-day-boundaries'
 
 import '@schedule-x/theme-default/dist/index.css'
 
@@ -92,10 +96,6 @@ function snapTo30Min(date: Date): Date {
 
 const DEFAULT_DAY_START_HOUR = 0
 const DEFAULT_DAY_END_HOUR = 24
-
-function formatDayBoundary(hour: number): string {
-  return `${String(hour).padStart(2, '0')}:00`
-}
 
 /** Find the display event under the cursor by matching click coordinates to day column + time */
 function findEventAtPosition(
@@ -371,7 +371,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const initialTimezoneRef = useRef(userTz)
   // Capture initial first-day-of-week for Schedule-X config (changes pushed via signal below)
   const initialFirstDayRef = useRef(sxFirstDayOfWeek)
-  const initialDayBoundariesRef = useRef({ start: formatDayBoundary(dayStartHour), end: formatDayBoundary(dayEndHour) })
+  const initialDayBoundariesRef = useRef(toScheduleXDayBoundariesExternal(dayStartHour, dayEndHour))
 
   // Memoize the event click handler
   const handleEventClick = useCallback(
@@ -467,7 +467,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     try {
       const app = (calendar as any).$app
       const boundariesSignal = app?.config?.dayBoundaries
-      const next = { start: formatDayBoundary(dayStartHour), end: formatDayBoundary(dayEndHour) }
+      const next = toScheduleXDayBoundariesInternal(dayStartHour, dayEndHour)
       if (boundariesSignal) {
         boundariesSignal.value = next
       }

--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatDayBoundary,
+  hourToScheduleXTimePoint,
+  toScheduleXDayBoundariesExternal,
+  toScheduleXDayBoundariesInternal,
+} from '../calendar-day-boundaries'
+
+describe('calendar day boundaries', () => {
+  it('formats external Schedule-X config as HH:00 strings', () => {
+    expect(formatDayBoundary(0)).toBe('00:00')
+    expect(formatDayBoundary(6)).toBe('06:00')
+    expect(formatDayBoundary(24)).toBe('24:00')
+    expect(toScheduleXDayBoundariesExternal(0, 24)).toEqual({ start: '00:00', end: '24:00' })
+  })
+
+  it('formats live Schedule-X signal updates as internal numeric time points', () => {
+    expect(hourToScheduleXTimePoint(0)).toBe(0)
+    expect(hourToScheduleXTimePoint(6)).toBe(600)
+    expect(hourToScheduleXTimePoint(24)).toBe(2400)
+    expect(toScheduleXDayBoundariesInternal(0, 24)).toEqual({ start: 0, end: 2400 })
+  })
+})

--- a/apps/web/app/(app)/calendar/lib/calendar-day-boundaries.ts
+++ b/apps/web/app/(app)/calendar/lib/calendar-day-boundaries.ts
@@ -1,0 +1,37 @@
+export interface ScheduleXDayBoundariesExternal {
+  start: string
+  end: string
+}
+
+export interface ScheduleXDayBoundariesInternal {
+  start: number
+  end: number
+}
+
+export function formatDayBoundary(hour: number): string {
+  return `${String(hour).padStart(2, '0')}:00`
+}
+
+export function hourToScheduleXTimePoint(hour: number): number {
+  return hour * 100
+}
+
+export function toScheduleXDayBoundariesExternal(
+  startHour: number,
+  endHour: number,
+): ScheduleXDayBoundariesExternal {
+  return {
+    start: formatDayBoundary(startHour),
+    end: formatDayBoundary(endHour),
+  }
+}
+
+export function toScheduleXDayBoundariesInternal(
+  startHour: number,
+  endHour: number,
+): ScheduleXDayBoundariesInternal {
+  return {
+    start: hourToScheduleXTimePoint(startHour),
+    end: hourToScheduleXTimePoint(endHour),
+  }
+}


### PR DESCRIPTION
## Summary
- Fix the blank Schedule-X calendar grid after configurable day bounds landed.
- Keep initial `dayBoundaries` config in Schedule-X's external `HH:00` string format.
- Convert live `config.dayBoundaries` signal updates to Schedule-X's internal numeric time-point format (`0`/`2400`) instead of writing strings into the internal signal.
- Add focused tests documenting the external-vs-internal boundary formats.

## Root cause
PR #383 updated `app.config.dayBoundaries.value` with `{ start: '00:00', end: '24:00' }`. Schedule-X only accepts that string shape in the initial external config. After initialization, `config.dayBoundaries` is an internal signal that expects numeric time points such as `{ start: 0, end: 2400 }`. Writing strings into that signal corrupted the calendar internals and caused the blank grid shown in preview.

## Validation
- `pnpm --filter @silentsuite/web test -- 'app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts' 'app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts' app/lib/__tests__/calendar-loading.test.ts` — passed; Vitest ran the related web suite (`34` files / `324` tests).
- `pnpm --filter @silentsuite/web type-check` — passed.
- `git diff --check` — passed.

Closes #376 follow-up regression.
