### PR TITLE
fix(android): support 16 KB native library alignment

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
 
-        versionCode 8
-        versionName "0.3.0-beta"
+        versionCode 9
+        versionName "0.3.1-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@
 
 ext {
     kotlin_version = '1.8.21'
-    gradle_version = '8.2.2'
+    gradle_version = '8.5.2'
     compileSdkVersion = 36
     buildToolsVersion = '36.0.0'
 }
@@ -16,7 +16,7 @@ ext {
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = '1.8.21'
-    ext.gradle_version = '8.2.2'
+    ext.gradle_version = '8.5.2'
 
     repositories {
         google()

--- a/android/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,1 @@
+Fixes Android App Bundle packaging compatibility for devices and stores that require 16 KB native library alignment.

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/fastlane/metadata/android/en-US/changelogs/9.txt
+++ b/fastlane/metadata/android/en-US/changelogs/9.txt
@@ -1,0 +1,1 @@
+Fixes Android App Bundle packaging compatibility for devices and stores that require 16 KB native library alignment.


### PR DESCRIPTION
## Summary
- Upgrade Android Gradle Plugin to 8.5.2 and the Gradle wrapper to 8.7 so release bundles request 16 KB native-library alignment.
- Bump the Android beta to versionCode 9 / versionName 0.3.1-beta instead of replacing the rejected 0.3.0-beta bundle.
- Add matching Fastlane changelogs for versionCode 9 in both metadata roots.

## Root cause
Google Play rejected the 0.3.0-beta AAB because native libraries in the bundle were not aligned for 16 KB page-size devices. The app already used `jniLibs.useLegacyPackaging = false`, so the intended uncompressed native-library packaging was present. The blocker was the older Android Gradle Plugin 8.2.2 / Gradle 8.2 toolchain, which predates the 16 KB AAB alignment support required by current Play checks.

## Test plan
- Static verification of Android version metadata, AGP version, Gradle wrapper URL, and `jniLibs.useLegacyPackaging = false`.
- GitHub Actions Android workflow builds the debug APK for PRs.
- The signed release APK/AAB is produced by the tag release workflow after this reaches `main` and `v0.3.1-beta` is tagged.
