### PR TITLE
Improve mobile calendar view options

### DIFF
--- a/apps/web/app/(app)/calendar/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/calendar/__tests__/page.test.tsx
@@ -67,16 +67,19 @@ vi.mock('../components/CalendarViewSwitcher', () => ({
 }))
 
 vi.mock('../components/CalendarGrid', () => ({
-  CalendarGrid: ({ events, displayView }: { events: { title: string }[]; displayView?: 'threeDay' }) => (
-    <div data-testid={displayView === 'threeDay' ? 'mobile-three-day-grid' : 'desktop-grid'} data-display-view={displayView ?? 'store'}>
+  CalendarGrid: ({ events, displayView }: { events: { title: string }[]; displayView?: 'threeDay' | 'sevenDay' }) => (
+    <div
+      data-testid={displayView === 'threeDay' ? 'mobile-three-day-grid' : displayView === 'sevenDay' ? 'mobile-seven-day-grid' : 'desktop-grid'}
+      data-display-view={displayView ?? 'store'}
+    >
       {events.map((event) => <span key={event.title}>{event.title}</span>)}
     </div>
   ),
 }))
 
 vi.mock('../components/AgendaView', () => ({
-  AgendaView: ({ events }: { events: { title: string }[] }) => (
-    <div data-testid="mobile-agenda">
+  AgendaView: ({ events, mode }: { events: { title: string }[]; mode?: 'day' | 'upcoming' }) => (
+    <div data-testid="mobile-agenda" data-mode={mode ?? 'day'}>
       {events.map((event) => <span key={event.title}>{event.title}</span>)}
     </div>
   ),
@@ -135,15 +138,20 @@ describe('CalendarPage calendar visibility', () => {
     expect(mobileAgenda.queryByText('Hidden event')).not.toBeInTheDocument()
   })
 
-  it('keeps hidden calendar events out of the mobile 3-day grid', () => {
+  it('keeps hidden calendar events out of the mobile multi-day grids', () => {
     renderWithIntl(<CalendarPage />)
 
     fireEvent.click(screen.getByRole('button', { name: '3 days' }))
 
-    const mobileGrid = within(screen.getByTestId('mobile-three-day-grid'))
-    expect(mobileGrid.getByText('Visible event')).toBeInTheDocument()
-    expect(mobileGrid.queryByText('Hidden event')).not.toBeInTheDocument()
+    const threeDayGrid = within(screen.getByTestId('mobile-three-day-grid'))
+    expect(threeDayGrid.getByText('Visible event')).toBeInTheDocument()
+    expect(threeDayGrid.queryByText('Hidden event')).not.toBeInTheDocument()
     expect(screen.queryByTestId('mobile-agenda')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '7 days' }))
+    const sevenDayGrid = within(screen.getByTestId('mobile-seven-day-grid'))
+    expect(sevenDayGrid.getByText('Visible event')).toBeInTheDocument()
+    expect(sevenDayGrid.queryByText('Hidden event')).not.toBeInTheDocument()
   })
 })
 
@@ -188,24 +196,31 @@ describe('CalendarPage mobile reachability', () => {
     expect(mobileToday!.className).not.toContain('touch-target')
   })
 
-  it('exposes mobile Agenda and 3-day view controls with accessible state', () => {
+  it('exposes mobile Agenda, 3-day, and 7-day view controls with accessible state', () => {
     renderWithIntl(<CalendarPage />)
 
     const agenda = screen.getByRole('button', { name: 'Agenda' })
     const threeDays = screen.getByRole('button', { name: '3 days' })
+    const sevenDays = screen.getByRole('button', { name: '7 days' })
 
     expect(agenda.className).toContain('max-md:min-h-[44px]')
     expect(threeDays.className).toContain('max-md:min-h-[44px]')
+    expect(sevenDays.className).toContain('max-md:min-h-[44px]')
     expect(agenda).toHaveAttribute('aria-pressed', 'true')
     expect(threeDays).toHaveAttribute('aria-pressed', 'false')
+    expect(sevenDays).toHaveAttribute('aria-pressed', 'false')
 
     fireEvent.click(threeDays)
 
     expect(threeDays).toHaveAttribute('aria-pressed', 'true')
     expect(storeMock.calendarState.setCurrentView).not.toHaveBeenCalledWith('threeDay')
+
+    fireEvent.click(sevenDays)
+    expect(sevenDays).toHaveAttribute('aria-pressed', 'true')
+    expect(storeMock.calendarState.setCurrentView).not.toHaveBeenCalledWith('sevenDay')
   })
 
-  it('moves mobile 3-day navigation in 3-day increments without changing the desktop view', () => {
+  it('moves mobile multi-day navigation by the selected range without changing the desktop view', () => {
     renderWithIntl(<CalendarPage />)
 
     fireEvent.click(screen.getByRole('button', { name: '3 days' }))
@@ -220,9 +235,16 @@ describe('CalendarPage mobile reachability', () => {
     expect(storeMock.calendarState.setCurrentDate).toHaveBeenLastCalledWith(new Date('2026-05-29T12:00:00Z'))
     expect(storeMock.calendarState.navigateBackward).not.toHaveBeenCalled()
     expect(storeMock.calendarState.setCurrentView).not.toHaveBeenCalledWith('threeDay')
+
+    fireEvent.click(screen.getByRole('button', { name: '7 days' }))
+    fireEvent.click(mobileNext)
+    expect(storeMock.calendarState.setCurrentDate).toHaveBeenLastCalledWith(new Date('2026-06-08T12:00:00Z'))
+    fireEvent.click(mobilePrevious)
+    expect(storeMock.calendarState.setCurrentDate).toHaveBeenLastCalledWith(new Date('2026-05-25T12:00:00Z'))
+    expect(storeMock.calendarState.setCurrentView).not.toHaveBeenCalledWith('sevenDay')
   })
 
-  it('shows a short 3-day range label in mobile 3-day mode', () => {
+  it('shows short range labels in mobile multi-day modes', () => {
     storeMock.calendarState.currentDate = new Date('2026-12-31T12:00:00Z')
 
     renderWithIntl(<CalendarPage />)
@@ -230,6 +252,17 @@ describe('CalendarPage mobile reachability', () => {
     fireEvent.click(screen.getByRole('button', { name: '3 days' }))
 
     expect(screen.getByText('Dec 31, 2026 – Jan 2, 2027')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '7 days' }))
+    expect(screen.getByText('Dec 31, 2026 – Jan 6, 2027')).toBeInTheDocument()
+  })
+
+  it('passes upcoming mode into the mobile agenda by default', () => {
+    storeMock.calendarState.isLoading = false
+
+    renderWithIntl(<CalendarPage />)
+
+    expect(screen.getByTestId('mobile-agenda')).toHaveAttribute('data-mode', 'upcoming')
   })
 
   it('exposes a mobile collection switcher with a 44px touch target', () => {

--- a/apps/web/app/(app)/calendar/components/AgendaView.tsx
+++ b/apps/web/app/(app)/calendar/components/AgendaView.tsx
@@ -11,6 +11,7 @@ import { resolveUserTimezone, shortTimezoneLabel } from '@/app/lib/tz'
 interface AgendaViewProps {
   events: CalendarEvent[]
   currentDate: Date
+  mode?: 'day' | 'upcoming'
   onEventClick?: (eventId: string) => void
 }
 
@@ -26,17 +27,60 @@ function isSameDay(a: Date, b: Date): boolean {
   )
 }
 
-export function AgendaView({ events, currentDate, onEventClick }: AgendaViewProps) {
+function formatAgendaDate(date: Date, currentDate: Date, tz: string): string {
+  if (isSameDay(date, currentDate)) return 'Today'
+
+  const tomorrow = new Date(currentDate)
+  tomorrow.setDate(currentDate.getDate() + 1)
+  if (isSameDay(date, tomorrow)) return 'Tomorrow'
+
+  return date.toLocaleDateString([], {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: tz,
+  })
+}
+
+function eventStart(event: CalendarEvent): Date {
+  return event.startDate instanceof Date ? event.startDate : new Date(event.startDate)
+}
+
+function eventEnd(event: CalendarEvent): Date {
+  return event.endDate instanceof Date ? event.endDate : new Date(event.endDate)
+}
+
+function compareEvents(a: CalendarEvent, b: CalendarEvent): number {
+  const aStart = eventStart(a)
+  const bStart = eventStart(b)
+  if (!isSameDay(aStart, bStart)) return aStart.getTime() - bStart.getTime()
+  if (a.allDay && !b.allDay) return -1
+  if (!a.allDay && b.allDay) return 1
+  return aStart.getTime() - bStart.getTime()
+}
+
+export function AgendaView({ events, currentDate, mode = 'day', onEventClick }: AgendaViewProps) {
   const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
   const userTz = resolveUserTimezone(defaultTimezonePref)
-  const dayEvents = useMemo(() => {
+  const agendaEvents = useMemo(() => {
     const currentDayStart = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate())
     const currentDayEnd = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate(), 23, 59, 59, 999)
 
+    if (mode === 'upcoming') {
+      return events
+        .filter((event) => {
+          const end = eventEnd(event)
+          // Keep in-progress all-day and timed events, then show upcoming items across future days.
+          return event.allDay ? end > currentDayStart : end >= currentDayStart
+        })
+        .sort(compareEvents)
+        .slice(0, 6)
+    }
+
     return events
       .filter((e) => {
-        const start = e.startDate instanceof Date ? e.startDate : new Date(e.startDate)
-        const end = e.endDate instanceof Date ? e.endDate : new Date(e.endDate)
+        const start = eventStart(e)
+        const end = eventEnd(e)
 
         // Event overlaps with current day if it starts before day ends AND ends after day starts.
         // For all-day events, endDate follows iCal DTEND;VALUE=DATE convention (exclusive — the
@@ -45,66 +89,77 @@ export function AgendaView({ events, currentDate, onEventClick }: AgendaViewProp
         const endComparison = e.allDay ? end > currentDayStart : end >= currentDayStart
         return start <= currentDayEnd && endComparison
       })
-      .sort((a, b) => {
-        if (a.allDay && !b.allDay) return -1
-        if (!a.allDay && b.allDay) return 1
-        const aStart = a.startDate instanceof Date ? a.startDate : new Date(a.startDate)
-        const bStart = b.startDate instanceof Date ? b.startDate : new Date(b.startDate)
-        return aStart.getTime() - bStart.getTime()
-      })
-  }, [events, currentDate])
+      .sort(compareEvents)
+  }, [events, currentDate, mode])
 
-  if (dayEvents.length === 0) {
+  if (agendaEvents.length === 0) {
     return <CalendarEmptyState />
   }
 
   return (
     <div className="flex flex-col gap-2 px-4 py-3">
-      {dayEvents.map((event) => (
-        <button
-          key={event.id}
-          type="button"
-          onClick={() => onEventClick?.(event.id)}
-          className="w-full text-left rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3 transition-colors hover:border-[rgb(var(--primary))] focus:outline-none focus:ring-2 focus:ring-emerald-500"
-        >
-          <div className="flex items-start gap-3">
-            <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-[rgb(var(--primary))]" />
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-[rgb(var(--foreground))] truncate">
-                {event.title}
-              </p>
-              {!event.allDay && (
-                <div className="mt-1 flex items-center gap-1 text-xs text-[rgb(var(--muted))]">
-                  <Clock className="h-3 w-3" />
-                  <span>
-                    {formatTime(event.startDate, userTz)} – {formatTime(event.endDate, userTz)}
-                  </span>
-                  {event.timezone && event.timezone !== userTz && (
-                    <span className="ml-1 rounded bg-[rgb(var(--surface-muted))] px-1 py-0.5 text-[10px] font-medium text-[rgb(var(--muted))]">
-                      {shortTimezoneLabel(event.timezone, event.startDate)}
+      {mode === 'upcoming' && (
+        <p className="px-1 text-xs font-medium text-[rgb(var(--muted))]">
+          Next events
+        </p>
+      )}
+      {agendaEvents.map((event, index) => {
+        const start = eventStart(event)
+        return (
+          <button
+            key={event.id}
+            type="button"
+            onClick={() => onEventClick?.(event.id)}
+            className={`w-full text-left rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3 transition-colors hover:border-[rgb(var(--primary))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${
+              mode === 'upcoming' && index === 5 ? 'max-[389px]:hidden' : ''
+            }`}
+          >
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-[rgb(var(--primary))]" />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-medium text-[rgb(var(--foreground))] truncate">
+                    {event.title}
+                  </p>
+                  {mode === 'upcoming' && (
+                    <span className="shrink-0 text-xs text-[rgb(var(--muted))]">
+                      {formatAgendaDate(start, currentDate, userTz)}
                     </span>
                   )}
                 </div>
-              )}
-              {event.allDay && (
-                <span className="mt-1 inline-block text-xs text-[rgb(var(--muted))]">All day</span>
-              )}
-              {event.location && (
-                <div className="mt-1 flex items-center gap-1 text-xs text-[rgb(var(--muted))]">
-                  <MapPin className="h-3 w-3" />
-                  <span className="truncate">{event.location}</span>
-                </div>
-              )}
-              {event.description && (
-                <p className="mt-1 text-xs text-[rgb(var(--muted))] line-clamp-2">
-                  {event.description}
-                </p>
-              )}
-              <LabelChips labels={event.categories} className="mt-1.5" />
+                {!event.allDay && (
+                  <div className="mt-1 flex items-center gap-1 text-xs text-[rgb(var(--muted))]">
+                    <Clock className="h-3 w-3" />
+                    <span>
+                      {formatTime(event.startDate, userTz)} – {formatTime(event.endDate, userTz)}
+                    </span>
+                    {event.timezone && event.timezone !== userTz && (
+                      <span className="ml-1 rounded bg-[rgb(var(--surface-muted))] px-1 py-0.5 text-[10px] font-medium text-[rgb(var(--muted))]">
+                        {shortTimezoneLabel(event.timezone, event.startDate)}
+                      </span>
+                    )}
+                  </div>
+                )}
+                {event.allDay && (
+                  <span className="mt-1 inline-block text-xs text-[rgb(var(--muted))]">All day</span>
+                )}
+                {event.location && (
+                  <div className="mt-1 flex items-center gap-1 text-xs text-[rgb(var(--muted))]">
+                    <MapPin className="h-3 w-3" />
+                    <span className="truncate">{event.location}</span>
+                  </div>
+                )}
+                {event.description && (
+                  <p className="mt-1 text-xs text-[rgb(var(--muted))] line-clamp-2">
+                    {event.description}
+                  </p>
+                )}
+                <LabelChips labels={event.categories} className="mt-1.5" />
+              </div>
             </div>
-          </div>
-        </button>
-      ))}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -28,10 +28,11 @@ import '@schedule-x/theme-default/dist/index.css'
 // Temporal polyfill — patches globalThis.Temporal and registers types
 import 'temporal-polyfill/global'
 
-type CalendarGridDisplayView = CalendarView | 'threeDay'
+type CalendarGridDisplayView = CalendarView | 'threeDay' | 'sevenDay'
 
 const VIEW_MAP: Record<CalendarGridDisplayView, string> = {
   threeDay: 'week',
+  sevenDay: 'week',
   week: 'week',
   month: 'month-grid',
 }
@@ -62,10 +63,11 @@ function toScheduleXDateTime(date: Date, tz: string): Temporal.ZonedDateTime {
 function getViewRange(currentDate: Date, view: CalendarGridDisplayView, firstDay: FirstDayOfWeek): DateRange {
   const d = new Date(currentDate)
   switch (view) {
-    case 'threeDay': {
+    case 'threeDay':
+    case 'sevenDay': {
       const start = new Date(d.getFullYear(), d.getMonth(), d.getDate())
       const end = new Date(start)
-      end.setDate(start.getDate() + 2)
+      end.setDate(start.getDate() + (view === 'threeDay' ? 2 : 6))
       end.setHours(23, 59, 59, 999)
       return { start, end }
     }
@@ -216,7 +218,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
     () => (currentDate instanceof Date ? currentDate : new Date(currentDate)),
     [currentDateTs],
   )
-  const effectiveSxFirstDayOfWeek = effectiveView === 'threeDay'
+  const effectiveSxFirstDayOfWeek = effectiveView === 'threeDay' || effectiveView === 'sevenDay'
     ? toScheduleXWeekday(currentDateForSx)
     : sxFirstDayOfWeek
   const effectiveWeekDays = effectiveView === 'threeDay' ? 3 : 7
@@ -252,7 +254,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
   displayEventMapRef.current = displayEventMap
 
   const sxEvents = useMemo(
-    () => toScheduleXEvents(displayEvents, calendarColors, userTz, effectiveView === 'threeDay' ? 'week' : effectiveView, toScheduleXDateTime),
+    () => toScheduleXEvents(displayEvents, calendarColors, userTz, effectiveView === 'threeDay' || effectiveView === 'sevenDay' ? 'week' : effectiveView, toScheduleXDateTime),
     [displayEvents, calendarColors, userTz, effectiveView],
   )
 
@@ -489,7 +491,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
   }, [calendar, effectiveSxFirstDayOfWeek])
 
   // Push the effective week column count through Schedule-X. The mobile 3-day
-  // view reuses the week renderer with nDays=3; normal week/month keep 7 days.
+  // views reuse the week renderer with nDays=3 or nDays=7; normal week/month keep 7 days.
   useEffect(() => {
     if (!calendar) return
     try {
@@ -598,9 +600,9 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
 
         // SX is showing a different range — update store to match.
         // Pick a representative date from the SX range for currentDate:
-        // 3-day view → range start; week view → Wednesday; month view → middle.
+        // Mobile multi-day views → range start; week view → Wednesday; month view → middle.
         let newDate: Date
-        if (effectiveView === 'threeDay') {
+        if (effectiveView === 'threeDay' || effectiveView === 'sevenDay') {
           newDate = new Date(sxRangeStart)
         } else if (storeState.currentView === 'week') {
           newDate = new Date(sxRangeStart)

--- a/apps/web/app/(app)/calendar/components/__tests__/AgendaView.test.tsx
+++ b/apps/web/app/(app)/calendar/components/__tests__/AgendaView.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AgendaView } from '../AgendaView'
+import type { CalendarEvent } from '@silentsuite/core'
+
+vi.mock('@/app/stores/use-preferences-store', () => ({
+  usePreferencesStore: (selector: (state: { defaultTimezone: string }) => unknown) => selector({ defaultTimezone: 'UTC' }),
+}))
+
+function makeEvent(id: string, title: string, startDate: Date, endDate: Date): CalendarEvent {
+  return {
+    id,
+    uid: id,
+    title,
+    description: '',
+    location: '',
+    startDate,
+    endDate,
+    allDay: false,
+    recurrenceRule: null,
+    exceptions: [],
+    alarms: [],
+    calendarId: 'default',
+    categories: [],
+    created: new Date('2026-06-01T00:00:00Z'),
+    updated: new Date('2026-06-01T00:00:00Z'),
+  }
+}
+
+describe('AgendaView upcoming mode', () => {
+  it('shows upcoming events across future days instead of only the selected day', () => {
+    render(
+      <AgendaView
+        mode="upcoming"
+        currentDate={new Date('2026-06-01T12:00:00Z')}
+        events={[
+          makeEvent('today', 'Today event', new Date('2026-06-01T13:00:00Z'), new Date('2026-06-01T14:00:00Z')),
+          makeEvent('tomorrow', 'Tomorrow event', new Date('2026-06-02T09:00:00Z'), new Date('2026-06-02T10:00:00Z')),
+          makeEvent('later', 'Later event', new Date('2026-06-04T09:00:00Z'), new Date('2026-06-04T10:00:00Z')),
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Next events')).toBeInTheDocument()
+    expect(screen.getByText('Today event')).toBeInTheDocument()
+    expect(screen.getByText('Tomorrow event')).toBeInTheDocument()
+    expect(screen.getByText('Later event')).toBeInTheDocument()
+    expect(screen.getByText('Tomorrow')).toBeInTheDocument()
+    expect(screen.getByText('Thu, Jun 4')).toBeInTheDocument()
+  })
+
+  it('caps the upcoming list at six rendered events', () => {
+    const events = Array.from({ length: 8 }, (_, index) => makeEvent(
+      `event-${index}`,
+      `Event ${index}`,
+      new Date(Date.UTC(2026, 5, 1 + index, 9)),
+      new Date(Date.UTC(2026, 5, 1 + index, 10)),
+    ))
+
+    render(<AgendaView mode="upcoming" currentDate={new Date('2026-06-01T12:00:00Z')} events={events} />)
+
+    expect(screen.getByText('Event 0')).toBeInTheDocument()
+    expect(screen.getByText('Event 5')).toBeInTheDocument()
+    expect(screen.queryByText('Event 6')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -29,8 +29,8 @@ function snapTo30Min(date: Date): Date {
   return snapped
 }
 
-type CalendarDateLabelView = 'week' | 'month' | 'threeDay'
-type MobileCalendarMode = 'agenda' | 'threeDay'
+type CalendarDateLabelView = 'week' | 'month' | 'threeDay' | 'sevenDay'
+type MobileCalendarMode = 'agenda' | 'threeDay' | 'sevenDay'
 
 function addDays(date: Date, days: number): Date {
   const next = new Date(date)
@@ -50,9 +50,9 @@ function formatDateRange(
     return formatDate(date, dateFormat, opts)
   }
 
-  if (view === 'threeDay') {
+  if (view === 'threeDay' || view === 'sevenDay') {
     const rangeStart = new Date(date.getFullYear(), date.getMonth(), date.getDate())
-    const rangeEnd = addDays(rangeStart, 2)
+    const rangeEnd = addDays(rangeStart, view === 'threeDay' ? 2 : 6)
     const startMonth = formatDate(rangeStart, 'system', { month: 'short' })
     const endMonth = formatDate(rangeEnd, 'system', { month: 'short' })
 
@@ -143,7 +143,12 @@ export default function CalendarPage() {
     [currentDate, currentView, dateFormat, firstDayOfWeek],
   )
   const mobileDateLabel = useMemo(
-    () => formatDateRange(currentDate, mobileCalendarMode === 'threeDay' ? 'threeDay' : currentView, dateFormat, firstDayOfWeek),
+    () => formatDateRange(
+      currentDate,
+      mobileCalendarMode === 'agenda' ? currentView : mobileCalendarMode,
+      dateFormat,
+      firstDayOfWeek,
+    ),
     [currentDate, currentView, dateFormat, firstDayOfWeek, mobileCalendarMode],
   )
 
@@ -213,16 +218,16 @@ export default function CalendarPage() {
   )
 
   const handleMobileNavigateBackward = useCallback(() => {
-    if (mobileCalendarMode === 'threeDay') {
-      setCurrentDate(addDays(currentDate, -3))
+    if (mobileCalendarMode !== 'agenda') {
+      setCurrentDate(addDays(currentDate, mobileCalendarMode === 'threeDay' ? -3 : -7))
       return
     }
     navigateBackward()
   }, [currentDate, mobileCalendarMode, navigateBackward, setCurrentDate])
 
   const handleMobileNavigateForward = useCallback(() => {
-    if (mobileCalendarMode === 'threeDay') {
-      setCurrentDate(addDays(currentDate, 3))
+    if (mobileCalendarMode !== 'agenda') {
+      setCurrentDate(addDays(currentDate, mobileCalendarMode === 'threeDay' ? 3 : 7))
       return
     }
     navigateForward()
@@ -319,7 +324,7 @@ export default function CalendarPage() {
         </div>
         <div className="flex items-center gap-2 px-1">
           <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">{mobileDateLabel}</h2>
-          {mobileCalendarMode !== 'threeDay' && weekNumber !== null && (
+          {mobileCalendarMode === 'agenda' && weekNumber !== null && (
             <span
               className="rounded-md bg-[rgb(var(--surface))] px-2 py-0.5 text-xs font-medium text-[rgb(var(--muted))]"
               title="Calendar week"
@@ -352,6 +357,18 @@ export default function CalendarPage() {
             }`}
           >
             3 days
+          </button>
+          <button
+            type="button"
+            onClick={() => setMobileCalendarMode('sevenDay')}
+            aria-pressed={mobileCalendarMode === 'sevenDay'}
+            className={`max-md:min-h-[44px] rounded-md px-3 text-sm font-medium transition-colors ${
+              mobileCalendarMode === 'sevenDay'
+                ? 'bg-[rgb(var(--primary))] text-white'
+                : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] active:bg-[rgb(var(--surface))]'
+            }`}
+          >
+            7 days
           </button>
         </div>
       </div>
@@ -433,13 +450,14 @@ export default function CalendarPage() {
             <CalendarGrid events={visibleEvents} onSlotClick={handleSlotClick} onEventClick={handleEventClick} />
           </div>
 
-          {/* Mobile: agenda list view or 3-day grid */}
+          {/* Mobile: upcoming agenda list or multi-day grid */}
           <div className="flex flex-col flex-1 min-h-0 md:hidden">
             {mobileCalendarMode === 'agenda' ? (
               <PullToRefresh>
                 <AgendaView
                   events={visibleEvents}
                   currentDate={currentDate}
+                  mode="upcoming"
                   onEventClick={(id) => {
                     setSelectedEvent(id)
                     setEventInstanceDate(undefined)
@@ -449,8 +467,8 @@ export default function CalendarPage() {
             ) : (
               <div className="flex flex-1 min-h-[520px] overflow-hidden">
                 <CalendarGrid
-                  key="mobile-three-day-grid"
-                  displayView="threeDay"
+                  key={mobileCalendarMode}
+                  displayView={mobileCalendarMode}
                   events={visibleEvents}
                   onSlotClick={handleSlotClick}
                   onEventClick={handleEventClick}


### PR DESCRIPTION
## Summary
- add a mobile 7-day calendar option next to Agenda and 3 days without writing mobile-only state into the shared desktop view store
- make mobile Agenda show the next upcoming events across future days, with 6 rendered and the sixth hidden on very narrow screens so small phones show 5
- keep hidden-calendar filtering and desktop Week/Month behavior intact

## Validation
- pnpm install
- pnpm --filter @silentsuite/web test -- 'app/(app)/calendar/__tests__/page.test.tsx' 'app/(app)/calendar/components/__tests__/AgendaView.test.tsx' (Vitest config ran 36 files / 340 tests, all passed)
- pnpm --filter @silentsuite/web type-check
- git diff --check

Refs #295