### PR TITLE
Reject existing-user claims in FastAPI signup flow

### DIFF
--- a/server/etebase_server/fastapi/routers/authentication.py
+++ b/server/etebase_server/fastapi/routers/authentication.py
@@ -247,7 +247,8 @@ def signup_save(data: SignupIn, request: Request) -> UserType:
 
         try:
             user_queryset = get_user_queryset(User.objects.all(), CallbackContext(request.path_params))
-            instance = user_queryset.get(**{User.USERNAME_FIELD: user_data.username.lower()})
+            user_queryset.get(**{User.USERNAME_FIELD: user_data.username.lower()})
+            raise HttpError("user_exists", "User already exists", status_code=status.HTTP_409_CONFLICT)
         except User.DoesNotExist:
             # Create the user and save the casing the user chose as the first name
             try:
@@ -265,9 +266,6 @@ def signup_save(data: SignupIn, request: Request) -> UserType:
             except Exception:
                 logger.exception("Unexpected signup error while creating user")
                 raise HttpError("generic", "An error occurred during signup. Please try again.")
-
-        if hasattr(instance, "userinfo"):
-            raise HttpError("user_exists", "User already exists", status_code=status.HTTP_409_CONFLICT)
 
         models.UserInfo.objects.create(**data.dict(exclude={"user"}), owner=instance)
     return instance

--- a/server/etebase_server/fastapi/routers/test_reset_view.py
+++ b/server/etebase_server/fastapi/routers/test_reset_view.py
@@ -3,12 +3,13 @@ from django.db import transaction
 from django.shortcuts import get_object_or_404
 from fastapi import APIRouter, Request, status
 
+from etebase_server.django import models
 from etebase_server.django.utils import CallbackContext, get_user_queryset
 from etebase_server.myauth.models import get_typed_user_model
 
 from ..exceptions import HttpError
 from ..msgpack import MsgpackRoute
-from .authentication import SignupIn, signup_save
+from .authentication import SignupIn
 
 test_reset_view_router = APIRouter(route_class=MsgpackRoute, tags=["test helpers"])
 User = get_typed_user_model()
@@ -30,7 +31,7 @@ def reset(data: SignupIn, request: Request):
         if hasattr(user, "userinfo"):
             user.userinfo.delete()
 
-        signup_save(data, request)
+        models.UserInfo.objects.create(**data.dict(exclude={"user"}), owner=user)
         # Delete all of the journal data for this user for a clear test env
         user.collection_set.all().delete()
         user.collectionmember_set.all().delete()

--- a/server/etebase_server/fastapi/routers/test_test_reset_view.py
+++ b/server/etebase_server/fastapi/routers/test_test_reset_view.py
@@ -1,0 +1,72 @@
+import pytest
+from django.test.utils import override_settings
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from etebase_server.fastapi.conftest import decode_response, msgpack_post
+from etebase_server.fastapi.exceptions import CustomHttpException
+from etebase_server.fastapi.msgpack import MsgpackResponse
+from etebase_server.fastapi.routers.test_reset_view import test_reset_view_router
+
+
+@pytest.fixture
+def reset_client():
+    app = FastAPI()
+    app.include_router(test_reset_view_router, prefix="/api/v1/test/authentication")
+
+    @app.exception_handler(CustomHttpException)
+    async def _custom_exception_handler(_request, exc: CustomHttpException):
+        return MsgpackResponse(status_code=exc.status_code, content=exc.as_dict)
+
+    return TestClient(app)
+
+
+def _reset_body(username, email, login_pubkey, encryption_pubkey, user_salt):
+    return {
+        "user": {"username": username, "email": email},
+        "salt": user_salt,
+        "loginPubkey": login_pubkey,
+        "pubkey": encryption_pubkey,
+        "encryptedContent": b"\x00" * 64,
+    }
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(DEBUG=True)
+def test_reset_reinitializes_existing_test_user(
+    reset_client, user_factory, login_pubkey, encryption_pubkey, user_salt
+):
+    user = user_factory(username="test_user_reset", email="reset@example.com")
+    body = _reset_body("test_user_reset", "reset@example.com", login_pubkey, encryption_pubkey, user_salt)
+
+    response = msgpack_post(reset_client, "/api/v1/test/authentication/reset/", body)
+
+    assert response.status_code in (200, 204)
+    user.refresh_from_db()
+    assert bytes(user.userinfo.loginPubkey) == login_pubkey
+    assert bytes(user.userinfo.pubkey) == encryption_pubkey
+    assert bytes(user.userinfo.salt) == user_salt
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(DEBUG=True)
+def test_reset_rejects_non_test_users(reset_client, user_factory, login_pubkey, encryption_pubkey, user_salt):
+    user_factory(username="regular_user", email="regular@example.com")
+    body = _reset_body("regular_user", "regular@example.com", login_pubkey, encryption_pubkey, user_salt)
+
+    response = msgpack_post(reset_client, "/api/v1/test/authentication/reset/", body)
+
+    assert response.status_code == 400
+    assert decode_response(response)["code"] == "generic"
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(DEBUG=False)
+def test_reset_rejects_when_debug_is_disabled(reset_client, user_factory, login_pubkey, encryption_pubkey, user_salt):
+    user_factory(username="test_user_reset", email="reset@example.com")
+    body = _reset_body("test_user_reset", "reset@example.com", login_pubkey, encryption_pubkey, user_salt)
+
+    response = msgpack_post(reset_client, "/api/v1/test/authentication/reset/", body)
+
+    assert response.status_code == 400
+    assert decode_response(response)["code"] == "generic"

--- a/server/etebase_server/fastapi/test_authentication.py
+++ b/server/etebase_server/fastapi/test_authentication.py
@@ -204,6 +204,23 @@ class TestSignup:
         assert response.status_code == 409
         assert decode_response(response)["code"] == "user_exists"
 
+    def test_signup_for_existing_user_without_userinfo_returns_409(
+        self, auth_client, user_factory, login_pubkey, encryption_pubkey, user_salt
+    ):
+        user_factory(username="test_user_uninitialized", email="uninitialized@example.com", with_userinfo=False)
+        body = self._signup_body(
+            "test_user_uninitialized",
+            "attacker@example.com",
+            login_pubkey,
+            encryption_pubkey,
+            user_salt,
+        )
+
+        response = msgpack_post(auth_client, f"{AUTH_PREFIX}/signup/", body)
+
+        assert response.status_code == 409
+        assert decode_response(response)["code"] == "user_exists"
+
     def test_signup_unexpected_creation_error_returns_safe_detail(
         self, auth_client, login_pubkey, encryption_pubkey, user_salt
     ):


### PR DESCRIPTION
Reject signup for existing users in FastAPI.Prevent unauthenticated account takeover where `/signup/` could initialize `UserInfo` for a pre-provisioned user and immediately return a valid auth token.

Details:
- Preserve existing new-user creation logic and UserInfo initialization for truly new accounts.
- In `signup_save` (`etebase_server/fastapi/routers/authentication.py`) check for an existing username via `get_user_queryset(...).get(...)` and immediately raise `HttpError("user_exists", ...) `(HTTP 409) if found.
- Remove the previous behavior that only rejected the request when instance already had a userinfo, so the endpoint is now strictly for new-user creation.