### PR TITLE
Fix Android status bar readability

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt
@@ -1,9 +1,26 @@
 package io.silentsuite.sync.ui
 
+import android.os.Build
+import android.os.Bundle
 import android.view.MenuItem
+import android.view.View
+import android.view.Window
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import io.silentsuite.sync.R
 
 open class BaseActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        applyReadableSystemBars()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        applyReadableSystemBars()
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
             if (!supportFragmentManager.popBackStackImmediate()) {
@@ -12,5 +29,34 @@ open class BaseActivity : AppCompatActivity() {
             return true
         }
         return false
+    }
+
+    private fun applyReadableSystemBars() {
+        val systemBarColor = ContextCompat.getColor(this, R.color.navy700)
+
+        window.statusBarColor = systemBarColor
+        window.navigationBarColor = systemBarColor
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        }
+
+        // Navy system bars require light clock/battery/connectivity icons. Explicitly
+        // clear light-system-bar flags so Android 15 / targetSdk 35 edge-to-edge
+        // defaults or theme inheritance cannot leave dark icons on a dark bar.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            window.clearLightStatusBar()
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            window.clearLightNavigationBar()
+        }
+    }
+
+    private fun Window.clearLightStatusBar() {
+        decorView.systemUiVisibility = decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
+    }
+
+    private fun Window.clearLightNavigationBar() {
+        decorView.systemUiVisibility = decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR.inv()
     }
 }

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -35,6 +35,12 @@
         <!-- Force white text/icons on the dark ActionBar -->
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
 
+        <!-- Solid navy system bars keep light status/navigation icons readable. -->
+        <item name="android:statusBarColor">@color/navy700</item>
+        <item name="android:navigationBarColor">@color/navy700</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+
         <!-- Shared rounded dialog treatment for Material dialogs. -->
         <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
         <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
@@ -44,6 +50,9 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:statusBarColor">@color/navy700</item>
+        <item name="android:navigationBarColor">@color/navy700</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="AppTheme.Dialog.Alert" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">

--- a/android/app/src/main/res/values-v21/styles.xml
+++ b/android/app/src/main/res/values-v21/styles.xml
@@ -17,6 +17,9 @@
              both light and dark themes. Previously transparent, which made light
              status-bar icons invisible on the light offwhite background. -->
         <item name="android:statusBarColor">@color/navy700</item>
+        <item name="android:navigationBarColor">@color/navy700</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
 
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -81,6 +81,12 @@
         <!-- Force white text/icons on the dark ActionBar -->
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
 
+        <!-- Solid navy system bars keep light status/navigation icons readable. -->
+        <item name="android:statusBarColor">@color/navy700</item>
+        <item name="android:navigationBarColor">@color/navy700</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+
         <!-- Shared rounded dialog treatment for Material dialogs. -->
         <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
         <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
@@ -91,6 +97,9 @@
         <item name="windowNoTitle">true</item>
         <!-- Solid navy status bar so light system icons stay readable (see values-v21). -->
         <item name="android:statusBarColor">@color/navy700</item>
+        <item name="android:navigationBarColor">@color/navy700</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
     </style>
 
 


### PR DESCRIPTION
Closes #408

## Root cause
Android theme XML set status bar colors in some places, but the app did not consistently enforce status/navigation bar appearance at runtime. On newer Android/target SDK behavior, light-theme screens could inherit transparent or light system bar treatment, leaving clock, battery, and connectivity icons unreadable over light app surfaces.

## Changes
- Centralized readable system bar setup in `BaseActivity` for all user-facing activities that inherit the shared base.
- Force solid navy status and navigation bars with light system icons in both light and dark themes.
- Added explicit theme defaults for `AppTheme` and `AppTheme.NoActionBar`, including status/navigation colors and light-system-bar flags.
- Kept API 21-22 readable via solid navy bars; API 23+ and API 26+ clear light status/navigation icon flags at runtime.

## Validation
- `git diff --check`
- Parsed modified Android XML resources and `AndroidManifest.xml` with Python XML parser.
- Searched Android source/resources after the change for status/navigation bar controls to confirm centralized runtime handling in `BaseActivity` plus theme fallbacks.

Android unsigned build is expected to run in GitHub Actions. After CI passes, manual device/screenshot verification should cover light and dark themes on login, account home, app settings, and about screens.