### PR TITLE
Fix Android login button safe area

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -235,6 +235,7 @@
             android:name=".ui.setup.LoginActivity"
             android:exported="false"
             android:label="@string/login_title"
+            android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".ui.AccountActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -19,6 +19,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.fragment.app.replace
+import androidx.core.view.ViewCompat
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
 import io.silentsuite.sync.ui.WebViewActivity
@@ -43,6 +44,8 @@ class LoginCredentialsFragment : Fragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val v = inflater.inflate(R.layout.login_credentials_fragment, container, false)
         advancedExpanded = savedInstanceState?.getBoolean(KEY_ADVANCED_EXPANDED) ?: false
+
+        applyLoginActionBarInsets(v.findViewById(R.id.login_action_bar))
 
         editUserName = v.findViewById<TextInputEditText>(R.id.user_name)
         editUrlPassword = v.findViewById<TextInputLayout>(R.id.url_password)
@@ -141,6 +144,36 @@ class LoginCredentialsFragment : Fragment() {
         showAdvanced.contentDescription = getString(
                 if (advancedExpanded) R.string.login_custom_server_expanded else R.string.login_custom_server_collapsed
         )
+    }
+
+    private fun applyLoginActionBarInsets(actionBar: View) {
+        val basePaddingLeft = actionBar.paddingLeft
+        val basePaddingTop = actionBar.paddingTop
+        val basePaddingRight = actionBar.paddingRight
+        val basePaddingBottom = actionBar.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(actionBar) { view, insets ->
+            view.setPadding(
+                    basePaddingLeft,
+                    basePaddingTop,
+                    basePaddingRight,
+                    basePaddingBottom + insets.systemWindowInsetBottom
+            )
+            insets
+        }
+
+        if (ViewCompat.isAttachedToWindow(actionBar)) {
+            ViewCompat.requestApplyInsets(actionBar)
+        } else {
+            actionBar.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(view: View) {
+                    view.removeOnAttachStateChangeListener(this)
+                    ViewCompat.requestApplyInsets(view)
+                }
+
+                override fun onViewDetachedFromWindow(view: View) = Unit
+            })
+        }
     }
 
     companion object {

--- a/android/app/src/main/res/layout/login_credentials_fragment.xml
+++ b/android/app/src/main/res/layout/login_credentials_fragment.xml
@@ -16,7 +16,9 @@
     <ScrollView android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:layout_weight="1"
-                android:layout_margin="@dimen/activity_margin">
+                android:layout_margin="@dimen/activity_margin"
+                android:clipToPadding="false"
+                android:paddingBottom="8dp">
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -152,6 +154,7 @@
     </ScrollView>
 
     <LinearLayout
+        android:id="@+id/login_action_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/stepper_nav_bar">


### PR DESCRIPTION
Closes #409

## Root cause

The login credentials screen uses a fixed bottom action bar with static padding. On Android 15 / targetSdk 35 devices, system navigation can overlap that bar, making the `Log In` button look clipped at the bottom.

## Changes

- Added a dedicated `login_action_bar` container ID for targeted bottom inset handling.
- Applied navigation/system-bar bottom inset padding to the login action bar while preserving its original padding.
- Added a small scroll padding buffer so expanded login content can scroll cleanly above the fixed action bar.
- Set `LoginActivity` to `adjustResize` so the screen resizes when the keyboard opens.
- Preserved existing login field/link/button IDs and click wiring.

## Validation

- `git diff --check`
- Parsed changed Android XML files with Python `xml.etree.ElementTree`
- Focused sanity check confirmed required IDs are still present and inset/keyboard handling is wired
- Android unsigned build is expected to run in GitHub Actions per project workflow

## Manual verification note

After CI produces a build, verify the add-account/login screen on a small Android device or emulator in light and dark themes, with gesture navigation and three-button navigation. Confirm the `Log In` button remains fully visible with the keyboard closed and reachable when the keyboard opens.
