### PR TITLE
Polish calendar day bounds and event chips

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -95,8 +95,8 @@ function snapTo30Min(date: Date): Date {
   return snapped
 }
 
-const DEFAULT_DAY_START_HOUR = 0
-const DEFAULT_DAY_END_HOUR = 24
+const DEFAULT_DAY_START_HOUR = 7
+const DEFAULT_DAY_END_HOUR = 23
 
 /** Find the display event under the cursor by matching click coordinates to day column + time */
 function findEventAtPosition(

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -619,27 +619,37 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     return () => cancelAnimationFrame(raf)
   }, [currentView, displayEvents.length, events.length, sxEvents.length])
 
-  // #331: Reveal the full title on short/clipped calendar events.
-  // Schedule-X clips event text with `overflow: hidden`, so a short event's
-  // title can be unreadable. The DOM still holds the full text, so mirror it
-  // into a native `title` tooltip on each event element so hovering shows the
-  // complete title (and time). A MutationObserver keeps titles in sync across
-  // re-renders, sync updates, and view switches.
+  // #331: Reveal the full title on short/clipped calendar events and mark event
+  // chips by rendered height so CSS can hide low-priority metadata before it
+  // gets half-clipped. Schedule-X lays out timed events with inline heights, so
+  // this must be measured after render rather than inferred from duration.
   useEffect(() => {
     const root = document.querySelector('.sx-silentsuite-calendar')
     if (!root) return
 
     const selector = '.sx__time-grid-event, .sx__month-grid-event, .sx__day-grid-event'
+    let raf = 0
+    let resizeObserver: ResizeObserver | null = null
+
     const applyAll = () => {
       root.querySelectorAll(selector).forEach((el) => {
         const text = (el.textContent || '').replace(/\s+/g, ' ').trim()
         if (text && el.getAttribute('title') !== text) {
           el.setAttribute('title', text)
         }
+
+        if (el.classList.contains('sx__time-grid-event')) {
+          const timedEvent = el as HTMLElement
+          resizeObserver?.observe(timedEvent)
+          const height = timedEvent.getBoundingClientRect().height
+          const size = height < 34 ? 'tiny' : height < 58 ? 'small' : height < 92 ? 'medium' : 'large'
+          if (timedEvent.dataset.ssEventSize !== size) {
+            timedEvent.dataset.ssEventSize = size
+          }
+        }
       })
     }
 
-    let raf = 0
     const schedule = () => {
       if (raf) return
       raf = requestAnimationFrame(() => {
@@ -648,11 +658,13 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       })
     }
 
+    resizeObserver = new ResizeObserver(schedule)
     applyAll()
     const observer = new MutationObserver(schedule)
     observer.observe(root, { childList: true, subtree: true })
     return () => {
       if (raf) cancelAnimationFrame(raf)
+      resizeObserver.disconnect()
       observer.disconnect()
     }
   }, [sxEvents, currentView])
@@ -666,7 +678,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       const pixelsPerHour = gridEl.scrollHeight / totalHours
       return dayStartHour + relativeY / pixelsPerHour
     },
-    [],
+    [dayStartHour, dayEndHour],
   )
 
   /** Find which day column the X coordinate is within */

--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts
@@ -11,13 +11,13 @@ describe('calendar day boundaries', () => {
     expect(formatDayBoundary(0)).toBe('00:00')
     expect(formatDayBoundary(6)).toBe('06:00')
     expect(formatDayBoundary(24)).toBe('24:00')
-    expect(toScheduleXDayBoundariesExternal(0, 24)).toEqual({ start: '00:00', end: '24:00' })
+    expect(toScheduleXDayBoundariesExternal(7, 23)).toEqual({ start: '07:00', end: '23:00' })
   })
 
   it('formats live Schedule-X signal updates as internal numeric time points', () => {
     expect(hourToScheduleXTimePoint(0)).toBe(0)
     expect(hourToScheduleXTimePoint(6)).toBe(600)
     expect(hourToScheduleXTimePoint(24)).toBe(2400)
-    expect(toScheduleXDayBoundariesInternal(0, 24)).toEqual({ start: 0, end: 2400 })
+    expect(toScheduleXDayBoundariesInternal(7, 23)).toEqual({ start: 700, end: 2300 })
   })
 })

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -312,6 +312,38 @@
   flex: 0 0 auto;
 }
 
+/* Keep timed events clean at every height. Schedule-X may render 30-minute and
+   60-minute chips too short for title, time, and location. The React wrapper
+   marks chips by measured height so we can hide lower-priority metadata before
+   it is visibly cut off. The full text remains available through the native
+   tooltip set on the event element. */
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="tiny"] .sx__time-grid-event-inner,
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="small"] .sx__time-grid-event-inner {
+  justify-content: center;
+  gap: 0;
+  padding-block: 2px !important;
+}
+
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="tiny"] .sx__time-grid-event-location,
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="tiny"] .sx__time-grid-event-people,
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="small"] .sx__time-grid-event-location,
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="small"] .sx__time-grid-event-people,
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="medium"] .sx__time-grid-event-location,
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="medium"] .sx__time-grid-event-people {
+  display: none !important;
+}
+
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="tiny"] .sx__title-and-time-compact,
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="small"] .sx__title-and-time-compact,
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="medium"] .sx__title-and-time-compact {
+  align-items: center;
+}
+
+.sx-silentsuite-calendar .sx__time-grid-event[data-ss-event-size="tiny"] .sx__time-grid-event-inner {
+  font-size: 0.68rem;
+  line-height: 1.05;
+}
+
 /* For 30-minute/short events Schedule-X uses the compact title+time row.
    Keep those chips single-line so location/extra metadata cannot be half-clipped. */
 .sx-silentsuite-calendar .sx__time-grid-event-inner:has(.sx__title-and-time-compact) {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -257,6 +257,7 @@
   border-radius: 6px !important;
   border: none !important;
   margin: 1px 3px !important;
+  padding: 0 !important;
   overflow: hidden;
   box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
   transition: box-shadow 0.15s ease, transform 0.1s ease;
@@ -269,13 +270,58 @@
 }
 
 .sx-silentsuite-calendar .sx__time-grid-event-inner {
-  padding: 2px 8px !important;
-  font-size: 0.75rem;
+  height: 100%;
+  min-height: 0;
+  padding: 3px 8px !important;
+  font-size: 0.72rem;
   font-weight: 500;
-  line-height: 1.25;
+  line-height: 1.15;
   border-radius: 6px !important;
   border: none !important;
   border-left: none !important;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 1px;
+}
+
+.sx-silentsuite-calendar .sx__time-grid-event-title,
+.sx-silentsuite-calendar .sx__time-grid-event-time,
+.sx-silentsuite-calendar .sx__time-grid-event-people,
+.sx-silentsuite-calendar .sx__time-grid-event-location {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sx-silentsuite-calendar .sx__title-and-time-compact {
+  width: 100%;
+  min-width: 0;
+  gap: 6px;
+}
+
+.sx-silentsuite-calendar .sx__title-and-time-compact .sx__time-grid-event-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.sx-silentsuite-calendar .sx__title-and-time-compact .sx__time-grid-event-time {
+  flex: 0 0 auto;
+}
+
+/* For 30-minute/short events Schedule-X uses the compact title+time row.
+   Keep those chips single-line so location/extra metadata cannot be half-clipped. */
+.sx-silentsuite-calendar .sx__time-grid-event-inner:has(.sx__title-and-time-compact) {
+  justify-content: center;
+  padding-block: 2px !important;
+}
+
+.sx-silentsuite-calendar .sx__time-grid-event-inner:has(.sx__title-and-time-compact) .sx__time-grid-event-location,
+.sx-silentsuite-calendar .sx__time-grid-event-inner:has(.sx__title-and-time-compact) .sx__time-grid-event-people {
+  display: none !important;
 }
 
 .sx-silentsuite-calendar .sx__time-grid-event-inner::before {

--- a/apps/web/app/stores/__tests__/use-preferences-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-preferences-store.test.ts
@@ -13,6 +13,44 @@ describe('usePreferencesStore synced preferences', () => {
     resetPreferencesStore()
   })
 
+  it('defaults the visible calendar day to 07:00-23:00', () => {
+    expect(usePreferencesStore.getState()).toMatchObject({
+      dayStartHour: 7,
+      dayEndHour: 23,
+    })
+  })
+
+  it('migrates unchanged old full-day local defaults to 07:00-23:00', async () => {
+    localStorage.setItem('silentsuite-preferences', JSON.stringify({
+      state: {
+        timeFormat: '12h',
+        firstDayOfWeek: 'monday',
+        defaultReminder: '15',
+        defaultTimezone: 'UTC',
+        dateFormat: 'system',
+        dayStartHour: 0,
+        dayEndHour: 24,
+        syncedPreferenceUpdatedAt: {
+          timeFormat: 0,
+          firstDayOfWeek: 0,
+          defaultReminder: 0,
+          defaultTimezone: 0,
+          dateFormat: 0,
+          dayStartHour: 0,
+          dayEndHour: 0,
+        },
+      },
+      version: 1,
+    }))
+
+    await usePreferencesStore.persist.rehydrate()
+
+    expect(usePreferencesStore.getState()).toMatchObject({
+      dayStartHour: 7,
+      dayEndHour: 23,
+    })
+  })
+
   it('does not include notificationSound in remote preferences', () => {
     usePreferencesStore.setState({ notificationSound: false })
     usePreferencesStore.getState().setTimeFormat('24h')

--- a/apps/web/app/stores/use-preferences-store.ts
+++ b/apps/web/app/stores/use-preferences-store.ts
@@ -48,9 +48,7 @@ interface PersistedPreferencesState extends Partial<SyncedPreferenceValues> {
 
 function migrateStoredPreferences(persisted: unknown): unknown {
   if (!persisted || typeof persisted !== 'object') return persisted
-  const root = persisted as { state?: PersistedPreferencesState }
-  const state = root.state
-  if (!state) return persisted
+  const state = persisted as PersistedPreferencesState
 
   const dayStartWasOldDefault = state.dayStartHour === 0
   const dayEndWasOldDefault = state.dayEndHour === 24
@@ -59,14 +57,14 @@ function migrateStoredPreferences(persisted: unknown): unknown {
     && (state.syncedPreferenceUpdatedAt?.dayEndHour ?? 0) === 0
 
   if (dayStartWasOldDefault && dayEndWasOldDefault && dayBoundsWereNeverChanged) {
-    root.state = {
+    return {
       ...state,
       dayStartHour: DEFAULT_SYNCED_PREFERENCES.dayStartHour,
       dayEndHour: DEFAULT_SYNCED_PREFERENCES.dayEndHour,
     }
   }
 
-  return root
+  return persisted
 }
 
 interface PreferencesState {

--- a/apps/web/app/stores/use-preferences-store.ts
+++ b/apps/web/app/stores/use-preferences-store.ts
@@ -42,6 +42,33 @@ function normalizeValues(values: Partial<SyncedPreferenceValues>): SyncedPrefere
   return getSyncedPreferenceValues(createSyncedPreferences({ ...defaultSyncedValues(), ...values }, zeroTimestamps(), 0))
 }
 
+interface PersistedPreferencesState extends Partial<SyncedPreferenceValues> {
+  syncedPreferenceUpdatedAt?: Partial<SyncedPreferenceTimestamps>
+}
+
+function migrateStoredPreferences(persisted: unknown): unknown {
+  if (!persisted || typeof persisted !== 'object') return persisted
+  const root = persisted as { state?: PersistedPreferencesState }
+  const state = root.state
+  if (!state) return persisted
+
+  const dayStartWasOldDefault = state.dayStartHour === 0
+  const dayEndWasOldDefault = state.dayEndHour === 24
+  const dayBoundsWereNeverChanged =
+    (state.syncedPreferenceUpdatedAt?.dayStartHour ?? 0) === 0
+    && (state.syncedPreferenceUpdatedAt?.dayEndHour ?? 0) === 0
+
+  if (dayStartWasOldDefault && dayEndWasOldDefault && dayBoundsWereNeverChanged) {
+    root.state = {
+      ...state,
+      dayStartHour: DEFAULT_SYNCED_PREFERENCES.dayStartHour,
+      dayEndHour: DEFAULT_SYNCED_PREFERENCES.dayEndHour,
+    }
+  }
+
+  return root
+}
+
 interface PreferencesState {
   timeFormat: TimeFormat
   firstDayOfWeek: FirstDayOfWeek
@@ -155,6 +182,8 @@ export const usePreferencesStore = create<PreferencesState>()(
     }),
     {
       name: 'silentsuite-preferences',
+      version: 2,
+      migrate: migrateStoredPreferences,
     },
   ),
 )

--- a/packages/core/src/models/preferences.test.ts
+++ b/packages/core/src/models/preferences.test.ts
@@ -37,8 +37,8 @@ describe('synced preferences', () => {
       defaultReminder: '30',
       defaultTimezone: 'Europe/Amsterdam',
       dateFormat: 'system',
-      dayStartHour: 0,
-      dayEndHour: 24,
+      dayStartHour: 7,
+      dayEndHour: 23,
     });
     expect(restored.updatedAt).toBe(99);
   });
@@ -61,8 +61,8 @@ describe('synced preferences', () => {
       defaultReminder: '15',
       defaultTimezone: 'UTC',
       dateFormat: 'system',
-      dayStartHour: 0,
-      dayEndHour: 24,
+      dayStartHour: 7,
+      dayEndHour: 23,
     });
   });
 
@@ -72,7 +72,7 @@ describe('synced preferences', () => {
     expect(getSyncedPreferenceValues(valid)).toMatchObject({ dayStartHour: 7, dayEndHour: 19 });
 
     const invalid = createSyncedPreferences({ dayStartHour: 22, dayEndHour: 6 }, {}, 42);
-    expect(getSyncedPreferenceValues(invalid)).toMatchObject({ dayStartHour: 0, dayEndHour: 24 });
+    expect(getSyncedPreferenceValues(invalid)).toMatchObject({ dayStartHour: 7, dayEndHour: 23 });
   });
 
   it('merges by newest timestamp per field', () => {
@@ -113,8 +113,8 @@ describe('synced preferences', () => {
       defaultReminder: '60',
       defaultTimezone: 'Europe/Amsterdam',
       dateFormat: 'system',
-      dayStartHour: 0,
-      dayEndHour: 24,
+      dayStartHour: 7,
+      dayEndHour: 23,
     });
   });
 });

--- a/packages/core/src/models/preferences.ts
+++ b/packages/core/src/models/preferences.ts
@@ -52,8 +52,8 @@ export const DEFAULT_SYNCED_PREFERENCES: SyncedPreferenceValues = {
   defaultReminder: '15',
   defaultTimezone: 'UTC',
   dateFormat: 'system',
-  dayStartHour: 0,
-  dayEndHour: 24,
+  dayStartHour: 7,
+  dayEndHour: 23,
 };
 
 const DEFAULT_TIMESTAMPS: SyncedPreferenceTimestamps = {


### PR DESCRIPTION
## Summary
- default visible calendar day now starts at 07:00 and ends at 23:00
- migrate unchanged old 00:00-24:00 local preference defaults to the new default range
- tighten Schedule-X timed event chip CSS so short events keep title/time on one clean row and hide half-clipped metadata

## Validation
- `pnpm --filter @silentsuite/core test -- src/models/preferences.test.ts`
- `pnpm --filter @silentsuite/web test -- 'app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts'`
- `pnpm --filter @silentsuite/web type-check`
- `git diff --check`
