### PR TITLE
Polish mobile calendar agenda and grid views

### DIFF
--- a/apps/web/app/(app)/calendar/components/AgendaView.tsx
+++ b/apps/web/app/(app)/calendar/components/AgendaView.tsx
@@ -1,18 +1,21 @@
 'use client'
 
 import { useMemo } from 'react'
-import { Clock, MapPin } from 'lucide-react'
+import { Clock, MapPin, Repeat2 } from 'lucide-react'
 import { CalendarEmptyState } from '@/app/components/empty-state'
 import { LabelChips } from '@/app/components/LabelEditor'
-import type { CalendarEvent } from '@silentsuite/core'
+import type { CalendarEvent, DateRange } from '@silentsuite/core'
+import type { CalendarList } from '@/app/stores/use-calendar-list-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
 import { resolveUserTimezone, shortTimezoneLabel } from '@/app/lib/tz'
+import { expandEventsForRange, type DisplayEvent } from '../lib/calendar-grid-events'
 
 interface AgendaViewProps {
   events: CalendarEvent[]
   currentDate: Date
+  calendars?: CalendarList[]
   mode?: 'day' | 'upcoming'
-  onEventClick?: (eventId: string) => void
+  onEventClick?: (eventId: string, instanceDate?: Date) => void
 }
 
 function formatTime(date: Date, tz: string): string {
@@ -42,54 +45,49 @@ function formatAgendaDate(date: Date, currentDate: Date, tz: string): string {
   })
 }
 
-function eventStart(event: CalendarEvent): Date {
-  return event.startDate instanceof Date ? event.startDate : new Date(event.startDate)
-}
-
-function eventEnd(event: CalendarEvent): Date {
-  return event.endDate instanceof Date ? event.endDate : new Date(event.endDate)
-}
-
-function compareEvents(a: CalendarEvent, b: CalendarEvent): number {
-  const aStart = eventStart(a)
-  const bStart = eventStart(b)
-  if (!isSameDay(aStart, bStart)) return aStart.getTime() - bStart.getTime()
+function compareEvents(a: DisplayEvent, b: DisplayEvent): number {
+  if (!isSameDay(a.startDate, b.startDate)) return a.startDate.getTime() - b.startDate.getTime()
   if (a.allDay && !b.allDay) return -1
   if (!a.allDay && b.allDay) return 1
-  return aStart.getTime() - bStart.getTime()
+  return a.startDate.getTime() - b.startDate.getTime()
 }
 
-export function AgendaView({ events, currentDate, mode = 'day', onEventClick }: AgendaViewProps) {
+function getAgendaRange(currentDate: Date, mode: 'day' | 'upcoming'): DateRange {
+  const start = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate())
+  const end = new Date(start)
+  if (mode === 'upcoming') {
+    // Wide enough to catch normal weekly/monthly recurrences while keeping expansion bounded.
+    end.setDate(start.getDate() + 180)
+  }
+  end.setHours(23, 59, 59, 999)
+  return { start, end }
+}
+
+function collectionFallback(calendarId: string): string {
+  return calendarId === 'default' ? 'Personal' : calendarId
+}
+
+export function AgendaView({ events, currentDate, calendars = [], mode = 'day', onEventClick }: AgendaViewProps) {
   const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
   const userTz = resolveUserTimezone(defaultTimezonePref)
-  const agendaEvents = useMemo(() => {
-    const currentDayStart = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate())
-    const currentDayEnd = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate(), 23, 59, 59, 999)
-
-    if (mode === 'upcoming') {
-      return events
-        .filter((event) => {
-          const end = eventEnd(event)
-          // Keep in-progress all-day and timed events, then show upcoming items across future days.
-          return event.allDay ? end > currentDayStart : end >= currentDayStart
-        })
-        .sort(compareEvents)
-        .slice(0, 6)
+  const calendarMeta = useMemo(() => {
+    const map = new Map<string, { name: string; color: string }>()
+    for (const calendar of calendars) {
+      map.set(calendar.id, { name: calendar.name, color: calendar.color })
     }
+    if (!map.has('default')) map.set('default', { name: 'Personal', color: '#10b981' })
+    return map
+  }, [calendars])
 
-    return events
-      .filter((e) => {
-        const start = eventStart(e)
-        const end = eventEnd(e)
-
-        // Event overlaps with current day if it starts before day ends AND ends after day starts.
-        // For all-day events, endDate follows iCal DTEND;VALUE=DATE convention (exclusive — the
-        // day *after* the last day of the event), so use `>` rather than `>=` to avoid bleeding
-        // a single-day event onto the morning of the next day.
-        const endComparison = e.allDay ? end > currentDayStart : end >= currentDayStart
-        return start <= currentDayEnd && endComparison
+  const agendaEvents = useMemo(() => {
+    const range = getAgendaRange(currentDate, mode)
+    return expandEventsForRange(events, range)
+      .filter((event) => {
+        const endComparison = event.allDay ? event.endDate > range.start : event.endDate >= range.start
+        return endComparison && event.startDate <= range.end
       })
       .sort(compareEvents)
+      .slice(0, mode === 'upcoming' ? 6 : undefined)
   }, [events, currentDate, mode])
 
   if (agendaEvents.length === 0) {
@@ -104,18 +102,23 @@ export function AgendaView({ events, currentDate, mode = 'day', onEventClick }: 
         </p>
       )}
       {agendaEvents.map((event, index) => {
-        const start = eventStart(event)
+        const calendarId = event.calendarId ?? 'default'
+        const collection = calendarMeta.get(calendarId) ?? { name: collectionFallback(calendarId), color: '#10b981' }
         return (
           <button
             key={event.id}
             type="button"
-            onClick={() => onEventClick?.(event.id)}
+            onClick={() => onEventClick?.(event.masterId, event.instanceDate)}
             className={`w-full text-left rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3 transition-colors hover:border-[rgb(var(--primary))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${
               mode === 'upcoming' && index === 5 ? 'max-[389px]:hidden' : ''
             }`}
           >
             <div className="flex items-start gap-3">
-              <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-[rgb(var(--primary))]" />
+              <div
+                className="mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: collection.color }}
+                aria-hidden="true"
+              />
               <div className="flex-1 min-w-0">
                 <div className="flex items-start justify-between gap-2">
                   <p className="text-sm font-medium text-[rgb(var(--foreground))] truncate">
@@ -123,7 +126,23 @@ export function AgendaView({ events, currentDate, mode = 'day', onEventClick }: 
                   </p>
                   {mode === 'upcoming' && (
                     <span className="shrink-0 text-xs text-[rgb(var(--muted))]">
-                      {formatAgendaDate(start, currentDate, userTz)}
+                      {formatAgendaDate(event.startDate, currentDate, userTz)}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-[rgb(var(--muted))]">
+                  <span className="inline-flex min-w-0 items-center gap-1 rounded-full bg-[rgb(var(--background))] px-2 py-0.5 font-medium">
+                    <span
+                      className="h-1.5 w-1.5 shrink-0 rounded-full"
+                      style={{ backgroundColor: collection.color }}
+                      aria-hidden="true"
+                    />
+                    <span className="truncate">{collection.name}</span>
+                  </span>
+                  {event.isRecurring && (
+                    <span className="inline-flex items-center gap-1">
+                      <Repeat2 className="h-3 w-3" />
+                      Repeats
                     </span>
                   )}
                 </div>

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -1477,6 +1477,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
       <div
         ref={rootRef}
         className="sx-silentsuite-calendar relative flex-1 min-h-0"
+        data-mobile-days={effectiveView === 'threeDay' ? '3' : effectiveView === 'sevenDay' ? '7' : undefined}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}

--- a/apps/web/app/(app)/calendar/components/__tests__/AgendaView.test.tsx
+++ b/apps/web/app/(app)/calendar/components/__tests__/AgendaView.test.tsx
@@ -1,13 +1,20 @@
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { AgendaView } from '../AgendaView'
 import type { CalendarEvent } from '@silentsuite/core'
+import type { CalendarList } from '@/app/stores/use-calendar-list-store'
 
 vi.mock('@/app/stores/use-preferences-store', () => ({
   usePreferencesStore: (selector: (state: { defaultTimezone: string }) => unknown) => selector({ defaultTimezone: 'UTC' }),
 }))
 
-function makeEvent(id: string, title: string, startDate: Date, endDate: Date): CalendarEvent {
+function makeEvent(
+  id: string,
+  title: string,
+  startDate: Date,
+  endDate: Date,
+  overrides: Partial<CalendarEvent> = {},
+): CalendarEvent {
   return {
     id,
     uid: id,
@@ -24,8 +31,14 @@ function makeEvent(id: string, title: string, startDate: Date, endDate: Date): C
     categories: [],
     created: new Date('2026-06-01T00:00:00Z'),
     updated: new Date('2026-06-01T00:00:00Z'),
+    ...overrides,
   }
 }
+
+const calendars: CalendarList[] = [
+  { id: 'work', name: 'Work', color: '#2563eb', visible: true },
+  { id: 'personal', name: 'Personal', color: '#10b981', visible: true },
+]
 
 describe('AgendaView upcoming mode', () => {
   it('shows upcoming events across future days instead of only the selected day', () => {
@@ -33,6 +46,7 @@ describe('AgendaView upcoming mode', () => {
       <AgendaView
         mode="upcoming"
         currentDate={new Date('2026-06-01T12:00:00Z')}
+        calendars={calendars}
         events={[
           makeEvent('today', 'Today event', new Date('2026-06-01T13:00:00Z'), new Date('2026-06-01T14:00:00Z')),
           makeEvent('tomorrow', 'Tomorrow event', new Date('2026-06-02T09:00:00Z'), new Date('2026-06-02T10:00:00Z')),
@@ -62,5 +76,46 @@ describe('AgendaView upcoming mode', () => {
     expect(screen.getByText('Event 0')).toBeInTheDocument()
     expect(screen.getByText('Event 5')).toBeInTheDocument()
     expect(screen.queryByText('Event 6')).not.toBeInTheDocument()
+  })
+
+  it('shows the event collection name in agenda rows', () => {
+    render(
+      <AgendaView
+        mode="upcoming"
+        currentDate={new Date('2026-06-01T12:00:00Z')}
+        calendars={calendars}
+        events={[
+          makeEvent('work-event', 'Work planning', new Date('2026-06-01T13:00:00Z'), new Date('2026-06-01T14:00:00Z'), {
+            calendarId: 'work',
+          }),
+        ]}
+      />,
+    )
+
+    expect(screen.getByText('Work planning')).toBeInTheDocument()
+    expect(screen.getByText('Work')).toBeInTheDocument()
+  })
+
+  it('expands recurring events into upcoming agenda occurrences', () => {
+    const onEventClick = vi.fn()
+    render(
+      <AgendaView
+        mode="upcoming"
+        currentDate={new Date('2026-06-02T12:00:00Z')}
+        onEventClick={onEventClick}
+        events={[
+          makeEvent('daily-standup', 'Daily standup', new Date('2026-06-01T09:00:00Z'), new Date('2026-06-01T09:30:00Z'), {
+            recurrenceRule: 'FREQ=DAILY;COUNT=3',
+            calendarId: 'work',
+          }),
+        ]}
+      />,
+    )
+
+    expect(screen.getAllByText('Daily standup')).toHaveLength(2)
+    expect(screen.getAllByText('Repeats')).toHaveLength(2)
+
+    fireEvent.click(screen.getAllByRole('button', { name: /Daily standup/ })[0])
+    expect(onEventClick).toHaveBeenCalledWith('daily-standup', new Date('2026-06-02T09:00:00Z'))
   })
 })

--- a/apps/web/app/(app)/calendar/lib/calendar-grid-events.ts
+++ b/apps/web/app/(app)/calendar/lib/calendar-grid-events.ts
@@ -18,6 +18,8 @@ export interface DisplayEvent {
   /** The specific occurrence date for this instance */
   instanceDate: Date
   calendarId?: string
+  categories?: string[]
+  timezone?: string
 }
 
 type CalendarGridView = 'week' | 'month'
@@ -50,6 +52,8 @@ export function expandEventsForRange(
           isRecurring: false,
           instanceDate: event.startDate,
           calendarId: event.calendarId,
+          categories: event.categories,
+          timezone: event.timezone,
         })
       }
     } else {
@@ -76,6 +80,8 @@ export function expandEventsForRange(
           isRecurring: true,
           instanceDate: occDate,
           calendarId: event.calendarId,
+          categories: event.categories,
+          timezone: event.timezone,
         })
       }
     }

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -457,15 +457,16 @@ export default function CalendarPage() {
                 <AgendaView
                   events={visibleEvents}
                   currentDate={currentDate}
+                  calendars={calendars}
                   mode="upcoming"
-                  onEventClick={(id) => {
+                  onEventClick={(id, instanceDate) => {
                     setSelectedEvent(id)
-                    setEventInstanceDate(undefined)
+                    setEventInstanceDate(instanceDate)
                   }}
                 />
               </PullToRefresh>
             ) : (
-              <div className="flex flex-1 min-h-[520px] overflow-hidden">
+              <div className="mobile-calendar-grid-scroll flex flex-1 min-h-[520px] overflow-x-auto overflow-y-hidden pb-1">
                 <CalendarGrid
                   key={mobileCalendarMode}
                   displayView={mobileCalendarMode}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -597,6 +597,82 @@
   border: 1px solid rgb(var(--border) / 0.25);
 }
 
+/* ---------------------------------------------------------------------------
+   17. MOBILE MULTI-DAY GRID – readable swipeable columns
+   --------------------------------------------------------------------------- */
+@media (max-width: 767px) {
+  .mobile-calendar-grid-scroll {
+    scrollbar-width: thin;
+    scrollbar-color: rgb(var(--muted) / 0.25) transparent;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days="3"] {
+    min-width: max(100%, 390px);
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days="7"] {
+    /* Seven columns are not readable when squeezed into a phone viewport.
+       Match common mobile calendar patterns: keep a vertical schedule grid,
+       but make the week swipe horizontally with usable day columns. */
+    min-width: 780px;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__time-axis {
+    width: 38px;
+    min-width: 38px;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__time-axis-hour {
+    font-size: 0.58rem;
+    padding-right: 6px;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__week-header {
+    padding: 6px 0 4px;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__week-header-day .sx__week-header-day-name {
+    font-size: 0.6rem;
+    letter-spacing: 0.04em;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__week-header-day .sx__week-header-day-date {
+    width: 28px;
+    height: 28px;
+    font-size: 0.95rem;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__time-grid-event {
+    margin-inline: 2px !important;
+    border-radius: 5px !important;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__time-grid-event-inner {
+    padding: 2px 4px !important;
+    font-size: 0.66rem;
+    line-height: 1.08;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__time-grid-event-time,
+  .sx-silentsuite-calendar[data-mobile-days] .sx__time-grid-event-location,
+  .sx-silentsuite-calendar[data-mobile-days] .sx__time-grid-event-people {
+    display: none !important;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days] .sx__time-grid-event-title {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .sx-silentsuite-calendar[data-mobile-days="7"] .sx__time-grid-event-inner {
+    font-size: 0.62rem;
+  }
+}
+
 /* ==========================================================================
    General UI Polish (from UI/UX improvements branch)
    ========================================================================== */


### PR DESCRIPTION
## Summary
- make mobile 3-day/7-day grids more readable by using a swipeable mobile grid with usable day-column widths instead of squeezing all text into the viewport
- hide lower-priority time/location metadata in mobile multi-day event chips and allow event titles to wrap to two lines
- add collection badges/colors to Agenda rows so users can see Work/Personal/etc.
- expand recurring events in Agenda and open recurring occurrences with their instance date

## Research notes
- Mobile calendar UI guidance generally favors Agenda/Schedule as the primary compact view and uses switchable day/week/schedule views rather than dense fixed grids.
- Google Calendar Android exposes Schedule, Day, 3-day, Week, and Month views; custom multi-day counts are a desktop setting, not a mobile-first control.
- Calendar UI examples and Mobiscroll guidance emphasize keeping mobile schedule content in a consistent vertical flow, supporting swiping/scrolling for denser multi-day layouts, and preserving recurring-event support across views.

## Validation
- pnpm install
- pnpm --filter @silentsuite/web test -- 'app/(app)/calendar/__tests__/page.test.tsx' 'app/(app)/calendar/components/__tests__/AgendaView.test.tsx' 'app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts' (Vitest config ran 36 files / 342 tests, all passed)
- pnpm --filter @silentsuite/web type-check
- git diff --check

Refs #295