### PR TITLE
Android: modernize rounded dialogs

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -25,7 +25,7 @@ import android.widget.*
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.ActionBarDrawerToggle
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
@@ -368,7 +368,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         val view = layoutInflater.inflate(R.layout.fingerprint_alertdialog, null)
         view.findViewById<View>(R.id.body).visibility = View.GONE
         (view.findViewById<View>(R.id.fingerprint) as TextView).text = displayFingerprint
-        AlertDialog.Builder(this@AccountActivity)
+        MaterialAlertDialogBuilder(this@AccountActivity)
                 .setIcon(R.drawable.ic_fingerprint_dark)
                 .setTitle(R.string.show_fingperprint_title)
                 .setView(view)
@@ -458,7 +458,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
     private fun showExportDialog() {
         val exportKinds = AndroidExportKind.values()
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
             .setTitle(R.string.export_data_title)
             .setItems(exportKinds.map { it.displayName }.toTypedArray()) { _, which ->
                 createExportDocument(exportKinds[which])
@@ -528,7 +528,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             return
         }
 
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
             .setTitle(R.string.account_delete_confirmation_title)
             .setMessage(R.string.account_delete_confirmation_text)
             .setPositiveButton(R.string.navigation_drawer_logout) { _, _ ->
@@ -564,7 +564,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             else -> 2
         }
 
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
             .setTitle(R.string.navigation_drawer_theme)
             .setSingleChoiceItems(themes, checkedItem) { dialog, which ->
                 val mode = when (which) {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/ChangeEncryptionPasswordActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/ChangeEncryptionPasswordActivity.kt
@@ -14,7 +14,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.etebase.client.Client
 import io.silentsuite.sync.AccountSettings
 import io.silentsuite.sync.HttpClient
@@ -49,7 +49,7 @@ open class ChangeEncryptionPasswordActivity : BaseActivity() {
 
     fun changePasswordError(e: Exception) {
         progress.dismiss()
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.wrong_encryption_password)
                 .setIcon(R.drawable.ic_error_dark)
                 .setMessage(e.localizedMessage)
@@ -77,7 +77,7 @@ open class ChangeEncryptionPasswordActivity : BaseActivity() {
                 }
 
                 progress.dismiss()
-                AlertDialog.Builder(this@ChangeEncryptionPasswordActivity)
+                MaterialAlertDialogBuilder(this@ChangeEncryptionPasswordActivity)
                         .setTitle(R.string.change_encryption_password_success_title)
                         .setMessage(R.string.change_encryption_password_success_body)
                         .setPositiveButton(android.R.string.ok) { _, _ ->
@@ -115,7 +115,7 @@ open class ChangeEncryptionPasswordActivity : BaseActivity() {
             return
         }
 
-        AlertDialog.Builder(this)
+        MaterialAlertDialogBuilder(this)
                 .setTitle(R.string.delete_collection_confirm_title)
                 .setMessage(R.string.change_encryption_password_are_you_sure)
                 .setPositiveButton(android.R.string.yes) { _, _ ->

--- a/android/app/src/main/java/io/silentsuite/sync/ui/DeleteCollectionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/DeleteCollectionFragment.kt
@@ -3,7 +3,7 @@ package io.silentsuite.sync.ui
 import android.accounts.Account
 import android.app.Dialog
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import io.silentsuite.sync.model.CollectionInfo
 
@@ -17,7 +17,7 @@ class DeleteCollectionFragment : DialogFragment() {
     class ConfirmDeleteCollectionFragment : DialogFragment() {
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-            return AlertDialog.Builder(requireContext())
+            return MaterialAlertDialogBuilder(requireContext())
                     .setMessage("Legacy fragment — not functional")
                     .setPositiveButton(android.R.string.ok) { _, _ -> dismiss() }
                     .create()

--- a/android/app/src/main/java/io/silentsuite/sync/ui/ExceptionInfoFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/ExceptionInfoFragment.kt
@@ -11,7 +11,7 @@ package io.silentsuite.sync.ui
 import android.accounts.Account
 import android.app.Dialog
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
@@ -31,7 +31,7 @@ class ExceptionInfoFragment : DialogFragment() {
         else if (exception is IOException)
             title = R.string.exception_ioexception
 
-        val dialog = AlertDialog.Builder(requireContext())
+        val dialog = MaterialAlertDialogBuilder(requireContext())
                 .setIcon(R.drawable.ic_error_dark)
                 .setTitle(title)
                 .setMessage("${exception.javaClass.canonicalName}\n" + exception.localizedMessage)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/StartupDialogFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/StartupDialogFragment.kt
@@ -17,7 +17,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import io.silentsuite.sync.BuildConfig
 import io.silentsuite.sync.Constants
@@ -41,7 +41,7 @@ class StartupDialogFragment : DialogFragment() {
 
         val mode = Mode.valueOf(requireArguments().getString(ARGS_MODE)!!)
         when (mode) {
-            StartupDialogFragment.Mode.BATTERY_OPTIMIZATIONS -> return AlertDialog.Builder(requireActivity())
+            StartupDialogFragment.Mode.BATTERY_OPTIMIZATIONS -> return MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.startup_battery_optimization)
                     .setMessage(R.string.startup_battery_optimization_message)
                     .setPositiveButton(android.R.string.ok) { dialog, which -> }
@@ -54,14 +54,14 @@ class StartupDialogFragment : DialogFragment() {
                     .setNegativeButton(R.string.startup_dont_show_again) { dialog, which -> HintManager.setHintSeen(requireContext(), HINT_BATTERY_OPTIMIZATIONS, true) }
                     .create()
 
-            StartupDialogFragment.Mode.DEVELOPMENT_VERSION -> return AlertDialog.Builder(requireActivity())
+            StartupDialogFragment.Mode.DEVELOPMENT_VERSION -> return MaterialAlertDialogBuilder(requireActivity())
                     .setIcon(R.mipmap.ic_launcher)
                     .setTitle(R.string.startup_development_version)
                     .setMessage(R.string.startup_development_version_message)
                     .setPositiveButton(android.R.string.ok) { dialog, which -> }
                     .setNeutralButton(R.string.startup_development_version_give_feedback) { dialog, which -> startActivity(Intent(Intent.ACTION_VIEW, Constants.feedbackUri)) }
                     .create()
-            StartupDialogFragment.Mode.VENDOR_SPECIFIC_BUGS -> return AlertDialog.Builder(requireActivity())
+            StartupDialogFragment.Mode.VENDOR_SPECIFIC_BUGS -> return MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.startup_vendor_specific_bugs)
                     .setMessage(R.string.startup_vendor_specific_bugs_message)
                     .setPositiveButton(android.R.string.ok) { dialog, which -> }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionItemFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionItemFragment.kt
@@ -8,7 +8,7 @@ import android.text.format.DateFormat
 import android.text.format.DateUtils
 import android.view.*
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentPagerAdapter
@@ -168,7 +168,7 @@ class CollectionItemFragment : Fragment() {
             }
         }
 
-        val dialog = AlertDialog.Builder(context)
+        val dialog = MaterialAlertDialogBuilder(context)
                 .setTitle(R.string.journal_item_restore_action)
                 .setIcon(R.drawable.ic_restore_black)
                 .setMessage(R.string.journal_item_restore_dialog_body)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionMembersFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionMembersFragment.kt
@@ -9,7 +9,7 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -102,7 +102,7 @@ class CollectionMembersFragment : Fragment() {
 
     private fun addMemberClicked() {
         val view = View.inflate(requireContext(), R.layout.add_member_fragment, null)
-        val dialog = AlertDialog.Builder(requireContext())
+        val dialog = MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.collection_members_add)
                 .setIcon(R.drawable.ic_account_add_dark)
                 .setPositiveButton(android.R.string.yes) { _, _ ->
@@ -142,7 +142,7 @@ class AddMemberFragment : DialogFragment() {
                 val view = LayoutInflater.from(context).inflate(R.layout.fingerprint_alertdialog, null)
                 (view.findViewById<View>(R.id.body) as TextView).text = getString(R.string.trust_fingerprint_body, username)
                 (view.findViewById<View>(R.id.fingerprint) as TextView).text = fingerprint
-                AlertDialog.Builder(requireContext())
+                MaterialAlertDialogBuilder(requireContext())
                         .setIcon(R.drawable.ic_fingerprint_dark)
                         .setTitle(R.string.trust_fingerprint_title)
                         .setView(view)
@@ -152,7 +152,7 @@ class AddMemberFragment : DialogFragment() {
                                     withContext(Dispatchers.IO) {
                                         invitationManager.invite(cachedCollection.col, username, profile.pubkey, accessLevel)
                                     }
-                                    AlertDialog.Builder(requireContext())
+                                    MaterialAlertDialogBuilder(requireContext())
                                         .setTitle(R.string.collection_members_add)
                                         .setIcon(R.drawable.ic_account_add_dark)
                                         .setMessage(R.string.collection_members_add_success)
@@ -176,7 +176,7 @@ class AddMemberFragment : DialogFragment() {
     }
 
     private fun handleError(message: String) {
-        AlertDialog.Builder(requireContext())
+        MaterialAlertDialogBuilder(requireContext())
                 .setIcon(R.drawable.ic_error_dark)
                 .setTitle(R.string.collection_members_add_error)
                 .setMessage(message)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionMembersListFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionMembersListFragment.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.TextView
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.ListFragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -82,7 +82,7 @@ class CollectionMembersListFragment : ListFragment(), AdapterView.OnItemClickLis
         val member = listAdapter?.getItem(position) as CollectionMember
 
         if (member.accessLevel == CollectionAccessLevel.Admin) {
-            AlertDialog.Builder(requireActivity())
+            MaterialAlertDialogBuilder(requireActivity())
                     .setIcon(R.drawable.ic_error_dark)
                     .setTitle(R.string.collection_members_remove_title)
                     .setMessage(R.string.collection_members_remove_admin)
@@ -90,7 +90,7 @@ class CollectionMembersListFragment : ListFragment(), AdapterView.OnItemClickLis
             return
         }
 
-        AlertDialog.Builder(requireActivity())
+        MaterialAlertDialogBuilder(requireActivity())
                 .setIcon(R.drawable.ic_info_dark)
                 .setTitle(R.string.collection_members_remove_title)
                 .setMessage(getString(R.string.collection_members_remove, member.username))

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/EditCollectionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/EditCollectionFragment.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import android.text.TextUtils
 import android.view.*
 import android.widget.EditText
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
@@ -145,7 +145,7 @@ class EditCollectionFragment : Fragment() {
         val meta = cachedCollection.meta
         val name = meta.name
 
-        AlertDialog.Builder(requireContext())
+        MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.delete_collection_confirm_title)
                 .setMessage(getString(R.string.delete_collection_confirm_warning, name))
                 .setPositiveButton(android.R.string.yes) { dialog, _ ->
@@ -176,7 +176,7 @@ class EditCollectionFragment : Fragment() {
             } catch (e: EtebaseException) {
                 Logger.log.warning("Collection edit failed: ${e.javaClass.name}")
                 context?.let { context ->
-                    AlertDialog.Builder(context)
+                    MaterialAlertDialogBuilder(context)
                             .setIcon(R.drawable.ic_info_dark)
                             .setTitle(R.string.exception)
                             .setMessage(e.localizedMessage)
@@ -243,7 +243,7 @@ class EditCollectionFragment : Fragment() {
                 } catch (e: EtebaseException) {
                     val context = context
                     if (context != null) {
-                        AlertDialog.Builder(requireContext())
+                        MaterialAlertDialogBuilder(requireContext())
                                 .setIcon(R.drawable.ic_info_dark)
                                 .setTitle(R.string.exception)
                                 .setMessage(e.localizedMessage)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/InvitationsListFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/InvitationsListFragment.kt
@@ -9,7 +9,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.TextView
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.ListFragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -87,7 +87,7 @@ class InvitationsListFragment : ListFragment(), AdapterView.OnItemClickListener 
         view.findViewById<TextView>(R.id.body).text = getString(R.string.invitations_accept_reject_dialog)
         view.findViewById<TextView>(R.id.fingerprint).text = fingerprint
 
-        AlertDialog.Builder(requireContext())
+        MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.invitations_title)
                 .setIcon(R.drawable.ic_email_black)
                 .setView(view)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -10,7 +10,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ProgressBar
 import androidx.activity.viewModels
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
@@ -83,7 +83,7 @@ class NewAccountWizardActivity : BaseActivity() {
 
 
 fun reportErrorHelper(context: Context, e: Throwable) {
-    AlertDialog.Builder(context)
+    MaterialAlertDialogBuilder(context)
             .setIcon(R.drawable.ic_info_dark)
             .setTitle(R.string.exception)
             .setMessage(e.localizedMessage)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ViewCollectionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ViewCollectionFragment.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import android.view.*
 import android.widget.TextView
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.commit
@@ -118,7 +118,7 @@ class ViewCollectionFragment : Fragment() {
                         addToBackStack(EditCollectionFragment::class.java.name)
                     }
                 } else {
-                    val dialog = AlertDialog.Builder(requireContext())
+                    val dialog = MaterialAlertDialogBuilder(requireContext())
                             .setIcon(R.drawable.ic_info_dark)
                             .setTitle(R.string.not_allowed_title)
                             .setMessage(R.string.edit_owner_only_anon)
@@ -146,7 +146,7 @@ class ViewCollectionFragment : Fragment() {
 
     private fun startImport(cachedCollection: CachedCollection) {
         if (cachedCollection.col.accessLevel == CollectionAccessLevel.ReadOnly) {
-            val dialog = AlertDialog.Builder(requireContext())
+            val dialog = MaterialAlertDialogBuilder(requireContext())
                     .setIcon(R.drawable.ic_info_dark)
                     .setTitle(R.string.not_allowed_title)
                     .setMessage(R.string.edit_owner_only_anon)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ResultFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ResultFragment.kt
@@ -3,7 +3,7 @@ package io.silentsuite.sync.ui.importlocal
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import io.silentsuite.sync.R
 import io.silentsuite.sync.log.Logger
@@ -33,7 +33,7 @@ class ResultFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         if (result!!.isFailed) {
             val failureMessage = result!!.failureMessage ?: getString(R.string.import_dialog_failed_generic)
-            return AlertDialog.Builder(requireActivity())
+            return MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.import_dialog_failed_title)
                     .setIcon(R.drawable.ic_error_dark)
                     .setMessage(getString(R.string.import_dialog_failed_body, failureMessage))
@@ -51,7 +51,7 @@ class ResultFragment : DialogFragment() {
             } else {
                 getString(R.string.import_dialog_success, result!!.total, result!!.added, result!!.updated, result!!.skipped)
             }
-            return AlertDialog.Builder(requireActivity())
+            return MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.import_dialog_title)
                     .setIcon(R.drawable.ic_import_export_black)
                     .setMessage(message)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
@@ -10,7 +10,7 @@ package io.silentsuite.sync.ui.setup
 
 import android.app.Dialog
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import io.silentsuite.sync.R
 import io.silentsuite.sync.log.Logger
@@ -86,7 +86,7 @@ class DetectConfigurationFragment : DialogFragment() {
     class NothingDetectedFragment : DialogFragment() {
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-            return AlertDialog.Builder(requireActivity())
+            return MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.setting_up_encryption)
                     .setIcon(R.drawable.ic_error_dark)
                     .setMessage(requireArguments().getString(KEY_LOGS))

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsChangeFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsChangeFragment.kt
@@ -11,7 +11,7 @@ package io.silentsuite.sync.ui.setup
 import android.accounts.Account
 import android.app.Dialog
 import android.os.Bundle
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import io.silentsuite.sync.AccountSettings
@@ -99,7 +99,7 @@ class LoginCredentialsChangeFragment : DialogFragment() {
     class NothingDetectedFragment : DialogFragment() {
 
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-            return AlertDialog.Builder(requireActivity())
+            return MaterialAlertDialogBuilder(requireActivity())
                     .setTitle(R.string.setting_up_encryption)
                     .setIcon(R.drawable.ic_error_dark)
                     .setMessage(R.string.login_wrong_username_or_password)

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -34,6 +34,10 @@
 
         <!-- Force white text/icons on the dark ActionBar -->
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+
+        <!-- Shared rounded dialog treatment for Material dialogs. -->
+        <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
+        <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
     </style>
 
     <style name="AppTheme.NoActionBar">
@@ -42,8 +46,19 @@
         <item name="android:statusBarColor">@color/navy700</item>
     </style>
 
-    <style name="AppTheme.Dialog.Alert" parent="Theme.AppCompat.DayNight.Dialog.Alert">
+    <style name="AppTheme.Dialog.Alert" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
         <item name="colorAccent">@color/teal400</item>
+        <item name="colorPrimary">@color/teal400</item>
+        <item name="colorSecondary">@color/teal400</item>
+        <item name="colorSurface">@color/navy600</item>
+        <item name="colorOnSurface">@android:color/white</item>
+        <item name="shapeAppearanceOverlay">@style/AppTheme.ShapeAppearance.Dialog</item>
+        <item name="buttonBarButtonStyle">@style/AppTheme.Dialog.Button</item>
+    </style>
+
+    <style name="AppTheme.Dialog.Button" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/teal400</item>
+        <item name="android:textAllCaps">true</item>
     </style>
 
     <!-- stepper (wizard) - dark variant -->

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -80,6 +80,10 @@
 
         <!-- Force white text/icons on the dark ActionBar -->
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+
+        <!-- Shared rounded dialog treatment for Material dialogs. -->
+        <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
+        <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
     </style>
 
     <style name="AppTheme.NoActionBar">
@@ -92,8 +96,24 @@
 
     <!-- dialogs -->
 
-    <style name="AppTheme.Dialog.Alert" parent="Theme.AppCompat.DayNight.Dialog.Alert">
+    <style name="AppTheme.Dialog.Alert" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
         <item name="colorAccent">@color/teal600</item>
+        <item name="colorPrimary">@color/teal600</item>
+        <item name="colorSecondary">@color/teal600</item>
+        <item name="colorSurface">@android:color/white</item>
+        <item name="colorOnSurface">@color/navy800</item>
+        <item name="shapeAppearanceOverlay">@style/AppTheme.ShapeAppearance.Dialog</item>
+        <item name="buttonBarButtonStyle">@style/AppTheme.Dialog.Button</item>
+    </style>
+
+    <style name="AppTheme.ShapeAppearance.Dialog" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">24dp</item>
+    </style>
+
+    <style name="AppTheme.Dialog.Button" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
+        <item name="android:textColor">@color/teal600</item>
+        <item name="android:textAllCaps">true</item>
     </style>
 
 


### PR DESCRIPTION
## Root cause

The Android app already uses a MaterialComponents day/night base theme, but most dialogs were still created with `androidx.appcompat.app.AlertDialog.Builder` and the shared dialog style only set `colorAccent`. That left the theme/settings dialog and other common flows using the older square AppCompat dialog presentation.

## Changes

- Adds a shared rounded Material alert dialog overlay for light and dark themes.
- Wires `materialAlertDialogTheme` and `alertDialogTheme` through `AppTheme`.
- Converts the theme selector, export, logout, fingerprint, setup/error, invitation, collection, and import dialogs to `MaterialAlertDialogBuilder` so they share the rounded treatment.
- Preserves the existing theme-mode choices and immediate application behavior.

## Validation

- `python3` XML parser check for changed style resources: passed.
- `git diff --check`: passed.
- `./gradlew :app:tasks --offline --quiet`: passed.
- `./gradlew :app:mergeDebugResources`: passed, with existing string formatting warnings unrelated to this change.

## CI / manual Android note

Android unsigned build validation should run in GitHub Actions for this PR. Manual device review should check the theme selector and at least one confirmation dialog in both light and dark themes.

Closes #407
