### PR TITLE
fix(android): rebuild native deps for 16 KB pages

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -48,7 +48,11 @@ jobs:
 
       - name: Install Android NDK r28
         run: |
-          yes | sdkmanager --install "ndk;28.2.13676358"
+          SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          if [ ! -x "$SDKMANAGER" ]; then
+            SDKMANAGER="$(command -v sdkmanager)"
+          fi
+          yes | "$SDKMANAGER" --install "ndk;28.2.13676358"
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
 
       - name: Cache Gradle
@@ -118,7 +122,11 @@ jobs:
 
       - name: Install Android NDK r28
         run: |
-          yes | sdkmanager --install "ndk;28.2.13676358"
+          SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          if [ ! -x "$SDKMANAGER" ]; then
+            SDKMANAGER="$(command -v sdkmanager)"
+          fi
+          yes | "$SDKMANAGER" --install "ndk;28.2.13676358"
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
 
       - name: Cache Gradle

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -40,6 +40,17 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - name: Install Android NDK r28
+        run: |
+          yes | sdkmanager --install "ndk;28.2.13676358"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
+
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -52,8 +63,18 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
+      - name: Build 16 KB-aligned Etebase client AAR
+        run: scripts/build-etebase-client-16kb.sh
+
       - name: Build debug APK
-        run: ./gradlew assembleDebug --no-daemon
+        run: ./gradlew assembleDebug --no-daemon -PrequireEtebase16Kb=true
+
+      - name: Verify debug native library alignment
+        run: |
+          python3 scripts/verify-native-16kb.py \
+            --require-lib libetebase_android.so \
+            --require-lib libconscrypt_jni.so \
+            app/build/outputs/apk/debug/*.apk
 
       - name: Upload debug APK artifact
         uses: actions/upload-artifact@v4
@@ -89,6 +110,17 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - name: Install Android NDK r28
+        run: |
+          yes | sdkmanager --install "ndk;28.2.13676358"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
+
       - name: Cache Gradle
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -100,6 +132,9 @@ jobs:
 
       - name: Make gradlew executable
         run: chmod +x gradlew
+
+      - name: Build 16 KB-aligned Etebase client AAR
+        run: scripts/build-etebase-client-16kb.sh
 
       - name: Decode release keystore
         env:
@@ -115,8 +150,17 @@ jobs:
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
           ./gradlew assembleRelease bundleRelease --no-daemon \
+            -PrequireEtebase16Kb=true \
             -PsigningStoreLocation="$KEYSTORE_PATH" \
             -PsigningKeyAlias="$KEY_ALIAS"
+
+      - name: Verify release native library alignment
+        run: |
+          python3 scripts/verify-native-16kb.py \
+            --require-lib libetebase_android.so \
+            --require-lib libconscrypt_jni.so \
+            app/build/outputs/apk/release/*.apk \
+            app/build/outputs/bundle/release/*.aab
 
       - name: Verify APK signature
         run: |

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -4,6 +4,7 @@
 # Built application files
 *.apk
 *.ap_
+app/libs/client-*-16kb.aar
 
 # Files for the Dalvik VM
 *.dex

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
 
-        versionCode 9
-        versionName "0.3.1-beta"
+        versionCode 10
+        versionName "0.3.2-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -136,7 +136,29 @@ dependencies {
 
     // Legacy journalmanager dependency removed — Etebase-only sync
     def etebaseVersion = '2.3.2'
-    implementation "com.etebase:client:$etebaseVersion"
+    def etebase16KbAar = file("libs/client-${etebaseVersion}-16kb.aar")
+    def etebase16KbRequired = providers.gradleProperty('requireEtebase16Kb')
+            .map { it.toBoolean() }
+            .getOrElse(false)
+    def releaseBuildRequested = gradle.startParameter.taskNames.any { taskName ->
+        def normalized = taskName.toLowerCase()
+        normalized == 'assemblerelease' || normalized.endsWith(':assemblerelease') ||
+                normalized == 'bundlerelease' || normalized.endsWith(':bundlerelease')
+    }
+
+    if (etebase16KbAar.exists()) {
+        implementation files(etebase16KbAar)
+        // Direct dependencies from com.etebase:client:2.3.2, kept explicit because
+        // a local AAR does not carry Maven transitive metadata. The upstream
+        // okhttp/logging-interceptor dependency is satisfied by this app's
+        // direct OkHttp dependencies below.
+        implementation 'androidx.annotation:annotation:1.1.0'
+    } else if (etebase16KbRequired || releaseBuildRequested) {
+        throw new GradleException("Missing ${etebase16KbAar}. Run android/scripts/build-etebase-client-16kb.sh before release builds, or pass -PrequireEtebase16Kb=false only for local non-release builds.")
+    } else {
+        logger.warn("Using Maven com.etebase:client:${etebaseVersion}; run android/scripts/build-etebase-client-16kb.sh to build the 16 KB-aligned local AAR.")
+        implementation "com.etebase:client:$etebaseVersion"
+    }
 
     // ACRA crash reporting removed - will be replaced with Sentry in Phase 2
     // def acraVersion = '5.7.0'

--- a/android/cert4android/build.gradle
+++ b/android/cert4android/build.gradle
@@ -1,7 +1,7 @@
 
 buildscript {
     ext.versions = [
-        conscrypt: '2.5.0'
+        conscrypt: '2.5.3'
     ]
 }
 

--- a/android/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,1 @@
+Fixes Google Play 16 KB native library compatibility by rebuilding native sync dependencies with 16 KB page-size support.

--- a/android/scripts/build-etebase-client-16kb.sh
+++ b/android/scripts/build-etebase-client-16kb.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rebuild Etebase Android 2.3.2 native libraries with 16 KB ELF LOAD
+# segment alignment, then repack the upstream Maven AAR as a local drop-in
+# artifact for SilentSuite Android builds.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_LIBS_DIR="$ROOT_DIR/app/libs"
+OUT_AAR="${OUT_AAR:-$APP_LIBS_DIR/client-2.3.2-16kb.aar}"
+ETEBASE_REPO_URL="${ETEBASE_REPO_URL:-https://github.com/etesync/etebase-java.git}"
+ETEBASE_REF="${ETEBASE_REF:-v2.3.2}"
+ETEBASE_EXPECTED_COMMIT="${ETEBASE_EXPECTED_COMMIT:-365f7af82b5e2cb39ec59c9711fd11096ee127a7}"
+BUILD_DIR="${ETEBASE_BUILD_DIR:-${RUNNER_TEMP:-$ROOT_DIR/build}/etebase-client-16kb}"
+ORIGINAL_AAR_URL="${ORIGINAL_AAR_URL:-https://repo1.maven.org/maven2/com/etebase/client/2.3.2/client-2.3.2.aar}"
+ORIGINAL_AAR_SHA256="${ORIGINAL_AAR_SHA256:-1d1ff77036911852b74f18f2854f86a731766f58138f87e1ac151f641291ede3}"
+ORIGINAL_AAR="$BUILD_DIR/client-2.3.2.aar"
+NATIVE_OUT="$BUILD_DIR/native"
+
+ABIS=(armeabi-v7a arm64-v8a x86 x86_64)
+TARGETS=(armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android)
+CLANGS=(armv7a-linux-androideabi21-clang aarch64-linux-android21-clang i686-linux-android21-clang x86_64-linux-android21-clang)
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command '$1' was not found" >&2
+    exit 1
+  fi
+}
+
+find_ndk() {
+  if [[ -n "${ANDROID_NDK_HOME:-}" && -d "${ANDROID_NDK_HOME}" ]]; then
+    printf '%s\n' "$ANDROID_NDK_HOME"
+    return
+  fi
+  if [[ -n "${ANDROID_NDK_ROOT:-}" && -d "${ANDROID_NDK_ROOT}" ]]; then
+    printf '%s\n' "$ANDROID_NDK_ROOT"
+    return
+  fi
+  if [[ -n "${ANDROID_HOME:-}" && -d "${ANDROID_HOME}/ndk" ]]; then
+    find "${ANDROID_HOME}/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1
+    return
+  fi
+  if [[ -n "${ANDROID_SDK_ROOT:-}" && -d "${ANDROID_SDK_ROOT}/ndk" ]]; then
+    find "${ANDROID_SDK_ROOT}/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1
+    return
+  fi
+  echo "error: could not locate Android NDK; set ANDROID_NDK_HOME or ANDROID_HOME" >&2
+  exit 1
+}
+
+upper_target_env() {
+  printf '%s' "$1" | tr '[:lower:]-' '[:upper:]_'
+}
+
+need_cmd git
+need_cmd python3
+need_cmd readelf
+need_cmd cargo
+need_cmd rustup
+
+NDK_DIR="$(find_ndk)"
+HOST_TAG="linux-x86_64"
+TOOLCHAIN_BIN="$NDK_DIR/toolchains/llvm/prebuilt/$HOST_TAG/bin"
+if [[ ! -d "$TOOLCHAIN_BIN" ]]; then
+  echo "error: NDK LLVM toolchain not found at $TOOLCHAIN_BIN" >&2
+  exit 1
+fi
+
+mkdir -p "$BUILD_DIR" "$NATIVE_OUT" "$APP_LIBS_DIR"
+rm -rf "$BUILD_DIR/etebase-java" "$NATIVE_OUT"
+mkdir -p "$NATIVE_OUT"
+
+printf 'Using NDK: %s\n' "$NDK_DIR"
+if [[ -f "$NDK_DIR/source.properties" ]]; then
+  sed -n 's/^Pkg.Revision *= */NDK revision: /p' "$NDK_DIR/source.properties"
+fi
+
+git clone --quiet --branch "$ETEBASE_REF" --depth 1 "$ETEBASE_REPO_URL" "$BUILD_DIR/etebase-java"
+cd "$BUILD_DIR/etebase-java"
+actual_commit="$(git rev-parse HEAD)"
+if [[ "$actual_commit" != "$ETEBASE_EXPECTED_COMMIT" ]]; then
+  echo "error: $ETEBASE_REF resolved to $actual_commit, expected $ETEBASE_EXPECTED_COMMIT" >&2
+  exit 1
+fi
+
+rustup target add "${TARGETS[@]}"
+
+# NDK r28+ emits 16 KB-aligned Android shared libraries by default, but
+# these flags keep the build correct if CI ever runs an older NDK. Android's
+# 16 KB page-size guidance requires both flags for old NDK/linker versions.
+export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-Wl,-z,max-page-size=16384 -C link-arg=-Wl,-z,common-page-size=16384"
+
+for i in "${!ABIS[@]}"; do
+  abi="${ABIS[$i]}"
+  target="${TARGETS[$i]}"
+  clang="${CLANGS[$i]}"
+  linker="$TOOLCHAIN_BIN/$clang"
+  if [[ ! -x "$linker" ]]; then
+    echo "error: missing NDK linker $linker" >&2
+    exit 1
+  fi
+
+  export CC="$linker"
+  env_name="CARGO_TARGET_$(upper_target_env "$target")_LINKER"
+  export "$env_name=$linker"
+
+  echo "Building Etebase native library for $abi ($target)"
+  cargo build --target "$target" --release --locked
+
+  built="target/$target/release/libetebase_android.so"
+  if [[ ! -f "$built" ]]; then
+    echo "error: expected native library was not produced: $built" >&2
+    exit 1
+  fi
+  mkdir -p "$NATIVE_OUT/jni/$abi"
+  cp "$built" "$NATIVE_OUT/jni/$abi/libetebase_android.so"
+done
+
+python3 - "$NATIVE_OUT" <<'PY'
+import pathlib
+import subprocess
+import sys
+
+root = pathlib.Path(sys.argv[1])
+failed = False
+for so in sorted(root.glob('jni/*/*.so')):
+    abi = so.parts[-2]
+    output = subprocess.check_output(['readelf', '-lW', str(so)], text=True)
+    alignments = []
+    lines = output.splitlines()
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith('LOAD'):
+            continue
+        fields = stripped.split()
+        if fields[-1].startswith('0x'):
+            alignments.append(int(fields[-1], 16))
+        elif index + 1 < len(lines):
+            alignments.append(int(lines[index + 1].split()[-1], 16))
+    print(f'{so}: LOAD alignments {[hex(value) for value in alignments]}')
+    if abi in {'arm64-v8a', 'x86_64'} and any(value < 0x4000 for value in alignments):
+        failed = True
+if failed:
+    raise SystemExit('error: rebuilt Etebase 64-bit library is not 16 KB aligned')
+PY
+
+python3 - "$ORIGINAL_AAR_URL" "$ORIGINAL_AAR" "$ORIGINAL_AAR_SHA256" <<'PY'
+import hashlib
+import pathlib
+import sys
+import urllib.request
+
+url = sys.argv[1]
+out = pathlib.Path(sys.argv[2])
+expected = sys.argv[3]
+out.parent.mkdir(parents=True, exist_ok=True)
+if not out.exists():
+    print(f'Downloading {url}')
+    urllib.request.urlretrieve(url, out)
+actual = hashlib.sha256(out.read_bytes()).hexdigest()
+if actual != expected:
+    raise SystemExit(f'error: {out} sha256 {actual} did not match expected {expected}')
+print(out)
+PY
+
+python3 - "$ORIGINAL_AAR" "$NATIVE_OUT" "$OUT_AAR" <<'PY'
+import pathlib
+import sys
+import zipfile
+
+original = pathlib.Path(sys.argv[1])
+native_root = pathlib.Path(sys.argv[2])
+out = pathlib.Path(sys.argv[3])
+replacements = {
+    f'jni/{path.parts[-2]}/{path.name}': path
+    for path in native_root.glob('jni/*/libetebase_android.so')
+}
+
+tmp = out.with_suffix(out.suffix + '.tmp')
+out.parent.mkdir(parents=True, exist_ok=True)
+with zipfile.ZipFile(original, 'r') as zin, zipfile.ZipFile(tmp, 'w') as zout:
+    seen = set()
+    for info in zin.infolist():
+        data = zin.read(info.filename)
+        if info.filename in replacements:
+            data = replacements[info.filename].read_bytes()
+            seen.add(info.filename)
+        zi = zipfile.ZipInfo(info.filename, date_time=info.date_time)
+        zi.compress_type = info.compress_type
+        zi.external_attr = info.external_attr
+        zi.comment = info.comment
+        zi.extra = info.extra
+        zout.writestr(zi, data)
+    missing = sorted(set(replacements) - seen)
+    if missing:
+        raise SystemExit(f'error: original AAR did not contain expected entries: {missing}')
+tmp.replace(out)
+print(f'Wrote {out}')
+PY
+
+python3 "$ROOT_DIR/scripts/verify-native-16kb.py" \
+  --require-lib libetebase_android.so \
+  "$OUT_AAR"

--- a/android/scripts/build-etebase-client-16kb.sh
+++ b/android/scripts/build-etebase-client-16kb.sh
@@ -17,9 +17,12 @@ ORIGINAL_AAR_SHA256="${ORIGINAL_AAR_SHA256:-1d1ff77036911852b74f18f2854f86a73176
 ORIGINAL_AAR="$BUILD_DIR/client-2.3.2.aar"
 NATIVE_OUT="$BUILD_DIR/native"
 
-ABIS=(armeabi-v7a arm64-v8a x86 x86_64)
-TARGETS=(armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android)
-CLANGS=(armv7a-linux-androideabi21-clang aarch64-linux-android21-clang i686-linux-android21-clang x86_64-linux-android21-clang)
+# Google Play's 16 KB page-size requirement applies to 64-bit Android
+# devices. Rebuild and replace only the 64-bit Etebase libraries; leave the
+# upstream 32-bit libraries untouched in the repacked AAR.
+ABIS=(arm64-v8a x86_64)
+TARGETS=(aarch64-linux-android x86_64-linux-android)
+CLANGS=(aarch64-linux-android21-clang x86_64-linux-android21-clang)
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then

--- a/android/scripts/verify-native-16kb.py
+++ b/android/scripts/verify-native-16kb.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Verify Android native libraries are compatible with 16 KB page sizes.
+
+Scans APK, AAB, or AAR files as zip archives. Every Android shared library
+under arm64-v8a or x86_64 must have ELF LOAD segment alignment of 0x4000 or
+greater. The Google Play 16 KB requirement applies to 64-bit devices; 32-bit
+ABIs are ignored by this gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import subprocess
+import sys
+import tempfile
+import zipfile
+from collections import defaultdict
+
+REQUIRED_64_BIT_ABIS = {"arm64-v8a", "x86_64"}
+KNOWN_ANDROID_ABIS = REQUIRED_64_BIT_ABIS | {"armeabi-v7a", "x86"}
+
+
+def abi_for_entry(name: str) -> str | None:
+    parts = pathlib.PurePosixPath(name).parts
+    for part in parts:
+        if part in KNOWN_ANDROID_ABIS:
+            return part
+    return None
+
+
+def load_alignments(path: pathlib.Path) -> list[int]:
+    output = subprocess.check_output(["readelf", "-lW", str(path)], text=True)
+    lines = output.splitlines()
+    alignments: list[int] = []
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped.startswith("LOAD"):
+            continue
+        fields = stripped.split()
+        if fields and fields[-1].startswith("0x"):
+            alignments.append(int(fields[-1], 16))
+        elif index + 1 < len(lines):
+            alignments.append(int(lines[index + 1].split()[-1], 16))
+    return alignments
+
+
+def verify_archive(archive: pathlib.Path, required_libs: set[str]) -> bool:
+    ok = True
+    checked = 0
+    seen_by_abi: dict[str, set[str]] = defaultdict(set)
+    with zipfile.ZipFile(archive) as zf, tempfile.TemporaryDirectory() as tmpdir:
+        tmp = pathlib.Path(tmpdir)
+        for info in zf.infolist():
+            if not info.filename.endswith(".so"):
+                continue
+            abi = abi_for_entry(info.filename)
+            if abi not in REQUIRED_64_BIT_ABIS:
+                continue
+            checked += 1
+            lib_name = pathlib.PurePosixPath(info.filename).name
+            seen_by_abi[abi].add(lib_name)
+            out = tmp / f"{abi}-{lib_name}"
+            out.write_bytes(zf.read(info.filename))
+            alignments = load_alignments(out)
+            formatted = ", ".join(hex(value) for value in alignments) or "none"
+            if alignments and all(value >= 0x4000 for value in alignments):
+                print(f"ALIGNED   {archive}: {info.filename}: {formatted}")
+            else:
+                print(f"UNALIGNED {archive}: {info.filename}: {formatted}")
+                ok = False
+    if checked == 0:
+        print(f"error: no 64-bit Android shared libraries found in {archive}", file=sys.stderr)
+        ok = False
+    for abi in sorted(REQUIRED_64_BIT_ABIS):
+        missing = sorted(required_libs - seen_by_abi.get(abi, set()))
+        if missing:
+            print(
+                f"error: {archive}: missing required 64-bit libraries for {abi}: {', '.join(missing)}",
+                file=sys.stderr,
+            )
+            ok = False
+    return ok
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--require-lib",
+        action="append",
+        default=[],
+        help="Shared-library basename that must be present for both arm64-v8a and x86_64. Repeatable.",
+    )
+    parser.add_argument("archives", nargs="+", type=pathlib.Path)
+    args = parser.parse_args()
+
+    required_libs = set(args.require_lib)
+    ok = True
+    for archive in args.archives:
+        if not archive.exists():
+            print(f"error: archive does not exist: {archive}", file=sys.stderr)
+            ok = False
+            continue
+        ok = verify_archive(archive, required_libs) and ok
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,1 @@
+Fixes Google Play 16 KB native library compatibility by rebuilding native sync dependencies with 16 KB page-size support.


### PR DESCRIPTION
## Summary
- Bump bundled Conscrypt from 2.5.0 to 2.5.3 so `libconscrypt_jni.so` resolves to a 16 KB-aligned native artifact.
- Add a reproducible Android CI step that rebuilds Etebase Java 2.3.2 native libraries with 16 KB ELF alignment, repacks the upstream AAR as a local drop-in artifact, and fails release/debug builds if that artifact is missing.
- Add APK/AAB/AAR native-library verification that checks 64-bit `.so` ELF `LOAD` segment alignment and requires both Etebase and Conscrypt native libraries in final app artifacts.

## Verification
- `bash -n android/scripts/build-etebase-client-16kb.sh`
- `python3 -m py_compile android/scripts/verify-native-16kb.py`
- `git diff --check`
- `python3 android/scripts/verify-native-16kb.py --require-lib libetebase_android.so <current Maven client-2.3.2.aar>` exits 1 and reports `0x1000` alignments, proving the verifier catches the current blocker.
- `python3 android/scripts/verify-native-16kb.py --require-lib libconscrypt_jni.so <conscrypt-android-2.5.3.aar>` exits 0 and reports `0x4000` alignments.
- `./gradlew --no-daemon --console=plain :app:dependencyInsight --configuration releaseRuntimeClasspath --dependency conscrypt-android` resolves `org.conscrypt:conscrypt-android:2.5.3`.
- `./gradlew --no-daemon --console=plain :app:dependencyInsight --configuration releaseRuntimeClasspath --dependency com.etebase:client -PrequireEtebase16Kb=true` fails closed when the rebuilt local Etebase AAR is absent.

## Notes
- The local rebuilt Etebase AAR is generated in CI and ignored by git.
- Full Android build validation is expected in GitHub Actions because the local development environment does not have the Android NDK/Rust toolchain configured for this native rebuild.
