### PR TITLE
fix(web): guard startup sync empty states

### DIFF
--- a/apps/web/app/(app)/calendar/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/calendar/__tests__/page.test.tsx
@@ -40,6 +40,10 @@ const storeMock = vi.hoisted(() => ({
   authState: {
     canWrite: vi.fn(() => true),
   },
+  syncState: {
+    initialSyncState: 'synced' as const,
+    error: null as string | null,
+  },
 }))
 
 vi.mock('@/app/stores/use-calendar-store', () => ({
@@ -52,6 +56,10 @@ vi.mock('@/app/stores/use-calendar-list-store', () => ({
 
 vi.mock('@/app/stores/use-auth-store', () => ({
   useAuthStore: (selector: (state: typeof storeMock.authState) => unknown) => selector(storeMock.authState),
+}))
+
+vi.mock('@/app/stores/use-sync-store', () => ({
+  useSyncStore: (selector: (state: typeof storeMock.syncState) => unknown) => selector(storeMock.syncState),
 }))
 
 vi.mock('@/app/stores/use-preferences-store', () => ({
@@ -110,6 +118,8 @@ function resetCalendarMocks() {
   storeMock.calendarState.setCurrentView.mockReset()
   storeMock.calendarState.setSearchQuery.mockReset()
   storeMock.authState.canWrite.mockReturnValue(true)
+  storeMock.syncState.initialSyncState = 'synced'
+  storeMock.syncState.error = null
 }
 
 describe('CalendarPage calendar visibility', () => {
@@ -263,6 +273,16 @@ describe('CalendarPage mobile reachability', () => {
     renderWithIntl(<CalendarPage />)
 
     expect(screen.getByTestId('mobile-agenda')).toHaveAttribute('data-mode', 'upcoming')
+  })
+
+  it('shows restore copy instead of an empty calendar before initial sync completes', () => {
+    storeMock.calendarState.isLoading = false
+    storeMock.syncState.initialSyncState = 'restoring'
+
+    renderWithIntl(<CalendarPage />)
+
+    expect(screen.getByText('Restoring encrypted data…')).toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-agenda')).not.toBeInTheDocument()
   })
 
   it('exposes a mobile collection switcher with a 44px touch target', () => {

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -8,6 +8,8 @@ import { formatDate, startOfWeek, getWeekNumber } from '@/app/lib/date'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+import { useSyncStore } from '@/app/stores/use-sync-store'
+import { SyncStartupState } from '@/app/components/empty-state'
 import { PullToRefresh } from '@/app/components/PullToRefresh'
 import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
 import { CalendarViewSwitcher } from './components/CalendarViewSwitcher'
@@ -154,6 +156,8 @@ export default function CalendarPage() {
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
   const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
   const firstDayOfWeek = usePreferencesStore((s) => s.firstDayOfWeek)
+  const initialSyncState = useSyncStore((s) => s.initialSyncState)
+  const syncError = useSyncStore((s) => s.error)
   const userTz = resolveUserTimezone(defaultTimezonePref)
 
   const [createDialog, setCreateDialog] = useState<CreateDialogState | null>(null)
@@ -195,6 +199,8 @@ export default function CalendarPage() {
     () => events.filter((event) => visibleCalendarIds.has(event.calendarId ?? 'default')),
     [events, visibleCalendarIds],
   )
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const shouldShowStartupState = !isLoading && visibleEvents.length === 0 && !initialLoadComplete
 
   // Search
   const searchQuery = useCalendarStore((s) => s.searchQuery)
@@ -399,6 +405,8 @@ export default function CalendarPage() {
       {/* Content */}
       {isLoading ? (
         <CalendarSkeleton />
+      ) : shouldShowStartupState ? (
+        <SyncStartupState state={initialSyncState} error={syncError} />
       ) : (
         <>
           {/* Search bar */}

--- a/apps/web/app/(app)/contacts/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/contacts/__tests__/page.test.tsx
@@ -32,6 +32,8 @@ const storeMock = vi.hoisted(() => ({
   },
   syncState: {
     isOnline: true,
+    initialSyncState: 'synced' as const,
+    error: null as string | null,
   },
   authState: {
     canWrite: vi.fn(() => true),
@@ -63,6 +65,8 @@ describe('ContactsPage mobile reachability', () => {
   beforeEach(() => {
     storeMock.contactState.isLoading = true
     storeMock.contactState.searchQuery = ''
+    storeMock.syncState.initialSyncState = 'synced'
+    storeMock.syncState.error = null
     storeMock.authState.canWrite.mockReturnValue(true)
   })
 
@@ -78,6 +82,16 @@ describe('ContactsPage mobile reachability', () => {
   it('exposes search on mobile', () => {
     renderWithIntl(<ContactsPage />)
     expect(screen.getByLabelText('Search contacts')).toBeInTheDocument()
+  })
+
+  it('shows restore copy before rendering the normal empty contact state', () => {
+    storeMock.contactState.isLoading = false
+    storeMock.syncState.initialSyncState = 'restoring'
+
+    renderWithIntl(<ContactsPage />)
+
+    expect(screen.getByText('Restoring encrypted data…')).toBeInTheDocument()
+    expect(screen.queryByText('No contacts yet')).not.toBeInTheDocument()
   })
 
   it('exposes a mobile collection switcher with a 44px touch target', () => {

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -11,7 +11,7 @@ import { useContactStore, getFilteredContacts } from '@/app/stores/use-contact-s
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { useSyncStore } from '@/app/stores/use-sync-store'
-import { ContactsEmptyState, SearchEmptyState, ContactDetailEmptyState } from '@/app/components/empty-state'
+import { ContactsEmptyState, ContactDetailEmptyState, SearchEmptyState, SyncStartupState } from '@/app/components/empty-state'
 import { ConfirmDialog } from '@/app/components/confirm-dialog'
 import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
@@ -1080,6 +1080,8 @@ export default function ContactsPage() {
   const isLoading = useContactStore((s) => s.isLoading)
   const searchQuery = useContactStore((s) => s.searchQuery)
   const isOnline = useSyncStore((s) => s.isOnline)
+  const initialSyncState = useSyncStore((s) => s.initialSyncState)
+  const syncError = useSyncStore((s) => s.error)
   const contactLists = useContactListStore((s) => s.lists)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [showNewForm, setShowNewForm] = useState(false)
@@ -1102,8 +1104,10 @@ export default function ContactsPage() {
     [contacts, selectedId],
   )
 
-  const isEmpty = listFilteredContacts.length === 0 && !isLoading
-  const isEmptySearch = filtered.length === 0 && searchQuery.trim() !== '' && !isLoading
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const shouldShowStartupState = listFilteredContacts.length === 0 && !isLoading && !initialLoadComplete
+  const isEmpty = listFilteredContacts.length === 0 && !isLoading && initialLoadComplete
+  const isEmptySearch = filtered.length === 0 && searchQuery.trim() !== '' && !isLoading && initialLoadComplete
 
   return (
     <div className="flex h-full flex-col gap-3">
@@ -1159,6 +1163,8 @@ export default function ContactsPage() {
       {/* Content */}
       {isLoading ? (
         <ContactSkeleton />
+      ) : shouldShowStartupState ? (
+        <SyncStartupState state={initialSyncState} error={syncError} />
       ) : isEmpty ? (
         <ContactsEmptyState onAddContact={canWrite ? () => setShowNewForm(true) : undefined} />
       ) : isEmptySearch ? (

--- a/apps/web/app/(app)/tasks/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/tasks/__tests__/page.test.tsx
@@ -31,6 +31,8 @@ const storeMock = vi.hoisted(() => ({
   },
   syncState: {
     isOnline: true,
+    initialSyncState: 'synced' as const,
+    error: null as string | null,
   },
   authState: {
     canWrite: vi.fn(() => true),
@@ -64,6 +66,8 @@ vi.mock('@/app/components/MobileCollectionSheet', () => ({
 describe('TasksPage mobile reachability', () => {
   beforeEach(() => {
     storeMock.taskState.isLoading = true
+    storeMock.syncState.initialSyncState = 'synced'
+    storeMock.syncState.error = null
     storeMock.authState.canWrite.mockReturnValue(true)
   })
 
@@ -79,6 +83,16 @@ describe('TasksPage mobile reachability', () => {
   it('exposes an inline quick-add on mobile', () => {
     renderWithIntl(<TasksPage />)
     expect(screen.getByPlaceholderText('Add a task...')).toBeInTheDocument()
+  })
+
+  it('shows restore copy before rendering the normal empty task state', () => {
+    storeMock.taskState.isLoading = false
+    storeMock.syncState.initialSyncState = 'restoring'
+
+    renderWithIntl(<TasksPage />)
+
+    expect(screen.getByText('Restoring encrypted data…')).toBeInTheDocument()
+    expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument()
   })
 
   it('exposes a mobile collection switcher with a 44px touch target', () => {

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -12,7 +12,7 @@ import { formatDate } from '@/app/lib/date'
 
 import { PullToRefresh } from '@/app/components/PullToRefresh'
 import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
-import { TasksEmptyState } from '@/app/components/empty-state'
+import { SyncStartupState, TasksEmptyState } from '@/app/components/empty-state'
 import { ConfirmDialog } from '@/app/components/confirm-dialog'
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
 import type { Task, TaskStatus, Priority } from '@silentsuite/core'
@@ -848,6 +848,8 @@ export default function TasksPage() {
   const tasks = useTaskStore((s) => s.tasks)
   const isLoading = useTaskStore((s) => s.isLoading)
   const isOnline = useSyncStore((s) => s.isOnline)
+  const initialSyncState = useSyncStore((s) => s.initialSyncState)
+  const syncError = useSyncStore((s) => s.error)
   const taskLists = useTaskListStore((s) => s.lists)
   const [showDialog, setShowDialog] = useState(false)
   const [editTask, setEditTask] = useState<Task | null>(null)
@@ -860,7 +862,9 @@ export default function TasksPage() {
     [tasks, visibleListIds],
   )
   const sortedTasks = useMemo(() => sortTasks(filteredTasks), [filteredTasks])
-  const isEmpty = tasks.length === 0 && !isLoading
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const shouldShowStartupState = tasks.length === 0 && !isLoading && !initialLoadComplete
+  const isEmpty = tasks.length === 0 && !isLoading && initialLoadComplete
 
   return (
     <div className="flex h-full flex-col gap-3">
@@ -903,6 +907,8 @@ export default function TasksPage() {
       {/* Content */}
       {isLoading ? (
         <TaskSkeleton />
+      ) : shouldShowStartupState ? (
+        <SyncStartupState state={initialSyncState} error={syncError} />
       ) : isEmpty ? (
         <TasksEmptyState />
       ) : (

--- a/apps/web/app/components/empty-state.tsx
+++ b/apps/web/app/components/empty-state.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CalendarDays, CheckSquare, Users, Search, type LucideIcon } from 'lucide-react'
+import { AlertTriangle, CalendarDays, CheckSquare, RefreshCw, Search, Users, type LucideIcon } from 'lucide-react'
 
 interface EmptyStateProps {
   icon: LucideIcon
@@ -74,6 +74,38 @@ export function SearchEmptyState({ query }: { query: string }) {
       icon={Search}
       title="No results found"
       description={`No contacts match "${query}". Try a different search term.`}
+    />
+  )
+}
+
+export type SyncStartupStatus = 'idle' | 'restoring' | 'hydrated-cache' | 'syncing' | 'synced' | 'empty' | 'offline' | 'error' | 'no-session'
+
+export function SyncStartupState({ state, error }: { state: SyncStartupStatus; error?: string | null }) {
+  if (state === 'error') {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title="Could not restore encrypted session"
+        description={error || 'Sign in again or retry when your connection is available.'}
+      />
+    )
+  }
+
+  if (state === 'offline') {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title="Waiting to sync encrypted data"
+        description="You appear to be offline. Cached data will stay visible when available; reconnect to finish sync."
+      />
+    )
+  }
+
+  return (
+    <EmptyState
+      icon={RefreshCw}
+      title={state === 'syncing' ? 'Syncing encrypted data…' : 'Restoring encrypted data…'}
+      description="SilentSuite is checking your encrypted session before showing an empty account."
     />
   )
 }

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -125,6 +125,7 @@ async function deserializeCalendarItemsIncrementally(
 export function SyncProvider({ children }: { children: React.ReactNode }) {
   const initializeSync = useSyncStore((s) => s.initializeSync)
   const setSyncStatus = useSyncStore((s) => s.setSyncStatus)
+  const setInitialSyncState = useSyncStore((s) => s.setInitialSyncState)
   const setLastSynced = useSyncStore((s) => s.setLastSynced)
   const setError = useSyncStore((s) => s.setError)
 
@@ -154,6 +155,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       const initStartedAt = markCalendarSyncStart()
       try {
         setSyncStatus('syncing')
+        setInitialSyncState('restoring')
         const cacheStatus = getCacheCapabilityStatus()
         logSyncTiming('cache-capability', initStartedAt, { ...cacheStatus })
 
@@ -161,13 +163,37 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         // from IndexedDB before the network sync starts. This is best-effort
         // — failures are logged and the normal init path proceeds.
         if (isLocalCacheEnabled()) {
-          await hydrateFromCache()
+          const hydrated = await hydrateFromCache()
+          if (hydrated) setInitialSyncState('hydrated-cache')
         }
 
         // Restore session, create/fetch collections, load items, start SyncEngine
         const etebaseInitStartedAt = nowMs()
-        await etebaseInitialize()
+        const initOutcome = await etebaseInitialize()
         logSyncTiming('etebase-initialize', etebaseInitStartedAt)
+
+        if (initOutcome.status === 'no-session') {
+          setInitialSyncState('no-session')
+          setSyncStatus('synced')
+          setError(null)
+          return
+        }
+
+        if (initOutcome.status === 'offline') {
+          setInitialSyncState('offline')
+          setSyncStatus('offline')
+          setError('Offline. Showing any cached encrypted data until sync can resume.')
+          return
+        }
+
+        if (initOutcome.status === 'error') {
+          setInitialSyncState('error')
+          setSyncStatus('error')
+          setError('Could not restore encrypted session')
+          return
+        }
+
+        setInitialSyncState('syncing')
 
         // Now load items from each collection into the data stores
         const loadHadErrors = await loadItemsIntoStores()
@@ -180,9 +206,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
         if (loadHadErrors) {
           setSyncStatus('error')
+          setInitialSyncState('error')
           setError('Some synced items could not be loaded')
         } else {
           setSyncStatus('synced')
+          setInitialSyncState(hasVisibleDomainData() ? 'synced' : 'empty')
           setError(null)
         }
         setLastSynced(new Date())
@@ -190,6 +218,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       } catch (err) {
         reportSyncError('init', err)
         setSyncStatus('error')
+        setInitialSyncState('error')
         setError('Sync initialization failed')
       }
     }
@@ -204,8 +233,15 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
      * Cheap (~10-50ms for a typical vault) and fully off the network path.
      * Failures here are non-fatal; we just skip the optimistic paint.
      */
-    async function hydrateFromCache() {
+    function hasVisibleDomainData(): boolean {
+      return useCalendarStore.getState().events.length > 0
+        || useTaskStore.getState().tasks.length > 0
+        || useContactStore.getState().contacts.length > 0
+    }
+
+    async function hydrateFromCache(): Promise<boolean> {
       const cacheHydrateStartedAt = nowMs()
+      let hydratedAny = false
       try {
         const [taskItems, contactItems, eventItems, core] = await Promise.all([
           cacheGetItemsByType('tasks'),
@@ -221,6 +257,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
               return { ...task, id: it.itemUid, listId: it.collectionUid }
             })
             useTaskStore.getState().syncFromRemote(tasks)
+            hydratedAny = tasks.length > 0 || hydratedAny
             logger.log(`[sync-provider] Hydrated ${tasks.length} tasks from cache`)
           } catch (err) {
             logger.warn('[sync-provider] Failed to hydrate tasks from cache', getSafeErrorDetails(err))
@@ -234,6 +271,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
               return { ...contact, id: it.itemUid, listId: it.collectionUid }
             })
             useContactStore.getState().syncFromRemote(contacts)
+            hydratedAny = contacts.length > 0 || hydratedAny
             logger.log(`[sync-provider] Hydrated ${contacts.length} contacts from cache`)
           } catch (err) {
             logger.warn('[sync-provider] Failed to hydrate contacts from cache', getSafeErrorDetails(err))
@@ -262,6 +300,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
               setError('Some cached calendar events could not be loaded')
               reportSyncError('hydrate cached calendar events', errors[0])
             } else {
+              hydratedAny = events.length > 0 || hydratedAny
               logger.log(`[sync-provider] Hydrated ${events.length} events from cache`)
             }
           } catch (err) {
@@ -277,6 +316,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         logger.warn('[sync-provider] Cache hydration failed', getSafeErrorDetails(err))
         logSyncTiming('cache-hydrate-failed', cacheHydrateStartedAt)
       }
+      return hydratedAny
     }
 
     async function loadItemsIntoStores(): Promise<boolean> {
@@ -331,6 +371,8 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             reportSyncError('load calendar event chunk', errors[0])
           }
           await mirrorToCache('calendar', eventItems)
+        } else {
+          useCalendarStore.getState().syncFromRemote([])
         }
       } catch (err) {
         hadErrors = true
@@ -354,6 +396,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: taskItems.length, taskCount: tasks.length })
           await mirrorToCache('tasks', taskItems)
         } else {
+          useTaskStore.getState().syncFromRemote([])
           logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: 0, taskCount: 0 })
         }
       } catch (err) {
@@ -376,6 +419,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: contactItems.length, contactCount: contacts.length })
           await mirrorToCache('contacts', contactItems)
         } else {
+          useContactStore.getState().syncFromRemote([])
           logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: 0, contactCount: 0 })
         }
       } catch (err) {

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { secureGet } from '@/app/lib/secure-storage'
 import { useEtebaseStore } from '../use-etebase-store'
 import { useCalendarStore } from '../use-calendar-store'
 import { useCalendarListStore } from '../use-calendar-list-store'
@@ -18,6 +19,10 @@ const coreMock = vi.hoisted(() => ({
   createItem: vi.fn(),
   deleteItem: vi.fn(),
   updateCollectionMeta: vi.fn(),
+  restoreSession: vi.fn(),
+  getAccountFingerprint: vi.fn(),
+  listItems: vi.fn(),
+  SyncEngine: vi.fn(),
 }))
 
 const toastStoreMock = vi.hoisted(() => ({
@@ -49,6 +54,10 @@ beforeEach(() => {
   coreMock.createItem.mockReset()
   coreMock.deleteItem.mockReset()
   coreMock.updateCollectionMeta.mockReset()
+  coreMock.restoreSession.mockReset()
+  coreMock.getAccountFingerprint.mockReset()
+  coreMock.listItems.mockReset()
+  coreMock.SyncEngine.mockReset()
   toastStoreMock.showErrorToast.mockReset()
 })
 
@@ -112,6 +121,68 @@ function setupStoreWithCollections(itemManagerByUid: Record<string, MockItemMana
     syncEngine: syncEngine as any,
   })
 }
+
+describe('useEtebaseStore.initialize outcomes', () => {
+  beforeEach(() => {
+    vi.mocked(secureGet).mockReset().mockResolvedValue(null)
+    useEtebaseStore.setState({
+      account: null,
+      accountFingerprint: null,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('returns no-session without marking Etebase initialized', async () => {
+    vi.mocked(secureGet).mockResolvedValue(null)
+
+    const outcome = await useEtebaseStore.getState().initialize()
+
+    expect(outcome).toEqual({ status: 'no-session' })
+    expect(useEtebaseStore.getState().isInitialized).toBe(false)
+    expect(coreMock.restoreSession).not.toHaveBeenCalled()
+  })
+
+  it('returns success after restoring a saved session and loading collections', async () => {
+    vi.mocked(secureGet).mockResolvedValue('saved-session')
+    const account = { id: 'account' }
+    coreMock.restoreSession.mockResolvedValue(account)
+    coreMock.getAccountFingerprint.mockReturnValue('fingerprint')
+    coreMock.listCollections.mockImplementation(async (_account: unknown, type: string) => [mockCollection(`${type}-col`)])
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+    const engine = {
+      trackCollection: vi.fn(),
+      onStokenAdvance: vi.fn(),
+      start: vi.fn(async () => {}),
+      stop: vi.fn(),
+    }
+    coreMock.SyncEngine.mockImplementation(function MockSyncEngine() {
+      return engine
+    })
+
+    const outcome = await useEtebaseStore.getState().initialize()
+
+    expect(outcome).toEqual({ status: 'success', itemCount: 0 })
+    expect(useEtebaseStore.getState().isInitialized).toBe(true)
+    expect(useEtebaseStore.getState().accountFingerprint).toBe('fingerprint')
+    expect(engine.start).toHaveBeenCalledWith(account)
+  })
+
+  it('returns error without marking initialized on restore failure', async () => {
+    vi.mocked(secureGet).mockResolvedValue('saved-session')
+    coreMock.restoreSession.mockRejectedValue(new Error('bad session'))
+
+    const outcome = await useEtebaseStore.getState().initialize()
+
+    expect(outcome.status).toBe('error')
+    expect(useEtebaseStore.getState().isInitialized).toBe(false)
+    expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith('Failed to restore session. Please try signing in again.')
+  })
+})
 
 describe('useEtebaseStore.createItemsBatch', () => {
   beforeEach(() => {

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -77,6 +77,7 @@ function resetStore() {
   calendarStoreMock.syncFromRemote.mockReset()
   useSyncStore.setState({
     syncStatus: 'synced',
+    initialSyncState: 'synced',
     lastSyncedAt: null,
     isOnline: true,
     error: null,
@@ -111,6 +112,16 @@ describe('useSyncStore', () => {
 
     useSyncStore.getState().setError(null)
     expect(useSyncStore.getState().error).toBeNull()
+  })
+
+  it('tracks explicit initial sync state transitions', () => {
+    expect(useSyncStore.getState().initialSyncState).toBe('synced')
+
+    useSyncStore.getState().setInitialSyncState('restoring')
+    expect(useSyncStore.getState().initialSyncState).toBe('restoring')
+
+    useSyncStore.getState().setInitialSyncState('empty')
+    expect(useSyncStore.getState().initialSyncState).toBe('empty')
   })
 
   it('simulateSyncCycle transitions synced→syncing→synced', async () => {

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -80,6 +80,12 @@ type EtebaseCore = typeof import('@silentsuite/core')
 
 type CachedContentItem = { uid: string; content: string; collectionUid: string }
 
+export type EtebaseInitializeOutcome =
+  | { status: 'no-session' }
+  | { status: 'success'; itemCount: number }
+  | { status: 'offline'; error: unknown }
+  | { status: 'error'; error: unknown }
+
 const COLLECTION_DEFINITIONS: [CollectionTypeKey, string, string][] = [
   ['calendar', COLLECTION_TYPE_CALENDAR, 'Personal Calendar'],
   ['tasks', COLLECTION_TYPE_TASKS, 'Personal Tasks'],
@@ -344,7 +350,7 @@ interface EtebaseActions {
    * Restore Etebase session from localStorage, initialize collections,
    * load all items into data stores, and start the SyncEngine.
    */
-  initialize: () => Promise<void>
+  initialize: () => Promise<EtebaseInitializeOutcome>
 
   /**
    * Create an item in the given collection type.
@@ -493,7 +499,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const savedSession = await secureGet('etebase_session')
     if (!savedSession) {
       logger.debug('[etebase-store] No saved session, skipping initialization')
-      return
+      set({ isInitialized: false })
+      return { status: 'no-session' }
     }
 
     try {
@@ -584,14 +591,16 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       await engine.start(account)
       set({ syncEngine: engine, isInitialized: true })
       logger.debug('[etebase-store] SyncEngine started')
+      return { status: 'success', itemCount: itemCache.size }
     } catch (err) {
       console.error('[etebase-store] Initialization failed', getSafeErrorDetails(err))
       // Don't clear the session -- the user might be offline
       // They can retry on next page load
-      set({ isInitialized: true })
+      set({ isInitialized: false })
       if (!isOfflineError(err)) {
         showErrorToast('Failed to restore session. Please try signing in again.')
       }
+      return isOfflineError(err) ? { status: 'offline', error: err } : { status: 'error', error: err }
     }
   },
 
@@ -1359,8 +1368,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
         const collectionUid = itemCollectionMap.get(uid)
         if (collectionUid) results.push({ uid, content: contentStr, collectionUid })
-      } catch {
-        // Skip items that fail to decode
+      } catch (err) {
+        logger.warn(`[etebase-store] Failed to decode cached ${type} item`, getSafeErrorDetails(err))
       }
     }
 
@@ -1372,7 +1381,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const targetCollections = collectionUid
       ? [resolveCollection(collections, type, collectionUid)].filter(Boolean)
       : collections[type]
-    if (!account || targetCollections.length === 0) return []
+    if (!account || targetCollections.length === 0) {
+      logger.warn(`[etebase-store] Cannot refresh ${type}: missing account or collection`)
+      return get().fetchAllItems(type)
+    }
 
     try {
       const colManager = account.getCollectionManager()
@@ -1386,6 +1398,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         // Fetch ALL items (no stoken = full fetch)
         const itemManager = colManager.getItemManager(freshCollection)
         const collectionItems: { item: any; content: string }[] = []
+        let skippedDecodeCount = 0
 
         // Paginate through all items
         let stoken: string | undefined = undefined
@@ -1399,13 +1412,18 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
                 const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
                 collectionItems.push({ item, content: contentStr })
                 allResults.push({ uid: item.uid, content: contentStr, collectionUid: freshCollection.uid })
-              } catch {
-                // Skip items that fail to decode
+              } catch (err) {
+                skippedDecodeCount++
+                logger.warn(`[etebase-store] Failed to decode refreshed ${type} item`, getSafeErrorDetails(err))
               }
             }
           }
           stoken = response.stoken || undefined
           done = response.done
+        }
+
+        if (skippedDecodeCount > 0 && collectionItems.length === 0) {
+          throw new Error(`Refreshed ${type} collection contained only undecodable items`)
         }
 
         refreshed.push({ collection: freshCollection, items: collectionItems })

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -7,8 +7,11 @@ import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
 
+export type InitialSyncState = 'idle' | 'restoring' | 'hydrated-cache' | 'syncing' | 'synced' | 'empty' | 'offline' | 'error' | 'no-session'
+
 interface SyncState {
   syncStatus: SyncStatus
+  initialSyncState: InitialSyncState
   lastSyncedAt: Date | null
   isOnline: boolean
   error: string | null
@@ -18,6 +21,7 @@ interface SyncState {
 
 interface SyncActions {
   setSyncStatus: (status: SyncStatus) => void
+  setInitialSyncState: (state: InitialSyncState) => void
   setLastSynced: (date: Date) => void
   setOnline: (online: boolean) => void
   setError: (error: string | null) => void
@@ -32,7 +36,8 @@ interface SyncActions {
 }
 
 export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
-  syncStatus: 'synced',
+  syncStatus: 'syncing',
+  initialSyncState: 'idle',
   lastSyncedAt: null,
   isOnline: typeof navigator !== 'undefined' ? navigator.onLine : true,
   error: null,
@@ -40,6 +45,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
   failedQueueCount: 0,
 
   setSyncStatus: (status) => set({ syncStatus: status }),
+  setInitialSyncState: (initialSyncState) => set({ initialSyncState }),
   setLastSynced: (date) => set({ lastSyncedAt: date }),
   setOnline: (online) => set({ isOnline: online }),
   setError: (error) => set({ error }),
@@ -258,7 +264,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       // Refresh counts to ensure UI is accurate after sync
       const pc = await getPendingCount()
       const fc = await getFailedCount()
-      set({ syncStatus: 'synced', lastSyncedAt: new Date(), error: null, pendingQueueCount: pc, failedQueueCount: fc })
+      set({ syncStatus: 'synced', initialSyncState: 'synced', lastSyncedAt: new Date(), error: null, pendingQueueCount: pc, failedQueueCount: fc })
     }).catch((err) => {
       console.error('[sync-store] Manual sync failed', getSafeErrorDetails(err))
       set({ syncStatus: 'error', error: 'Sync failed' })


### PR DESCRIPTION
## Summary
- Add explicit initial restore/sync states for the web app startup path.
- Prevent calendar, tasks, and contacts from showing normal empty states before the encrypted session and initial sync are resolved.
- Preserve hydrated/current data when refresh results are indeterminate, while keeping full-replacement behavior after successful collection loads.

## Test Plan
- `pnpm --filter @silentsuite/web exec vitest run app/stores/__tests__/use-etebase-store.test.ts app/stores/__tests__/use-sync-store.test.ts app/'(app)'/calendar/__tests__/page.test.tsx app/'(app)'/tasks/__tests__/page.test.tsx app/'(app)'/contacts/__tests__/page.test.tsx`
- `pnpm --filter @silentsuite/web type-check`
