### PR TITLE
Refresh store copy for cross-device sync

### DIFF
--- a/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,17 +1,13 @@
-SilentSuite privately syncs your Android calendar, contacts, and tasks, so you can keep using the apps you like without giving up control of your data. Your content is encrypted on your device before sync, and your keys stay on your device.
+Your calendar, contacts, and tasks should stay in sync wherever you work: Android, macOS, Windows, Linux, and the web. SilentSuite keeps that data available across your devices while applying end-to-end encryption before anything leaves your device.
 
-<b>Sync Your Android Life Privately</b><br />SilentSuite works as an Android sync adapter. After you sign in, your encrypted calendars, contacts, and tasks appear in compatible Android apps, so you can keep using the calendar, contacts, and task apps you already like.
+<b>Zero-Knowledge Sync</b><br />Encryption and decryption happen on your device, and your keys stay there. The server stores only ciphertext, so it cannot read what you keep on it. This is what zero-knowledge means in practice: the privacy guarantee is a technical constraint, not a policy statement.
 
-<b>Only Your Devices Can Read It</b><br />Your plaintext data stays on your devices. The server stores encrypted sync data and the limited metadata needed to keep sync working, such as sync tokens and timestamps. It cannot decrypt your calendar events, address book, or task lists.
+<b>Fits Into Every System You Use</b><br />On Android, SilentSuite works as a native sync adapter for compatible calendar, contacts, and task apps. On macOS, Windows, and Linux it integrates through a lightweight desktop bridge, so your encrypted data can appear in the tools already built into your workflow. The web app gives you browser access when you are away from your own devices. iPhone support is coming soon.
 
-<b>Keep Personal And Work Separate</b><br />Organize calendars, contacts, and tasks in one account. SilentSuite is designed for everyday productivity data, with private sync across your Android devices and no need to hand readable copies to a Big Tech account.
+<b>Open Source And Inspectable</b><br />Anyone can read the code, review the encryption, and confirm the privacy claims for themselves. There are no proprietary components to take on trust.
 
-<b>No Vendor Lock-In</b><br />Import and export your data anytime. SilentSuite is built around open standards and open source code, so you stay in control if you move devices, switch apps, or self-host later.
+<b>Hosted Or Self-Hosted</b><br />Use the hosted service, or run your own server on hardware you control. Your data stays portable: export it at any time in standard formats, with no lock-in.
 
-<b>Hosted Or Self-Hosted</b><br />Start with a hosted silentsuite.io account, or connect to your own compatible SilentSuite server. The server, bridge, web app, and Android app are open source, so privacy claims can be inspected instead of merely trusted.
+<b>Beta Note</b><br />This is a beta release. Calendar, contacts, and task sync are the focus of this version and form its stable core. Feedback and bug reports are welcome through the link in the app.
 
-<b>What Works Today</b><br />• End-to-end encrypted calendar, contacts, and tasks sync<br />• Works with compatible Android calendar, contacts, and tasks apps<br />• Hosted account or custom server<br />• Import and export for data portability<br />• Open source, inspectable, and self-hostable
-
-<b>What You Need</b><br />To use this app, you need a silentsuite.io account or a compatible self-hosted server. A 7-day hosted trial is available at https://app.silentsuite.io/signup with no card required.
-
-<b>Beta Note</b><br />SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta. Please report issues through the app, GitHub, or info@silentsuite.io so we can keep making the Android experience better.
+<b>What You Need</b><br />Requires a SilentSuite account. Self-hosting documentation is available at docs.silentsuite.io.

--- a/android/fastlane/metadata/android/en-US/google-play-listing-copy.md
+++ b/android/fastlane/metadata/android/en-US/google-play-listing-copy.md
@@ -1,4 +1,4 @@
-# Google Play listing paste copy for SilentSuite v0.3.0-beta
+# Store listing paste copy for SilentSuite v0.3.0-beta
 
 Use with the final 8 screenshots exported from Figma on 2026-06-27.
 
@@ -8,39 +8,23 @@ SilentSuite - Secure Data Sync
 
 ## Short description
 
-Private calendar, contacts, and tasks sync for Android
+End-to-end encrypted sync for calendar, contacts, and tasks
 
 ## Full description
 
-SilentSuite privately syncs your Android calendar, contacts, and tasks, so you can keep using the apps you like without giving up control of your data. Your content is encrypted on your device before sync, and your keys stay on your device.
+Your calendar, contacts, and tasks should stay in sync wherever you work: Android, macOS, Windows, Linux, and the web. SilentSuite keeps that data available across your devices while applying end-to-end encryption before anything leaves your device.
 
-SYNC YOUR ANDROID LIFE PRIVATELY
-SilentSuite works as an Android sync adapter. After you sign in, your encrypted calendars, contacts, and tasks appear in compatible Android apps, so you can keep using the calendar, contacts, and task apps you already like.
+Encryption and decryption happen on your device, and your keys stay there. The server stores only ciphertext, so it cannot read what you keep on it. This is what zero-knowledge means in practice: the privacy guarantee is a technical constraint, not a policy statement.
 
-ONLY YOUR DEVICES CAN READ IT
-Your plaintext data stays on your devices. The server stores encrypted sync data and the limited metadata needed to keep sync working, such as sync tokens and timestamps. It cannot decrypt your calendar events, address book, or task lists.
+SilentSuite is built to fit into each system you use. On Android it works as a native sync adapter for compatible calendar, contacts, and task apps. On macOS, Windows, and Linux it integrates through a lightweight desktop bridge, so your encrypted data can appear in the tools already built into your workflow. The web app gives you browser access when you are away from your own devices. iPhone support is coming soon.
 
-KEEP PERSONAL AND WORK SEPARATE
-Organize calendars, contacts, and tasks in one account. SilentSuite is designed for everyday productivity data, with private sync across your Android devices and no need to hand readable copies to a Big Tech account.
+The app is fully open source. Anyone can read the code, review the encryption, and confirm the privacy claims for themselves. There are no proprietary components to take on trust.
 
-NO VENDOR LOCK-IN
-Import and export your data anytime. SilentSuite is built around open standards and open source code, so you stay in control if you move devices, switch apps, or self-host later.
+You choose where your data lives. Use the hosted service, or run your own server on hardware you control. Your data stays portable: export it at any time in standard formats, with no lock-in.
 
-HOSTED OR SELF-HOSTED
-Start with a hosted silentsuite.io account, or connect to your own compatible SilentSuite server. The server, bridge, web app, and Android app are open source, so privacy claims can be inspected instead of merely trusted.
+This is a beta release. Calendar, contacts, and task sync are the focus of this version and form its stable core. Feedback and bug reports are welcome through the link in the app.
 
-WHAT WORKS TODAY
-- End-to-end encrypted calendar, contacts, and tasks sync
-- Works with compatible Android calendar, contacts, and tasks apps
-- Hosted account or custom server
-- Import and export for data portability
-- Open source, inspectable, and self-hostable
-
-WHAT YOU NEED
-To use this app, you need a silentsuite.io account or a compatible self-hosted server. A 7-day hosted trial is available at https://app.silentsuite.io/signup with no card required.
-
-BETA NOTE
-SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta. Please report issues through the app, GitHub, or info@silentsuite.io so we can keep making the Android experience better.
+Requires a SilentSuite account. Self-hosting documentation is available at docs.silentsuite.io.
 
 ## Phone screenshot order
 

--- a/android/fastlane/metadata/android/en-US/short_description.txt
+++ b/android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Private calendar, contacts, and tasks sync for Android
+End-to-end encrypted sync for calendar, contacts, and tasks

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,17 +1,13 @@
-SilentSuite privately syncs your Android calendar, contacts, and tasks, so you can keep using the apps you like without giving up control of your data. Your content is encrypted on your device before sync, and your keys stay on your device.
+Your calendar, contacts, and tasks should stay in sync wherever you work: Android, macOS, Windows, Linux, and the web. SilentSuite keeps that data available across your devices while applying end-to-end encryption before anything leaves your device.
 
-<b>Sync Your Android Life Privately</b><br />SilentSuite works as an Android sync adapter. After you sign in, your encrypted calendars, contacts, and tasks appear in compatible Android apps, so you can keep using the calendar, contacts, and task apps you already like.
+<b>Zero-Knowledge Sync</b><br />Encryption and decryption happen on your device, and your keys stay there. The server stores only ciphertext, so it cannot read what you keep on it. This is what zero-knowledge means in practice: the privacy guarantee is a technical constraint, not a policy statement.
 
-<b>Only Your Devices Can Read It</b><br />Your plaintext data stays on your devices. The server stores encrypted sync data and the limited metadata needed to keep sync working, such as sync tokens and timestamps. It cannot decrypt your calendar events, address book, or task lists.
+<b>Fits Into Every System You Use</b><br />On Android, SilentSuite works as a native sync adapter for compatible calendar, contacts, and task apps. On macOS, Windows, and Linux it integrates through a lightweight desktop bridge, so your encrypted data can appear in the tools already built into your workflow. The web app gives you browser access when you are away from your own devices. iPhone support is coming soon.
 
-<b>Keep Personal And Work Separate</b><br />Organize calendars, contacts, and tasks in one account. SilentSuite is designed for everyday productivity data, with private sync across your Android devices and no need to hand readable copies to a Big Tech account.
+<b>Open Source And Inspectable</b><br />Anyone can read the code, review the encryption, and confirm the privacy claims for themselves. There are no proprietary components to take on trust.
 
-<b>No Vendor Lock-In</b><br />Import and export your data anytime. SilentSuite is built around open standards and open source code, so you stay in control if you move devices, switch apps, or self-host later.
+<b>Hosted Or Self-Hosted</b><br />Use the hosted service, or run your own server on hardware you control. Your data stays portable: export it at any time in standard formats, with no lock-in.
 
-<b>Hosted Or Self-Hosted</b><br />Start with a hosted silentsuite.io account, or connect to your own compatible SilentSuite server. The server, bridge, web app, and Android app are open source, so privacy claims can be inspected instead of merely trusted.
+<b>Beta Note</b><br />This is a beta release. Calendar, contacts, and task sync are the focus of this version and form its stable core. Feedback and bug reports are welcome through the link in the app.
 
-<b>What Works Today</b><br />• End-to-end encrypted calendar, contacts, and tasks sync<br />• Works with compatible Android calendar, contacts, and tasks apps<br />• Hosted account or custom server<br />• Import and export for data portability<br />• Open source, inspectable, and self-hostable
-
-<b>What You Need</b><br />To use this app, you need a silentsuite.io account or a compatible self-hosted server. A 7-day hosted trial is available at https://app.silentsuite.io/signup with no card required.
-
-<b>Beta Note</b><br />SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta. Please report issues through the app, GitHub, or info@silentsuite.io so we can keep making the Android experience better.
+<b>What You Need</b><br />Requires a SilentSuite account. Self-hosting documentation is available at docs.silentsuite.io.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Private calendar, contacts, and tasks sync for Android
+End-to-end encrypted sync for calendar, contacts, and tasks

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -2,15 +2,21 @@ repository: https://github.com/silent-suite/silentsuite
 release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.3.0-beta/silentsuite-android-v0.3.0-beta.apk
 pubkey: npub1zuusadlzq6vehhaqhqpup0mhnx70q9cnf9hs48t79g6qn4wpg2eqsy8m35
 name: SilentSuite
-summary: Private calendar, contacts, and tasks sync for Android
+summary: End-to-end encrypted sync for calendar, contacts, and tasks
 description: |
-  SilentSuite privately syncs your Android calendar, contacts, and tasks, so you can keep using the apps you like without giving up control of your data. Your content is encrypted on your device before sync, and your keys stay on your device.
+  Your calendar, contacts, and tasks should stay in sync wherever you work: Android, macOS, Windows, Linux, and the web. SilentSuite keeps that data available across your devices while applying end-to-end encryption before anything leaves your device.
 
-  SilentSuite works as an Android sync adapter. After you sign in, your encrypted calendars, contacts, and tasks appear in compatible Android apps. Your plaintext data stays on your devices, while the server stores encrypted sync data and the limited metadata needed to keep sync working.
+  Encryption and decryption happen on your device, and your keys stay there. The server stores only ciphertext, so it cannot read what you keep on it. This is what zero-knowledge means in practice: the privacy guarantee is a technical constraint, not a policy statement.
 
-  Use a hosted silentsuite.io account, or connect to your own compatible SilentSuite server. SilentSuite is open source, import and export friendly, and built for people who want private Android sync without vendor lock-in.
+  SilentSuite is built to fit into each system you use. On Android it works as a native sync adapter for compatible calendar, contacts, and task apps. On macOS, Windows, and Linux it integrates through a lightweight desktop bridge, so your encrypted data can appear in the tools already built into your workflow. The web app gives you browser access when you are away from your own devices. iPhone support is coming soon.
 
-  Beta note: SilentSuite is actively improving. Calendar, contacts, and tasks sync are the core focus of this beta; please report issues so we can make the Android experience better.
+  The app is fully open source. Anyone can read the code, review the encryption, and confirm the privacy claims for themselves. There are no proprietary components to take on trust.
+
+  You choose where your data lives. Use the hosted service, or run your own server on hardware you control. Your data stays portable: export it at any time in standard formats, with no lock-in.
+
+  This is a beta release. Calendar, contacts, and task sync are the focus of this version and form its stable core. Feedback and bug reports are welcome through the link in the app.
+
+  Requires a SilentSuite account. Self-hosting documentation is available at docs.silentsuite.io.
 tags:
   - productivity
   - privacy


### PR DESCRIPTION
## Summary
- update Android Fastlane/F-Droid metadata copy to the approved Option 1 positioning
- emphasize encrypted calendar, contacts, and tasks sync across Android, macOS, Windows, Linux, and web access
- update Zapstore summary/description and the Play Console paste-copy artifact to match

## Verification
- python3 copy check: short description is 59 chars, zapstore.yaml parses with 8 images, no em or en dashes in updated public copy
- git diff --check

Notes:
- iPhone support is described only as coming soon.
- APK and changelog remain pinned to v0.3.0-beta; this is a metadata-only refresh.