### PR TITLE
feat(web): add encrypted label suggestions

### DIFF
--- a/apps/web/app/components/LabelEditor.tsx
+++ b/apps/web/app/components/LabelEditor.tsx
@@ -1,13 +1,15 @@
 'use client'
 
-import { useCallback, useRef, useState, type FormEvent } from 'react'
+import { useCallback, useMemo, useRef, useState, type FormEvent } from 'react'
 import { Palette, Tag, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import { getLabelSuggestions } from '@silentsuite/core'
 import {
   getLabelColor,
   labelTextColor,
   useLabelColorStore,
 } from '@/app/stores/use-label-color-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 
 // ---------------------------------------------------------------------------
 // Shared label / category chip components (#291)
@@ -137,12 +139,19 @@ export function LabelEditor({
 }) {
   const t = useTranslations('Labels')
   const [input, setInput] = useState('')
+  const [activeSuggestion, setActiveSuggestion] = useState(0)
+  const labelIndex = useLabelSuggestionsStore((state) => state.index)
+  const suggestions = useMemo(
+    () => getLabelSuggestions(labelIndex, input, 6, labels),
+    [labelIndex, input, labels],
+  )
 
   const commit = useCallback(
     (raw: string) => {
       const next = normalizeLabels([...labels, raw])
       if (next.length !== labels.length) onChange(next)
       setInput('')
+      setActiveSuggestion(0)
     },
     [labels, onChange],
   )
@@ -158,17 +167,28 @@ export function LabelEditor({
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter' || e.key === ',') {
         e.preventDefault()
-        if (input.trim()) commit(input)
+        if (suggestions.length > 0 && (e.key === 'Enter' || !input.trim())) {
+          commit(suggestions[activeSuggestion] ?? suggestions[0]!)
+        } else if (input.trim()) commit(input)
+      } else if (e.key === 'ArrowDown' && suggestions.length > 0) {
+        e.preventDefault()
+        setActiveSuggestion((current) => (current + 1) % suggestions.length)
+      } else if (e.key === 'ArrowUp' && suggestions.length > 0) {
+        e.preventDefault()
+        setActiveSuggestion((current) => (current - 1 + suggestions.length) % suggestions.length)
+      } else if (e.key === 'Escape') {
+        setInput('')
+        setActiveSuggestion(0)
       } else if (e.key === 'Backspace' && !input && labels.length > 0) {
         // Quick-delete the last chip when the input is empty
         remove(labels[labels.length - 1]!)
       }
     },
-    [input, labels, commit, remove],
+    [input, labels, commit, remove, suggestions, activeSuggestion],
   )
 
   return (
-    <div className="flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">
+    <div className="relative flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">
       {labels.map((label, index) => (
         <LabelChip
           key={`${label}-${index}`}
@@ -183,13 +203,42 @@ export function LabelEditor({
         <input
           type="text"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={(e) => {
+            setInput(e.target.value)
+            setActiveSuggestion(0)
+          }}
           onKeyDown={handleKeyDown}
           onBlur={() => input.trim() && commit(input)}
           placeholder={labels.length === 0 ? (placeholder ?? t('addLabelPlaceholder')) : ''}
           aria-label={ariaLabel ?? t('editorAriaLabel')}
+          aria-autocomplete="list"
+          aria-expanded={suggestions.length > 0}
           className="min-w-[6rem] flex-1 bg-transparent text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none"
         />
+      )}
+      {!disabled && suggestions.length > 0 && (
+        <div
+          role="listbox"
+          aria-label={t('suggestionsAriaLabel')}
+          className="absolute left-2 right-2 top-[calc(100%+0.25rem)] z-50 max-h-48 overflow-auto rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] py-1 text-sm shadow-lg"
+        >
+          {suggestions.map((suggestion, index) => (
+            <button
+              key={suggestion}
+              type="button"
+              role="option"
+              aria-selected={index === activeSuggestion}
+              onMouseDown={(event) => {
+                event.preventDefault()
+                commit(suggestion)
+              }}
+              onMouseEnter={() => setActiveSuggestion(index)}
+              className={`block w-full px-3 py-1.5 text-left ${index === activeSuggestion ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300' : 'text-[rgb(var(--foreground))]'}`}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/apps/web/app/components/__tests__/LabelEditor.test.tsx
+++ b/apps/web/app/components/__tests__/LabelEditor.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { LabelEditor, LabelChips, normalizeLabels } from '../LabelEditor'
 import { renderWithIntl } from '@/src/__tests__/render-with-intl'
 import { getLabelColor, labelTextColor, useLabelColorStore } from '@/app/stores/use-label-color-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
+import { createLabelIndex } from '@silentsuite/core'
 
 vi.mock('lucide-react', () => ({
   Palette: () => <svg data-testid="palette-icon" />,
@@ -12,6 +14,7 @@ vi.mock('lucide-react', () => ({
 
 beforeEach(() => {
   useLabelColorStore.setState({ colors: {} })
+  useLabelSuggestionsStore.getState().destroy()
   localStorage.clear()
 })
 
@@ -136,5 +139,37 @@ describe('LabelEditor', () => {
     expect(screen.queryByLabelText('Labels')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Remove label Work')).not.toBeInTheDocument()
     expect(screen.getByText('Work')).toBeInTheDocument()
+  })
+
+  it('shows synced suggestions and selects one with keyboard', () => {
+    useLabelSuggestionsStore.setState({
+      index: createLabelIndex([
+        { label: 'Work', count: 5, lastUsedAt: 10 },
+        { label: 'Workout', count: 3, lastUsedAt: 9 },
+      ], 10),
+    })
+    const onChange = vi.fn()
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} />)
+    const input = screen.getByLabelText('Labels')
+
+    fireEvent.change(input, { target: { value: 'wor' } })
+    expect(screen.getByRole('option', { name: 'Work' })).toBeInTheDocument()
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenCalledWith(['Workout'])
+  })
+
+  it('does not suggest labels that are already selected', () => {
+    useLabelSuggestionsStore.setState({
+      index: createLabelIndex([
+        { label: 'Work', count: 5, lastUsedAt: 10 },
+        { label: 'Home', count: 3, lastUsedAt: 9 },
+      ], 10),
+    })
+
+    renderWithIntl(<LabelEditor labels={['Work']} onChange={vi.fn()} />)
+    expect(screen.queryByRole('option', { name: 'Work' })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Home' })).toBeInTheDocument()
   })
 })

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -17,7 +17,7 @@
  */
 import { logger } from '@/app/lib/logger'
 
-export type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
+export type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'labelIndex'
 
 export interface CachedItem {
   itemUid: string

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -5,7 +5,7 @@
  */
 import { logger } from '@/app/lib/logger'
 
-type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
+type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'labelIndex'
 type MutationType = 'create' | 'update' | 'delete' | 'move'
 
 export interface QueueEntry {

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -9,6 +9,7 @@ import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { usePreferencesSyncStore } from '@/app/stores/use-preferences-sync-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 import {
   getItemsByType as cacheGetItemsByType,
   replaceItemsForType as cacheReplaceItemsForType,
@@ -395,6 +396,17 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         reportSyncError('initialize preferences sync', err)
       }
 
+      // Load the encrypted label suggestion index from its dedicated Etebase
+      // collection. Plaintext labels only exist inside decrypted item content.
+      try {
+        const labelIndexStartedAt = nowMs()
+        await useLabelSuggestionsStore.getState().initialize()
+        logSyncTiming('label-index-initialize', labelIndexStartedAt)
+      } catch (err) {
+        hadErrors = true
+        reportSyncError('initialize label suggestions', err)
+      }
+
       return hadErrors
     }
 
@@ -452,6 +464,13 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           } catch (err) {
             reportSyncError('sync preferences', err)
           }
+        } else if (collectionType === 'silentsuite.labelindex') {
+          try {
+            const labelIndexItems = await refresher('labelIndex', event.collectionUid)
+            await useLabelSuggestionsStore.getState().loadFromRemote(labelIndexItems)
+          } catch (err) {
+            reportSyncError('sync label suggestions', err)
+          }
         }
 
         setLastSynced(new Date())
@@ -477,6 +496,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       if (unsubChange) unsubChange()
       if (unsubStatus) unsubStatus()
       usePreferencesSyncStore.getState().destroy()
+      useLabelSuggestionsStore.getState().destroy()
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -86,7 +86,7 @@ function setupStoreWithMocks(itemManager: MockItemManager, syncEngine: MockSyncE
   }
   useEtebaseStore.setState({
     account: account as any,
-    collections: { calendar: [collection as any], tasks: [], contacts: [], preferences: [] },
+    collections: { calendar: [collection as any], tasks: [], contacts: [], preferences: [], labelIndex: [] },
     itemCache: new Map(),
     itemTypeMap: new Map(),
     itemCollectionMap: new Map(),
@@ -104,7 +104,7 @@ function setupStoreWithCollections(itemManagerByUid: Record<string, MockItemMana
   }
   useEtebaseStore.setState({
     account: account as any,
-    collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [] },
+    collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
     itemCache: new Map(),
     itemTypeMap: new Map(),
     itemCollectionMap: new Map(),
@@ -129,7 +129,7 @@ describe('useEtebaseStore.createItemsBatch', () => {
     })
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -302,7 +302,7 @@ describe('useEtebaseStore.moveItem', () => {
     offlineQueueMock.isOfflineError.mockReset().mockReturnValue(false)
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -321,7 +321,7 @@ describe('useEtebaseStore.moveItem', () => {
     coreMock.deleteItem.mockResolvedValue(undefined)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [sourceCollection, targetCollection] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [sourceCollection, targetCollection] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([['item-old', sourceItem]]),
       itemTypeMap: new Map([['item-old', 'calendar']]),
       itemCollectionMap: new Map([['item-old', 'col-1']]),
@@ -355,7 +355,7 @@ describe('useEtebaseStore.moveItem', () => {
     offlineQueueMock.isOfflineError.mockReturnValue(true)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [sourceCollection, targetCollection] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [sourceCollection, targetCollection] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([['item-old', sourceItem]]),
       itemTypeMap: new Map([['item-old', 'calendar']]),
       itemCollectionMap: new Map([['item-old', 'col-1']]),
@@ -386,7 +386,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
   beforeEach(() => {
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -408,7 +408,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [{ uid: 'col-1' }, { uid: 'col-2' }] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [{ uid: 'col-1' }, { uid: 'col-2' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([
         ['item-1', deleteItemOne],
         ['item-2', deleteItemTwo],
@@ -464,7 +464,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -502,7 +502,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(items.map((item) => [item.uid, item])),
       itemTypeMap: new Map(items.map((item) => [item.uid, 'calendar' as const])),
       itemCollectionMap: new Map(items.map((item) => [item.uid, 'col-1'])),
@@ -533,7 +533,7 @@ describe('useEtebaseStore.refreshCollection', () => {
   beforeEach(() => {
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -564,7 +564,7 @@ describe('useEtebaseStore.refreshCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([
         ['old-col-1', staleItem],
         ['keep-col-2', survivorItem],
@@ -606,7 +606,7 @@ describe('useEtebaseStore.refreshCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([['existing', existingItem]]),
       itemTypeMap: new Map([['existing', 'calendar']]),
       itemCollectionMap: new Map([['existing', 'col-1']]),
@@ -650,7 +650,7 @@ describe('useEtebaseStore.reconcileCollections', () => {
     })
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -682,7 +682,7 @@ describe('useEtebaseStore.reconcileCollections', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [deletedCalendar] as any[], tasks: [taskCollection] as any[], contacts: [contactCollection] as any[], preferences: [] },
+      collections: { calendar: [deletedCalendar] as any[], tasks: [taskCollection] as any[], contacts: [contactCollection] as any[], preferences: [], labelIndex: [] },
       itemCache: new Map([['event-1', mockItem('event-1', 'deleted event')]]),
       itemTypeMap: new Map([['event-1', 'calendar']]),
       itemCollectionMap: new Map([['event-1', 'deleted-cal']]),
@@ -728,7 +728,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
     })
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -752,7 +752,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
     coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [collection] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [collection] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       isInitialized: true,
     })
 
@@ -788,7 +788,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
     coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [], tasks: [collection] as any[], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [collection] as any[], contacts: [], preferences: [], labelIndex: [] },
       isInitialized: true,
     })
 
@@ -824,7 +824,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
     coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [], tasks: [], contacts: [collection] as any[], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [collection] as any[], preferences: [], labelIndex: [] },
       isInitialized: true,
     })
 
@@ -863,7 +863,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
         calendar: type === 'calendar' ? [collection] as any[] : [],
         tasks: type === 'tasks' ? [collection] as any[] : [],
         contacts: type === 'contacts' ? [collection] as any[] : [],
-        preferences: [],
+        preferences: [], labelIndex: [],
       },
       isInitialized: true,
     })

--- a/apps/web/app/stores/__tests__/use-label-suggestions-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-label-suggestions-store.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLabelIndex, serializeLabelIndex } from '@silentsuite/core'
+import { useEtebaseStore } from '../use-etebase-store'
+import { useLabelSuggestionsStore } from '../use-label-suggestions-store'
+
+vi.mock('@/app/lib/secure-storage', () => ({
+  secureGet: vi.fn(async () => null),
+  secureSet: vi.fn(async () => {}),
+  secureRemove: vi.fn(async () => {}),
+  secureClear: vi.fn(async () => {}),
+  migrateFromLocalStorage: vi.fn(async () => {}),
+}))
+
+vi.mock('@/app/stores/use-toast-store', () => ({
+  showErrorToast: vi.fn(),
+}))
+
+vi.mock('@/app/lib/offline-queue', () => ({
+  enqueue: vi.fn(async () => {}),
+  getAll: vi.fn(async () => []),
+  remove: vi.fn(async () => {}),
+  isOfflineError: vi.fn(() => false),
+}))
+
+function resetStores() {
+  useLabelSuggestionsStore.getState().destroy()
+  useEtebaseStore.setState({
+    account: null,
+    collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+    itemCache: new Map(),
+    itemTypeMap: new Map(),
+    itemCollectionMap: new Map(),
+    isInitialized: false,
+    syncEngine: null,
+  })
+}
+
+describe('useLabelSuggestionsStore', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    resetStores()
+  })
+
+  it('creates label index in a dedicated encrypted labelIndex collection', async () => {
+    const createItem = vi.fn(async () => 'label-index-1')
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [{ uid: 'label-col' }] as any[] },
+      isInitialized: true,
+      createItem: createItem as any,
+    })
+
+    await useLabelSuggestionsStore.getState().recordLabelsUsed(['Work'])
+    await useLabelSuggestionsStore.getState().syncLocalToRemote()
+
+    expect(createItem).toHaveBeenCalledTimes(1)
+    expect(createItem.mock.calls[0]?.[0]).toBe('labelIndex')
+    expect(createItem.mock.calls[0]?.[3]).toBe('label-col')
+    const content = createItem.mock.calls[0]?.[1] as string
+    expect(content).toContain('silentsuite.labelindex.v1')
+    expect(content).toContain('Work')
+    expect(useLabelSuggestionsStore.getState().remoteItemUid).toBe('label-index-1')
+  })
+
+  it('merges remote indexes idempotently and suggests by rank', async () => {
+    const updateItem = vi.fn(async () => {})
+    const remote = serializeLabelIndex(createLabelIndex([
+      { label: 'Work', count: 4, lastUsedAt: 10 },
+      { label: 'Home', count: 1, lastUsedAt: 9 },
+    ], 10))
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [{ uid: 'label-col' }] as any[] },
+      isInitialized: true,
+      fetchAllItems: vi.fn(async () => [{ uid: 'remote-1', content: remote, collectionUid: 'label-col' }]) as any,
+      updateItem: updateItem as any,
+    })
+
+    await useLabelSuggestionsStore.getState().recordLabelsUsed(['work', 'Urgent'])
+    await useLabelSuggestionsStore.getState().loadFromRemote()
+    await useLabelSuggestionsStore.getState().loadFromRemote()
+
+    expect(useLabelSuggestionsStore.getState().suggestionsFor('', [], 3)).toEqual(['Work', 'Urgent', 'Home'])
+    expect(useLabelSuggestionsStore.getState().index.labels.work.count).toBe(4)
+  })
+})

--- a/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
@@ -22,7 +22,7 @@ function resetStores() {
   usePreferencesStore.setState({ notificationSound: true })
   useEtebaseStore.setState({
     account: null,
-    collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+    collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
     itemCache: new Map(),
     itemTypeMap: new Map(),
     itemCollectionMap: new Map(),

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -73,8 +73,9 @@ const COLLECTION_TYPE_CALENDAR = 'etebase.vevent'
 const COLLECTION_TYPE_TASKS = 'etebase.vtodo'
 const COLLECTION_TYPE_CONTACTS = 'etebase.vcard'
 const COLLECTION_TYPE_PREFERENCES = 'silentsuite.preferences'
+const COLLECTION_TYPE_LABEL_INDEX = 'silentsuite.labelindex'
 
-type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
+type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'labelIndex'
 type CollectionMetaUpdates = { name?: string; description?: string; color?: string }
 type EtebaseCore = typeof import('@silentsuite/core')
 
@@ -85,6 +86,7 @@ const COLLECTION_DEFINITIONS: [CollectionTypeKey, string, string][] = [
   ['tasks', COLLECTION_TYPE_TASKS, 'Personal Tasks'],
   ['contacts', COLLECTION_TYPE_CONTACTS, 'Personal Contacts'],
   ['preferences', COLLECTION_TYPE_PREFERENCES, 'Preferences'],
+  ['labelIndex', COLLECTION_TYPE_LABEL_INDEX, 'Label Suggestions'],
 ]
 
 function collectionTypeToKey(ct: string): CollectionTypeKey | null {
@@ -92,6 +94,7 @@ function collectionTypeToKey(ct: string): CollectionTypeKey | null {
   if (ct === COLLECTION_TYPE_TASKS) return 'tasks'
   if (ct === COLLECTION_TYPE_CONTACTS) return 'contacts'
   if (ct === COLLECTION_TYPE_PREFERENCES) return 'preferences'
+  if (ct === COLLECTION_TYPE_LABEL_INDEX) return 'labelIndex'
   return null
 }
 
@@ -99,6 +102,7 @@ function keyToCollectionType(type: CollectionTypeKey): string {
   if (type === 'calendar') return COLLECTION_TYPE_CALENDAR
   if (type === 'tasks') return COLLECTION_TYPE_TASKS
   if (type === 'contacts') return COLLECTION_TYPE_CONTACTS
+  if (type === 'labelIndex') return COLLECTION_TYPE_LABEL_INDEX
   return COLLECTION_TYPE_PREFERENCES
 }
 
@@ -111,6 +115,7 @@ async function ensureCollectionsForAccount(
     tasks: [],
     contacts: [],
     preferences: [],
+    labelIndex: [],
   }
 
   for (const [key, colType, defaultName] of COLLECTION_DEFINITIONS) {
@@ -236,7 +241,7 @@ async function hydrateListStores(collections: Record<CollectionTypeKey, any[]>):
 }
 
 async function removeItemsFromDomainStore(type: CollectionTypeKey, collectionUid: string, itemUids?: string[]): Promise<number> {
-  if (type === 'preferences') return 0
+  if (type === 'preferences' || type === 'labelIndex') return 0
 
   const itemUidSet = itemUids ? new Set(itemUids) : null
 
@@ -310,6 +315,7 @@ function collectionItemNoun(type: CollectionTypeKey): string {
   if (type === 'calendar') return 'events'
   if (type === 'tasks') return 'tasks'
   if (type === 'preferences') return 'preferences'
+  if (type === 'labelIndex') return 'label suggestions'
   return 'contacts'
 }
 
@@ -317,7 +323,25 @@ function collectionDisplayName(type: CollectionTypeKey): string {
   if (type === 'calendar') return 'calendar'
   if (type === 'tasks') return 'task list'
   if (type === 'contacts') return 'address book'
+  if (type === 'labelIndex') return 'label suggestions'
   return 'preferences'
+}
+
+async function recordLabelsFromContent(type: CollectionTypeKey, content: string): Promise<void> {
+  if (type !== 'calendar' && type !== 'tasks' && type !== 'contacts') return
+  try {
+    const core = await import('@silentsuite/core')
+    const labels = type === 'calendar'
+      ? core.deserializeCalendarEvent(content).categories
+      : type === 'tasks'
+        ? core.deserializeTask(content).categories
+        : core.deserializeContact(content).categories
+    if (!labels || labels.length === 0) return
+    const { useLabelSuggestionsStore } = await import('@/app/stores/use-label-suggestions-store')
+    await useLabelSuggestionsStore.getState().recordLabelsUsed(labels)
+  } catch (err) {
+    logger.warn(`[etebase-store] Failed to record ${type} label suggestions`, err)
+  }
 }
 
 interface EtebaseState {
@@ -482,7 +506,7 @@ interface EtebaseActions {
 export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) => ({
   account: null,
   accountFingerprint: null,
-  collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+  collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
   itemCache: new Map(),
   itemTypeMap: new Map(),
   itemCollectionMap: new Map(),
@@ -1067,6 +1091,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       set({ itemCache, itemTypeMap, itemCollectionMap })
       // Write through to the local persistence cache so a reload paints it.
       void writeItemToCache(type, collection.uid, item.uid, content)
+      void recordLabelsFromContent(type, content)
       return item.uid
     } catch (err) {
       if (isOfflineError(err)) {
@@ -1240,6 +1265,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       newCache.set(itemUid, updated)
       set({ itemCache: newCache })
       void writeItemToCache(type, collection.uid, itemUid, content)
+      void recordLabelsFromContent(type, content)
     } catch (err) {
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
@@ -1472,7 +1498,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     set({
       account: null,
       accountFingerprint: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),

--- a/apps/web/app/stores/use-label-suggestions-store.ts
+++ b/apps/web/app/stores/use-label-suggestions-store.ts
@@ -1,0 +1,177 @@
+'use client'
+
+import { create } from 'zustand'
+import {
+  createLabelIndex,
+  deserializeLabelIndex,
+  getLabelSuggestions,
+  mergeLabelIndexes,
+  recordLabelsUsed as recordLabelsUsedInIndex,
+  serializeLabelIndex,
+  type LabelIndexV1,
+} from '@silentsuite/core'
+import { enqueue } from '@/app/lib/offline-queue'
+import { logger } from '@/app/lib/logger'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+
+const LABEL_INDEX_TEMP_ID = 'silentsuite-label-index'
+const WRITE_DEBOUNCE_MS = 500
+
+interface RemoteLabelIndexItem {
+  uid: string
+  index: LabelIndexV1
+}
+
+interface LabelSuggestionsState {
+  index: LabelIndexV1
+  remoteItemUid: string | null
+  pendingCreateTempId: string | null
+  isInitialized: boolean
+  isApplyingRemote: boolean
+  writeTimer: ReturnType<typeof setTimeout> | null
+}
+
+interface LabelSuggestionsActions {
+  initialize: () => Promise<void>
+  loadFromRemote: (items?: { uid: string; content: string }[]) => Promise<void>
+  syncLocalToRemote: () => Promise<void>
+  scheduleUpload: () => void
+  recordLabelsUsed: (labels: string[]) => Promise<void>
+  suggestionsFor: (query?: string, excluded?: string[], limit?: number) => string[]
+  destroy: () => void
+}
+
+function parseRemoteItems(items: { uid: string; content: string }[]): RemoteLabelIndexItem[] {
+  const parsed: RemoteLabelIndexItem[] = []
+  for (const item of items) {
+    try {
+      parsed.push({ uid: item.uid, index: deserializeLabelIndex(item.content) })
+    } catch (err) {
+      logger.warn(`[label-suggestions] Ignoring invalid label-index item ${item.uid}`, err)
+    }
+  }
+  return parsed
+}
+
+function chooseCanonical(items: RemoteLabelIndexItem[]): RemoteLabelIndexItem | null {
+  if (items.length === 0) return null
+  return [...items].sort((a, b) => b.index.updatedAt - a.index.updatedAt)[0] ?? null
+}
+
+function labelIndexCollectionUid(): string | undefined {
+  return useEtebaseStore.getState().collections.labelIndex[0]?.uid
+}
+
+export const useLabelSuggestionsStore = create<LabelSuggestionsState & LabelSuggestionsActions>((set, get) => ({
+  index: createLabelIndex([], 0),
+  remoteItemUid: null,
+  pendingCreateTempId: null,
+  isInitialized: false,
+  isApplyingRemote: false,
+  writeTimer: null,
+
+  initialize: async () => {
+    if (get().isInitialized) return
+    if (!useEtebaseStore.getState().account) return
+    await get().loadFromRemote()
+    set({ isInitialized: true })
+  },
+
+  loadFromRemote: async (itemsFromRefresh) => {
+    const etebase = useEtebaseStore.getState()
+    if (!etebase.account) return
+
+    const items = itemsFromRefresh ?? await etebase.fetchAllItems('labelIndex')
+    const remoteItems = parseRemoteItems(items)
+    const canonical = chooseCanonical(remoteItems)
+
+    if (!canonical) {
+      await get().syncLocalToRemote()
+      return
+    }
+
+    const merged = mergeLabelIndexes([get().index, ...remoteItems.map((item) => item.index)])
+    set({ index: merged, remoteItemUid: canonical.uid, pendingCreateTempId: null })
+
+    const mergedContent = serializeLabelIndex(merged)
+    const canonicalContent = serializeLabelIndex(canonical.index)
+    if (remoteItems.length > 1 || mergedContent !== canonicalContent) {
+      await etebase.updateItem('labelIndex', canonical.uid, mergedContent)
+    }
+  },
+
+  syncLocalToRemote: async () => {
+    if (get().isApplyingRemote) return
+    const etebase = useEtebaseStore.getState()
+    if (!etebase.account) return
+
+    const content = serializeLabelIndex(get().index)
+    const remoteItemUid = get().remoteItemUid
+
+    if (remoteItemUid && etebase.itemCache.has(remoteItemUid)) {
+      await etebase.updateItem('labelIndex', remoteItemUid, content)
+      return
+    }
+
+    const existing = parseRemoteItems(await etebase.fetchAllItems('labelIndex'))
+    const canonical = chooseCanonical(existing)
+    if (canonical) {
+      const merged = mergeLabelIndexes([get().index, ...existing.map((item) => item.index)])
+      set({ index: merged, remoteItemUid: canonical.uid, pendingCreateTempId: null })
+      await etebase.updateItem('labelIndex', canonical.uid, serializeLabelIndex(merged))
+      return
+    }
+
+    const collectionUid = labelIndexCollectionUid()
+    const pendingCreateTempId = get().pendingCreateTempId
+    if (pendingCreateTempId && collectionUid) {
+      await enqueue({
+        type: 'create',
+        collectionType: 'labelIndex',
+        collectionUid,
+        content,
+        tempId: pendingCreateTempId,
+      })
+      return
+    }
+
+    const itemUid = await etebase.createItem('labelIndex', content, LABEL_INDEX_TEMP_ID, collectionUid)
+    if (itemUid) {
+      set({ remoteItemUid: itemUid, pendingCreateTempId: null })
+    } else if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      set({ pendingCreateTempId: LABEL_INDEX_TEMP_ID })
+    }
+  },
+
+  scheduleUpload: () => {
+    const existingTimer = get().writeTimer
+    if (existingTimer) clearTimeout(existingTimer)
+    const writeTimer = setTimeout(() => {
+      set({ writeTimer: null })
+      void get().syncLocalToRemote()
+    }, WRITE_DEBOUNCE_MS)
+    set({ writeTimer })
+  },
+
+  recordLabelsUsed: async (labels) => {
+    if (labels.length === 0) return
+    const next = recordLabelsUsedInIndex(get().index, labels)
+    set({ index: next })
+    get().scheduleUpload()
+  },
+
+  suggestionsFor: (query = '', excluded = [], limit = 8) => getLabelSuggestions(get().index, query, limit, excluded),
+
+  destroy: () => {
+    const { writeTimer } = get()
+    if (writeTimer) clearTimeout(writeTimer)
+    set({
+      index: createLabelIndex([], 0),
+      remoteItemUid: null,
+      pendingCreateTempId: null,
+      isInitialized: false,
+      isApplyingRemote: false,
+      writeTimer: null,
+    })
+  },
+}))

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -38,6 +38,7 @@
     "editorAriaLabel": "Labels",
     "changeLabelColor": "Change label {label} color",
     "removeLabel": "Remove label {label}",
+    "suggestionsAriaLabel": "Label suggestions",
     "eventLabels": "Event labels",
     "taskLabels": "Task labels",
     "contactLabels": "Contact labels",

--- a/packages/core/src/etebase/constants.ts
+++ b/packages/core/src/etebase/constants.ts
@@ -2,9 +2,11 @@ export const COLLECTION_TYPE_CALENDAR = 'etebase.vevent' as const;
 export const COLLECTION_TYPE_TASKS = 'etebase.vtodo' as const;
 export const COLLECTION_TYPE_CONTACTS = 'etebase.vcard' as const;
 export const COLLECTION_TYPE_PREFERENCES = 'silentsuite.preferences' as const;
+export const COLLECTION_TYPE_LABEL_INDEX = 'silentsuite.labelindex' as const;
 
 export type CollectionType =
   | typeof COLLECTION_TYPE_CALENDAR
   | typeof COLLECTION_TYPE_TASKS
   | typeof COLLECTION_TYPE_CONTACTS
-  | typeof COLLECTION_TYPE_PREFERENCES;
+  | typeof COLLECTION_TYPE_PREFERENCES
+  | typeof COLLECTION_TYPE_LABEL_INDEX;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export {
   COLLECTION_TYPE_TASKS,
   COLLECTION_TYPE_CONTACTS,
   COLLECTION_TYPE_PREFERENCES,
+  COLLECTION_TYPE_LABEL_INDEX,
 } from './etebase/constants.js';
 export type { CollectionType } from './etebase/constants.js';
 
@@ -128,6 +129,21 @@ export type {
   VersionedPreference,
   SyncedPreferencesV1,
 } from './models/preferences.js';
+
+// Synced encrypted label suggestion index
+export {
+  LABEL_INDEX_KIND,
+  createLabelIndex,
+  normalizeLabel,
+  normalizeLabelKey,
+  normalizeLabelIndex,
+  mergeLabelIndexes,
+  recordLabelsUsed,
+  getLabelSuggestions,
+  serializeLabelIndex,
+  deserializeLabelIndex,
+} from './models/label-index.js';
+export type { LabelIndexEntry, LabelIndexV1 } from './models/label-index.js';
 
 // iCal parser
 export {

--- a/packages/core/src/models/label-index.test.ts
+++ b/packages/core/src/models/label-index.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createLabelIndex,
+  deserializeLabelIndex,
+  getLabelSuggestions,
+  mergeLabelIndexes,
+  recordLabelsUsed,
+  serializeLabelIndex,
+} from './label-index.js';
+
+describe('label index', () => {
+  it('normalizes, serializes, and deserializes labels by case-insensitive key', () => {
+    const index = createLabelIndex([
+      { label: ' Work ', count: 2, lastUsedAt: 10 },
+      { label: 'work', count: 5, lastUsedAt: 5 },
+      { label: 'Personal', count: 1, lastUsedAt: 20 },
+    ], 30);
+
+    const restored = deserializeLabelIndex(serializeLabelIndex(index));
+
+    expect(Object.keys(restored.labels)).toEqual(['work', 'personal']);
+    expect(restored.labels.work).toMatchObject({ label: 'Work', count: 5, lastUsedAt: 10 });
+    expect(restored.labels.personal).toMatchObject({ label: 'Personal', count: 1, lastUsedAt: 20 });
+  });
+
+  it('records label use without duplicating keys', () => {
+    const recorded = recordLabelsUsed(createLabelIndex([], 0), ['Work', ' work ', '', 'Home'], 100);
+
+    expect(recorded.labels.work).toMatchObject({ label: 'work', count: 2, lastUsedAt: 100 });
+    expect(recorded.labels.home).toMatchObject({ label: 'Home', count: 1, lastUsedAt: 100 });
+  });
+
+  it('merges idempotently with union/max/last-used semantics', () => {
+    const first = createLabelIndex([
+      { label: 'Work', count: 4, lastUsedAt: 10 },
+      { label: 'Home', count: 1, lastUsedAt: 5 },
+    ], 10);
+    const second = createLabelIndex([
+      { label: 'work', count: 2, lastUsedAt: 20 },
+      { label: 'Urgent', count: 3, lastUsedAt: 15 },
+    ], 20);
+
+    const once = mergeLabelIndexes([first, second]);
+    const twice = mergeLabelIndexes([once, first, second]);
+
+    expect(twice.labels.work).toMatchObject({ label: 'Work', count: 4, lastUsedAt: 20 });
+    expect(twice.labels.home).toMatchObject({ label: 'Home', count: 1, lastUsedAt: 5 });
+    expect(twice.labels.urgent).toMatchObject({ label: 'Urgent', count: 3, lastUsedAt: 15 });
+    expect(twice).toEqual(once);
+  });
+
+  it('ranks suggestions by count, recency, and excludes selected labels', () => {
+    const index = createLabelIndex([
+      { label: 'Work', count: 2, lastUsedAt: 10 },
+      { label: 'Workout', count: 5, lastUsedAt: 2 },
+      { label: 'Personal', count: 10, lastUsedAt: 20 },
+    ], 20);
+
+    expect(getLabelSuggestions(index, 'wor', 5, ['Workout'])).toEqual(['Work']);
+    expect(getLabelSuggestions(index, '', 2)).toEqual(['Personal', 'Workout']);
+  });
+
+  it('rejects documents with a different explicit kind', () => {
+    expect(() => deserializeLabelIndex(JSON.stringify({ kind: 'silentsuite.preferences.v1' }))).toThrow(/kind/);
+  });
+});

--- a/packages/core/src/models/label-index.ts
+++ b/packages/core/src/models/label-index.ts
@@ -1,0 +1,140 @@
+export const LABEL_INDEX_KIND = 'silentsuite.labelindex.v1';
+
+export interface LabelIndexEntry {
+  label: string;
+  count: number;
+  lastUsedAt: number;
+}
+
+export interface LabelIndexV1 {
+  kind: typeof LABEL_INDEX_KIND;
+  schemaVersion: 1;
+  updatedAt: number;
+  labels: Record<string, LabelIndexEntry>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function timestamp(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function count(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+export function normalizeLabel(label: string): string {
+  return label.trim().replace(/\s+/g, ' ');
+}
+
+export function normalizeLabelKey(label: string): string {
+  return normalizeLabel(label).toLocaleLowerCase();
+}
+
+export function createLabelIndex(entries: LabelIndexEntry[] = [], now = Date.now()): LabelIndexV1 {
+  const index: LabelIndexV1 = {
+    kind: LABEL_INDEX_KIND,
+    schemaVersion: 1,
+    updatedAt: 0,
+    labels: {},
+  };
+  for (const entry of entries) {
+    const label = normalizeLabel(entry.label);
+    if (!label) continue;
+    const key = normalizeLabelKey(label);
+    const lastUsedAt = timestamp(entry.lastUsedAt, now);
+    const existing = index.labels[key];
+    index.labels[key] = {
+      label: existing?.lastUsedAt && existing.lastUsedAt > lastUsedAt ? existing.label : label,
+      count: Math.max(existing?.count ?? 0, count(entry.count)),
+      lastUsedAt: Math.max(existing?.lastUsedAt ?? 0, lastUsedAt),
+    };
+  }
+  index.updatedAt = Math.max(now, ...Object.values(index.labels).map((entry) => entry.lastUsedAt), 0);
+  return index;
+}
+
+export function normalizeLabelIndex(input: unknown): LabelIndexV1 {
+  const root = isRecord(input) ? input : {};
+  if ('kind' in root && root.kind !== LABEL_INDEX_KIND) {
+    throw new Error('Invalid label index kind');
+  }
+  const labels = isRecord(root.labels) ? root.labels : {};
+  const entries: LabelIndexEntry[] = [];
+  for (const value of Object.values(labels)) {
+    if (!isRecord(value) || typeof value.label !== 'string') continue;
+    const label = normalizeLabel(value.label);
+    if (!label) continue;
+    entries.push({
+      label,
+      count: count(value.count, 0),
+      lastUsedAt: timestamp(value.lastUsedAt, timestamp(root.updatedAt, 0)),
+    });
+  }
+  const normalized = createLabelIndex(entries, timestamp(root.updatedAt, 0));
+  normalized.updatedAt = Math.max(timestamp(root.updatedAt, 0), ...Object.values(normalized.labels).map((entry) => entry.lastUsedAt), 0);
+  return normalized;
+}
+
+export function mergeLabelIndexes(indexes: LabelIndexV1[]): LabelIndexV1 {
+  const merged = createLabelIndex([], 0);
+  for (const index of indexes) {
+    const normalized = normalizeLabelIndex(index);
+    for (const [key, incoming] of Object.entries(normalized.labels)) {
+      const existing = merged.labels[key];
+      const shouldUseIncomingLabel = !existing
+        || incoming.count > existing.count
+        || (incoming.count === existing.count && incoming.lastUsedAt >= existing.lastUsedAt);
+      merged.labels[key] = {
+        label: shouldUseIncomingLabel ? incoming.label : existing.label,
+        // Counts are approximate ranking signals. Use max rather than summing so
+        // repeated cold-start merges are idempotent.
+        count: Math.max(existing?.count ?? 0, incoming.count),
+        lastUsedAt: Math.max(existing?.lastUsedAt ?? 0, incoming.lastUsedAt),
+      };
+    }
+    merged.updatedAt = Math.max(merged.updatedAt, normalized.updatedAt);
+  }
+  merged.updatedAt = Math.max(merged.updatedAt, ...Object.values(merged.labels).map((entry) => entry.lastUsedAt), 0);
+  return merged;
+}
+
+export function recordLabelsUsed(index: LabelIndexV1, labels: string[], now = Date.now()): LabelIndexV1 {
+  const next = mergeLabelIndexes([index]);
+  for (const raw of labels) {
+    const label = normalizeLabel(raw);
+    if (!label) continue;
+    const key = normalizeLabelKey(label);
+    const existing = next.labels[key];
+    next.labels[key] = {
+      label,
+      count: (existing?.count ?? 0) + 1,
+      lastUsedAt: Math.max(existing?.lastUsedAt ?? 0, now),
+    };
+  }
+  next.updatedAt = Math.max(next.updatedAt, now);
+  return next;
+}
+
+export function getLabelSuggestions(index: LabelIndexV1, query = '', limit = 8, excluded: string[] = []): string[] {
+  const normalized = normalizeLabelIndex(index);
+  const q = normalizeLabelKey(query);
+  const excludedKeys = new Set(excluded.map(normalizeLabelKey));
+  return Object.entries(normalized.labels)
+    .filter(([key]) => !excludedKeys.has(key) && (!q || key.includes(q)))
+    .sort(([, a], [, b]) => (b.count - a.count) || (b.lastUsedAt - a.lastUsedAt) || a.label.localeCompare(b.label))
+    .slice(0, limit)
+    .map(([, entry]) => entry.label);
+}
+
+export function serializeLabelIndex(index: LabelIndexV1): string {
+  return JSON.stringify(normalizeLabelIndex(index));
+}
+
+export function deserializeLabelIndex(content: string): LabelIndexV1 {
+  return normalizeLabelIndex(JSON.parse(content) as unknown);
+}

--- a/packages/core/src/models/preferences.test.ts
+++ b/packages/core/src/models/preferences.test.ts
@@ -6,6 +6,7 @@ import {
   mergeSyncedPreferences,
   serializePreferences,
 } from './preferences.js';
+import { createLabelIndex, serializeLabelIndex } from './label-index.js';
 
 describe('synced preferences', () => {
   it('serializes only synced account preferences', () => {
@@ -64,6 +65,14 @@ describe('synced preferences', () => {
       dayStartHour: 7,
       dayEndHour: 23,
     });
+  });
+
+  it('rejects label-index content instead of treating it as preferences', () => {
+    const labelIndexContent = serializeLabelIndex(createLabelIndex([
+      { label: 'Work', count: 1, lastUsedAt: 1 },
+    ], 1));
+
+    expect(() => deserializePreferences(labelIndexContent)).toThrow(/preferences kind/);
   });
 
 

--- a/packages/core/src/models/preferences.ts
+++ b/packages/core/src/models/preferences.ts
@@ -1,3 +1,5 @@
+export const PREFERENCES_KIND = 'silentsuite.preferences.v1';
+
 export const SYNCED_PREFERENCE_KEYS = [
   'timeFormat',
   'firstDayOfWeek',
@@ -31,6 +33,7 @@ export interface VersionedPreference<T> {
 }
 
 export interface SyncedPreferencesV1 {
+  kind: typeof PREFERENCES_KIND;
   schemaVersion: 1;
   updatedAt: number;
   fields: {
@@ -143,6 +146,7 @@ export function createSyncedPreferences(
   const updatedAt = Math.max(...SYNCED_PREFERENCE_KEYS.map((key) => normalizedTimestamps[key]));
 
   return {
+    kind: PREFERENCES_KIND,
     schemaVersion: 1,
     updatedAt,
     fields: {
@@ -159,6 +163,9 @@ export function createSyncedPreferences(
 
 export function normalizeSyncedPreferences(input: unknown): SyncedPreferencesV1 {
   const root = isRecord(input) ? input : {};
+  if ('kind' in root && root.kind !== PREFERENCES_KIND) {
+    throw new Error('Invalid preferences kind');
+  }
   const fields = isRecord(root.fields) ? root.fields : {};
   const rootUpdatedAt = timestamp(root.updatedAt, 0);
 


### PR DESCRIPTION
## Summary
- add a dedicated encrypted label-index model and collection for synced label suggestions
- wire label suggestion loading/sync into the web Etebase startup and sync-change paths
- extend the shared label editor with autocomplete suggestions while preserving plain `CATEGORIES` import/export strings

## Validation
- `pnpm --filter @silentsuite/core test -- src/models/label-index.test.ts`
- `pnpm --filter @silentsuite/web test -- app/components/__tests__/LabelEditor.test.tsx app/stores/__tests__/use-label-suggestions-store.test.ts app/stores/__tests__/use-preferences-sync-store.test.ts`
- `pnpm --filter @silentsuite/web type-check`

## Privacy notes
- label suggestions are stored as encrypted Etebase item content in a dedicated `silentsuite.labelindex` collection
- labels are not stored in server-visible metadata
- existing event/task/contact labels continue to round-trip as plain category names inside encrypted PIM item content
