### PR TITLE
docs: explain Android signing certificate channels

### DIFF
--- a/apps/docs/user-guide/apps/android.md
+++ b/apps/docs/user-guide/apps/android.md
@@ -8,11 +8,15 @@ Once set up, your SilentSuite data syncs directly into Android's system calendar
 
 ## Install
 
-Choose one of the install options below. Both deliver the same APK from the same GitHub release.
+Choose the install channel you want to keep using for updates.
 
-### Option 1: Obtainium (recommended)
+### Option 1: Google Play
 
-[Obtainium](https://github.com/ImranR98/Obtainium) is an open-source Android app that installs and auto-updates apps directly from their GitHub releases -- no Google Play, no tracking, no account needed.
+Install from Google Play if you want Play-managed updates. If you installed SilentSuite from Google Play, keep updating it from Google Play.
+
+### Option 2: Obtainium
+
+[Obtainium](https://github.com/ImranR98/Obtainium) is an open-source Android app that installs and auto-updates apps directly from GitHub releases -- no Google Play, no tracking, no account needed.
 
 1. Install Obtainium from [GitHub Releases](https://github.com/ImranR98/Obtainium/releases) or [F-Droid](https://f-droid.org/packages/dev.imranr.obtainium.fdroid/).
 2. In Obtainium, tap **Add App** and paste this URL:
@@ -21,13 +25,24 @@ Choose one of the install options below. Both deliver the same APK from the same
    ```
 3. Obtainium will detect the latest SilentSuite release and install the APK. It will notify you whenever a new release is published.
 
-### Option 2: Direct APK download
+### Option 3: Direct APK download
 
 Grab the latest APK directly from GitHub Releases:
 
 - [github.com/silent-suite/silentsuite/releases/latest](https://github.com/silent-suite/silentsuite/releases/latest)
 
 Look for the asset named `silentsuite-android-vX.Y.Z-beta.apk` and install it. You'll need to allow installation from unknown sources the first time.
+
+### Certificate hashes and channel switching
+
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+
+SilentSuite's known Android signing certificate SHA-256 hashes are:
+
+- **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
+- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+
+If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching between Google Play and direct APK channels may require uninstalling and reinstalling the app. A certificate mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 
 ::: tip
 The SilentSuite Android app is a fork of the [EteSync Android app](https://github.com/etesync/android) with SilentSuite branding and `server.silentsuite.io` pre-configured as the default server. If you prefer, the original EteSync app from [Google Play](https://play.google.com/store/apps/details?id=com.etesync.syncadapter) or [F-Droid](https://f-droid.org/packages/com.etesync.syncadapter/) also works -- just enter the server URL manually.

--- a/apps/docs/user-guide/faq.md
+++ b/apps/docs/user-guide/faq.md
@@ -15,7 +15,7 @@ SilentSuite offers a hosted service with paid plans to fund development. Self-ho
 SilentSuite works across all major platforms:
 
 - **Web:** The web app is live at [app.silentsuite.io](https://app.silentsuite.io).
-- **Android:** A dedicated Android sync adapter is available as an APK from [GitHub Releases](https://github.com/silent-suite/silentsuite/releases).
+- **Android:** A dedicated Android sync adapter is available from Google Play and direct APK channels such as [GitHub Releases](https://github.com/silent-suite/silentsuite/releases), Zapstore, and F-Droid.
 - **iOS:** Use the third-party [EteSync for iOS](https://apps.apple.com/app/etesync/id1489574285) app from the App Store. Enter your server URL during setup.
 - **Desktop:** Use the [SilentSuite Bridge](./apps/dav-bridge.md) with any CalDAV/CardDAV app (Thunderbird, macOS Calendar, GNOME Calendar, and more).
 
@@ -32,6 +32,19 @@ SilentSuite uses the [Etebase protocol](https://www.etebase.com/) with XChaCha20
 ### Can I reset my password?
 
 No. Your encryption keys are derived from your password, and the server never has access to them. If you forget your password, your data cannot be recovered. Use a password manager.
+
+## Apps & Devices
+
+### Why do I see a certificate mismatch when switching Android install channels?
+
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+
+SilentSuite's known Android signing certificate SHA-256 hashes are:
+
+- **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
+- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+
+If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching channels may require uninstalling and reinstalling the app. A certificate mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 
 ## Self-Hosting
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -11,7 +11,7 @@ A privacy-focused, end-to-end encrypted sync service for calendar, contacts, and
 The v0.1.0-beta release covers:
 
 - **Web app** at [app.silentsuite.io](https://app.silentsuite.io) — calendar, contacts, tasks, import/export, settings, admin
-- **Android** — signed APK for sideloading (download via QR code in the app's *Settings → Mobile*)
+- **Android** — Google Play plus signed APK channels such as GitHub Releases, Zapstore, and F-Droid
 - **Desktop bridge** — CalDAV/CardDAV bridge for Thunderbird, Apple Calendar, Evolution, etc., on Linux / macOS / Windows
 - **Self-hosting** — two-container Docker stack (PostgreSQL + SilentSuite server)
 
@@ -22,7 +22,6 @@ See the [v0.1.0-beta release notes](https://github.com/silent-suite/silentsuite/
 On the roadmap, not yet shipped:
 
 - Native iOS app (the [EteSync iOS app](https://www.etesync.com/) works against your account in the meantime — same Etebase protocol)
-- Google Play / F-Droid listings (Android ships as a sideload APK)
 - OAuth-based one-click import from Google / iCloud
 - Push notifications
 - Multiple collections per account ([#88](https://github.com/silent-suite/silentsuite/issues/88))
@@ -68,13 +67,23 @@ No — an account belongs to a single server. Pick one when you sign up. To migr
 
 ## Apps & Devices
 
-### How do I get the Android APK?
+### How do I install the Android app?
 
-Sign in to [app.silentsuite.io](https://app.silentsuite.io) on a device with a screen, open *Settings → Mobile*, and either scan the QR code or use the direct download link to the latest GitHub Release.
+Use the same channel for install and updates:
 
-### Why is the Android app not on Google Play?
+- **Google Play** - recommended if you installed from Play and want Play-managed updates.
+- **GitHub Releases / Zapstore / F-Droid** - direct APK channels for sideloading and open app-store distribution. To get the direct APK, sign in to [app.silentsuite.io](https://app.silentsuite.io) on a device with a screen, open *Settings → Mobile*, and either scan the QR code or use the direct download link to the latest GitHub Release.
 
-Distribution channels (Google Play, F-Droid) are on the roadmap — see [#58](https://github.com/silent-suite/silentsuite-internal/issues/58) and [#59](https://github.com/silent-suite/silentsuite-internal/issues/59). For now it's a signed sideloadable APK.
+### Why do I see a certificate mismatch when switching Android install channels?
+
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+
+SilentSuite's known Android signing certificate SHA-256 hashes are:
+
+- **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
+- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+
+If you installed from Google Play, update through Google Play. If you installed from a direct APK channel, update through that same channel. Switching channels may require uninstalling and reinstalling the app. A mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 
 ### How does the desktop bridge work?
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -35,9 +35,19 @@ Open [app.silentsuite.io](https://app.silentsuite.io/login) on the second device
 
 ### Android
 
-In **Settings → Mobile** there's a QR code that links to the latest signed APK on GitHub Releases. Scan it from your phone or download manually. Sideload, open the app, log in. The Android app supports a custom server URL in advanced settings if you self-host.
+Install SilentSuite from the channel you want to keep using for updates:
 
-> Currently distributed as a sideloadable APK. Google Play and F-Droid listings are on the roadmap.
+- **Google Play** - use the Play listing if you installed from Play or want Play-managed updates.
+- **GitHub Releases / Zapstore / F-Droid** - use these direct APK channels if you prefer sideloading or open app-store distribution. In **Settings → Mobile** there is a QR code that links to the latest signed APK on GitHub Releases.
+
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching between Google Play and direct APK channels may require uninstalling and reinstalling the app.
+
+SilentSuite's known Android signing certificate SHA-256 hashes are:
+
+- **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
+- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+
+A certificate mismatch warning while switching install channels is expected and does not by itself indicate a compromised build. The Android app supports a custom server URL in advanced settings if you self-host.
 
 ### Desktop (CalDAV / CardDAV via the bridge)
 


### PR DESCRIPTION
## Summary
- Add Android install-channel guidance for Google Play vs direct APK updates
- Document the verified Play app-signing and direct APK certificate SHA-256 hashes
- Add certificate-mismatch FAQ wording so users understand cross-channel update warnings

## Verification
- pnpm --filter @silentsuite/docs build
- git diff --check
- Python hash-presence assertion across edited docs files