### PR TITLE
Update Zapstore metadata for v0.3.0-beta

### DIFF
--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/silent-suite/silentsuite
-release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.2.0-beta/silentsuite-android-v0.2.0-beta.apk
+release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.3.0-beta/silentsuite-android-v0.3.0-beta.apk
 pubkey: npub1zuusadlzq6vehhaqhqpup0mhnx70q9cnf9hs48t79g6qn4wpg2eqsy8m35
 name: SilentSuite
 summary: Zero-knowledge calendar, contacts, and tasks sync for Android
@@ -20,10 +20,10 @@ tags:
   - sync
 license: GPL-3.0-only
 website: https://silentsuite.io
-icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/icon.png
+icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/icon.png
 images:
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-main.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-account.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-create-calendar.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.2.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-view-collection.png
-release_notes: android/fastlane/metadata/android/en-US/changelogs/6.txt
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-add-account.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-sync-overview.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-navigation-drawer.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-encryption-fingerprint.png
+release_notes: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.0-beta/android/fastlane/metadata/android/en-US/changelogs/8.txt


### PR DESCRIPTION
## Summary
- update Zapstore release source to the v0.3.0-beta APK
- pin icon, screenshots, and release notes to the v0.3.0-beta tag
- replace stale screenshot filenames with the actual v0.3.0-beta Fastlane assets

## Verification
- GitHub release v0.3.0-beta exists and is published with APK and sha256 assets
- tag contains icon, four screenshot PNGs, and changelog 8.txt
- all zapstore.yaml URLs returned HTTP 200
- /tmp/zsp publish --check zapstore.yaml returned {"package_id":"io.silentsuite.android"}
- downloaded APK matched release sha256