### PR TITLE
Fix web calendar event time preference

### DIFF
--- a/apps/web/app/(app)/calendar/components/AgendaView.tsx
+++ b/apps/web/app/(app)/calendar/components/AgendaView.tsx
@@ -18,8 +18,13 @@ interface AgendaViewProps {
   onEventClick?: (eventId: string, instanceDate?: Date) => void
 }
 
-function formatTime(date: Date, tz: string): string {
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: tz })
+function formatTime(date: Date, tz: string, hour12: boolean): string {
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12,
+    timeZone: tz,
+  })
 }
 
 function isSameDay(a: Date, b: Date): boolean {
@@ -69,7 +74,9 @@ function collectionFallback(calendarId: string): string {
 
 export function AgendaView({ events, currentDate, calendars = [], mode = 'day', onEventClick }: AgendaViewProps) {
   const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
+  const timeFormat = usePreferencesStore((s) => s.timeFormat)
   const userTz = resolveUserTimezone(defaultTimezonePref)
+  const use12h = timeFormat !== '24h'
   const calendarMeta = useMemo(() => {
     const map = new Map<string, { name: string; color: string }>()
     for (const calendar of calendars) {
@@ -150,7 +157,7 @@ export function AgendaView({ events, currentDate, calendars = [], mode = 'day', 
                   <div className="mt-1 flex items-center gap-1 text-xs text-[rgb(var(--muted))]">
                     <Clock className="h-3 w-3" />
                     <span>
-                      {formatTime(event.startDate, userTz)} – {formatTime(event.endDate, userTz)}
+                      {formatTime(event.startDate, userTz, use12h)} – {formatTime(event.endDate, userTz, use12h)}
                     </span>
                     {event.timezone && event.timezone !== userTz && (
                       <span className="ml-1 rounded bg-[rgb(var(--surface-muted))] px-1 py-0.5 text-[10px] font-medium text-[rgb(var(--muted))]">

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -40,6 +40,8 @@ function makeFormatTime(hour12: boolean, tz: string) {
 }
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
 
+type EventTimeFormat = '12h' | '24h'
+
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -77,6 +79,57 @@ function formatTimeForInput(date: Date, tz: string | undefined): string {
     return `${h}:${m}`
   }
   return formatTimeForInputInZone(date, tz)
+}
+
+function normalizeTimeFormat(timeFormat: string): EventTimeFormat {
+  return timeFormat === '24h' ? '24h' : '12h'
+}
+
+export function formatEventTimeInput(value: string, timeFormat: string): string {
+  const match = /^(\d{2}):(\d{2})$/.exec(value)
+  if (!match) return value
+
+  const hour = Number(match[1])
+  const minute = Number(match[2])
+  if (hour > 23 || minute > 59) return value
+
+  if (normalizeTimeFormat(timeFormat) === '24h') {
+    return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+  }
+
+  const meridiem = hour >= 12 ? 'PM' : 'AM'
+  const displayHour = hour % 12 === 0 ? 12 : hour % 12
+  return `${displayHour}:${String(minute).padStart(2, '0')} ${meridiem}`
+}
+
+export function parseEventTimeInput(input: string, timeFormat: string): string | null {
+  const value = input.trim().replace(/\s+/g, ' ')
+  if (!value) return null
+
+  const meridiemMatch = /^(\d{1,2})(?::([0-5]\d))?\s*([ap])\.?m\.?$/i.exec(value)
+  if (meridiemMatch) {
+    const rawHour = Number(meridiemMatch[1])
+    const minute = Number(meridiemMatch[2] ?? '00')
+    if (rawHour < 1 || rawHour > 12) return null
+    const meridiem = meridiemMatch[3]!.toLowerCase()
+    const hour = meridiem === 'p' ? (rawHour % 12) + 12 : rawHour % 12
+    return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
+  }
+
+  const twentyFourHourMatch = /^(\d{1,2}):([0-5]\d)$/.exec(value)
+  if (!twentyFourHourMatch) return null
+
+  const hour = Number(twentyFourHourMatch[1])
+  const minute = Number(twentyFourHourMatch[2])
+  if (hour > 23) return null
+
+  if (normalizeTimeFormat(timeFormat) === '12h' && hour >= 1 && hour <= 12) {
+    return null
+  }
+
+  // 12-hour users may still paste or type a stored 24-hour HH:mm value;
+  // normalize it back to storage format and let the display formatter add AM/PM.
+  return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
 }
 
 function formatDateForInput(date: Date, tz: string | undefined): string {
@@ -168,10 +221,14 @@ export function EventDialog({
   const [location, setLocation] = useState(isEdit ? (event.location || '') : '')
   const [description, setDescription] = useState(isEdit ? (event.description || '') : '')
   const [allDay, setAllDay] = useState(initialIsAllDay)
+  const initialStartTime = formatTimeForInput(defaultStart, initialFormTz)
+  const initialEndTime = formatTimeForInput(defaultEnd, initialFormTz)
   const [startDate, setStartDate] = useState(formatDateForInput(defaultStart, initialFormTz))
-  const [startTime, setStartTime] = useState(formatTimeForInput(defaultStart, initialFormTz))
+  const [startTime, setStartTime] = useState(initialStartTime)
+  const [startTimeInput, setStartTimeInput] = useState(() => formatEventTimeInput(initialStartTime, timeFormat))
   const [endDate, setEndDate] = useState(formatDateForInput(defaultEnd, initialFormTz))
-  const [endTime, setEndTime] = useState(formatTimeForInput(defaultEnd, initialFormTz))
+  const [endTime, setEndTime] = useState(initialEndTime)
+  const [endTimeInput, setEndTimeInput] = useState(() => formatEventTimeInput(initialEndTime, timeFormat))
   const [recurrenceRule, setRecurrenceRule] = useState<string | null>(
     isEdit ? event.recurrenceRule : null,
   )
@@ -201,6 +258,14 @@ export function EventDialog({
   const allTimezones = (() => {
     try { return Intl.supportedValuesOf('timeZone') } catch { return ['UTC'] }
   })()
+
+  useEffect(() => {
+    setStartTimeInput(formatEventTimeInput(startTime, timeFormat))
+  }, [startTime, timeFormat])
+
+  useEffect(() => {
+    setEndTimeInput(formatEventTimeInput(endTime, timeFormat))
+  }, [endTime, timeFormat])
 
   // Calendar selection
   const calendarLists = useCalendarListStore((s) => s.calendars)
@@ -471,17 +536,21 @@ export function EventDialog({
   const handleStartTimeChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
-      setStartTime(value)
+      setStartTimeInput(value)
+      const parsedTime = parseEventTimeInput(value, timeFormat)
+      if (!parsedTime) return
+
+      setStartTime(parsedTime)
       // Auto-adjust end time to 30 min after start if on same day. Pure HH:MM
       // arithmetic via a synthetic local Date; format back as browser-local
       // since we only need the wall-clock string back.
       if (startDate === endDate) {
-        const [h, m] = value.split(':').map(Number)
+        const [h, m] = parsedTime.split(':').map(Number)
         const newEnd = new Date(2000, 0, 1, h, m + 30)
         setEndTime(formatTimeForInput(newEnd, undefined))
       }
     },
-    [startDate, endDate],
+    [startDate, endDate, timeFormat],
   )
 
   const handleEndDateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -489,8 +558,19 @@ export function EventDialog({
   }, [])
 
   const handleEndTimeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setEndTime(e.target.value)
-  }, [])
+    const value = e.target.value
+    setEndTimeInput(value)
+    const parsedTime = parseEventTimeInput(value, timeFormat)
+    if (parsedTime) setEndTime(parsedTime)
+  }, [timeFormat])
+
+  const handleStartTimeBlur = useCallback(() => {
+    setStartTimeInput(formatEventTimeInput(startTime, timeFormat))
+  }, [startTime, timeFormat])
+
+  const handleEndTimeBlur = useCallback(() => {
+    setEndTimeInput(formatEventTimeInput(endTime, timeFormat))
+  }, [endTime, timeFormat])
 
   const handleAllDayToggle = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setAllDay(e.target.checked)
@@ -705,12 +785,16 @@ export function EventDialog({
                       />
                       {!allDay && (
                         <input
-                          type="time"
-                          value={startTime}
+                          type="text"
+                          inputMode="text"
+                          pattern={timeFormat === '24h' ? '[0-2]?[0-9]:[0-5][0-9]' : undefined}
+                          placeholder={timeFormat === '24h' ? '14:00' : '2:00 PM'}
+                          value={startTimeInput}
                           onChange={handleStartTimeChange}
+                          onBlur={handleStartTimeBlur}
                           aria-label="Start time"
                           readOnly={!canWrite}
-                          className={`w-[6.5rem] rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-xs text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
+                          className={`w-[7rem] rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-xs text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
                         />
                       )}
                     </div>
@@ -733,12 +817,16 @@ export function EventDialog({
                       />
                       {!allDay && (
                         <input
-                          type="time"
-                          value={endTime}
+                          type="text"
+                          inputMode="text"
+                          pattern={timeFormat === '24h' ? '[0-2]?[0-9]:[0-5][0-9]' : undefined}
+                          placeholder={timeFormat === '24h' ? '14:30' : '2:30 PM'}
+                          value={endTimeInput}
                           onChange={handleEndTimeChange}
+                          onBlur={handleEndTimeBlur}
                           aria-label="End time"
                           readOnly={!canWrite}
-                          className={`w-[6.5rem] rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-xs text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
+                          className={`w-[7rem] rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 text-xs text-[rgb(var(--foreground))] focus:outline-none focus:ring-2 focus:ring-emerald-500 ${!canWrite ? 'opacity-60' : ''}`}
                         />
                       )}
                     </div>

--- a/apps/web/app/(app)/calendar/components/__tests__/EventDialog.test.tsx
+++ b/apps/web/app/(app)/calendar/components/__tests__/EventDialog.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import type { CalendarEvent } from '@silentsuite/core'
-import { EventDialog } from '../EventDialog'
+import { EventDialog, formatEventTimeInput, parseEventTimeInput } from '../EventDialog'
 import { renderWithIntl } from '@/src/__tests__/render-with-intl'
 
 const mocks = vi.hoisted(() => ({
@@ -12,6 +12,12 @@ const mocks = vi.hoisted(() => ({
   deleteRecurringEvent: vi.fn(),
   onClose: vi.fn(),
   requestPermission: vi.fn(),
+  preferences: {
+    defaultReminder: 'none',
+    timeFormat: '24h',
+    defaultTimezone: 'UTC',
+    dateFormat: 'system',
+  },
   calendars: [
     { id: 'cal-a', name: 'Work', color: '#10b981', visible: true },
     { id: 'cal-b', name: 'Family', color: '#ef4444', visible: true },
@@ -52,16 +58,10 @@ vi.mock('@/app/stores/use-calendar-list-store', () => ({
 }))
 
 vi.mock('@/app/stores/use-preferences-store', () => {
-  const state = {
-    defaultReminder: 'none',
-    timeFormat: '24h',
-    defaultTimezone: 'UTC',
-    dateFormat: 'system',
+  const usePreferencesStore = function usePreferencesStore<T>(selector: (currentState: typeof mocks.preferences) => T): T {
+    return selector(mocks.preferences)
   }
-  const usePreferencesStore = function usePreferencesStore<T>(selector: (currentState: typeof state) => T): T {
-    return selector(state)
-  }
-  usePreferencesStore.getState = () => state
+  usePreferencesStore.getState = () => mocks.preferences
   return { usePreferencesStore }
 })
 
@@ -103,6 +103,84 @@ describe('EventDialog edit calendar selection', () => {
     mocks.deleteRecurringEvent.mockReset()
     mocks.onClose.mockReset()
     mocks.requestPermission.mockReset()
+    mocks.preferences.timeFormat = '24h'
+    mocks.preferences.defaultTimezone = 'UTC'
+    mocks.preferences.dateFormat = 'system'
+  })
+
+  it.each([
+    ['00:00', '00:00', '12:00 AM'],
+    ['09:05', '09:05', '9:05 AM'],
+    ['12:00', '12:00', '12:00 PM'],
+    ['14:00', '14:00', '2:00 PM'],
+    ['23:59', '23:59', '11:59 PM'],
+  ])('formats %s according to the account time preference', (stored, expected24h, expected12h) => {
+    expect(formatEventTimeInput(stored, '24h')).toBe(expected24h)
+    expect(formatEventTimeInput(stored, '12h')).toBe(expected12h)
+  })
+
+  it.each([
+    ['00:00', '24h', '00:00'],
+    ['09:05', '24h', '09:05'],
+    ['9:05', '24h', '09:05'],
+    ['12:00', '24h', '12:00'],
+    ['14:00', '24h', '14:00'],
+    ['23:59', '24h', '23:59'],
+    ['12:00 AM', '12h', '00:00'],
+    ['9:05 AM', '12h', '09:05'],
+    ['12:00 PM', '12h', '12:00'],
+    ['2:00 PM', '12h', '14:00'],
+    ['11:59 PM', '12h', '23:59'],
+    ['14:00', '12h', '14:00'],
+  ])('parses %s in %s mode back to HH:mm', (input, preference, expected) => {
+    expect(parseEventTimeInput(input, preference)).toBe(expected)
+  })
+
+  it('renders event dialog time controls as 24-hour text fields for the 24-hour preference', () => {
+    mocks.preferences.timeFormat = '24h'
+
+    renderWithIntl(<EventDialog mode="edit" event={makeEvent({ startDate: new Date('2026-06-01T14:00:00Z'), endDate: new Date('2026-06-01T15:30:00Z') })} onClose={mocks.onClose} />)
+
+    expect(screen.getByLabelText('Start time')).toHaveAttribute('type', 'text')
+    expect(screen.getByLabelText('Start time')).toHaveValue('14:00')
+    expect(screen.getByLabelText('End time')).toHaveValue('15:30')
+  })
+
+  it('renders event dialog time controls with AM/PM for the 12-hour preference', () => {
+    mocks.preferences.timeFormat = '12h'
+
+    renderWithIntl(<EventDialog mode="edit" event={makeEvent({ startDate: new Date('2026-06-01T14:00:00Z'), endDate: new Date('2026-06-01T15:30:00Z') })} onClose={mocks.onClose} />)
+
+    expect(screen.getByLabelText('Start time')).toHaveValue('2:00 PM')
+    expect(screen.getByLabelText('End time')).toHaveValue('3:30 PM')
+  })
+
+  it('accepts 24-hour typed values and saves unchanged HH:mm wall-clock times', async () => {
+    mocks.preferences.timeFormat = '24h'
+
+    renderWithIntl(
+      <EventDialog
+        mode="create"
+        startDate={new Date('2026-06-01T14:00:00Z')}
+        endDate={new Date('2026-06-01T14:30:00Z')}
+        onClose={mocks.onClose}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Event title'), { target: { value: '24-hour event' } })
+    fireEvent.change(screen.getByLabelText('Start time'), { target: { value: '16:45' } })
+    fireEvent.change(screen.getByLabelText('End time'), { target: { value: '17:30' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    await waitFor(() => {
+      expect(mocks.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDate: new Date('2026-06-01T16:45:00Z'),
+          endDate: new Date('2026-06-01T17:30:00Z'),
+          timezone: 'UTC',
+        }),
+      )
+    })
   })
 
   it('includes calendarId in the edit patch when the selected calendar changes', async () => {

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -15,6 +15,7 @@ import { CalendarGrid, type SlotClickEvent, type EventClickInfo } from './compon
 import { AgendaView } from './components/AgendaView'
 import { EventDialog } from './components/EventDialog'
 import { FloatingAddButton } from './components/FloatingAddButton'
+import { resolveUserTimezone } from '@/app/lib/tz'
 
 /** Snap a Date to the nearest 30-minute boundary */
 function snapTo30Min(date: Date): Date {
@@ -27,6 +28,25 @@ function snapTo30Min(date: Date): Date {
     snapped.setMinutes(minutes + (30 - remainder), 0, 0)
   }
   return snapped
+}
+
+function formatSearchResultDate(
+  date: Date,
+  dateFormat: import('@silentsuite/core').DateFormat,
+  timeFormat: string,
+  timeZone: string,
+  allDay: boolean,
+): string {
+  const dateLabel = formatDate(date, dateFormat, { dateStyle: 'medium' })
+  if (allDay) return dateLabel
+
+  const timeLabel = date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: timeFormat !== '24h',
+    timeZone,
+  })
+  return `${dateLabel}, ${timeLabel}`
 }
 
 type CalendarDateLabelView = 'week' | 'month' | 'threeDay' | 'sevenDay'
@@ -131,7 +151,10 @@ export default function CalendarPage() {
   const setSelectedEvent = useCalendarStore((s) => s.setSelectedEvent)
   const calendars = useCalendarListStore((s) => s.calendars)
   const dateFormat = usePreferencesStore((s) => s.dateFormat)
+  const timeFormat = usePreferencesStore((s) => s.timeFormat)
+  const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
   const firstDayOfWeek = usePreferencesStore((s) => s.firstDayOfWeek)
+  const userTz = resolveUserTimezone(defaultTimezonePref)
 
   const [createDialog, setCreateDialog] = useState<CreateDialogState | null>(null)
   const [eventInstanceDate, setEventInstanceDate] = useState<Date | undefined>(undefined)
@@ -417,7 +440,7 @@ export default function CalendarPage() {
                           <span className="text-sm font-medium text-[rgb(var(--foreground))] truncate">{e.title || 'Untitled'}</span>
                         </div>
                         <div className="ml-4 text-xs text-[rgb(var(--muted))] truncate">
-                          {calendarName ? `${calendarName} · ` : ''}{formatDate(e.startDate, dateFormat, { dateStyle: 'medium', timeStyle: e.allDay ? undefined : 'short' })}
+                          {calendarName ? `${calendarName} · ` : ''}{formatSearchResultDate(e.startDate, dateFormat, timeFormat, userTz, e.allDay)}
                         </div>
                       </button>
                     )


### PR DESCRIPTION
Closes #411

## Root cause
The event dialog used native time inputs for start/end fields, so browser and OS locale settings could display AM/PM even when SilentSuite was configured for 24-hour time.

## Changes
- Replaced event dialog native time inputs with preference-controlled text fields backed by the existing HH:mm state.
- Added formatter/parser coverage for 24-hour and 12-hour event dialog time entry.
- Updated agenda and search result time rendering to explicitly follow the account time preference.
- Preserved existing event save/date/timezone serialization paths.

## Validation
- pnpm install
- pnpm --filter @silentsuite/web test -- app/'(app)'/calendar/components/__tests__/EventDialog.test.tsx
- pnpm --filter @silentsuite/web type-check
- git diff --check

## Browser QA note
Verify the branch preview with the account time preference set to 24-hour and 12-hour, including create and edit event dialogs.
