### PR TITLE
Add mobile 3-day calendar view

### DIFF
--- a/apps/web/app/(app)/calendar/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/calendar/__tests__/page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, within } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CalendarPage from '../page'
@@ -28,6 +28,8 @@ const storeMock = vi.hoisted(() => ({
     navigateToday: vi.fn(),
     selectedEventId: null as string | null,
     setSelectedEvent: vi.fn(),
+    setCurrentDate: vi.fn(),
+    setCurrentView: vi.fn(),
     searchQuery: '',
     setSearchQuery: vi.fn(),
     getFilteredEvents: () => storeMock.calendarState.events,
@@ -53,7 +55,7 @@ vi.mock('@/app/stores/use-auth-store', () => ({
 }))
 
 vi.mock('@/app/stores/use-preferences-store', () => ({
-  usePreferencesStore: (selector: (state: { dateFormat: 'system' }) => unknown) => selector({ dateFormat: 'system' }),
+  usePreferencesStore: (selector: (state: { dateFormat: 'system'; firstDayOfWeek: 'monday' }) => unknown) => selector({ dateFormat: 'system', firstDayOfWeek: 'monday' }),
 }))
 
 vi.mock('@/app/components/PullToRefresh', () => ({
@@ -65,8 +67,8 @@ vi.mock('../components/CalendarViewSwitcher', () => ({
 }))
 
 vi.mock('../components/CalendarGrid', () => ({
-  CalendarGrid: ({ events }: { events: { title: string }[] }) => (
-    <div data-testid="desktop-grid">
+  CalendarGrid: ({ events, displayView }: { events: { title: string }[]; displayView?: 'threeDay' }) => (
+    <div data-testid={displayView === 'threeDay' ? 'mobile-three-day-grid' : 'desktop-grid'} data-display-view={displayView ?? 'store'}>
       {events.map((event) => <span key={event.title}>{event.title}</span>)}
     </div>
   ),
@@ -92,16 +94,29 @@ vi.mock('@/app/components/MobileCollectionSheet', () => ({
   MobileCollectionSheet: ({ open }: { open: boolean }) => (open ? <div data-testid="collection-sheet" /> : null),
 }))
 
+function resetCalendarMocks() {
+  storeMock.calendarState.currentView = 'week'
+  storeMock.calendarState.currentDate = new Date('2026-06-01T12:00:00Z')
+  storeMock.calendarState.selectedEventId = null
+  storeMock.calendarState.searchQuery = ''
+  storeMock.calendarState.navigateForward.mockReset()
+  storeMock.calendarState.navigateBackward.mockReset()
+  storeMock.calendarState.navigateToday.mockReset()
+  storeMock.calendarState.setSelectedEvent.mockReset()
+  storeMock.calendarState.setCurrentDate.mockReset()
+  storeMock.calendarState.setCurrentView.mockReset()
+  storeMock.calendarState.setSearchQuery.mockReset()
+  storeMock.authState.canWrite.mockReturnValue(true)
+}
+
 describe('CalendarPage calendar visibility', () => {
   beforeEach(() => {
+    resetCalendarMocks()
     storeMock.calendarState.isLoading = false
     storeMock.calendarState.events = [
       { id: 'visible-event', calendarId: 'visible-cal', title: 'Visible event' },
       { id: 'hidden-event', calendarId: 'hidden-cal', title: 'Hidden event' },
     ]
-    storeMock.calendarState.selectedEventId = null
-    storeMock.calendarState.searchQuery = ''
-    storeMock.calendarState.setSearchQuery.mockReset()
     storeMock.calendarListState.calendars = [
       { id: 'visible-cal', name: 'Visible', color: '#10b981', visible: true },
       { id: 'hidden-cal', name: 'Hidden', color: '#ef4444', visible: false },
@@ -119,15 +134,25 @@ describe('CalendarPage calendar visibility', () => {
     expect(mobileAgenda.getByText('Visible event')).toBeInTheDocument()
     expect(mobileAgenda.queryByText('Hidden event')).not.toBeInTheDocument()
   })
+
+  it('keeps hidden calendar events out of the mobile 3-day grid', () => {
+    renderWithIntl(<CalendarPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: '3 days' }))
+
+    const mobileGrid = within(screen.getByTestId('mobile-three-day-grid'))
+    expect(mobileGrid.getByText('Visible event')).toBeInTheDocument()
+    expect(mobileGrid.queryByText('Hidden event')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-agenda')).not.toBeInTheDocument()
+  })
 })
 
 describe('CalendarPage mobile reachability', () => {
   beforeEach(() => {
+    resetCalendarMocks()
     storeMock.calendarState.isLoading = true
     storeMock.calendarState.events = []
-    storeMock.calendarState.searchQuery = ''
     storeMock.calendarListState.calendars = []
-    storeMock.authState.canWrite.mockReturnValue(true)
   })
 
   it('exposes mobile nav buttons with a mobile-scoped 44px hit area', () => {
@@ -161,6 +186,50 @@ describe('CalendarPage mobile reachability', () => {
     expect(mobileToday).toBeDefined()
     expect(mobileToday!.className).toContain('max-md:min-w-[44px]')
     expect(mobileToday!.className).not.toContain('touch-target')
+  })
+
+  it('exposes mobile Agenda and 3-day view controls with accessible state', () => {
+    renderWithIntl(<CalendarPage />)
+
+    const agenda = screen.getByRole('button', { name: 'Agenda' })
+    const threeDays = screen.getByRole('button', { name: '3 days' })
+
+    expect(agenda.className).toContain('max-md:min-h-[44px]')
+    expect(threeDays.className).toContain('max-md:min-h-[44px]')
+    expect(agenda).toHaveAttribute('aria-pressed', 'true')
+    expect(threeDays).toHaveAttribute('aria-pressed', 'false')
+
+    fireEvent.click(threeDays)
+
+    expect(threeDays).toHaveAttribute('aria-pressed', 'true')
+    expect(storeMock.calendarState.setCurrentView).not.toHaveBeenCalledWith('threeDay')
+  })
+
+  it('moves mobile 3-day navigation in 3-day increments without changing the desktop view', () => {
+    renderWithIntl(<CalendarPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: '3 days' }))
+
+    const mobileNext = screen.getAllByRole('button', { name: 'Next' }).find((btn) => btn.className.includes('max-md:min-h-[44px]'))!
+    fireEvent.click(mobileNext)
+    expect(storeMock.calendarState.setCurrentDate).toHaveBeenLastCalledWith(new Date('2026-06-04T12:00:00Z'))
+    expect(storeMock.calendarState.navigateForward).not.toHaveBeenCalled()
+
+    const mobilePrevious = screen.getAllByRole('button', { name: 'Previous' }).find((btn) => btn.className.includes('max-md:min-h-[44px]'))!
+    fireEvent.click(mobilePrevious)
+    expect(storeMock.calendarState.setCurrentDate).toHaveBeenLastCalledWith(new Date('2026-05-29T12:00:00Z'))
+    expect(storeMock.calendarState.navigateBackward).not.toHaveBeenCalled()
+    expect(storeMock.calendarState.setCurrentView).not.toHaveBeenCalledWith('threeDay')
+  })
+
+  it('shows a short 3-day range label in mobile 3-day mode', () => {
+    storeMock.calendarState.currentDate = new Date('2026-12-31T12:00:00Z')
+
+    renderWithIntl(<CalendarPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: '3 days' }))
+
+    expect(screen.getByText('Dec 31, 2026 – Jan 2, 2027')).toBeInTheDocument()
   })
 
   it('exposes a mobile collection switcher with a 44px touch target', () => {

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -28,9 +28,17 @@ import '@schedule-x/theme-default/dist/index.css'
 // Temporal polyfill — patches globalThis.Temporal and registers types
 import 'temporal-polyfill/global'
 
-const VIEW_MAP: Record<CalendarView, string> = {
+type CalendarGridDisplayView = CalendarView | 'threeDay'
+
+const VIEW_MAP: Record<CalendarGridDisplayView, string> = {
+  threeDay: 'week',
   week: 'week',
   month: 'month-grid',
+}
+
+function toScheduleXWeekday(date: Date): number {
+  const day = date.getDay()
+  return day === 0 ? 7 : day
 }
 
 function toPlainDate(date: Date): Temporal.PlainDate {
@@ -51,9 +59,16 @@ function toScheduleXDateTime(date: Date, tz: string): Temporal.ZonedDateTime {
 }
 
 /** Get the visible date range for the current view, honoring the first-day preference */
-function getViewRange(currentDate: Date, view: CalendarView, firstDay: FirstDayOfWeek): DateRange {
+function getViewRange(currentDate: Date, view: CalendarGridDisplayView, firstDay: FirstDayOfWeek): DateRange {
   const d = new Date(currentDate)
   switch (view) {
+    case 'threeDay': {
+      const start = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+      const end = new Date(start)
+      end.setDate(start.getDate() + 2)
+      end.setHours(23, 59, 59, 999)
+      return { start, end }
+    }
     case 'week': {
       const start = startOfWeek(d, firstDay)
       const end = new Date(start)
@@ -171,14 +186,16 @@ export interface EventClickInfo {
 
 interface CalendarGridProps {
   events: CalendarEvent[]
+  displayView?: CalendarGridDisplayView
   onSlotClick?: (event: SlotClickEvent) => void
   onEventClick?: (info: EventClickInfo) => void
 }
 
-export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGridProps) {
+export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }: CalendarGridProps) {
   const { resolvedTheme } = useTheme()
   const canWrite = useAuthStore((s) => s.canWrite())
   const currentView = useCalendarStore((s) => s.currentView)
+  const effectiveView = displayView ?? currentView
   const currentDate = useCalendarStore((s) => s.currentDate)
   const setSelectedEvent = useCalendarStore((s) => s.setSelectedEvent)
   const setCurrentView = useCalendarStore((s) => s.setCurrentView)
@@ -194,7 +211,17 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const dayEndHour = usePreferencesStore((s) => s.dayEndHour ?? DEFAULT_DAY_END_HOUR)
   // Schedule-X WeekDay enum: MONDAY = 1 … SUNDAY = 7 (not 0-indexed).
   const sxFirstDayOfWeek = firstDayOfWeek === 'sunday' ? 7 : 1
+  const currentDateTs = currentDate instanceof Date ? currentDate.getTime() : new Date(currentDate).getTime()
+  const currentDateForSx = useMemo(
+    () => (currentDate instanceof Date ? currentDate : new Date(currentDate)),
+    [currentDateTs],
+  )
+  const effectiveSxFirstDayOfWeek = effectiveView === 'threeDay'
+    ? toScheduleXWeekday(currentDateForSx)
+    : sxFirstDayOfWeek
+  const effectiveWeekDays = effectiveView === 'threeDay' ? 3 : 7
 
+  const rootRef = useRef<HTMLDivElement>(null)
   const lastClickPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
 
   // Ref to prevent feedback loops between store↔Schedule-X sync
@@ -210,7 +237,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const [eventsPlugin] = useState(() => createEventsServicePlugin())
 
   // Expand recurring events for the visible range
-  const viewRange = useMemo(() => getViewRange(currentDate, currentView, firstDayOfWeek), [currentDate, currentView, firstDayOfWeek])
+  const viewRange = useMemo(() => getViewRange(currentDate, effectiveView, firstDayOfWeek), [currentDate, effectiveView, firstDayOfWeek])
   const displayEvents = useMemo(() => expandEventsForRange(events, viewRange), [events, viewRange])
 
   // Keep a ref map to look up display events by schedule-x id
@@ -225,8 +252,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   displayEventMapRef.current = displayEventMap
 
   const sxEvents = useMemo(
-    () => toScheduleXEvents(displayEvents, calendarColors, userTz, currentView, toScheduleXDateTime),
-    [displayEvents, calendarColors, userTz, currentView],
+    () => toScheduleXEvents(displayEvents, calendarColors, userTz, effectiveView === 'threeDay' ? 'week' : effectiveView, toScheduleXDateTime),
+    [displayEvents, calendarColors, userTz, effectiveView],
   )
 
   // Inject calendar color styles via useInsertionEffect (avoids dangerouslySetInnerHTML)
@@ -247,9 +274,8 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
 .${cls} * { color: #fff !important; }`
       })
       .join('\n')
-    return () => {
-      style.remove()
-    }
+    // Keep the shared style node in place across multiple CalendarGrid instances
+    // (desktop hidden grid + mobile 3-day grid can be mounted together).
   }, [calendarColors])
 
   const selectedDate = useMemo(() => toPlainDate(currentDate), [currentDate])
@@ -364,14 +390,14 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   const views = viewsRef.current
 
   // Capture initial view so useNextCalendarApp config doesn't change on view switch
-  const initialViewRef = useRef(VIEW_MAP[currentView])
+  const initialViewRef = useRef(VIEW_MAP[effectiveView])
   const initialDateRef = useRef(selectedDate)
   // Capture time format at mount — Schedule-X locale can't change after init
   const initialLocaleRef = useRef(timeFormat === '24h' ? 'en-GB' : 'en-US')
   // Capture initial timezone for Schedule-X config (changes are pushed via signal below)
   const initialTimezoneRef = useRef(userTz)
   // Capture initial first-day-of-week for Schedule-X config (changes pushed via signal below)
-  const initialFirstDayRef = useRef(sxFirstDayOfWeek)
+  const initialFirstDayRef = useRef(effectiveSxFirstDayOfWeek)
   const initialDayBoundariesRef = useRef(toScheduleXDayBoundariesExternal(dayStartHour, dayEndHour))
 
   // Memoize the event click handler
@@ -421,6 +447,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       // makes Schedule-X divide the day column among concurrent events so both
       // are visible. See issue #330.
       eventOverlap: false,
+      nDays: effectiveWeekDays,
     },
     plugins: [eventsPlugin],
     callbacks: {
@@ -445,22 +472,36 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
     }
   }, [calendar, userTz])
 
-  // Push first-day-of-week changes to the Schedule-X config signal so the grid
-  // AND the date picker re-render when the user updates the preference in
-  // Settings — without a full page reload. config.firstDayOfWeek is shared
-  // between the calendar and its date picker, so this fixes both at once.
+  // Push first-day-of-week changes to the Schedule-X config signal. Week/month
+  // use the user's preference; mobile 3-day mode anchors the first rendered
+  // column to currentDate so Schedule-X's nDays=3 range matches getViewRange().
   useEffect(() => {
     if (!calendar) return
     try {
       const app = (calendar as any).$app
       const fdowSignal = app?.config?.firstDayOfWeek
-      if (fdowSignal && fdowSignal.value !== sxFirstDayOfWeek) {
-        fdowSignal.value = sxFirstDayOfWeek
+      if (fdowSignal && fdowSignal.value !== effectiveSxFirstDayOfWeek) {
+        fdowSignal.value = effectiveSxFirstDayOfWeek
       }
     } catch {
       // Schedule-X internals may not be ready
     }
-  }, [calendar, sxFirstDayOfWeek])
+  }, [calendar, effectiveSxFirstDayOfWeek])
+
+  // Push the effective week column count through Schedule-X. The mobile 3-day
+  // view reuses the week renderer with nDays=3; normal week/month keep 7 days.
+  useEffect(() => {
+    if (!calendar) return
+    try {
+      const app = (calendar as any).$app
+      const weekOptionsSignal = app?.config?.weekOptions
+      if (weekOptionsSignal?.value && weekOptionsSignal.value.nDays !== effectiveWeekDays) {
+        weekOptionsSignal.value = { ...weekOptionsSignal.value, nDays: effectiveWeekDays }
+      }
+    } catch {
+      // Schedule-X internals may not be ready
+    }
+  }, [calendar, effectiveWeekDays])
 
   // Push day-boundary preference changes into Schedule-X and our drag/select math.
   useEffect(() => {
@@ -482,13 +523,11 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   // singleton which exposes calendarState.setView(viewName, date) and
   // calendarState.setRange(date). Both operate on Preact signals internally.
   //
-  // Use currentDate.getTime() as dependency to ensure React detects Date changes
+  // Use currentDateTs as dependency to ensure React detects Date changes
   // (Date objects compared by reference would miss updates).
-  const currentDateTs = currentDate instanceof Date ? currentDate.getTime() : new Date(currentDate).getTime()
-
   useEffect(() => {
     if (!calendar) return
-    const sxViewName = VIEW_MAP[currentView]
+    const sxViewName = VIEW_MAP[effectiveView]
     try {
       const app = (calendar as any).$app
       if (!app?.calendarState) return
@@ -514,7 +553,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       isSyncingToSxRef.current = false
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [calendar, currentView, currentDateTs])
+  }, [calendar, effectiveView, currentDateTs])
 
   // Reverse sync: Schedule-X → store.
   // Schedule-X maintains its own internal date state via Preact signals.
@@ -551,7 +590,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         // Compare with the store's expected range for the current view
         const storeState = useCalendarStore.getState()
         const currentFirstDay = usePreferencesStore.getState().firstDayOfWeek
-        const storeRange = getViewRange(storeState.currentDate, storeState.currentView, currentFirstDay)
+        const storeRange = getViewRange(storeState.currentDate, effectiveView, currentFirstDay)
 
         // Allow 1-day tolerance (month views may extend into adjacent months)
         const startDiff = Math.abs(sxRangeStart.getTime() - storeRange.start.getTime())
@@ -559,9 +598,11 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
 
         // SX is showing a different range — update store to match.
         // Pick a representative date from the SX range for currentDate:
-        // week view → Wednesday of the SX week; month view → middle of range.
+        // 3-day view → range start; week view → Wednesday; month view → middle.
         let newDate: Date
-        if (storeState.currentView === 'week') {
+        if (effectiveView === 'threeDay') {
+          newDate = new Date(sxRangeStart)
+        } else if (storeState.currentView === 'week') {
           newDate = new Date(sxRangeStart)
           newDate.setDate(newDate.getDate() + 3) // mid-week avoids boundary issues
         } else {
@@ -613,18 +654,18 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         scheduleXEventCount: sxEvents.length,
         displayEventCount: displayEvents.length,
         rawEventCount: events.length,
-        view: currentView,
+        view: effectiveView,
       })
     })
     return () => cancelAnimationFrame(raf)
-  }, [currentView, displayEvents.length, events.length, sxEvents.length])
+  }, [effectiveView, displayEvents.length, events.length, sxEvents.length])
 
   // #331: Reveal the full title on short/clipped calendar events and mark event
   // chips by rendered height so CSS can hide low-priority metadata before it
   // gets half-clipped. Schedule-X lays out timed events with inline heights, so
   // this must be measured after render rather than inferred from duration.
   useEffect(() => {
-    const root = document.querySelector('.sx-silentsuite-calendar')
+    const root = rootRef.current
     if (!root) return
 
     const selector = '.sx__time-grid-event, .sx__month-grid-event, .sx__day-grid-event'
@@ -667,7 +708,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       resizeObserver.disconnect()
       observer.disconnect()
     }
-  }, [sxEvents, currentView])
+  }, [sxEvents, effectiveView])
 
   /** Find the time grid scrollable container and calculate time from Y */
   const getTimeFromY = useCallback(
@@ -843,7 +884,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       lastClickPos.current = { x: e.clientX, y: e.clientY }
 
       // Only enable drag in day/week views
-      if (currentView === 'month') return
+      if (effectiveView === 'month') return
 
       const target = e.target as HTMLElement
       const wrapper = e.currentTarget as HTMLElement
@@ -924,7 +965,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
       isDraggingRef.current = false
       dragEndTimeRef.current = null
     },
-    [currentView, getDayColumnInfo, getTimeFromY, buildDateFromHour, viewRange, displayEvents],
+    [effectiveView, getDayColumnInfo, getTimeFromY, buildDateFromHour, viewRange, displayEvents],
   )
 
   const handleMouseMove = useCallback(
@@ -1304,7 +1345,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   // Phase 2C: Touch handlers for mobile long-press drag
   const handleTouchStart = useCallback(
     (e: React.TouchEvent) => {
-      if (currentView === 'month') return
+      if (effectiveView === 'month') return
       const touch = e.touches[0]
       const target = touch.target as HTMLElement
       if (!target.closest('.sx__time-grid-event')) return
@@ -1348,7 +1389,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
         if (navigator.vibrate) navigator.vibrate(50)
       }, 500)
     },
-    [currentView, viewRange, displayEvents, getTimeFromY],
+    [effectiveView, viewRange, displayEvents, getTimeFromY],
   )
 
   const handleTouchMove = useCallback(
@@ -1432,6 +1473,7 @@ export function CalendarGrid({ events, onSlotClick, onEventClick }: CalendarGrid
   return (
     <>
       <div
+        ref={rootRef}
         className="sx-silentsuite-calendar relative flex-1 min-h-0"
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -29,9 +29,18 @@ function snapTo30Min(date: Date): Date {
   return snapped
 }
 
+type CalendarDateLabelView = 'week' | 'month' | 'threeDay'
+type MobileCalendarMode = 'agenda' | 'threeDay'
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date)
+  next.setDate(next.getDate() + days)
+  return next
+}
+
 function formatDateRange(
   date: Date,
-  view: 'week' | 'month',
+  view: CalendarDateLabelView,
   dateFormat: import('@silentsuite/core').DateFormat,
   firstDay: import('@silentsuite/core').FirstDayOfWeek,
 ): string {
@@ -39,6 +48,21 @@ function formatDateRange(
 
   if (view === 'month') {
     return formatDate(date, dateFormat, opts)
+  }
+
+  if (view === 'threeDay') {
+    const rangeStart = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+    const rangeEnd = addDays(rangeStart, 2)
+    const startMonth = formatDate(rangeStart, 'system', { month: 'short' })
+    const endMonth = formatDate(rangeEnd, 'system', { month: 'short' })
+
+    if (rangeStart.getFullYear() !== rangeEnd.getFullYear()) {
+      return `${startMonth} ${rangeStart.getDate()}, ${rangeStart.getFullYear()} – ${endMonth} ${rangeEnd.getDate()}, ${rangeEnd.getFullYear()}`
+    }
+    if (rangeStart.getMonth() !== rangeEnd.getMonth()) {
+      return `${startMonth} ${rangeStart.getDate()} – ${endMonth} ${rangeEnd.getDate()}, ${rangeStart.getFullYear()}`
+    }
+    return `${startMonth} ${rangeStart.getDate()}–${rangeEnd.getDate()}, ${rangeStart.getFullYear()}`
   }
 
   // Week view: derive the week start/end from the first-day preference
@@ -102,6 +126,7 @@ export default function CalendarPage() {
   const navigateForward = useCalendarStore((s) => s.navigateForward)
   const navigateBackward = useCalendarStore((s) => s.navigateBackward)
   const navigateToday = useCalendarStore((s) => s.navigateToday)
+  const setCurrentDate = useCalendarStore((s) => s.setCurrentDate)
   const selectedEventId = useCalendarStore((s) => s.selectedEventId)
   const setSelectedEvent = useCalendarStore((s) => s.setSelectedEvent)
   const calendars = useCalendarListStore((s) => s.calendars)
@@ -111,10 +136,15 @@ export default function CalendarPage() {
   const [createDialog, setCreateDialog] = useState<CreateDialogState | null>(null)
   const [eventInstanceDate, setEventInstanceDate] = useState<Date | undefined>(undefined)
   const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
+  const [mobileCalendarMode, setMobileCalendarMode] = useState<MobileCalendarMode>('agenda')
 
   const dateLabel = useMemo(
     () => formatDateRange(currentDate, currentView, dateFormat, firstDayOfWeek),
     [currentDate, currentView, dateFormat, firstDayOfWeek],
+  )
+  const mobileDateLabel = useMemo(
+    () => formatDateRange(currentDate, mobileCalendarMode === 'threeDay' ? 'threeDay' : currentView, dateFormat, firstDayOfWeek),
+    [currentDate, currentView, dateFormat, firstDayOfWeek, mobileCalendarMode],
   )
 
   // Active calendar-week indicator (#292). Shown in week view; respects the
@@ -182,6 +212,22 @@ export default function CalendarPage() {
     [selectedEventId, events],
   )
 
+  const handleMobileNavigateBackward = useCallback(() => {
+    if (mobileCalendarMode === 'threeDay') {
+      setCurrentDate(addDays(currentDate, -3))
+      return
+    }
+    navigateBackward()
+  }, [currentDate, mobileCalendarMode, navigateBackward, setCurrentDate])
+
+  const handleMobileNavigateForward = useCallback(() => {
+    if (mobileCalendarMode === 'threeDay') {
+      setCurrentDate(addDays(currentDate, 3))
+      return
+    }
+    navigateForward()
+  }, [currentDate, mobileCalendarMode, navigateForward, setCurrentDate])
+
   return (
     <div className="flex h-full flex-col gap-3">
       {/* Desktop toolbar */}
@@ -243,7 +289,7 @@ export default function CalendarPage() {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1">
             <button
-              onClick={navigateBackward}
+              onClick={handleMobileNavigateBackward}
               className="max-md:min-h-[44px] max-md:min-w-[44px] max-md:flex max-md:items-center max-md:justify-center rounded-md text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] active:bg-[rgb(var(--surface))] transition-colors"
               aria-label="Previous"
             >
@@ -256,14 +302,13 @@ export default function CalendarPage() {
               Today
             </button>
             <button
-              onClick={navigateForward}
+              onClick={handleMobileNavigateForward}
               className="max-md:min-h-[44px] max-md:min-w-[44px] max-md:flex max-md:items-center max-md:justify-center rounded-md text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] active:bg-[rgb(var(--surface))] transition-colors"
               aria-label="Next"
             >
               <ChevronRight className="h-5 w-5" />
             </button>
           </div>
-          {/* On mobile, only agenda view is shown — hide the view switcher */}
           <button
             onClick={() => setCollectionSheetOpen(true)}
             className="touch-target md:hidden rounded-md text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] active:bg-[rgb(var(--surface))] transition-colors"
@@ -273,8 +318,8 @@ export default function CalendarPage() {
           </button>
         </div>
         <div className="flex items-center gap-2 px-1">
-          <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">{dateLabel}</h2>
-          {weekNumber !== null && (
+          <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">{mobileDateLabel}</h2>
+          {mobileCalendarMode !== 'threeDay' && weekNumber !== null && (
             <span
               className="rounded-md bg-[rgb(var(--surface))] px-2 py-0.5 text-xs font-medium text-[rgb(var(--muted))]"
               title="Calendar week"
@@ -282,6 +327,32 @@ export default function CalendarPage() {
               Week {weekNumber}
             </span>
           )}
+        </div>
+        <div className="flex items-center gap-1 px-1" role="group" aria-label="Mobile calendar view">
+          <button
+            type="button"
+            onClick={() => setMobileCalendarMode('agenda')}
+            aria-pressed={mobileCalendarMode === 'agenda'}
+            className={`max-md:min-h-[44px] rounded-md px-3 text-sm font-medium transition-colors ${
+              mobileCalendarMode === 'agenda'
+                ? 'bg-[rgb(var(--primary))] text-white'
+                : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] active:bg-[rgb(var(--surface))]'
+            }`}
+          >
+            Agenda
+          </button>
+          <button
+            type="button"
+            onClick={() => setMobileCalendarMode('threeDay')}
+            aria-pressed={mobileCalendarMode === 'threeDay'}
+            className={`max-md:min-h-[44px] rounded-md px-3 text-sm font-medium transition-colors ${
+              mobileCalendarMode === 'threeDay'
+                ? 'bg-[rgb(var(--primary))] text-white'
+                : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] active:bg-[rgb(var(--surface))]'
+            }`}
+          >
+            3 days
+          </button>
         </div>
       </div>
 
@@ -362,18 +433,30 @@ export default function CalendarPage() {
             <CalendarGrid events={visibleEvents} onSlotClick={handleSlotClick} onEventClick={handleEventClick} />
           </div>
 
-          {/* Mobile: agenda list view */}
-          <div className="flex flex-col flex-1 md:hidden">
-            <PullToRefresh>
-              <AgendaView
-                events={visibleEvents}
-                currentDate={currentDate}
-                onEventClick={(id) => {
-                  setSelectedEvent(id)
-                  setEventInstanceDate(undefined)
-                }}
-              />
-            </PullToRefresh>
+          {/* Mobile: agenda list view or 3-day grid */}
+          <div className="flex flex-col flex-1 min-h-0 md:hidden">
+            {mobileCalendarMode === 'agenda' ? (
+              <PullToRefresh>
+                <AgendaView
+                  events={visibleEvents}
+                  currentDate={currentDate}
+                  onEventClick={(id) => {
+                    setSelectedEvent(id)
+                    setEventInstanceDate(undefined)
+                  }}
+                />
+              </PullToRefresh>
+            ) : (
+              <div className="flex flex-1 min-h-[520px] overflow-hidden">
+                <CalendarGrid
+                  key="mobile-three-day-grid"
+                  displayView="threeDay"
+                  events={visibleEvents}
+                  onSlotClick={handleSlotClick}
+                  onEventClick={handleEventClick}
+                />
+              </div>
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary
- add a mobile-only Agenda / 3 days toggle for the web calendar
- render the 3-day mobile view through the existing Schedule-X calendar grid without adding a desktop 3-day state
- keep hidden-calendar filtering, mobile agenda behavior, and desktop week/month behavior intact

## BMAD plan and review

## Validation
- `pnpm install`
- `pnpm --filter @silentsuite/web test -- 'app/(app)/calendar/__tests__/page.test.tsx'` (Vitest config ran 35 files / 337 tests, all passed)
- `pnpm --filter @silentsuite/web test -- 'app/(app)/calendar/lib/__tests__/*.test.ts'` (Vitest config ran 35 files / 337 tests, all passed)
- `pnpm --filter @silentsuite/web type-check`
- `git diff --check`

Closes #229

Parent epic context: #295 remains open for broader mobile web UX work.