### PR TITLE
fix: simplify add-card flow to pay now

### DIFF
--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -419,7 +419,7 @@ export default function SubscriptionPage() {
             <div>
               <p className="text-xs text-[rgb(var(--muted))]">Trial type</p>
               <p className="text-sm text-[rgb(var(--foreground))]">
-                {data.trialPath === '7day' ? '7-day trial (no card)' : data.trialPath === '30day' ? '30-day trial' : 'Paid + 30-day bonus'}
+                {data.trialPath === '7day' ? '7-day trial (no card)' : data.trialPath === '30day' ? '30-day trial' : 'Paid + 14-day bonus'}
               </p>
             </div>
           )}

--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import AddCardBanner from '../add-card-banner'
+
+vi.mock('next/dynamic', () => ({
+  default: () => function MockStripePaymentForm({ mode, submitLabel }: { mode: string; submitLabel: string }) {
+    return <div data-testid="stripe-payment-form">{mode}:{submitLabel}</div>
+  },
+}))
+
+vi.mock('@/app/lib/config', () => ({
+  BILLING_API_URL: 'https://billing.example.test',
+}))
+
+vi.stubGlobal('fetch', vi.fn())
+
+describe('AddCardBanner', () => {
+  beforeEach(() => {
+    vi.mocked(fetch).mockReset()
+  })
+
+  it('offers only pay-now monthly/annual choices and requests immediate payment setup', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ clientSecret: 'pi_secret' }),
+    } as Response)
+
+    render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Add payment method'))
+
+    expect(screen.getByText('Pay now + 14 bonus days')).toBeInTheDocument()
+    expect(screen.getByText('Choose monthly or annual. Your card is charged now.')).toBeInTheDocument()
+    expect(screen.queryByText('30-day trial')).not.toBeInTheDocument()
+    expect(screen.getByText('Monthly')).toBeInTheDocument()
+    expect(screen.getByText('Annual')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Annual'))
+    fireEvent.click(screen.getByText('Continue to payment'))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      'https://billing.example.test/subscription/setup-card',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ planId: 'early_annual', trialPath: 'immediate' }),
+      }),
+    ))
+
+    expect(await screen.findByText('14 bonus days included after today\'s payment.')).toBeInTheDocument()
+    expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €36')
+  })
+})

--- a/apps/web/app/components/add-card-banner.tsx
+++ b/apps/web/app/components/add-card-banner.tsx
@@ -17,7 +17,6 @@ const StripePaymentForm = dynamic(() => import('./stripe-payment-form'), {
 })
 
 type BillingInterval = 'monthly' | 'annual'
-type TrialPath = '30day' | 'immediate'
 
 interface AddCardBannerProps {
   daysRemaining: number
@@ -89,7 +88,6 @@ function AddCardModal({
   onCardAdded: () => void
 }) {
   const [interval, setInterval] = useState<BillingInterval>('monthly')
-  const [trialPath, setTrialPath] = useState<TrialPath>('30day')
   const [clientSecret, setClientSecret] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -104,7 +102,7 @@ function AddCardModal({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ planId, trialPath }),
+        body: JSON.stringify({ planId, trialPath: 'immediate' }),
       })
       if (!res.ok) {
         const data = await res.json().catch(() => null)
@@ -133,61 +131,24 @@ function AddCardModal({
 
         {!clientSecret ? (
           <>
-            {/* Plan selection */}
-            <div className="space-y-3">
-              {/* 30-day trial */}
-              <button
-                onClick={() => setTrialPath('30day')}
-                className={`w-full rounded-xl border p-4 text-left transition-all ${
-                  trialPath === '30day'
-                    ? 'border-emerald-500/50 bg-emerald-500/5'
-                    : 'border-[rgb(var(--border))] hover:border-slate-600/50'
-                }`}
-              >
-                <div className="flex items-start gap-3">
-                  <div className="rounded-lg bg-[rgb(var(--border))] p-2 shrink-0">
-                    <Lock className="h-4 w-4 text-amber-400" />
-                  </div>
-                  <div>
-                    <h3 className="font-medium text-[rgb(var(--foreground))]">30-day trial</h3>
-                    <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">First charge on day 30</p>
-                  </div>
-                  {trialPath === '30day' && (
-                    <div className="ml-auto shrink-0 rounded-full bg-emerald-500 p-0.5">
-                      <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-                      </svg>
-                    </div>
-                  )}
+            {/* Pay now summary */}
+            <div className="rounded-xl border border-emerald-500/50 bg-emerald-500/5 p-4 text-left">
+              <div className="flex items-start gap-3">
+                <div className="rounded-lg bg-[rgb(var(--border))] p-2 shrink-0">
+                  <Zap className="h-4 w-4 text-amber-400" />
                 </div>
-              </button>
-
-              {/* Pay now + 30 bonus days */}
-              <button
-                onClick={() => setTrialPath('immediate')}
-                className={`w-full rounded-xl border p-4 text-left transition-all ${
-                  trialPath === 'immediate'
-                    ? 'border-emerald-500/50 bg-emerald-500/5'
-                    : 'border-[rgb(var(--border))] hover:border-slate-600/50'
-                }`}
-              >
-                <div className="flex items-start gap-3">
-                  <div className="rounded-lg bg-[rgb(var(--border))] p-2 shrink-0">
-                    <Zap className="h-4 w-4 text-amber-400" />
-                  </div>
-                  <div>
-                    <h3 className="font-medium text-[rgb(var(--foreground))]">Pay now + 30 bonus days</h3>
-                    <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">Get an extra month free</p>
-                  </div>
-                  {trialPath === 'immediate' && (
-                    <div className="ml-auto shrink-0 rounded-full bg-emerald-500 p-0.5">
-                      <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-                      </svg>
-                    </div>
-                  )}
+                <div>
+                  <h3 className="font-medium text-[rgb(var(--foreground))]">Pay now + 14 bonus days</h3>
+                  <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">
+                    Choose monthly or annual. Your card is charged now.
+                  </p>
                 </div>
-              </button>
+                <div className="ml-auto shrink-0 rounded-full bg-emerald-500 p-0.5">
+                  <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                  </svg>
+                </div>
+              </div>
             </div>
 
             {/* Billing toggle + price */}
@@ -228,9 +189,7 @@ function AddCardModal({
                 <PriceDisplay interval={interval} />
               </div>
               <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-                {trialPath === '30day'
-                  ? 'First charge in 30 days. Cancel anytime before.'
-                  : '30 bonus days included. Next charge in 30 days.'}
+                14 bonus days included after today&apos;s payment.
               </p>
             </div>
 
@@ -238,8 +197,8 @@ function AddCardModal({
             <StripePaymentForm
               clientSecret={clientSecret}
               onSuccess={onCardAdded}
-              submitLabel={trialPath === '30day' ? 'Start 30-day trial' : `Pay ${interval === 'monthly' ? '\u20AC3.60' : '\u20AC36'}`}
-              mode={trialPath === '30day' ? 'setup' : 'payment'}
+              submitLabel={`Pay ${interval === 'monthly' ? '\u20AC3.60' : '\u20AC36'}`}
+              mode="payment"
             />
 
             <div className="flex items-center justify-center gap-1.5 text-xs text-[rgb(var(--muted))]">


### PR DESCRIPTION
## Summary

- simplify the trial add-card modal to the pay-now path only
- keep only monthly/annual choice in the modal
- update copy to pay now + 14 bonus days
- send `trialPath: immediate` and render Stripe in payment mode

## Validation

- `pnpm --filter @silentsuite/web exec vitest run app/components/__tests__/AddCardBanner.test.tsx 'app/(app)/settings/subscription/__tests__/page.test.tsx'`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web build`
