### PR TITLE
fix: show billing payment recovery actions

### DIFF
--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import SubscriptionPage from '../page'
+
+vi.mock('next/dynamic', () => ({
+  default: () => function MockStripePaymentForm({ mode, submitLabel, onSuccess }: { mode: string; submitLabel: string; onSuccess?: () => Promise<void> | void }) {
+    return (
+      <div data-testid="stripe-payment-form">
+        {mode}:{submitLabel}
+        <button onClick={() => { void onSuccess?.() }}>mock payment success</button>
+      </div>
+    )
+  },
+}))
+
+vi.mock('@silentsuite/ui', () => ({
+  Button: ({ children, onClick, disabled, ...props }: {
+    children: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+  }) => <button onClick={onClick} disabled={disabled} {...props}>{children}</button>,
+}))
+
+vi.mock('lucide-react', () => ({
+  Crown: ({ className }: { className?: string }) => <svg data-testid="crown-icon" className={className} />,
+  Loader2: ({ className }: { className?: string }) => <svg data-testid="loader-icon" className={className} />,
+  Check: ({ className }: { className?: string }) => <svg data-testid="check-icon" className={className} />,
+  CreditCard: ({ className }: { className?: string }) => <svg data-testid="credit-card-icon" className={className} />,
+  Clock: ({ className }: { className?: string }) => <svg data-testid="clock-icon" className={className} />,
+  X: ({ className }: { className?: string }) => <svg data-testid="x-icon" className={className} />,
+  Lock: ({ className }: { className?: string }) => <svg data-testid="lock-icon" className={className} />,
+  Zap: ({ className }: { className?: string }) => <svg data-testid="zap-icon" className={className} />,
+}))
+
+vi.mock('@/app/lib/config', () => ({ BILLING_API_URL: 'https://billing.test' }))
+vi.mock('@/app/lib/date', () => ({
+  formatDate: (date: Date) => date.toISOString().slice(0, 10),
+}))
+
+const baseSubscription = {
+  plan: 'early_monthly',
+  planLabel: 'Early Adopter',
+  billingInterval: 'monthly',
+  status: 'active',
+  renewalDate: '2026-07-30T00:00:00.000Z',
+  trial: { active: false, endsAt: null, daysRemaining: null },
+  cancelAtPeriodEnd: false,
+  trialPath: null,
+  earlyAdopter: true,
+  capabilities: {
+    trialActive: false,
+    trialExpired: false,
+    needsPaymentMethod: false,
+    canSetupCard: false,
+    canStartPaidSubscription: false,
+    canReactivate: false,
+    canRetryPayment: false,
+    canResumeCancellation: false,
+  },
+}
+
+function mockSubscription(subscription: Record<string, unknown>) {
+  const response = { ...baseSubscription, ...subscription }
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === 'https://billing.test/subscription' && !init?.method) {
+      return { ok: true, json: async () => response }
+    }
+    if (url === 'https://billing.test/subscription/reactivate') {
+      return { ok: true, json: async () => ({ clientSecret: 'cs_test' }) }
+    }
+    return { ok: false, status: 404, json: async () => ({ detail: 'not found' }) }
+  }))
+}
+
+describe('SubscriptionPage billing recovery CTAs', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows add payment method for active no-card trials without making cancel the only action', async () => {
+    mockSubscription({
+      status: 'trialing',
+      trial: { active: true, endsAt: '2026-07-03T00:00:00.000Z', daysRemaining: 3 },
+      trialPath: '7day',
+      renewalDate: null,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        trialActive: true,
+        needsPaymentMethod: true,
+        canSetupCard: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByRole('button', { name: /add payment method/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /cancel subscription/i })).not.toBeInTheDocument()
+  })
+
+  it('shows subscribe recovery for expired no-card trials', async () => {
+    mockSubscription({
+      status: 'trialing',
+      trial: { active: false, endsAt: '2026-06-01T00:00:00.000Z', daysRemaining: null },
+      trialPath: '7day',
+      renewalDate: null,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        trialExpired: true,
+        canStartPaidSubscription: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByRole('button', { name: /^subscribe$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /change plan/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /cancel subscription/i })).not.toBeInTheDocument()
+  })
+
+  it('shows retry payment for pending payments', async () => {
+    mockSubscription({
+      status: 'none',
+      renewalDate: null,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        canRetryPayment: true,
+        canStartPaidSubscription: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByText(/payment incomplete/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry payment/i })).toBeInTheDocument()
+  })
+
+  it('shows a paid recovery path for derived expired prepaid users', async () => {
+    mockSubscription({
+      status: 'expired',
+      renewalDate: '2026-06-01T00:00:00.000Z',
+      capabilities: {
+        ...baseSubscription.capabilities,
+        canStartPaidSubscription: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByRole('button', { name: /^subscribe$/i })).toBeInTheDocument()
+  })
+
+  it('shows visible reactivate errors and recovers the loading state', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === 'https://billing.test/subscription' && !init?.method) {
+        return { ok: true, json: async () => ({
+          ...baseSubscription,
+          status: 'cancelled',
+          capabilities: { ...baseSubscription.capabilities, canReactivate: true },
+        }) }
+      }
+      if (url === 'https://billing.test/subscription/reactivate') {
+        return { ok: false, status: 500, json: async () => ({ detail: 'Payment setup failed safely' }) }
+      }
+      return { ok: false, status: 404, json: async () => ({}) }
+    }))
+
+    render(<SubscriptionPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /reactivate/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /subscribe by card/i }))
+
+    expect(await screen.findByText('Payment setup failed safely')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('button', { name: /subscribe by card/i })).not.toBeDisabled())
+  })
+
+  it('suppresses retry CTA while payment confirmation is pending after client-side success', async () => {
+    let subscriptionFetches = 0
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === 'https://billing.test/subscription' && !init?.method) {
+        subscriptionFetches += 1
+        return { ok: true, json: async () => subscriptionFetches === 1
+          ? {
+              ...baseSubscription,
+              status: 'cancelled',
+              capabilities: { ...baseSubscription.capabilities, canReactivate: true },
+            }
+          : {
+              ...baseSubscription,
+              status: 'none',
+              capabilities: { ...baseSubscription.capabilities, canRetryPayment: true, canStartPaidSubscription: true },
+            } }
+      }
+      if (url === 'https://billing.test/subscription/reactivate') {
+        return { ok: true, json: async () => ({ clientSecret: 'cs_test' }) }
+      }
+      return { ok: false, status: 404, json: async () => ({}) }
+    }))
+
+    render(<SubscriptionPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /reactivate/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /subscribe by card/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /mock payment success/i }))
+
+    expect(await screen.findByText(/confirming your payment/i)).toBeInTheDocument()
+    expect(screen.queryByText(/payment incomplete/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /retry payment/i })).not.toBeInTheDocument()
+  })
+
+  it('does not route cancel-at-period-end users into reactivation', async () => {
+    mockSubscription({
+      status: 'active',
+      cancelAtPeriodEnd: true,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        canResumeCancellation: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    await screen.findByText(/subscription will be cancelled/i)
+    expect(screen.queryByRole('button', { name: /reactivate/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@silentsuite/ui'
 import dynamic from 'next/dynamic'
 import { BILLING_API_URL } from '@/app/lib/config'
 import { formatDate as formatDateUtil } from '@/app/lib/date'
+import AddCardBanner from '@/app/components/add-card-banner'
 
 const StripePaymentForm = dynamic(() => import('@/app/components/stripe-payment-form'), {
   loading: () => (
@@ -24,6 +25,17 @@ interface CryptoCheckoutResponse {
   checkoutUrl: string
 }
 
+interface SubscriptionCapabilities {
+  trialActive: boolean
+  trialExpired: boolean
+  needsPaymentMethod: boolean
+  canSetupCard: boolean
+  canStartPaidSubscription: boolean
+  canReactivate: boolean
+  canRetryPayment: boolean
+  canResumeCancellation: boolean
+}
+
 interface SubscriptionData {
   plan: string | null
   planLabel: string
@@ -38,6 +50,7 @@ interface SubscriptionData {
   cancelAtPeriodEnd: boolean
   trialPath: '7day' | '30day' | 'immediate' | null
   earlyAdopter: boolean
+  capabilities?: SubscriptionCapabilities
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -60,6 +73,23 @@ const STATUS_LABELS: Record<string, string> = {
 
 function formatDateStr(iso: string): string {
   return formatDateUtil(new Date(iso), 'system', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+function getCapabilities(data: SubscriptionData): SubscriptionCapabilities {
+  if (data.capabilities) return data.capabilities
+
+  const canSetupCard = data.trialPath === '7day' && data.trial.active
+  const canReactivate = data.status === 'cancelled' || data.status === 'expired' || data.status === 'none'
+  return {
+    trialActive: data.trial.active,
+    trialExpired: false,
+    needsPaymentMethod: canSetupCard,
+    canSetupCard,
+    canStartPaidSubscription: false,
+    canReactivate,
+    canRetryPayment: false,
+    canResumeCancellation: data.cancelAtPeriodEnd && data.status === 'active',
+  }
 }
 
 function LoadingSkeleton() {
@@ -136,6 +166,7 @@ export default function SubscriptionPage() {
   const [reactivating, setReactivating] = useState<string | null>(null)
   const [reactivateClientSecret, setReactivateClientSecret] = useState<string | null>(null)
   const [reactivatePlanId, setReactivatePlanId] = useState<string | null>(null)
+  const [reactivateError, setReactivateError] = useState<string | null>(null)
   const [showChangePlanDialog, setShowChangePlanDialog] = useState(false)
   const [changingPlan, setChangingPlan] = useState(false)
   const [changePlanSuccess, setChangePlanSuccess] = useState<{ plan: string; effectiveDate: string; prorated: boolean } | null>(null)
@@ -145,6 +176,7 @@ export default function SubscriptionPage() {
   const [billingInterval, setBillingInterval] = useState<'monthly' | 'annual'>('monthly')
   const [cryptoCheckoutLoading, setCryptoCheckoutLoading] = useState(false)
   const [cryptoCheckoutError, setCryptoCheckoutError] = useState<string | null>(null)
+  const [paymentConfirmationPending, setPaymentConfirmationPending] = useState(false)
 
   const fetchSubscription = useCallback(async () => {
     try {
@@ -164,6 +196,12 @@ export default function SubscriptionPage() {
   useEffect(() => {
     fetchSubscription()
   }, [fetchSubscription])
+
+  useEffect(() => {
+    if (data?.status === 'active' || data?.status === 'trialing') {
+      setPaymentConfirmationPending(false)
+    }
+  }, [data?.status])
 
   async function handleCancel() {
     setCancelling(true)
@@ -185,6 +223,7 @@ export default function SubscriptionPage() {
 
   async function handleReactivate(planId: string) {
     setReactivating(planId)
+    setReactivateError(null)
     try {
       const res = await fetch(`${BILLING_API_URL}/subscription/reactivate`, {
         method: 'POST',
@@ -196,9 +235,12 @@ export default function SubscriptionPage() {
         const { clientSecret } = await res.json()
         setReactivateClientSecret(clientSecret)
         setReactivatePlanId(planId)
+      } else {
+        const body = await res.json().catch(() => null)
+        setReactivateError(body?.detail ?? body?.error ?? 'Unable to set up payment. Please try again.')
       }
     } catch {
-      // API may not be running in dev
+      setReactivateError('Unable to reach billing service. Please try again.')
     } finally {
       setReactivating(null)
     }
@@ -279,14 +321,31 @@ export default function SubscriptionPage() {
     )
   }
 
+  const capabilities = getCapabilities(data)
   const showTrialBanner =
     !bannerDismissed &&
     data.trial.active &&
     data.trial.daysRemaining != null &&
-    data.trial.daysRemaining <= 7
+    data.trial.daysRemaining <= 7 &&
+    !capabilities.canSetupCard
 
   const isCancelled = data.status === 'cancelled' || data.status === 'expired'
-  const isActiveOrTrialing = data.status === 'active' || data.status === 'trialing'
+  const hasLiveSubscriptionActions = (data.status === 'active' || data.status === 'trialing')
+    && !data.cancelAtPeriodEnd
+    && !capabilities.canSetupCard
+    && !capabilities.trialExpired
+    && !capabilities.canRetryPayment
+    && !capabilities.canStartPaidSubscription
+  const canOpenPaidRecovery = !paymentConfirmationPending && (
+    capabilities.canRetryPayment
+    || capabilities.canStartPaidSubscription
+    || capabilities.canReactivate
+  )
+  const paidRecoveryLabel = capabilities.canRetryPayment
+    ? 'Retry payment'
+    : data.status === 'cancelled'
+      ? 'Reactivate'
+      : 'Subscribe'
   const accessUntilFormatted = data.renewalDate ? formatDateStr(data.renewalDate) : 'the end of your current period'
   // Only show Early Adopter plans — Standard plans will be enabled later
   const availablePlans = REACTIVATION_PLANS.filter((p) => p.earlyOnly)
@@ -384,9 +443,27 @@ export default function SubscriptionPage() {
         </div>
       </section>
 
+      {capabilities.canSetupCard && data.trial.daysRemaining != null && (
+        <AddCardBanner daysRemaining={data.trial.daysRemaining} onCardAdded={fetchSubscription} />
+      )}
+
+      {paymentConfirmationPending && (
+        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
+          <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">Confirming your payment.</p>
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">This usually takes a few seconds. We will update this page automatically.</p>
+        </div>
+      )}
+
+      {capabilities.canRetryPayment && !paymentConfirmationPending && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment incomplete. Please try again.</p>
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">Your subscription will activate after payment is completed.</p>
+        </div>
+      )}
+
       {/* Action buttons */}
       <div className="flex gap-3">
-        {isActiveOrTrialing && !data.cancelAtPeriodEnd && (
+        {hasLiveSubscriptionActions && (
           <>
             <Button variant="outline" size="sm" onClick={() => { setShowChangePlanDialog(true); setChangePlanSuccess(null); setSelectedChangePlan(null); setChangePlanError(null) }}>
               Change plan
@@ -401,9 +478,9 @@ export default function SubscriptionPage() {
             </Button>
           </>
         )}
-        {(isCancelled || data.status === 'none' || data.cancelAtPeriodEnd) && (
-          <Button size="sm" onClick={() => { setCryptoCheckoutError(null); setShowPlanSelection(true) }}>
-            Reactivate
+        {canOpenPaidRecovery && !capabilities.canSetupCard && !data.cancelAtPeriodEnd && (
+          <Button size="sm" onClick={() => { setReactivateError(null); setCryptoCheckoutError(null); setShowPlanSelection(true) }}>
+            {paidRecoveryLabel}
           </Button>
         )}
       </div>
@@ -418,10 +495,14 @@ export default function SubscriptionPage() {
                 <StripePaymentForm
                   clientSecret={reactivateClientSecret}
                   onSuccess={async () => {
+                    setPaymentConfirmationPending(true)
                     setReactivateClientSecret(null)
                     setReactivatePlanId(null)
                     setShowPlanSelection(false)
                     await fetchSubscription()
+                    for (const delayMs of [2000, 5000, 10000]) {
+                      window.setTimeout(() => { void fetchSubscription() }, delayMs)
+                    }
                   }}
                   submitLabel="Reactivate subscription"
                   mode="payment"
@@ -499,6 +580,9 @@ export default function SubscriptionPage() {
                       >
                         {reactivating === plan.id ? 'Setting up...' : 'Subscribe by card'}
                       </button>
+                      {reactivateError && (
+                        <p className="mt-2 text-sm text-red-600 dark:text-red-400">{reactivateError}</p>
+                      )}
                       {billingInterval === 'annual' && CRYPTO_CHECKOUT_ENABLED && (
                         <div className="mt-3 rounded-lg border border-amber-500/25 bg-amber-500/5 p-3">
                           <div className="flex items-center justify-between gap-3">

--- a/apps/web/app/components/add-card-banner.tsx
+++ b/apps/web/app/components/add-card-banner.tsx
@@ -287,7 +287,7 @@ export default function AddCardBanner({ daysRemaining, onCardAdded }: AddCardBan
         <div className="flex items-center gap-2">
           <Button size="sm" onClick={() => setShowModal(true)}>
             <CreditCard className="h-3.5 w-3.5 mr-1.5" />
-            Add card
+            Add payment method
           </Button>
           <button onClick={() => setDismissed(true)} className="text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]">
             <X className="h-4 w-4" />


### PR DESCRIPTION
## Summary

- render add-payment-method CTA for active no-card trial users
- add capability-driven paid recovery CTAs for expired trial, pending payment, and cancelled states
- show visible card recovery errors and suppress retry CTA immediately after successful card confirmation
- add focused subscription settings regression tests

## Validation

- `pnpm --filter @silentsuite/web exec vitest run 'app/(app)/settings/subscription/__tests__/page.test.tsx'`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web build`
