### PR TITLE
Instrument calendar sync timing

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -13,6 +13,7 @@ import { useCalendarStore, type CalendarView } from '@/app/stores/use-calendar-s
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { logCalendarPaintTiming } from '@/app/lib/sync-timing'
 import type { CalendarEvent, DateRange, FirstDayOfWeek } from '@silentsuite/core'
 import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
 import { startOfWeek, endOfWeek } from '@/app/lib/date'
@@ -599,6 +600,24 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       // events service may not be ready yet
     }
   }, [sxEvents, eventsPlugin])
+
+  // Log the first browser paint after Schedule-X receives events. This keeps
+  // the sync-speed investigation grounded in a visible-calendar milestone,
+  // without logging event titles, times, labels, or other PIM content.
+  const firstEventsPaintLoggedRef = useRef(false)
+  useEffect(() => {
+    if (firstEventsPaintLoggedRef.current || sxEvents.length === 0) return
+    firstEventsPaintLoggedRef.current = true
+    const raf = requestAnimationFrame(() => {
+      logCalendarPaintTiming({
+        scheduleXEventCount: sxEvents.length,
+        displayEventCount: displayEvents.length,
+        rawEventCount: events.length,
+        view: currentView,
+      })
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [currentView, displayEvents.length, events.length, sxEvents.length])
 
   // #331: Reveal the full title on short/clipped calendar events.
   // Schedule-X clips event text with `overflow: hidden`, so a short event's

--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -17,6 +17,7 @@ import {
   clearAll,
   ensureFingerprint,
   isCacheEnabled,
+  getCacheCapabilityStatus,
   CACHE_SCHEMA_VERSION,
   _resetForTests,
   _setEncryptedCacheAvailableForTests,
@@ -52,6 +53,27 @@ describe('data-cache', () => {
       _setEncryptedCacheAvailableForTests(false)
 
       expect(isCacheEnabled()).toBe(false)
+
+      process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = previous
+    })
+
+    it('reports privacy-safe cache capability diagnostics', () => {
+      const previous = process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED
+      process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'
+      _setEncryptedCacheAvailableForTests(true)
+
+      expect(getCacheCapabilityStatus()).toEqual({
+        featureFlagEnabled: true,
+        encryptedEnvelopeAvailable: true,
+        enabled: true,
+      })
+
+      _setEncryptedCacheAvailableForTests(false)
+      expect(getCacheCapabilityStatus()).toEqual({
+        featureFlagEnabled: true,
+        encryptedEnvelopeAvailable: false,
+        enabled: false,
+      })
 
       process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = previous
     })

--- a/apps/web/app/lib/__tests__/sync-timing.test.ts
+++ b/apps/web/app/lib/__tests__/sync-timing.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  elapsedMs,
+  getCalendarSyncStartedAt,
+  isSyncTimingEnabled,
+  logCalendarPaintTiming,
+  logSyncTiming,
+  markCalendarSyncStart,
+} from '../sync-timing'
+
+describe('sync timing helpers', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    delete (globalThis as unknown as Record<string, unknown>).__silentsuiteCalendarSyncStartedAt
+    window.localStorage.clear()
+    window.history.replaceState(null, '', '/')
+    process.env.NODE_ENV = originalNodeEnv
+  })
+
+  it('rounds elapsed milliseconds without going negative', () => {
+    expect(elapsedMs(10, 42.4)).toBe(32)
+    expect(elapsedMs(42, 10)).toBe(0)
+  })
+
+  it('stores and reads the calendar sync start marker', () => {
+    markCalendarSyncStart(123)
+    expect(getCalendarSyncStartedAt()).toBe(123)
+  })
+
+  it('enables timing logs in production only when explicitly requested', () => {
+    process.env.NODE_ENV = 'production'
+
+    expect(isSyncTimingEnabled()).toBe(false)
+
+    window.localStorage.setItem('silentsuite:syncTiming', 'true')
+    expect(isSyncTimingEnabled()).toBe(true)
+
+    window.localStorage.clear()
+    window.history.replaceState(null, '', '/calendar?syncTiming=1')
+    expect(isSyncTimingEnabled()).toBe(true)
+  })
+
+  it('logs privacy-safe sync timing fields when enabled', () => {
+    process.env.NODE_ENV = 'production'
+    window.localStorage.setItem('silentsuite:syncTiming', 'true')
+
+    logSyncTiming('calendar-fetch', 100, { itemCount: 12, source: 'server' })
+
+    expect(console.info).toHaveBeenCalledWith('[sync-provider] timing', expect.objectContaining({
+      phase: 'calendar-fetch',
+      itemCount: 12,
+      source: 'server',
+      elapsedMs: expect.any(Number),
+    }))
+  })
+
+  it('logs first paint relative to the sync marker when available', () => {
+    process.env.NODE_ENV = 'production'
+    window.localStorage.setItem('silentsuite:syncTiming', 'true')
+    markCalendarSyncStart(100)
+
+    logCalendarPaintTiming({ eventCount: 5 })
+
+    expect(console.info).toHaveBeenCalledWith('[calendar-grid] timing', expect.objectContaining({
+      phase: 'first-events-paint',
+      elapsedSinceSyncStartMs: expect.any(Number),
+      eventCount: 5,
+    }))
+  })
+})

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -379,13 +379,33 @@ export async function ensureFingerprint(accountFingerprint: string): Promise<boo
 
 // ── Feature flag helper ──
 
+export interface CacheCapabilityStatus {
+  featureFlagEnabled: boolean
+  encryptedEnvelopeAvailable: boolean
+  enabled: boolean
+}
+
+/**
+ * Privacy-safe cache capability status for sync timing diagnostics. Contains
+ * only booleans; no account identifiers, item contents, or collection IDs.
+ */
+export function getCacheCapabilityStatus(): CacheCapabilityStatus {
+  const featureFlagEnabled = process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED === 'true'
+  const encryptedEnvelopeAvailable = hasEncryptedCacheEnvelope()
+  return {
+    featureFlagEnabled,
+    encryptedEnvelopeAvailable,
+    enabled: featureFlagEnabled && encryptedEnvelopeAvailable,
+  }
+}
+
 /**
  * Returns true only when the local cache feature is enabled and encrypted
  * cache storage is available. Off by default, and fail-closed if the flag is
  * enabled before encryption exists.
  */
 export function isCacheEnabled(): boolean {
-  return process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED === 'true' && hasEncryptedCacheEnvelope()
+  return getCacheCapabilityStatus().enabled
 }
 
 // ── Test helpers ──

--- a/apps/web/app/lib/sync-timing.ts
+++ b/apps/web/app/lib/sync-timing.ts
@@ -1,0 +1,69 @@
+const GLOBAL_CALENDAR_SYNC_STARTED_AT = '__silentsuiteCalendarSyncStartedAt'
+const LOCAL_STORAGE_SYNC_TIMING = 'silentsuite:syncTiming'
+
+export interface SyncTimingFields {
+  [key: string]: string | number | boolean | null | undefined
+}
+
+export function nowMs(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now()
+  }
+  return Date.now()
+}
+
+export function elapsedMs(startedAt: number, endedAt = nowMs()): number {
+  return Math.max(0, Math.round(endedAt - startedAt))
+}
+
+export function markCalendarSyncStart(startedAt = nowMs()): number {
+  ;(globalThis as unknown as Record<string, number>)[GLOBAL_CALENDAR_SYNC_STARTED_AT] = startedAt
+  return startedAt
+}
+
+export function getCalendarSyncStartedAt(): number | null {
+  const value = (globalThis as unknown as Record<string, unknown>)[GLOBAL_CALENDAR_SYNC_STARTED_AT]
+  return typeof value === 'number' ? value : null
+}
+
+/**
+ * Timing logs are enabled automatically in local development. Production and
+ * Cloudflare preview builds can enable them before reload with:
+ *
+ *   localStorage.setItem('silentsuite:syncTiming', 'true')
+ *
+ * or on a single page load with `?syncTiming=1`. Logged fields are counts,
+ * booleans, phase names, and durations only — never PIM content or IDs.
+ */
+export function isSyncTimingEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'production') return true
+  if (typeof window === 'undefined') return false
+  try {
+    return window.localStorage.getItem(LOCAL_STORAGE_SYNC_TIMING) === 'true' ||
+      new URLSearchParams(window.location.search).get('syncTiming') === '1'
+  } catch {
+    return false
+  }
+}
+
+function logTiming(label: string, payload: SyncTimingFields): void {
+  if (!isSyncTimingEnabled()) return
+  console.info(label, payload)
+}
+
+export function logSyncTiming(phase: string, startedAt: number, fields: SyncTimingFields = {}): void {
+  logTiming('[sync-provider] timing', {
+    phase,
+    elapsedMs: elapsedMs(startedAt),
+    ...fields,
+  })
+}
+
+export function logCalendarPaintTiming(fields: SyncTimingFields = {}): void {
+  const syncStartedAt = getCalendarSyncStartedAt()
+  logTiming('[calendar-grid] timing', {
+    phase: 'first-events-paint',
+    elapsedSinceSyncStartMs: syncStartedAt === null ? null : elapsedMs(syncStartedAt),
+    ...fields,
+  })
+}

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -13,8 +13,14 @@ import {
   getItemsByType as cacheGetItemsByType,
   replaceItemsForType as cacheReplaceItemsForType,
   isCacheEnabled as isLocalCacheEnabled,
+  getCacheCapabilityStatus,
   type CachedItem,
 } from '@/app/lib/data-cache'
+import {
+  logSyncTiming,
+  markCalendarSyncStart,
+  nowMs,
+} from '@/app/lib/sync-timing'
 import {
   createSafeOperationalError,
   getSafeErrorDetails,
@@ -44,9 +50,11 @@ async function deserializeCalendarItemsIncrementally(
   deserializeCalendarEvent: (content: string) => CalendarEvent,
   source: 'cache' | 'server',
 ): Promise<{ events: CalendarEvent[]; errors: unknown[] }> {
+  const startedAt = nowMs()
   const { priority, backlog } = partitionCalendarItemsForFastPaint(items)
   const allEvents: CalendarEvent[] = []
   const errors: unknown[] = []
+  let firstStoreUpdateLogged = false
 
   async function processGroup(group: CalendarContentItem[], groupName: 'priority' | 'backlog') {
     for (let start = 0; start < group.length; start += CALENDAR_DESERIALIZE_CHUNK_SIZE) {
@@ -66,6 +74,17 @@ async function deserializeCalendarItemsIncrementally(
       if (chunkEvents.length > 0) {
         allEvents.push(...chunkEvents)
         useCalendarStore.getState().upsertFromRemote(chunkEvents)
+        if (!firstStoreUpdateLogged) {
+          firstStoreUpdateLogged = true
+          logSyncTiming('calendar-first-store-update', startedAt, {
+            source,
+            group: groupName,
+            chunkEventCount: chunkEvents.length,
+            totalItemCount: items.length,
+            priorityItemCount: priority.length,
+            backlogItemCount: backlog.length,
+          })
+        }
         logger.debug(
           `[sync-provider] Loaded ${chunkEvents.length} ${source} calendar events from ${groupName} chunk`,
         )
@@ -84,6 +103,14 @@ async function deserializeCalendarItemsIncrementally(
   // Final replace is still required: it preserves full-history search while
   // dropping items that were deleted remotely after the previous local state.
   useCalendarStore.getState().syncFromRemote(allEvents)
+  logSyncTiming('calendar-deserialize-complete', startedAt, {
+    source,
+    totalItemCount: items.length,
+    priorityItemCount: priority.length,
+    backlogItemCount: backlog.length,
+    eventCount: allEvents.length,
+    errorCount: errors.length,
+  })
   return { events: allEvents, errors }
 }
 
@@ -124,8 +151,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     let unsubStatus: (() => void) | null = null
 
     async function init() {
+      const initStartedAt = markCalendarSyncStart()
       try {
         setSyncStatus('syncing')
+        const cacheStatus = getCacheCapabilityStatus()
+        logSyncTiming('cache-capability', initStartedAt, { ...cacheStatus })
 
         // Cache-first hydration: when the feature flag is on, paint the UI
         // from IndexedDB before the network sync starts. This is best-effort
@@ -135,7 +165,9 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         }
 
         // Restore session, create/fetch collections, load items, start SyncEngine
+        const etebaseInitStartedAt = nowMs()
         await etebaseInitialize()
+        logSyncTiming('etebase-initialize', etebaseInitStartedAt)
 
         // Now load items from each collection into the data stores
         const loadHadErrors = await loadItemsIntoStores()
@@ -154,6 +186,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           setError(null)
         }
         setLastSynced(new Date())
+        logSyncTiming('initial-sync-complete', initStartedAt, { hadErrors: loadHadErrors })
       } catch (err) {
         reportSyncError('init', err)
         setSyncStatus('error')
@@ -172,6 +205,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
      * Failures here are non-fatal; we just skip the optimistic paint.
      */
     async function hydrateFromCache() {
+      const cacheHydrateStartedAt = nowMs()
       try {
         const [taskItems, contactItems, eventItems, core] = await Promise.all([
           cacheGetItemsByType('tasks'),
@@ -206,6 +240,12 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           }
         }
 
+        logSyncTiming('cache-read', cacheHydrateStartedAt, {
+          taskItemCount: taskItems.length,
+          contactItemCount: contactItems.length,
+          calendarItemCount: eventItems.length,
+        })
+
         if (eventItems.length > 0) {
           try {
             const { events, errors } = await deserializeCalendarItemsIncrementally(
@@ -228,8 +268,14 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             logger.warn('[sync-provider] Failed to hydrate calendar events from cache', getSafeErrorDetails(err))
           }
         }
+        logSyncTiming('cache-hydrate-complete', cacheHydrateStartedAt, {
+          taskItemCount: taskItems.length,
+          contactItemCount: contactItems.length,
+          calendarItemCount: eventItems.length,
+        })
       } catch (err) {
         logger.warn('[sync-provider] Cache hydration failed', getSafeErrorDetails(err))
+        logSyncTiming('cache-hydrate-failed', cacheHydrateStartedAt)
       }
     }
 
@@ -243,6 +289,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         items: { uid: string; content: string; collectionUid: string }[],
       ) {
         if (!cacheEnabled || items.length === 0) return
+        const mirrorStartedAt = nowMs()
         const records: CachedItem[] = items.map((it) => ({
           itemUid: it.uid,
           collectionType: type,
@@ -252,16 +299,21 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         }))
         try {
           await cacheReplaceItemsForType(type, records)
+          logSyncTiming('cache-mirror', mirrorStartedAt, { type, itemCount: items.length })
         } catch (err) {
           logger.warn(`[sync-provider] Failed to mirror ${type} to cache`, getSafeErrorDetails(err))
+          logSyncTiming('cache-mirror-failed', mirrorStartedAt, { type, itemCount: items.length })
         }
       }
 
       // Load calendar events first so the calendar can paint before unrelated
       // task/contact deserialization work on large accounts.
       try {
+        const calendarFetchStartedAt = nowMs()
         const eventItems = await etebase.fetchAllItems('calendar')
+        logSyncTiming('calendar-fetch', calendarFetchStartedAt, { itemCount: eventItems.length })
         if (eventItems.length > 0) {
+          const calendarImportStartedAt = nowMs()
           const { deserializeCalendarEvent } = await import('@silentsuite/core')
           const { events, errors } = await deserializeCalendarItemsIncrementally(
             eventItems,
@@ -269,6 +321,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             'server',
           )
           logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
+          logSyncTiming('calendar-load', calendarImportStartedAt, {
+            itemCount: eventItems.length,
+            eventCount: events.length,
+            errorCount: errors.length,
+          })
           if (errors.length > 0) {
             hadErrors = true
             reportSyncError('load calendar event chunk', errors[0])
@@ -282,6 +339,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
       // Load tasks
       try {
+        const taskLoadStartedAt = nowMs()
         const taskItems = await etebase.fetchAllItems('tasks')
         if (taskItems.length > 0) {
           const { deserializeTask } = await import('@silentsuite/core')
@@ -293,7 +351,10 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           })
           useTaskStore.getState().syncFromRemote(tasks)
           logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
+          logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: taskItems.length, taskCount: tasks.length })
           await mirrorToCache('tasks', taskItems)
+        } else {
+          logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: 0, taskCount: 0 })
         }
       } catch (err) {
         hadErrors = true
@@ -302,6 +363,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
       // Load contacts
       try {
+        const contactLoadStartedAt = nowMs()
         const contactItems = await etebase.fetchAllItems('contacts')
         if (contactItems.length > 0) {
           const { deserializeContact } = await import('@silentsuite/core')
@@ -311,7 +373,10 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           })
           useContactStore.getState().syncFromRemote(contacts)
           logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
+          logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: contactItems.length, contactCount: contacts.length })
           await mirrorToCache('contacts', contactItems)
+        } else {
+          logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: 0, contactCount: 0 })
         }
       } catch (err) {
         hadErrors = true
@@ -322,7 +387,9 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       // cache is ready. Preferences stay in their own local store because one
       // field, notificationSound, is intentionally device-local.
       try {
+        const preferencesStartedAt = nowMs()
         await usePreferencesSyncStore.getState().initialize()
+        logSyncTiming('preferences-initialize', preferencesStartedAt)
       } catch (err) {
         hadErrors = true
         reportSyncError('initialize preferences sync', err)


### PR DESCRIPTION
## Summary
- Add privacy-safe timing diagnostics for the calendar sync path so calendar-loading complaints are grounded in measured phases.
- Log cache capability booleans, cache read/hydration timing, Etebase initialization, calendar fetch/deserialization/first store update, task/contact/preference load timing, and initial sync completion.
- Add a first visible calendar-events paint milestone in `CalendarGrid` without logging event titles, timestamps, labels, IDs, or item content.
- Expose privacy-safe cache capability status so preview/browser logs can show whether cache-first paint is actually available.

## Why
The prior calendar-loading change only optimized post-fetch deserialization. User-perceived speed can still be dominated by session restore, Etebase init, collection fetch, or the local cache being disabled. These logs identify the actual bottleneck before another optimization slice.

## Validation
- `pnpm --filter @silentsuite/web test -- app/lib/__tests__/sync-timing.test.ts app/lib/__tests__/data-cache.test.ts app/lib/__tests__/calendar-loading.test.ts` — passed; Vitest ran the related web suite (`35` files / `329` tests).
- `pnpm --filter @silentsuite/web type-check` — passed.
- `git diff --check` — passed.
