### PR TITLE
feat(web): add low-friction signup email recovery

### DIFF
--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -19,6 +19,7 @@ import { normalizeServerUrl } from '@/app/stores/use-etebase-store'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { BILLING_API_URL } from '@/app/lib/config'
 import { DISPLAY_VERSION } from '@/app/lib/constants'
+import { findCommonEmailDomainTypo, normalizeEmailForComparison, signupEmailSchema } from '@/app/lib/email-recovery'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
 import { StepCreateVault } from './components/step-create-vault'
@@ -71,9 +72,8 @@ const PLAN_PRICES: Record<PlanId, { monthly: number; annual: number; annualPerMo
 // Validation
 // ---------------------------------------------------------------------------
 
-const signupSchema = z
-  .object({
-    email: z.string().min(1, 'Please enter a valid email address'),
+const signupSchema = signupEmailSchema
+  .and(z.object({
     password: z
       .string()
       .min(8, 'Password must be at least 8 characters')
@@ -81,14 +81,10 @@ const signupSchema = z
       .regex(/[a-z]/, 'Must contain a lowercase letter')
       .regex(/[0-9]/, 'Must contain a number'),
     confirmPassword: z.string(),
-  })
+  }))
   .refine((data) => data.password === data.confirmPassword, {
     message: 'Passwords do not match',
     path: ['confirmPassword'],
-  })
-  .refine((data) => data.email.includes('@'), {
-    message: 'Please enter a valid email address',
-    path: ['email'],
   })
 
 type SignupFormData = z.infer<typeof signupSchema>
@@ -244,6 +240,7 @@ function StepCreateAccount({
   })
 
   const password = watch('password', '')
+  const emailTypoWarning = findCommonEmailDomainTypo(watch('email', ''))
 
   return (
     <div className="space-y-4 sm:space-y-6">
@@ -271,19 +268,44 @@ function StepCreateAccount({
             htmlFor="email"
             className="block text-sm font-medium text-[rgb(var(--foreground))]/80"
           >
-            Email address
+            Email
           </label>
           <Input
             id="email"
             type="email"
             autoFocus
             aria-invalid={!!errors.email}
-            aria-describedby={errors.email ? 'signup-email-error' : undefined}
+            aria-describedby={errors.email ? 'signup-email-error' : emailTypoWarning ? 'signup-email-warning' : undefined}
             {...register('email')}
             className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
           />
           {errors.email && (
             <p id="signup-email-error" role="alert" className="text-xs text-red-600 dark:text-red-400">{errors.email.message}</p>
+          )}
+          {!errors.email && emailTypoWarning && (
+            <p id="signup-email-warning" className="text-xs text-amber-600 dark:text-amber-300">{emailTypoWarning.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="confirmEmail"
+            className="block text-sm font-medium text-[rgb(var(--foreground))]/80"
+          >
+            Confirm email
+          </label>
+          <Input
+            id="confirmEmail"
+            type="email"
+            aria-invalid={!!errors.confirmEmail}
+            aria-describedby={errors.confirmEmail ? 'signup-confirm-email-error' : undefined}
+            {...register('confirmEmail')}
+            className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
+          />
+          {errors.confirmEmail && (
+            <p id="signup-confirm-email-error" role="alert" className="text-xs text-red-600 dark:text-red-400">
+              {errors.confirmEmail.message}
+            </p>
           )}
         </div>
 
@@ -1327,7 +1349,7 @@ export default function SignupPage() {
       localStorage.removeItem('silentsuite-server-url')
     }
 
-    const identifier = data.email || ''
+    const identifier = normalizeEmailForComparison(data.email || '')
     const selfHosted = isSelfHosted || isCustomServer(normalizedUrl)
 
     if (selfHosted) {

--- a/apps/web/app/components/EmailVerificationBanner.tsx
+++ b/apps/web/app/components/EmailVerificationBanner.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, type FormEvent } from 'react'
 import { MailWarning, Loader2 } from 'lucide-react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { isSelfHosted } from '@/app/lib/self-hosted'
 import { BILLING_API_URL } from '@/app/lib/config'
+import { normalizeEmailForComparison, signupEmailSchema } from '@/app/lib/email-recovery'
 
 // Minimum gap between focus-triggered refreshes. Cheap guard against burst
 // refreshes when the tab visibility flickers (e.g. fast alt-tab) or when
@@ -17,6 +18,11 @@ export function EmailVerificationBanner() {
   const [resending, setResending] = useState(false)
   const [resent, setResent] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [showChangeEmail, setShowChangeEmail] = useState(false)
+  const [newEmail, setNewEmail] = useState('')
+  const [confirmNewEmail, setConfirmNewEmail] = useState('')
+  const [changingEmail, setChangingEmail] = useState(false)
+  const [changeSuccess, setChangeSuccess] = useState<string | null>(null)
   const lastRefreshRef = useRef(0)
 
   const shouldShow = !isSelfHosted && user && user.emailVerified === false
@@ -73,28 +79,135 @@ export function EmailVerificationBanner() {
     }
   }
 
+  const handleChangeEmail = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setChangeSuccess(null)
+
+    const parsed = signupEmailSchema.safeParse({ email: newEmail, confirmEmail: confirmNewEmail })
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? 'Enter a valid email address.')
+      return
+    }
+
+    const normalizedEmail = normalizeEmailForComparison(parsed.data.email)
+    setChangingEmail(true)
+    try {
+      const res = await fetch(`${BILLING_API_URL}/account/email/change`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+        body: JSON.stringify({ email: normalizedEmail }),
+      })
+      if (!res.ok) {
+        const errData = await res.json().catch(() => null)
+        if (res.status === 429) {
+          throw new Error('Too many requests. Please try again later.')
+        }
+        throw new Error(errData?.detail ?? 'Could not change email. Please try again.')
+      }
+      const data = await res.json().catch(() => null)
+      const updatedEmail = normalizeEmailForComparison(data?.email ?? normalizedEmail)
+      setNewEmail('')
+      setConfirmNewEmail('')
+      setResent(false)
+      setChangeSuccess(
+        data?.sent === false
+          ? `Email changed to ${updatedEmail}, but the verification email could not be sent. Try Resend email in a moment.`
+          : `Verification email sent to ${updatedEmail}.`,
+      )
+      await refreshSession()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not change email. Please try again.')
+    } finally {
+      setChangingEmail(false)
+    }
+  }
+
   return (
-    <div role="alert" className="flex items-center gap-3 px-4 py-2 bg-amber-500/10 border-b border-amber-500/20 text-amber-800 dark:text-amber-200 text-sm">
-      <MailWarning className="w-4 h-4 text-amber-400 shrink-0" />
-      <span className="flex-1 text-xs">
-        {resent
-          ? 'Verification email sent. Check your inbox.'
-          : 'Please verify your email address to ensure you receive important account notifications.'}
-      </span>
-      {!resent && (
+    <div className="border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm text-amber-800 dark:text-amber-200">
+      <div role="alert" className="flex items-center gap-3">
+        <MailWarning className="w-4 h-4 text-amber-400 shrink-0" />
+        <span className="flex-1 text-xs">
+          {changeSuccess
+            ? changeSuccess
+            : resent
+              ? 'Verification email sent. Check your inbox.'
+              : 'Please verify your email so you can receive account and billing messages.'}
+        </span>
+        {!resent && !changeSuccess && (
+          <button
+            onClick={handleResend}
+            disabled={resending}
+            className="shrink-0 text-xs font-medium text-amber-400 hover:text-amber-300 underline underline-offset-2 disabled:opacity-50"
+          >
+            {resending ? (
+              <Loader2 className="w-3 h-3 animate-spin" />
+            ) : (
+              'Resend email'
+            )}
+          </button>
+        )}
         <button
-          onClick={handleResend}
-          disabled={resending}
-          className="shrink-0 text-xs font-medium text-amber-400 hover:text-amber-300 underline underline-offset-2 disabled:opacity-50"
+          onClick={() => {
+            setShowChangeEmail((value) => !value)
+            setError(null)
+            setChangeSuccess(null)
+          }}
+          className="shrink-0 text-xs font-medium text-amber-400 hover:text-amber-300 underline underline-offset-2"
         >
-          {resending ? (
-            <Loader2 className="w-3 h-3 animate-spin" />
-          ) : (
-            'Resend email'
-          )}
+          Change email
         </button>
+      </div>
+
+      {showChangeEmail && (
+        <form onSubmit={handleChangeEmail} className="mt-3 grid gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 sm:grid-cols-2">
+          <p className="text-xs text-amber-900 dark:text-amber-100 sm:col-span-2">
+            This changes the email we use for account and billing messages. Your current login email may stay the same for now.
+          </p>
+          <div className="space-y-1">
+            <label htmlFor="account-contact-email" className="block text-xs font-medium">
+              New email
+            </label>
+            <input
+              id="account-contact-email"
+              type="email"
+              value={newEmail}
+              onChange={(event) => setNewEmail(event.target.value)}
+              className="w-full rounded-md border border-amber-500/30 bg-white/80 px-2 py-1.5 text-sm text-slate-900 dark:bg-slate-950/80 dark:text-slate-100"
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="account-contact-email-confirm" className="block text-xs font-medium">
+              Confirm new email
+            </label>
+            <input
+              id="account-contact-email-confirm"
+              type="email"
+              value={confirmNewEmail}
+              onChange={(event) => setConfirmNewEmail(event.target.value)}
+              className="w-full rounded-md border border-amber-500/30 bg-white/80 px-2 py-1.5 text-sm text-slate-900 dark:bg-slate-950/80 dark:text-slate-100"
+            />
+          </div>
+          <div className="flex items-center gap-3 sm:col-span-2">
+            <button
+              type="submit"
+              disabled={changingEmail}
+              className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-medium text-slate-950 hover:bg-amber-400 disabled:opacity-50"
+            >
+              {changingEmail ? 'Saving...' : 'Save email'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowChangeEmail(false)}
+              className="text-xs font-medium text-amber-700 underline underline-offset-2 hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-200"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
       )}
-      {error && <span className="text-xs text-red-400">{error}</span>}
+      {error && <p className="mt-2 text-xs text-red-500 dark:text-red-400">{error}</p>}
     </div>
   )
 }

--- a/apps/web/app/components/__tests__/EmailVerificationBanner.test.tsx
+++ b/apps/web/app/components/__tests__/EmailVerificationBanner.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { EmailVerificationBanner } from '../EmailVerificationBanner'
+
+let mockUser: { id: string; email: string; planId: string; emailVerified?: boolean } | null = null
+const mockRefreshSession = vi.fn(async () => true)
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      user: mockUser,
+      refreshSession: mockRefreshSession,
+    }),
+}))
+
+vi.mock('@/app/lib/self-hosted', () => ({
+  isSelfHosted: false,
+}))
+
+vi.mock('lucide-react', () => ({
+  MailWarning: () => <svg data-testid="mail-warning-icon" />,
+  Loader2: () => <svg data-testid="loader-icon" />,
+}))
+
+vi.stubGlobal('fetch', vi.fn())
+
+describe('EmailVerificationBanner', () => {
+  beforeEach(() => {
+    mockUser = { id: 'user-1', email: 'typo@gmial.com', planId: 'early_annual', emailVerified: false }
+    mockRefreshSession.mockClear()
+    vi.mocked(fetch).mockReset()
+  })
+
+  it('renders persistent unverified copy and both recovery actions', () => {
+    render(<EmailVerificationBanner />)
+
+    expect(screen.getByText('Please verify your email so you can receive account and billing messages.')).toBeInTheDocument()
+    expect(screen.getByText('Resend email')).toBeInTheDocument()
+    expect(screen.getByText('Change email')).toBeInTheDocument()
+  })
+
+  it('opens a change email form with confirmation and careful contact-email copy', () => {
+    render(<EmailVerificationBanner />)
+
+    fireEvent.click(screen.getByText('Change email'))
+
+    expect(screen.getByLabelText('New email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Confirm new email')).toBeInTheDocument()
+    expect(screen.getByText('This changes the email we use for account and billing messages. Your current login email may stay the same for now.')).toBeInTheDocument()
+  })
+
+  it('submits normalized contact email changes to billing and refreshes the session', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ email: 'correct@gmail.com', emailVerified: false }),
+    } as Response)
+    render(<EmailVerificationBanner />)
+
+    fireEvent.click(screen.getByText('Change email'))
+    fireEvent.change(screen.getByLabelText('New email'), { target: { value: ' Correct@GMail.com ' } })
+    fireEvent.change(screen.getByLabelText('Confirm new email'), { target: { value: 'correct@gmail.COM' } })
+    fireEvent.click(screen.getByText('Save email'))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/account/email/change'),
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }),
+        body: JSON.stringify({ email: 'correct@gmail.com' }),
+      }),
+    ))
+    await waitFor(() => expect(mockRefreshSession).toHaveBeenCalled())
+    expect(await screen.findByText('Verification email sent to correct@gmail.com.')).toBeInTheDocument()
+  })
+
+  it('shows a recoverable message when billing changes the email but sending fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ email: 'correct@gmail.com', emailVerified: false, sent: false }),
+    } as Response)
+    render(<EmailVerificationBanner />)
+
+    fireEvent.click(screen.getByText('Change email'))
+    fireEvent.change(screen.getByLabelText('New email'), { target: { value: 'correct@gmail.com' } })
+    fireEvent.change(screen.getByLabelText('Confirm new email'), { target: { value: 'correct@gmail.com' } })
+    fireEvent.click(screen.getByText('Save email'))
+
+    expect(await screen.findByText('Email changed to correct@gmail.com, but the verification email could not be sent. Try Resend email in a moment.')).toBeInTheDocument()
+  })
+
+  it('blocks mismatched changed-email confirmation before calling billing', () => {
+    render(<EmailVerificationBanner />)
+
+    fireEvent.click(screen.getByText('Change email'))
+    fireEvent.change(screen.getByLabelText('New email'), { target: { value: 'one@example.com' } })
+    fireEvent.change(screen.getByLabelText('Confirm new email'), { target: { value: 'two@example.com' } })
+    fireEvent.click(screen.getByText('Save email'))
+
+    expect(screen.getByText('Email addresses do not match.')).toBeInTheDocument()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/lib/__tests__/email-recovery.test.ts
+++ b/apps/web/app/lib/__tests__/email-recovery.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findCommonEmailDomainTypo,
+  normalizeEmailForComparison,
+  signupEmailSchema,
+} from '../email-recovery'
+
+describe('email recovery validation helpers', () => {
+  it('normalizes email case and whitespace for comparison', () => {
+    expect(normalizeEmailForComparison('  User@GMail.COM ')).toBe('user@gmail.com')
+  })
+
+  it('rejects malformed signup emails with public copy', () => {
+    const result = signupEmailSchema.safeParse({ email: 'person@', confirmEmail: 'person@' })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toBe('Enter a valid email address.')
+  })
+
+  it('rejects signup email confirmation mismatches after normalization', () => {
+    const result = signupEmailSchema.safeParse({
+      email: 'person@example.com',
+      confirmEmail: 'person@other.com',
+    })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toBe('Email addresses do not match.')
+  })
+
+  it('accepts matching emails with different case and surrounding whitespace', () => {
+    const result = signupEmailSchema.safeParse({
+      email: ' Person@Example.com ',
+      confirmEmail: 'person@example.COM',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('warns when both pasted emails use a common typo domain', () => {
+    expect(findCommonEmailDomainTypo('person@gmial.com')).toEqual({
+      typedDomain: 'gmial.com',
+      suggestedDomain: 'gmail.com',
+      message: 'Did you mean gmail.com?',
+    })
+  })
+
+  it('warns for common provider TLD mistakes', () => {
+    expect(findCommonEmailDomainTypo('person@gmail.con')?.suggestedDomain).toBe('gmail.com')
+  })
+})

--- a/apps/web/app/lib/email-recovery.ts
+++ b/apps/web/app/lib/email-recovery.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod'
+
+const COMMON_EMAIL_DOMAINS = [
+  'gmail.com',
+  'outlook.com',
+  'hotmail.com',
+  'yahoo.com',
+  'proton.me',
+  'protonmail.com',
+  'icloud.com',
+]
+
+const COMMON_DOMAIN_TYPOS: Record<string, string> = {
+  'gmai.com': 'gmail.com',
+  'gmail.co': 'gmail.com',
+  'gmail.con': 'gmail.com',
+  'gmail.om': 'gmail.com',
+  'gmial.com': 'gmail.com',
+  'gmal.com': 'gmail.com',
+  'hotmial.com': 'hotmail.com',
+  'hotmai.com': 'hotmail.com',
+  'hotmail.co': 'hotmail.com',
+  'hotmal.com': 'hotmail.com',
+  'outlok.com': 'outlook.com',
+  'outlook.co': 'outlook.com',
+  'outlook.con': 'outlook.com',
+  'yaho.com': 'yahoo.com',
+  'yahoo.co': 'yahoo.com',
+  'yahoo.con': 'yahoo.com',
+  'protonmail.co': 'protonmail.com',
+  'protonmail.con': 'protonmail.com',
+  'proton.me.com': 'proton.me',
+  'iclould.com': 'icloud.com',
+  'icoud.com': 'icloud.com',
+  'icloud.co': 'icloud.com',
+  'icloud.con': 'icloud.com',
+}
+
+export type EmailDomainTypoWarning = {
+  typedDomain: string
+  suggestedDomain: string
+  message: string
+}
+
+export function normalizeEmailForComparison(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+function domainFromEmail(email: string): string | null {
+  const normalized = normalizeEmailForComparison(email)
+  const atIndex = normalized.lastIndexOf('@')
+  if (atIndex < 0 || atIndex === normalized.length - 1) return null
+  return normalized.slice(atIndex + 1)
+}
+
+function oneEditAway(left: string, right: string): boolean {
+  if (left === right) return false
+  if (Math.abs(left.length - right.length) > 1) return false
+
+  let edits = 0
+  let i = 0
+  let j = 0
+  while (i < left.length && j < right.length) {
+    if (left[i] === right[j]) {
+      i += 1
+      j += 1
+      continue
+    }
+    edits += 1
+    if (edits > 1) return false
+    if (left.length > right.length) {
+      i += 1
+    } else if (right.length > left.length) {
+      j += 1
+    } else {
+      i += 1
+      j += 1
+    }
+  }
+
+  if (i < left.length || j < right.length) edits += 1
+  return edits === 1
+}
+
+export function findCommonEmailDomainTypo(email: string): EmailDomainTypoWarning | null {
+  const typedDomain = domainFromEmail(email)
+  if (!typedDomain) return null
+
+  const suggestedDomain = COMMON_DOMAIN_TYPOS[typedDomain]
+    ?? COMMON_EMAIL_DOMAINS.find((domain) => oneEditAway(typedDomain, domain))
+
+  if (!suggestedDomain || suggestedDomain === typedDomain) return null
+
+  return {
+    typedDomain,
+    suggestedDomain,
+    message: `Did you mean ${suggestedDomain}?`,
+  }
+}
+
+export const signupEmailSchema = z
+  .object({
+    email: z.string().trim().toLowerCase().pipe(z.email('Enter a valid email address.')),
+    confirmEmail: z.string().trim().toLowerCase().pipe(z.email('Enter a valid email address.')),
+  })
+  .refine((data) => normalizeEmailForComparison(data.email) === normalizeEmailForComparison(data.confirmEmail), {
+    message: 'Email addresses do not match.',
+    path: ['confirmEmail'],
+  })


### PR DESCRIPTION
## Summary
- add stricter signup email validation with a required confirm-email field
- warn users about common email domain typos such as `gmial.com` before account creation
- expand the persistent unverified-email banner with a change-email recovery flow that calls billing

## Related
- Part of #174
- Requires the billing endpoint in silent-suite/silentsuite-internal#173 for the Change email action to work after deploy
- Etebase login-email migration remains separately tracked in #423

## Verification
- `pnpm --filter @silentsuite/web test -- app/lib/__tests__/email-recovery.test.ts app/components/__tests__/EmailVerificationBanner.test.tsx` (Vitest ran full web suite: 38 files, 375 tests passed)
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint` (passed with existing warnings in unrelated files)
- `pnpm --filter @silentsuite/web build` (passed; existing Sentry/standalone trace warnings remain)
