### PR TITLE
Promote dev to main

### DIFF
--- a/apps/docs/user-guide/apps/android.md
+++ b/apps/docs/user-guide/apps/android.md
@@ -8,11 +8,15 @@ Once set up, your SilentSuite data syncs directly into Android's system calendar
 
 ## Install
 
-Choose one of the install options below. Both deliver the same APK from the same GitHub release.
+Choose the install channel you want to keep using for updates.
 
-### Option 1: Obtainium (recommended)
+### Option 1: Google Play
 
-[Obtainium](https://github.com/ImranR98/Obtainium) is an open-source Android app that installs and auto-updates apps directly from their GitHub releases -- no Google Play, no tracking, no account needed.
+Install from Google Play if you want Play-managed updates. If you installed SilentSuite from Google Play, keep updating it from Google Play.
+
+### Option 2: Obtainium
+
+[Obtainium](https://github.com/ImranR98/Obtainium) is an open-source Android app that installs and auto-updates apps directly from GitHub releases -- no Google Play, no tracking, no account needed.
 
 1. Install Obtainium from [GitHub Releases](https://github.com/ImranR98/Obtainium/releases) or [F-Droid](https://f-droid.org/packages/dev.imranr.obtainium.fdroid/).
 2. In Obtainium, tap **Add App** and paste this URL:
@@ -21,13 +25,24 @@ Choose one of the install options below. Both deliver the same APK from the same
    ```
 3. Obtainium will detect the latest SilentSuite release and install the APK. It will notify you whenever a new release is published.
 
-### Option 2: Direct APK download
+### Option 3: Direct APK download
 
 Grab the latest APK directly from GitHub Releases:
 
 - [github.com/silent-suite/silentsuite/releases/latest](https://github.com/silent-suite/silentsuite/releases/latest)
 
 Look for the asset named `silentsuite-android-vX.Y.Z-beta.apk` and install it. You'll need to allow installation from unknown sources the first time.
+
+### Certificate hashes and channel switching
+
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+
+SilentSuite's known Android signing certificate SHA-256 hashes are:
+
+- **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
+- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+
+If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching between Google Play and direct APK channels may require uninstalling and reinstalling the app. A certificate mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 
 ::: tip
 The SilentSuite Android app is a fork of the [EteSync Android app](https://github.com/etesync/android) with SilentSuite branding and `server.silentsuite.io` pre-configured as the default server. If you prefer, the original EteSync app from [Google Play](https://play.google.com/store/apps/details?id=com.etesync.syncadapter) or [F-Droid](https://f-droid.org/packages/com.etesync.syncadapter/) also works -- just enter the server URL manually.

--- a/apps/docs/user-guide/faq.md
+++ b/apps/docs/user-guide/faq.md
@@ -15,7 +15,7 @@ SilentSuite offers a hosted service with paid plans to fund development. Self-ho
 SilentSuite works across all major platforms:
 
 - **Web:** The web app is live at [app.silentsuite.io](https://app.silentsuite.io).
-- **Android:** A dedicated Android sync adapter is available as an APK from [GitHub Releases](https://github.com/silent-suite/silentsuite/releases).
+- **Android:** A dedicated Android sync adapter is available from Google Play and direct APK channels such as [GitHub Releases](https://github.com/silent-suite/silentsuite/releases), Zapstore, and F-Droid.
 - **iOS:** Use the third-party [EteSync for iOS](https://apps.apple.com/app/etesync/id1489574285) app from the App Store. Enter your server URL during setup.
 - **Desktop:** Use the [SilentSuite Bridge](./apps/dav-bridge.md) with any CalDAV/CardDAV app (Thunderbird, macOS Calendar, GNOME Calendar, and more).
 
@@ -32,6 +32,19 @@ SilentSuite uses the [Etebase protocol](https://www.etebase.com/) with XChaCha20
 ### Can I reset my password?
 
 No. Your encryption keys are derived from your password, and the server never has access to them. If you forget your password, your data cannot be recovered. Use a password manager.
+
+## Apps & Devices
+
+### Why do I see a certificate mismatch when switching Android install channels?
+
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+
+SilentSuite's known Android signing certificate SHA-256 hashes are:
+
+- **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
+- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+
+If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching channels may require uninstalling and reinstalling the app. A certificate mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 
 ## Self-Hosting
 

--- a/apps/web/app/(app)/calendar/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/calendar/__tests__/page.test.tsx
@@ -40,6 +40,10 @@ const storeMock = vi.hoisted(() => ({
   authState: {
     canWrite: vi.fn(() => true),
   },
+  syncState: {
+    initialSyncState: 'synced' as const,
+    error: null as string | null,
+  },
 }))
 
 vi.mock('@/app/stores/use-calendar-store', () => ({
@@ -52,6 +56,10 @@ vi.mock('@/app/stores/use-calendar-list-store', () => ({
 
 vi.mock('@/app/stores/use-auth-store', () => ({
   useAuthStore: (selector: (state: typeof storeMock.authState) => unknown) => selector(storeMock.authState),
+}))
+
+vi.mock('@/app/stores/use-sync-store', () => ({
+  useSyncStore: (selector: (state: typeof storeMock.syncState) => unknown) => selector(storeMock.syncState),
 }))
 
 vi.mock('@/app/stores/use-preferences-store', () => ({
@@ -110,6 +118,8 @@ function resetCalendarMocks() {
   storeMock.calendarState.setCurrentView.mockReset()
   storeMock.calendarState.setSearchQuery.mockReset()
   storeMock.authState.canWrite.mockReturnValue(true)
+  storeMock.syncState.initialSyncState = 'synced'
+  storeMock.syncState.error = null
 }
 
 describe('CalendarPage calendar visibility', () => {
@@ -263,6 +273,16 @@ describe('CalendarPage mobile reachability', () => {
     renderWithIntl(<CalendarPage />)
 
     expect(screen.getByTestId('mobile-agenda')).toHaveAttribute('data-mode', 'upcoming')
+  })
+
+  it('shows restore copy instead of an empty calendar before initial sync completes', () => {
+    storeMock.calendarState.isLoading = false
+    storeMock.syncState.initialSyncState = 'restoring'
+
+    renderWithIntl(<CalendarPage />)
+
+    expect(screen.getByText('Restoring encrypted data…')).toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-agenda')).not.toBeInTheDocument()
   })
 
   it('exposes a mobile collection switcher with a 44px touch target', () => {

--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -9,7 +9,7 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { RecurrencePicker } from './RecurrencePicker'
 import { RecurrenceScopeDialog, type RecurrenceScope } from './RecurrenceScopeDialog'
-import type { CalendarEvent, VAlarm } from '@silentsuite/core'
+import type { CalendarEvent, DateFormat, VAlarm } from '@silentsuite/core'
 import { buildAlarmTrigger, parseAlarmTriggerMinutes } from '@silentsuite/core'
 import { useNotifications } from '@/app/providers/notification-provider'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
@@ -132,6 +132,102 @@ export function parseEventTimeInput(input: string, timeFormat: string): string |
   return `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
 }
 
+function effectiveDateFormat(dateFormat: DateFormat): Exclude<DateFormat, 'system'> {
+  return dateFormat === 'system' ? 'YYYY-MM-DD' : dateFormat
+}
+
+export function dateFormatExample(dateFormat: DateFormat): string {
+  return formatEventDateInput('2026-06-09', dateFormat)
+}
+
+export function formatEventDateInput(isoDate: string, dateFormat: DateFormat): string {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(isoDate)
+  if (!match) return isoDate
+  const [, y, m, d] = match
+
+  switch (effectiveDateFormat(dateFormat)) {
+    case 'DD/MM/YYYY':
+      return `${d}/${m}/${y}`
+    case 'MM/DD/YYYY':
+      return `${m}/${d}/${y}`
+    case 'DD.MM.YYYY':
+      return `${d}.${m}.${y}`
+    case 'YYYY/MM/DD':
+      return `${y}/${m}/${d}`
+    case 'YYYY-MM-DD':
+      return `${y}-${m}-${d}`
+  }
+}
+
+function isValidIsoDate(y: number, m: number, d: number): boolean {
+  if (!Number.isInteger(y) || !Number.isInteger(m) || !Number.isInteger(d)) return false
+  if (y < 1 || m < 1 || m > 12 || d < 1 || d > 31) return false
+  const date = new Date(y, m - 1, d)
+  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d
+}
+
+export function parseEventDateInput(input: string, dateFormat: DateFormat): string | null {
+  const value = input.trim()
+  if (!value) return null
+
+  const format = effectiveDateFormat(dateFormat)
+  const separator = format.includes('.') ? '\\.' : format.includes('/') ? '/' : '-'
+  const match = new RegExp(`^(\\d{1,4})${separator}(\\d{1,2})${separator}(\\d{1,4})$`).exec(value)
+  if (!match) return null
+
+  const a = Number(match[1])
+  const b = Number(match[2])
+  const c = Number(match[3])
+  let y: number
+  let m: number
+  let d: number
+
+  switch (format) {
+    case 'DD/MM/YYYY':
+    case 'DD.MM.YYYY':
+      d = a; m = b; y = c
+      break
+    case 'MM/DD/YYYY':
+      m = a; d = b; y = c
+      break
+    case 'YYYY/MM/DD':
+    case 'YYYY-MM-DD':
+      y = a; m = b; d = c
+      break
+  }
+
+  if (y < 1000 || !isValidIsoDate(y, m, d)) return null
+  return `${String(y).padStart(4, '0')}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`
+}
+
+const PRESET_ALARM_MINUTES = ['5', '15', '30', '60', '1440'] as const
+
+function isPresetAlarm(value: string): boolean {
+  return PRESET_ALARM_MINUTES.includes(value as typeof PRESET_ALARM_MINUTES[number])
+}
+
+function normalizeAlarmMinutes(value: string): string | null {
+  const minutes = Number(value)
+  if (!Number.isInteger(minutes) || minutes <= 0 || minutes > 525600) return null
+  return String(minutes)
+}
+
+function alarmLabel(value: string): string {
+  if (value === '60') return '1 hour before'
+  if (value === '1440') return '1 day before'
+  return `${value} minutes before`
+}
+
+function alarmToVAlarm(minutes: string, title: string): VAlarm | null {
+  const normalized = normalizeAlarmMinutes(minutes)
+  if (!normalized) return null
+  return {
+    action: 'DISPLAY' as const,
+    trigger: buildAlarmTrigger(Number(normalized)),
+    description: title.trim(),
+  }
+}
+
 function formatDateForInput(date: Date, tz: string | undefined): string {
   if (!tz) {
     const y = date.getFullYear()
@@ -184,6 +280,7 @@ export function EventDialog({
   const t = useTranslations('Labels')
   const defaultReminder = usePreferencesStore((s) => s.defaultReminder)
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
+  const dateFormat = usePreferencesStore((s) => s.dateFormat)
   const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
   const userTz = resolveUserTimezone(defaultTimezonePref)
   const defaultTimezone = userTz
@@ -223,10 +320,16 @@ export function EventDialog({
   const [allDay, setAllDay] = useState(initialIsAllDay)
   const initialStartTime = formatTimeForInput(defaultStart, initialFormTz)
   const initialEndTime = formatTimeForInput(defaultEnd, initialFormTz)
-  const [startDate, setStartDate] = useState(formatDateForInput(defaultStart, initialFormTz))
+  const initialStartDateIso = formatDateForInput(defaultStart, initialFormTz)
+  const initialEndDateIso = formatDateForInput(defaultEnd, initialFormTz)
+  const [startDate, setStartDate] = useState(initialStartDateIso)
+  const [startDateInput, setStartDateInput] = useState(() => formatEventDateInput(initialStartDateIso, dateFormat))
+  const [startDateError, setStartDateError] = useState<string | null>(null)
   const [startTime, setStartTime] = useState(initialStartTime)
   const [startTimeInput, setStartTimeInput] = useState(() => formatEventTimeInput(initialStartTime, timeFormat))
-  const [endDate, setEndDate] = useState(formatDateForInput(defaultEnd, initialFormTz))
+  const [endDate, setEndDate] = useState(initialEndDateIso)
+  const [endDateInput, setEndDateInput] = useState(() => formatEventDateInput(initialEndDateIso, dateFormat))
+  const [endDateError, setEndDateError] = useState<string | null>(null)
   const [endTime, setEndTime] = useState(initialEndTime)
   const [endTimeInput, setEndTimeInput] = useState(() => formatEventTimeInput(initialEndTime, timeFormat))
   const [recurrenceRule, setRecurrenceRule] = useState<string | null>(
@@ -266,6 +369,14 @@ export function EventDialog({
   useEffect(() => {
     setEndTimeInput(formatEventTimeInput(endTime, timeFormat))
   }, [endTime, timeFormat])
+
+  useEffect(() => {
+    if (!startDateError) setStartDateInput(formatEventDateInput(startDate, dateFormat))
+    if (!endDateError) setEndDateInput(formatEventDateInput(endDate, dateFormat))
+    // Re-render displayed dates when the account preference changes; regular
+    // typing is normalized on blur so partial-but-valid entries are not clobbered.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dateFormat])
 
   // Calendar selection
   const calendarLists = useCalendarListStore((s) => s.calendars)
@@ -363,6 +474,7 @@ export function EventDialog({
 
   const handleSave = useCallback(async () => {
     if (!title.trim() || saving) return
+    if (startDateError || endDateError) return
 
     const newStart = buildStartDate()
     const newEnd = buildEndDate()
@@ -390,12 +502,8 @@ export function EventDialog({
 
         // Compare alarms
         const eventAlarms: VAlarm[] = alarms
-          .filter((a) => a !== 'none')
-          .map((a) => ({
-            action: 'DISPLAY' as const,
-            trigger: buildAlarmTrigger(parseInt(a)),
-            description: title.trim(),
-          }))
+          .map((a) => alarmToVAlarm(a, title))
+          .filter((a): a is VAlarm => a !== null)
         const existingTriggers = (event.alarms ?? []).map((a) => a.trigger).sort().join(',')
         const newTriggers = eventAlarms.map((a) => a.trigger).sort().join(',')
         if (existingTriggers !== newTriggers) {
@@ -429,12 +537,8 @@ export function EventDialog({
           timezone,
           calendarId: selectedCalendarId,
           alarms: alarms
-            .filter((a) => a !== 'none')
-            .map((a) => ({
-              action: 'DISPLAY' as const,
-              trigger: buildAlarmTrigger(parseInt(a)),
-              description: title.trim(),
-            })),
+            .map((a) => alarmToVAlarm(a, title))
+            .filter((a): a is VAlarm => a !== null),
         })
       }
 
@@ -454,6 +558,8 @@ export function EventDialog({
     timezone,
     defaultTimezone,
     saving,
+    startDateError,
+    endDateError,
     isEdit,
     isRecurring,
     event,
@@ -524,13 +630,23 @@ export function EventDialog({
   const handleStartDateChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
-      setStartDate(value)
+      setStartDateInput(value)
+      const parsedDate = parseEventDateInput(value, dateFormat)
+      if (!parsedDate) {
+        setStartDateError(`Use ${dateFormatExample(dateFormat)} format`)
+        return
+      }
+
+      setStartDateError(null)
+      setStartDate(parsedDate)
       // If end date is before start date, push it forward
-      if (value > endDate) {
-        setEndDate(value)
+      if (parsedDate > endDate) {
+        setEndDate(parsedDate)
+        setEndDateInput(formatEventDateInput(parsedDate, dateFormat))
+        setEndDateError(null)
       }
     },
-    [endDate],
+    [dateFormat, endDate],
   )
 
   const handleStartTimeChange = useCallback(
@@ -554,8 +670,17 @@ export function EventDialog({
   )
 
   const handleEndDateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setEndDate(e.target.value)
-  }, [])
+    const value = e.target.value
+    setEndDateInput(value)
+    const parsedDate = parseEventDateInput(value, dateFormat)
+    if (!parsedDate) {
+      setEndDateError(`Use ${dateFormatExample(dateFormat)} format`)
+      return
+    }
+
+    setEndDateError(null)
+    setEndDate(parsedDate)
+  }, [dateFormat])
 
   const handleEndTimeChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -571,6 +696,14 @@ export function EventDialog({
   const handleEndTimeBlur = useCallback(() => {
     setEndTimeInput(formatEventTimeInput(endTime, timeFormat))
   }, [endTime, timeFormat])
+
+  const handleStartDateBlur = useCallback(() => {
+    if (!startDateError) setStartDateInput(formatEventDateInput(startDate, dateFormat))
+  }, [dateFormat, startDate, startDateError])
+
+  const handleEndDateBlur = useCallback(() => {
+    if (!endDateError) setEndDateInput(formatEventDateInput(endDate, dateFormat))
+  }, [dateFormat, endDate, endDateError])
 
   const handleAllDayToggle = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setAllDay(e.target.checked)
@@ -615,7 +748,8 @@ export function EventDialog({
   // Render
   // ---------------------------------------------------------------------------
 
-  const canSave = title.trim().length > 0
+  const canSave = title.trim().length > 0 && !startDateError && !endDateError
+  const datePlaceholder = dateFormatExample(dateFormat)
   const focusRing = 'focus:outline-none focus:ring-2 focus:ring-emerald-500/80 focus:ring-offset-2 focus:ring-offset-[rgb(var(--background))]'
   const fieldClass = `min-h-11 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3.5 py-2.5 text-sm text-[rgb(var(--foreground))] shadow-sm shadow-black/5 transition-colors placeholder:text-[rgb(var(--muted))] hover:border-emerald-500/40 focus:border-emerald-500 ${focusRing}`
   const compactFieldClass = `min-h-10 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--foreground))] shadow-sm shadow-black/5 transition-colors hover:border-emerald-500/40 focus:border-emerald-500 ${focusRing}`
@@ -780,14 +914,26 @@ export function EventDialog({
                   <div className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--background))]/60 p-3">
                     <div className="grid gap-2 sm:grid-cols-[5rem_minmax(0,1fr)_7.5rem] sm:items-center">
                       <span className="text-sm font-medium text-[rgb(var(--muted))]">Starts</span>
-                      <input
-                        type="date"
-                        value={startDate}
-                        onChange={handleStartDateChange}
-                        aria-label="Start date"
-                        readOnly={!canWrite}
-                        className={`w-full ${compactFieldClass} ${disabledClass}`}
-                      />
+                      <div>
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          placeholder={datePlaceholder}
+                          value={startDateInput}
+                          onChange={handleStartDateChange}
+                          onBlur={handleStartDateBlur}
+                          aria-label="Start date"
+                          aria-invalid={startDateError ? 'true' : undefined}
+                          aria-describedby={startDateError ? 'start-date-error' : undefined}
+                          readOnly={!canWrite}
+                          className={`w-full ${compactFieldClass} ${disabledClass}`}
+                        />
+                        {startDateError && (
+                          <p id="start-date-error" className="mt-1 text-xs text-red-500" role="alert">
+                            {startDateError}
+                          </p>
+                        )}
+                      </div>
                       {!allDay && (
                         <input
                           type="text"
@@ -808,14 +954,26 @@ export function EventDialog({
                   <div className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--background))]/60 p-3">
                     <div className="grid gap-2 sm:grid-cols-[5rem_minmax(0,1fr)_7.5rem] sm:items-center">
                       <span className="text-sm font-medium text-[rgb(var(--muted))]">Ends</span>
-                      <input
-                        type="date"
-                        value={endDate}
-                        onChange={handleEndDateChange}
-                        aria-label="End date"
-                        readOnly={!canWrite}
-                        className={`w-full ${compactFieldClass} ${disabledClass}`}
-                      />
+                      <div>
+                        <input
+                          type="text"
+                          inputMode="numeric"
+                          placeholder={datePlaceholder}
+                          value={endDateInput}
+                          onChange={handleEndDateChange}
+                          onBlur={handleEndDateBlur}
+                          aria-label="End date"
+                          aria-invalid={endDateError ? 'true' : undefined}
+                          aria-describedby={endDateError ? 'end-date-error' : undefined}
+                          readOnly={!canWrite}
+                          className={`w-full ${compactFieldClass} ${disabledClass}`}
+                        />
+                        {endDateError && (
+                          <p id="end-date-error" className="mt-1 text-xs text-red-500" role="alert">
+                            {endDateError}
+                          </p>
+                        )}
+                      </div>
                       {!allDay && (
                         <input
                           type="text"
@@ -890,33 +1048,68 @@ export function EventDialog({
                   </div>
                 )}
 
-                {alarms.map((alarm, i) => (
-                  <div key={i} className="flex items-center gap-2 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--background))]/60 p-2">
+                {alarms.map((alarm, i) => {
+                  const isCustomAlarm = !isPresetAlarm(alarm)
+                  return (
+                  <div key={i} className="flex flex-col gap-2 rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--background))]/60 p-2 sm:flex-row sm:items-start">
                     <select
-                      value={alarm}
+                      value={isCustomAlarm ? 'custom' : alarm}
                       onChange={(e) => {
                         const next = [...alarms]
-                        next[i] = e.target.value
+                        next[i] = e.target.value === 'custom' ? '10' : e.target.value
                         setAlarms(next)
                       }}
-                      className={`min-w-0 flex-1 ${compactFieldClass}`}
+                      disabled={!canWrite}
+                      aria-label={`Reminder ${i + 1}`}
+                      className={`min-w-0 flex-1 ${compactFieldClass} ${disabledClass}`}
                     >
                       <option value="5">5 minutes before</option>
                       <option value="15">15 minutes before</option>
                       <option value="30">30 minutes before</option>
                       <option value="60">1 hour before</option>
                       <option value="1440">1 day before</option>
+                      <option value="custom">Custom…</option>
                     </select>
+                    {isCustomAlarm && (
+                      <label className="flex min-w-0 flex-1 items-center gap-2 text-sm text-[rgb(var(--muted))] sm:max-w-[14rem]">
+                        <input
+                          type="number"
+                          min="1"
+                          max="525600"
+                          step="1"
+                          value={alarm}
+                          onChange={(e) => {
+                            const next = [...alarms]
+                            next[i] = e.target.value
+                            setAlarms(next)
+                          }}
+                          onBlur={(e) => {
+                            const next = [...alarms]
+                            next[i] = normalizeAlarmMinutes(e.target.value) ?? '15'
+                            setAlarms(next)
+                          }}
+                          aria-label={`Custom reminder ${i + 1} minutes before`}
+                          readOnly={!canWrite}
+                          className={`w-24 ${compactFieldClass} ${disabledClass}`}
+                        />
+                        minutes before
+                      </label>
+                    )}
+                    {!isCustomAlarm && (
+                      <span className="sr-only">{alarmLabel(alarm)}</span>
+                    )}
                     <button
                       type="button"
                       onClick={() => setAlarms((prev) => prev.filter((_, j) => j !== i))}
-                      className={`rounded-full p-2 text-[rgb(var(--muted))] transition-colors hover:bg-red-500/10 hover:text-red-500 ${focusRing}`}
+                      disabled={!canWrite}
+                      className={`self-start rounded-full p-2 text-[rgb(var(--muted))] transition-colors hover:bg-red-500/10 hover:text-red-500 disabled:cursor-not-allowed disabled:opacity-50 ${focusRing}`}
                       aria-label="Remove reminder"
                     >
                       <X className="h-4 w-4" />
                     </button>
                   </div>
-                ))}
+                  )
+                })}
 
                 {alarms.length > 0 && notifications.permission === 'default' && (
                   <div className="flex flex-col gap-2 rounded-xl border border-amber-500/25 bg-amber-500/10 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/app/(app)/calendar/components/__tests__/EventDialog.test.tsx
+++ b/apps/web/app/(app)/calendar/components/__tests__/EventDialog.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import type { CalendarEvent } from '@silentsuite/core'
-import { EventDialog, formatEventTimeInput, parseEventTimeInput } from '../EventDialog'
+import { EventDialog, formatEventDateInput, formatEventTimeInput, parseEventDateInput, parseEventTimeInput } from '../EventDialog'
 import { renderWithIntl } from '@/src/__tests__/render-with-intl'
 
 const mocks = vi.hoisted(() => ({
@@ -136,6 +136,85 @@ describe('EventDialog edit calendar selection', () => {
     expect(parseEventTimeInput(input, preference)).toBe(expected)
   })
 
+  it.each([
+    ['2026-06-09', 'YYYY-MM-DD', '2026-06-09'],
+    ['2026-06-09', 'DD/MM/YYYY', '09/06/2026'],
+    ['2026-06-09', 'MM/DD/YYYY', '06/09/2026'],
+    ['2026-06-09', 'DD.MM.YYYY', '09.06.2026'],
+    ['2026-06-09', 'YYYY/MM/DD', '2026/06/09'],
+    ['2026-06-09', 'system', '2026-06-09'],
+  ] as const)('formats date input %s using %s', (isoDate, preference, expected) => {
+    expect(formatEventDateInput(isoDate, preference)).toBe(expected)
+  })
+
+  it.each([
+    ['09/06/2026', 'DD/MM/YYYY', '2026-06-09'],
+    ['06/09/2026', 'MM/DD/YYYY', '2026-06-09'],
+    ['09.06.2026', 'DD.MM.YYYY', '2026-06-09'],
+    ['2026/06/09', 'YYYY/MM/DD', '2026-06-09'],
+    ['2026-06-09', 'YYYY-MM-DD', '2026-06-09'],
+    ['2026-06-09', 'system', '2026-06-09'],
+  ] as const)('parses date input %s using %s', (input, preference, expected) => {
+    expect(parseEventDateInput(input, preference)).toBe(expected)
+  })
+
+  it('rejects invalid typed dates', () => {
+    expect(parseEventDateInput('31/02/2026', 'DD/MM/YYYY')).toBeNull()
+    expect(parseEventDateInput('2026/31/02', 'YYYY/MM/DD')).toBeNull()
+  })
+
+  it('renders event dialog date controls as preference-formatted text fields', () => {
+    mocks.preferences.dateFormat = 'DD.MM.YYYY'
+
+    renderWithIntl(<EventDialog mode="edit" event={makeEvent({ startDate: new Date('2026-06-01T14:00:00Z'), endDate: new Date('2026-06-02T15:30:00Z') })} onClose={mocks.onClose} />)
+
+    expect(screen.getByLabelText('Start date')).toHaveAttribute('type', 'text')
+    expect(screen.getByLabelText('Start date')).toHaveValue('01.06.2026')
+    expect(screen.getByLabelText('End date')).toHaveValue('02.06.2026')
+  })
+
+  it('normalizes typed preference-formatted dates on blur and saves ISO-backed dates', async () => {
+    mocks.preferences.dateFormat = 'YYYY/MM/DD'
+
+    renderWithIntl(
+      <EventDialog
+        mode="create"
+        startDate={new Date('2026-06-01T14:00:00Z')}
+        endDate={new Date('2026-06-01T14:30:00Z')}
+        onClose={mocks.onClose}
+      />,
+    )
+
+    fireEvent.change(screen.getByLabelText('Event title'), { target: { value: 'Date formatted event' } })
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '2026/6/9' } })
+    fireEvent.blur(screen.getByLabelText('Start date'))
+    fireEvent.change(screen.getByLabelText('End date'), { target: { value: '2026/6/10' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    expect(screen.getByLabelText('Start date')).toHaveValue('2026/06/09')
+    await waitFor(() => {
+      expect(mocks.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDate: new Date('2026-06-09T14:00:00Z'),
+          endDate: new Date('2026-06-10T14:30:00Z'),
+        }),
+      )
+    })
+  })
+
+  it('marks invalid typed dates and blocks save until corrected', () => {
+    mocks.preferences.dateFormat = 'DD/MM/YYYY'
+
+    renderWithIntl(<EventDialog mode="create" startDate={new Date('2026-06-01T14:00:00Z')} onClose={mocks.onClose} />)
+
+    fireEvent.change(screen.getByLabelText('Event title'), { target: { value: 'Invalid date event' } })
+    fireEvent.change(screen.getByLabelText('Start date'), { target: { value: '31/02/2026' } })
+
+    expect(screen.getByLabelText('Start date')).toHaveAttribute('aria-invalid', 'true')
+    expect(screen.getByRole('alert')).toHaveTextContent('Use 09/06/2026 format')
+    expect(screen.getByRole('button', { name: 'Done' })).toBeDisabled()
+  })
+
   it('renders event dialog time controls as 24-hour text fields for the 24-hour preference', () => {
     mocks.preferences.timeFormat = '24h'
 
@@ -216,6 +295,45 @@ describe('EventDialog edit calendar selection', () => {
       expect(mocks.updateEvent).toHaveBeenCalledWith(
         'event-item-1',
         expect.objectContaining({ categories: ['Work', 'Home'] }),
+      )
+    })
+  })
+
+  it('preserves imported custom minute reminders when saving unchanged', async () => {
+    const event = makeEvent({
+      alarms: [{ action: 'DISPLAY', trigger: '-PT11M', description: 'Existing event' }],
+    })
+
+    renderWithIntl(<EventDialog mode="edit" event={event} onClose={mocks.onClose} />)
+
+    expect(screen.getByLabelText('Reminder 1')).toHaveValue('custom')
+    expect(screen.getByLabelText('Custom reminder 1 minutes before')).toHaveValue(11)
+
+    fireEvent.change(screen.getByLabelText('Event title'), { target: { value: 'Renamed custom reminder' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    await waitFor(() => {
+      expect(mocks.updateEvent).toHaveBeenCalledWith(
+        'event-item-1',
+        expect.not.objectContaining({ alarms: expect.anything() }),
+      )
+    })
+  })
+
+  it('saves user-entered custom minute reminders as simple negative-duration VALARMs', async () => {
+    renderWithIntl(<EventDialog mode="create" startDate={new Date('2026-06-01T09:00:00Z')} onClose={mocks.onClose} />)
+
+    fireEvent.change(screen.getByLabelText('Event title'), { target: { value: 'Custom reminder event' } })
+    fireEvent.click(screen.getByRole('button', { name: '+ Add' }))
+    fireEvent.change(screen.getByLabelText('Reminder 1'), { target: { value: 'custom' } })
+    fireEvent.change(screen.getByLabelText('Custom reminder 1 minutes before'), { target: { value: '11' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+    await waitFor(() => {
+      expect(mocks.createEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          alarms: [expect.objectContaining({ action: 'DISPLAY', trigger: '-PT11M' })],
+        }),
       )
     })
   })

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -8,6 +8,8 @@ import { formatDate, startOfWeek, getWeekNumber } from '@/app/lib/date'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+import { useSyncStore } from '@/app/stores/use-sync-store'
+import { SyncStartupState } from '@/app/components/empty-state'
 import { PullToRefresh } from '@/app/components/PullToRefresh'
 import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
 import { CalendarViewSwitcher } from './components/CalendarViewSwitcher'
@@ -154,6 +156,8 @@ export default function CalendarPage() {
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
   const defaultTimezonePref = usePreferencesStore((s) => s.defaultTimezone)
   const firstDayOfWeek = usePreferencesStore((s) => s.firstDayOfWeek)
+  const initialSyncState = useSyncStore((s) => s.initialSyncState)
+  const syncError = useSyncStore((s) => s.error)
   const userTz = resolveUserTimezone(defaultTimezonePref)
 
   const [createDialog, setCreateDialog] = useState<CreateDialogState | null>(null)
@@ -195,6 +199,8 @@ export default function CalendarPage() {
     () => events.filter((event) => visibleCalendarIds.has(event.calendarId ?? 'default')),
     [events, visibleCalendarIds],
   )
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const shouldShowStartupState = !isLoading && visibleEvents.length === 0 && !initialLoadComplete
 
   // Search
   const searchQuery = useCalendarStore((s) => s.searchQuery)
@@ -399,6 +405,8 @@ export default function CalendarPage() {
       {/* Content */}
       {isLoading ? (
         <CalendarSkeleton />
+      ) : shouldShowStartupState ? (
+        <SyncStartupState state={initialSyncState} error={syncError} />
       ) : (
         <>
           {/* Search bar */}

--- a/apps/web/app/(app)/contacts/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/contacts/__tests__/page.test.tsx
@@ -32,6 +32,8 @@ const storeMock = vi.hoisted(() => ({
   },
   syncState: {
     isOnline: true,
+    initialSyncState: 'synced' as const,
+    error: null as string | null,
   },
   authState: {
     canWrite: vi.fn(() => true),
@@ -63,6 +65,8 @@ describe('ContactsPage mobile reachability', () => {
   beforeEach(() => {
     storeMock.contactState.isLoading = true
     storeMock.contactState.searchQuery = ''
+    storeMock.syncState.initialSyncState = 'synced'
+    storeMock.syncState.error = null
     storeMock.authState.canWrite.mockReturnValue(true)
   })
 
@@ -78,6 +82,16 @@ describe('ContactsPage mobile reachability', () => {
   it('exposes search on mobile', () => {
     renderWithIntl(<ContactsPage />)
     expect(screen.getByLabelText('Search contacts')).toBeInTheDocument()
+  })
+
+  it('shows restore copy before rendering the normal empty contact state', () => {
+    storeMock.contactState.isLoading = false
+    storeMock.syncState.initialSyncState = 'restoring'
+
+    renderWithIntl(<ContactsPage />)
+
+    expect(screen.getByText('Restoring encrypted data…')).toBeInTheDocument()
+    expect(screen.queryByText('No contacts yet')).not.toBeInTheDocument()
   })
 
   it('exposes a mobile collection switcher with a 44px touch target', () => {

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -11,7 +11,7 @@ import { useContactStore, getFilteredContacts } from '@/app/stores/use-contact-s
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { useSyncStore } from '@/app/stores/use-sync-store'
-import { ContactsEmptyState, SearchEmptyState, ContactDetailEmptyState } from '@/app/components/empty-state'
+import { ContactsEmptyState, ContactDetailEmptyState, SearchEmptyState, SyncStartupState } from '@/app/components/empty-state'
 import { ConfirmDialog } from '@/app/components/confirm-dialog'
 import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
@@ -1080,6 +1080,8 @@ export default function ContactsPage() {
   const isLoading = useContactStore((s) => s.isLoading)
   const searchQuery = useContactStore((s) => s.searchQuery)
   const isOnline = useSyncStore((s) => s.isOnline)
+  const initialSyncState = useSyncStore((s) => s.initialSyncState)
+  const syncError = useSyncStore((s) => s.error)
   const contactLists = useContactListStore((s) => s.lists)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [showNewForm, setShowNewForm] = useState(false)
@@ -1102,8 +1104,10 @@ export default function ContactsPage() {
     [contacts, selectedId],
   )
 
-  const isEmpty = listFilteredContacts.length === 0 && !isLoading
-  const isEmptySearch = filtered.length === 0 && searchQuery.trim() !== '' && !isLoading
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const shouldShowStartupState = listFilteredContacts.length === 0 && !isLoading && !initialLoadComplete
+  const isEmpty = listFilteredContacts.length === 0 && !isLoading && initialLoadComplete
+  const isEmptySearch = filtered.length === 0 && searchQuery.trim() !== '' && !isLoading && initialLoadComplete
 
   return (
     <div className="flex h-full flex-col gap-3">
@@ -1159,6 +1163,8 @@ export default function ContactsPage() {
       {/* Content */}
       {isLoading ? (
         <ContactSkeleton />
+      ) : shouldShowStartupState ? (
+        <SyncStartupState state={initialSyncState} error={syncError} />
       ) : isEmpty ? (
         <ContactsEmptyState onAddContact={canWrite ? () => setShowNewForm(true) : undefined} />
       ) : isEmptySearch ? (

--- a/apps/web/app/(app)/settings/account/page.tsx
+++ b/apps/web/app/(app)/settings/account/page.tsx
@@ -263,6 +263,8 @@ export default function AccountPage() {
                   <option value="system">System locale</option>
                   <option value="DD/MM/YYYY">DD/MM/YYYY</option>
                   <option value="MM/DD/YYYY">MM/DD/YYYY</option>
+                  <option value="DD.MM.YYYY">DD.MM.YYYY</option>
+                  <option value="YYYY/MM/DD">YYYY/MM/DD</option>
                   <option value="YYYY-MM-DD">YYYY-MM-DD</option>
                 </select>
               </div>

--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -1,0 +1,226 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import SubscriptionPage from '../page'
+
+vi.mock('next/dynamic', () => ({
+  default: () => function MockStripePaymentForm({ mode, submitLabel, onSuccess }: { mode: string; submitLabel: string; onSuccess?: () => Promise<void> | void }) {
+    return (
+      <div data-testid="stripe-payment-form">
+        {mode}:{submitLabel}
+        <button onClick={() => { void onSuccess?.() }}>mock payment success</button>
+      </div>
+    )
+  },
+}))
+
+vi.mock('@silentsuite/ui', () => ({
+  Button: ({ children, onClick, disabled, ...props }: {
+    children: React.ReactNode
+    onClick?: () => void
+    disabled?: boolean
+  }) => <button onClick={onClick} disabled={disabled} {...props}>{children}</button>,
+}))
+
+vi.mock('lucide-react', () => ({
+  Crown: ({ className }: { className?: string }) => <svg data-testid="crown-icon" className={className} />,
+  Loader2: ({ className }: { className?: string }) => <svg data-testid="loader-icon" className={className} />,
+  Check: ({ className }: { className?: string }) => <svg data-testid="check-icon" className={className} />,
+  CreditCard: ({ className }: { className?: string }) => <svg data-testid="credit-card-icon" className={className} />,
+  Clock: ({ className }: { className?: string }) => <svg data-testid="clock-icon" className={className} />,
+  X: ({ className }: { className?: string }) => <svg data-testid="x-icon" className={className} />,
+  Lock: ({ className }: { className?: string }) => <svg data-testid="lock-icon" className={className} />,
+  Zap: ({ className }: { className?: string }) => <svg data-testid="zap-icon" className={className} />,
+}))
+
+vi.mock('@/app/lib/config', () => ({ BILLING_API_URL: 'https://billing.test' }))
+vi.mock('@/app/lib/date', () => ({
+  formatDate: (date: Date) => date.toISOString().slice(0, 10),
+}))
+
+const baseSubscription = {
+  plan: 'early_monthly',
+  planLabel: 'Early Adopter',
+  billingInterval: 'monthly',
+  status: 'active',
+  renewalDate: '2026-07-30T00:00:00.000Z',
+  trial: { active: false, endsAt: null, daysRemaining: null },
+  cancelAtPeriodEnd: false,
+  trialPath: null,
+  earlyAdopter: true,
+  capabilities: {
+    trialActive: false,
+    trialExpired: false,
+    needsPaymentMethod: false,
+    canSetupCard: false,
+    canStartPaidSubscription: false,
+    canReactivate: false,
+    canRetryPayment: false,
+    canResumeCancellation: false,
+  },
+}
+
+function mockSubscription(subscription: Record<string, unknown>) {
+  const response = { ...baseSubscription, ...subscription }
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === 'https://billing.test/subscription' && !init?.method) {
+      return { ok: true, json: async () => response }
+    }
+    if (url === 'https://billing.test/subscription/reactivate') {
+      return { ok: true, json: async () => ({ clientSecret: 'cs_test' }) }
+    }
+    return { ok: false, status: 404, json: async () => ({ detail: 'not found' }) }
+  }))
+}
+
+describe('SubscriptionPage billing recovery CTAs', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows add payment method for active no-card trials without making cancel the only action', async () => {
+    mockSubscription({
+      status: 'trialing',
+      trial: { active: true, endsAt: '2026-07-03T00:00:00.000Z', daysRemaining: 3 },
+      trialPath: '7day',
+      renewalDate: null,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        trialActive: true,
+        needsPaymentMethod: true,
+        canSetupCard: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByRole('button', { name: /add payment method/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /cancel subscription/i })).not.toBeInTheDocument()
+  })
+
+  it('shows subscribe recovery for expired no-card trials', async () => {
+    mockSubscription({
+      status: 'trialing',
+      trial: { active: false, endsAt: '2026-06-01T00:00:00.000Z', daysRemaining: null },
+      trialPath: '7day',
+      renewalDate: null,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        trialExpired: true,
+        canStartPaidSubscription: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByRole('button', { name: /^subscribe$/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /change plan/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /cancel subscription/i })).not.toBeInTheDocument()
+  })
+
+  it('shows retry payment for pending payments', async () => {
+    mockSubscription({
+      status: 'none',
+      renewalDate: null,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        canRetryPayment: true,
+        canStartPaidSubscription: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByText(/payment incomplete/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry payment/i })).toBeInTheDocument()
+  })
+
+  it('shows a paid recovery path for derived expired prepaid users', async () => {
+    mockSubscription({
+      status: 'expired',
+      renewalDate: '2026-06-01T00:00:00.000Z',
+      capabilities: {
+        ...baseSubscription.capabilities,
+        canStartPaidSubscription: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByRole('button', { name: /^subscribe$/i })).toBeInTheDocument()
+  })
+
+  it('shows visible reactivate errors and recovers the loading state', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === 'https://billing.test/subscription' && !init?.method) {
+        return { ok: true, json: async () => ({
+          ...baseSubscription,
+          status: 'cancelled',
+          capabilities: { ...baseSubscription.capabilities, canReactivate: true },
+        }) }
+      }
+      if (url === 'https://billing.test/subscription/reactivate') {
+        return { ok: false, status: 500, json: async () => ({ detail: 'Payment setup failed safely' }) }
+      }
+      return { ok: false, status: 404, json: async () => ({}) }
+    }))
+
+    render(<SubscriptionPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /reactivate/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /subscribe by card/i }))
+
+    expect(await screen.findByText('Payment setup failed safely')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('button', { name: /subscribe by card/i })).not.toBeDisabled())
+  })
+
+  it('suppresses retry CTA while payment confirmation is pending after client-side success', async () => {
+    let subscriptionFetches = 0
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === 'https://billing.test/subscription' && !init?.method) {
+        subscriptionFetches += 1
+        return { ok: true, json: async () => subscriptionFetches === 1
+          ? {
+              ...baseSubscription,
+              status: 'cancelled',
+              capabilities: { ...baseSubscription.capabilities, canReactivate: true },
+            }
+          : {
+              ...baseSubscription,
+              status: 'none',
+              capabilities: { ...baseSubscription.capabilities, canRetryPayment: true, canStartPaidSubscription: true },
+            } }
+      }
+      if (url === 'https://billing.test/subscription/reactivate') {
+        return { ok: true, json: async () => ({ clientSecret: 'cs_test' }) }
+      }
+      return { ok: false, status: 404, json: async () => ({}) }
+    }))
+
+    render(<SubscriptionPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /reactivate/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /subscribe by card/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /mock payment success/i }))
+
+    expect(await screen.findByText(/confirming your payment/i)).toBeInTheDocument()
+    expect(screen.queryByText(/payment incomplete/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /retry payment/i })).not.toBeInTheDocument()
+  })
+
+  it('does not route cancel-at-period-end users into reactivation', async () => {
+    mockSubscription({
+      status: 'active',
+      cancelAtPeriodEnd: true,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        canResumeCancellation: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    await screen.findByText(/subscription will be cancelled/i)
+    expect(screen.queryByRole('button', { name: /reactivate/i })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -419,7 +419,7 @@ export default function SubscriptionPage() {
             <div>
               <p className="text-xs text-[rgb(var(--muted))]">Trial type</p>
               <p className="text-sm text-[rgb(var(--foreground))]">
-                {data.trialPath === '7day' ? '7-day trial (no card)' : data.trialPath === '30day' ? '30-day trial' : 'Paid + 30-day bonus'}
+                {data.trialPath === '7day' ? '7-day trial (no card)' : data.trialPath === '30day' ? '30-day trial' : 'Paid + 14-day bonus'}
               </p>
             </div>
           )}

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@silentsuite/ui'
 import dynamic from 'next/dynamic'
 import { BILLING_API_URL } from '@/app/lib/config'
 import { formatDate as formatDateUtil } from '@/app/lib/date'
+import AddCardBanner from '@/app/components/add-card-banner'
 
 const StripePaymentForm = dynamic(() => import('@/app/components/stripe-payment-form'), {
   loading: () => (
@@ -24,6 +25,17 @@ interface CryptoCheckoutResponse {
   checkoutUrl: string
 }
 
+interface SubscriptionCapabilities {
+  trialActive: boolean
+  trialExpired: boolean
+  needsPaymentMethod: boolean
+  canSetupCard: boolean
+  canStartPaidSubscription: boolean
+  canReactivate: boolean
+  canRetryPayment: boolean
+  canResumeCancellation: boolean
+}
+
 interface SubscriptionData {
   plan: string | null
   planLabel: string
@@ -38,6 +50,7 @@ interface SubscriptionData {
   cancelAtPeriodEnd: boolean
   trialPath: '7day' | '30day' | 'immediate' | null
   earlyAdopter: boolean
+  capabilities?: SubscriptionCapabilities
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -60,6 +73,23 @@ const STATUS_LABELS: Record<string, string> = {
 
 function formatDateStr(iso: string): string {
   return formatDateUtil(new Date(iso), 'system', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+function getCapabilities(data: SubscriptionData): SubscriptionCapabilities {
+  if (data.capabilities) return data.capabilities
+
+  const canSetupCard = data.trialPath === '7day' && data.trial.active
+  const canReactivate = data.status === 'cancelled' || data.status === 'expired' || data.status === 'none'
+  return {
+    trialActive: data.trial.active,
+    trialExpired: false,
+    needsPaymentMethod: canSetupCard,
+    canSetupCard,
+    canStartPaidSubscription: false,
+    canReactivate,
+    canRetryPayment: false,
+    canResumeCancellation: data.cancelAtPeriodEnd && data.status === 'active',
+  }
 }
 
 function LoadingSkeleton() {
@@ -136,6 +166,7 @@ export default function SubscriptionPage() {
   const [reactivating, setReactivating] = useState<string | null>(null)
   const [reactivateClientSecret, setReactivateClientSecret] = useState<string | null>(null)
   const [reactivatePlanId, setReactivatePlanId] = useState<string | null>(null)
+  const [reactivateError, setReactivateError] = useState<string | null>(null)
   const [showChangePlanDialog, setShowChangePlanDialog] = useState(false)
   const [changingPlan, setChangingPlan] = useState(false)
   const [changePlanSuccess, setChangePlanSuccess] = useState<{ plan: string; effectiveDate: string; prorated: boolean } | null>(null)
@@ -145,6 +176,7 @@ export default function SubscriptionPage() {
   const [billingInterval, setBillingInterval] = useState<'monthly' | 'annual'>('monthly')
   const [cryptoCheckoutLoading, setCryptoCheckoutLoading] = useState(false)
   const [cryptoCheckoutError, setCryptoCheckoutError] = useState<string | null>(null)
+  const [paymentConfirmationPending, setPaymentConfirmationPending] = useState(false)
 
   const fetchSubscription = useCallback(async () => {
     try {
@@ -164,6 +196,12 @@ export default function SubscriptionPage() {
   useEffect(() => {
     fetchSubscription()
   }, [fetchSubscription])
+
+  useEffect(() => {
+    if (data?.status === 'active' || data?.status === 'trialing') {
+      setPaymentConfirmationPending(false)
+    }
+  }, [data?.status])
 
   async function handleCancel() {
     setCancelling(true)
@@ -185,6 +223,7 @@ export default function SubscriptionPage() {
 
   async function handleReactivate(planId: string) {
     setReactivating(planId)
+    setReactivateError(null)
     try {
       const res = await fetch(`${BILLING_API_URL}/subscription/reactivate`, {
         method: 'POST',
@@ -196,9 +235,12 @@ export default function SubscriptionPage() {
         const { clientSecret } = await res.json()
         setReactivateClientSecret(clientSecret)
         setReactivatePlanId(planId)
+      } else {
+        const body = await res.json().catch(() => null)
+        setReactivateError(body?.detail ?? body?.error ?? 'Unable to set up payment. Please try again.')
       }
     } catch {
-      // API may not be running in dev
+      setReactivateError('Unable to reach billing service. Please try again.')
     } finally {
       setReactivating(null)
     }
@@ -279,14 +321,31 @@ export default function SubscriptionPage() {
     )
   }
 
+  const capabilities = getCapabilities(data)
   const showTrialBanner =
     !bannerDismissed &&
     data.trial.active &&
     data.trial.daysRemaining != null &&
-    data.trial.daysRemaining <= 7
+    data.trial.daysRemaining <= 7 &&
+    !capabilities.canSetupCard
 
   const isCancelled = data.status === 'cancelled' || data.status === 'expired'
-  const isActiveOrTrialing = data.status === 'active' || data.status === 'trialing'
+  const hasLiveSubscriptionActions = (data.status === 'active' || data.status === 'trialing')
+    && !data.cancelAtPeriodEnd
+    && !capabilities.canSetupCard
+    && !capabilities.trialExpired
+    && !capabilities.canRetryPayment
+    && !capabilities.canStartPaidSubscription
+  const canOpenPaidRecovery = !paymentConfirmationPending && (
+    capabilities.canRetryPayment
+    || capabilities.canStartPaidSubscription
+    || capabilities.canReactivate
+  )
+  const paidRecoveryLabel = capabilities.canRetryPayment
+    ? 'Retry payment'
+    : data.status === 'cancelled'
+      ? 'Reactivate'
+      : 'Subscribe'
   const accessUntilFormatted = data.renewalDate ? formatDateStr(data.renewalDate) : 'the end of your current period'
   // Only show Early Adopter plans — Standard plans will be enabled later
   const availablePlans = REACTIVATION_PLANS.filter((p) => p.earlyOnly)
@@ -384,9 +443,27 @@ export default function SubscriptionPage() {
         </div>
       </section>
 
+      {capabilities.canSetupCard && data.trial.daysRemaining != null && (
+        <AddCardBanner daysRemaining={data.trial.daysRemaining} onCardAdded={fetchSubscription} />
+      )}
+
+      {paymentConfirmationPending && (
+        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
+          <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">Confirming your payment.</p>
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">This usually takes a few seconds. We will update this page automatically.</p>
+        </div>
+      )}
+
+      {capabilities.canRetryPayment && !paymentConfirmationPending && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment incomplete. Please try again.</p>
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">Your subscription will activate after payment is completed.</p>
+        </div>
+      )}
+
       {/* Action buttons */}
       <div className="flex gap-3">
-        {isActiveOrTrialing && !data.cancelAtPeriodEnd && (
+        {hasLiveSubscriptionActions && (
           <>
             <Button variant="outline" size="sm" onClick={() => { setShowChangePlanDialog(true); setChangePlanSuccess(null); setSelectedChangePlan(null); setChangePlanError(null) }}>
               Change plan
@@ -401,9 +478,9 @@ export default function SubscriptionPage() {
             </Button>
           </>
         )}
-        {(isCancelled || data.status === 'none' || data.cancelAtPeriodEnd) && (
-          <Button size="sm" onClick={() => { setCryptoCheckoutError(null); setShowPlanSelection(true) }}>
-            Reactivate
+        {canOpenPaidRecovery && !capabilities.canSetupCard && !data.cancelAtPeriodEnd && (
+          <Button size="sm" onClick={() => { setReactivateError(null); setCryptoCheckoutError(null); setShowPlanSelection(true) }}>
+            {paidRecoveryLabel}
           </Button>
         )}
       </div>
@@ -418,10 +495,14 @@ export default function SubscriptionPage() {
                 <StripePaymentForm
                   clientSecret={reactivateClientSecret}
                   onSuccess={async () => {
+                    setPaymentConfirmationPending(true)
                     setReactivateClientSecret(null)
                     setReactivatePlanId(null)
                     setShowPlanSelection(false)
                     await fetchSubscription()
+                    for (const delayMs of [2000, 5000, 10000]) {
+                      window.setTimeout(() => { void fetchSubscription() }, delayMs)
+                    }
                   }}
                   submitLabel="Reactivate subscription"
                   mode="payment"
@@ -499,6 +580,9 @@ export default function SubscriptionPage() {
                       >
                         {reactivating === plan.id ? 'Setting up...' : 'Subscribe by card'}
                       </button>
+                      {reactivateError && (
+                        <p className="mt-2 text-sm text-red-600 dark:text-red-400">{reactivateError}</p>
+                      )}
                       {billingInterval === 'annual' && CRYPTO_CHECKOUT_ENABLED && (
                         <div className="mt-3 rounded-lg border border-amber-500/25 bg-amber-500/5 p-3">
                           <div className="flex items-center justify-between gap-3">

--- a/apps/web/app/(app)/tasks/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/tasks/__tests__/page.test.tsx
@@ -31,6 +31,8 @@ const storeMock = vi.hoisted(() => ({
   },
   syncState: {
     isOnline: true,
+    initialSyncState: 'synced' as const,
+    error: null as string | null,
   },
   authState: {
     canWrite: vi.fn(() => true),
@@ -64,6 +66,8 @@ vi.mock('@/app/components/MobileCollectionSheet', () => ({
 describe('TasksPage mobile reachability', () => {
   beforeEach(() => {
     storeMock.taskState.isLoading = true
+    storeMock.syncState.initialSyncState = 'synced'
+    storeMock.syncState.error = null
     storeMock.authState.canWrite.mockReturnValue(true)
   })
 
@@ -79,6 +83,16 @@ describe('TasksPage mobile reachability', () => {
   it('exposes an inline quick-add on mobile', () => {
     renderWithIntl(<TasksPage />)
     expect(screen.getByPlaceholderText('Add a task...')).toBeInTheDocument()
+  })
+
+  it('shows restore copy before rendering the normal empty task state', () => {
+    storeMock.taskState.isLoading = false
+    storeMock.syncState.initialSyncState = 'restoring'
+
+    renderWithIntl(<TasksPage />)
+
+    expect(screen.getByText('Restoring encrypted data…')).toBeInTheDocument()
+    expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument()
   })
 
   it('exposes a mobile collection switcher with a 44px touch target', () => {

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -12,7 +12,7 @@ import { formatDate } from '@/app/lib/date'
 
 import { PullToRefresh } from '@/app/components/PullToRefresh'
 import { MobileCollectionSheet } from '@/app/components/MobileCollectionSheet'
-import { TasksEmptyState } from '@/app/components/empty-state'
+import { SyncStartupState, TasksEmptyState } from '@/app/components/empty-state'
 import { ConfirmDialog } from '@/app/components/confirm-dialog'
 import { useFocusTrap } from '@/app/lib/use-focus-trap'
 import type { Task, TaskStatus, Priority } from '@silentsuite/core'
@@ -848,6 +848,8 @@ export default function TasksPage() {
   const tasks = useTaskStore((s) => s.tasks)
   const isLoading = useTaskStore((s) => s.isLoading)
   const isOnline = useSyncStore((s) => s.isOnline)
+  const initialSyncState = useSyncStore((s) => s.initialSyncState)
+  const syncError = useSyncStore((s) => s.error)
   const taskLists = useTaskListStore((s) => s.lists)
   const [showDialog, setShowDialog] = useState(false)
   const [editTask, setEditTask] = useState<Task | null>(null)
@@ -860,7 +862,9 @@ export default function TasksPage() {
     [tasks, visibleListIds],
   )
   const sortedTasks = useMemo(() => sortTasks(filteredTasks), [filteredTasks])
-  const isEmpty = tasks.length === 0 && !isLoading
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const shouldShowStartupState = tasks.length === 0 && !isLoading && !initialLoadComplete
+  const isEmpty = tasks.length === 0 && !isLoading && initialLoadComplete
 
   return (
     <div className="flex h-full flex-col gap-3">
@@ -903,6 +907,8 @@ export default function TasksPage() {
       {/* Content */}
       {isLoading ? (
         <TaskSkeleton />
+      ) : shouldShowStartupState ? (
+        <SyncStartupState state={initialSyncState} error={syncError} />
       ) : isEmpty ? (
         <TasksEmptyState />
       ) : (

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -19,6 +19,7 @@ import { normalizeServerUrl } from '@/app/stores/use-etebase-store'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { BILLING_API_URL } from '@/app/lib/config'
 import { DISPLAY_VERSION } from '@/app/lib/constants'
+import { findCommonEmailDomainTypo, normalizeEmailForComparison, signupEmailSchema } from '@/app/lib/email-recovery'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
 import { StepCreateVault } from './components/step-create-vault'
@@ -71,9 +72,8 @@ const PLAN_PRICES: Record<PlanId, { monthly: number; annual: number; annualPerMo
 // Validation
 // ---------------------------------------------------------------------------
 
-const signupSchema = z
-  .object({
-    email: z.string().min(1, 'Please enter a valid email address'),
+const signupSchema = signupEmailSchema
+  .and(z.object({
     password: z
       .string()
       .min(8, 'Password must be at least 8 characters')
@@ -81,14 +81,10 @@ const signupSchema = z
       .regex(/[a-z]/, 'Must contain a lowercase letter')
       .regex(/[0-9]/, 'Must contain a number'),
     confirmPassword: z.string(),
-  })
+  }))
   .refine((data) => data.password === data.confirmPassword, {
     message: 'Passwords do not match',
     path: ['confirmPassword'],
-  })
-  .refine((data) => data.email.includes('@'), {
-    message: 'Please enter a valid email address',
-    path: ['email'],
   })
 
 type SignupFormData = z.infer<typeof signupSchema>
@@ -244,6 +240,7 @@ function StepCreateAccount({
   })
 
   const password = watch('password', '')
+  const emailTypoWarning = findCommonEmailDomainTypo(watch('email', ''))
 
   return (
     <div className="space-y-4 sm:space-y-6">
@@ -271,19 +268,44 @@ function StepCreateAccount({
             htmlFor="email"
             className="block text-sm font-medium text-[rgb(var(--foreground))]/80"
           >
-            Email address
+            Email
           </label>
           <Input
             id="email"
             type="email"
             autoFocus
             aria-invalid={!!errors.email}
-            aria-describedby={errors.email ? 'signup-email-error' : undefined}
+            aria-describedby={errors.email ? 'signup-email-error' : emailTypoWarning ? 'signup-email-warning' : undefined}
             {...register('email')}
             className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
           />
           {errors.email && (
             <p id="signup-email-error" role="alert" className="text-xs text-red-600 dark:text-red-400">{errors.email.message}</p>
+          )}
+          {!errors.email && emailTypoWarning && (
+            <p id="signup-email-warning" className="text-xs text-amber-600 dark:text-amber-300">{emailTypoWarning.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="confirmEmail"
+            className="block text-sm font-medium text-[rgb(var(--foreground))]/80"
+          >
+            Confirm email
+          </label>
+          <Input
+            id="confirmEmail"
+            type="email"
+            aria-invalid={!!errors.confirmEmail}
+            aria-describedby={errors.confirmEmail ? 'signup-confirm-email-error' : undefined}
+            {...register('confirmEmail')}
+            className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
+          />
+          {errors.confirmEmail && (
+            <p id="signup-confirm-email-error" role="alert" className="text-xs text-red-600 dark:text-red-400">
+              {errors.confirmEmail.message}
+            </p>
           )}
         </div>
 
@@ -1327,7 +1349,7 @@ export default function SignupPage() {
       localStorage.removeItem('silentsuite-server-url')
     }
 
-    const identifier = data.email || ''
+    const identifier = normalizeEmailForComparison(data.email || '')
     const selfHosted = isSelfHosted || isCustomServer(normalizedUrl)
 
     if (selfHosted) {

--- a/apps/web/app/components/EmailVerificationBanner.tsx
+++ b/apps/web/app/components/EmailVerificationBanner.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, type FormEvent } from 'react'
 import { MailWarning, Loader2 } from 'lucide-react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { isSelfHosted } from '@/app/lib/self-hosted'
 import { BILLING_API_URL } from '@/app/lib/config'
+import { normalizeEmailForComparison, signupEmailSchema } from '@/app/lib/email-recovery'
 
 // Minimum gap between focus-triggered refreshes. Cheap guard against burst
 // refreshes when the tab visibility flickers (e.g. fast alt-tab) or when
@@ -17,6 +18,11 @@ export function EmailVerificationBanner() {
   const [resending, setResending] = useState(false)
   const [resent, setResent] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [showChangeEmail, setShowChangeEmail] = useState(false)
+  const [newEmail, setNewEmail] = useState('')
+  const [confirmNewEmail, setConfirmNewEmail] = useState('')
+  const [changingEmail, setChangingEmail] = useState(false)
+  const [changeSuccess, setChangeSuccess] = useState<string | null>(null)
   const lastRefreshRef = useRef(0)
 
   const shouldShow = !isSelfHosted && user && user.emailVerified === false
@@ -73,28 +79,135 @@ export function EmailVerificationBanner() {
     }
   }
 
+  const handleChangeEmail = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setChangeSuccess(null)
+
+    const parsed = signupEmailSchema.safeParse({ email: newEmail, confirmEmail: confirmNewEmail })
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? 'Enter a valid email address.')
+      return
+    }
+
+    const normalizedEmail = normalizeEmailForComparison(parsed.data.email)
+    setChangingEmail(true)
+    try {
+      const res = await fetch(`${BILLING_API_URL}/account/email/change`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+        body: JSON.stringify({ email: normalizedEmail }),
+      })
+      if (!res.ok) {
+        const errData = await res.json().catch(() => null)
+        if (res.status === 429) {
+          throw new Error('Too many requests. Please try again later.')
+        }
+        throw new Error(errData?.detail ?? 'Could not change email. Please try again.')
+      }
+      const data = await res.json().catch(() => null)
+      const updatedEmail = normalizeEmailForComparison(data?.email ?? normalizedEmail)
+      setNewEmail('')
+      setConfirmNewEmail('')
+      setResent(false)
+      setChangeSuccess(
+        data?.sent === false
+          ? `Email changed to ${updatedEmail}, but the verification email could not be sent. Try Resend email in a moment.`
+          : `Verification email sent to ${updatedEmail}.`,
+      )
+      await refreshSession()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not change email. Please try again.')
+    } finally {
+      setChangingEmail(false)
+    }
+  }
+
   return (
-    <div role="alert" className="flex items-center gap-3 px-4 py-2 bg-amber-500/10 border-b border-amber-500/20 text-amber-800 dark:text-amber-200 text-sm">
-      <MailWarning className="w-4 h-4 text-amber-400 shrink-0" />
-      <span className="flex-1 text-xs">
-        {resent
-          ? 'Verification email sent. Check your inbox.'
-          : 'Please verify your email address to ensure you receive important account notifications.'}
-      </span>
-      {!resent && (
+    <div className="border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm text-amber-800 dark:text-amber-200">
+      <div role="alert" className="flex items-center gap-3">
+        <MailWarning className="w-4 h-4 text-amber-400 shrink-0" />
+        <span className="flex-1 text-xs">
+          {changeSuccess
+            ? changeSuccess
+            : resent
+              ? 'Verification email sent. Check your inbox.'
+              : 'Please verify your email so you can receive account and billing messages.'}
+        </span>
+        {!resent && !changeSuccess && (
+          <button
+            onClick={handleResend}
+            disabled={resending}
+            className="shrink-0 text-xs font-medium text-amber-400 hover:text-amber-300 underline underline-offset-2 disabled:opacity-50"
+          >
+            {resending ? (
+              <Loader2 className="w-3 h-3 animate-spin" />
+            ) : (
+              'Resend email'
+            )}
+          </button>
+        )}
         <button
-          onClick={handleResend}
-          disabled={resending}
-          className="shrink-0 text-xs font-medium text-amber-400 hover:text-amber-300 underline underline-offset-2 disabled:opacity-50"
+          onClick={() => {
+            setShowChangeEmail((value) => !value)
+            setError(null)
+            setChangeSuccess(null)
+          }}
+          className="shrink-0 text-xs font-medium text-amber-400 hover:text-amber-300 underline underline-offset-2"
         >
-          {resending ? (
-            <Loader2 className="w-3 h-3 animate-spin" />
-          ) : (
-            'Resend email'
-          )}
+          Change email
         </button>
+      </div>
+
+      {showChangeEmail && (
+        <form onSubmit={handleChangeEmail} className="mt-3 grid gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 sm:grid-cols-2">
+          <p className="text-xs text-amber-900 dark:text-amber-100 sm:col-span-2">
+            This changes the email we use for account and billing messages. Your current login email may stay the same for now.
+          </p>
+          <div className="space-y-1">
+            <label htmlFor="account-contact-email" className="block text-xs font-medium">
+              New email
+            </label>
+            <input
+              id="account-contact-email"
+              type="email"
+              value={newEmail}
+              onChange={(event) => setNewEmail(event.target.value)}
+              className="w-full rounded-md border border-amber-500/30 bg-white/80 px-2 py-1.5 text-sm text-slate-900 dark:bg-slate-950/80 dark:text-slate-100"
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="account-contact-email-confirm" className="block text-xs font-medium">
+              Confirm new email
+            </label>
+            <input
+              id="account-contact-email-confirm"
+              type="email"
+              value={confirmNewEmail}
+              onChange={(event) => setConfirmNewEmail(event.target.value)}
+              className="w-full rounded-md border border-amber-500/30 bg-white/80 px-2 py-1.5 text-sm text-slate-900 dark:bg-slate-950/80 dark:text-slate-100"
+            />
+          </div>
+          <div className="flex items-center gap-3 sm:col-span-2">
+            <button
+              type="submit"
+              disabled={changingEmail}
+              className="rounded-md bg-amber-500 px-3 py-1.5 text-xs font-medium text-slate-950 hover:bg-amber-400 disabled:opacity-50"
+            >
+              {changingEmail ? 'Saving...' : 'Save email'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowChangeEmail(false)}
+              className="text-xs font-medium text-amber-700 underline underline-offset-2 hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-200"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
       )}
-      {error && <span className="text-xs text-red-400">{error}</span>}
+      {error && <p className="mt-2 text-xs text-red-500 dark:text-red-400">{error}</p>}
     </div>
   )
 }

--- a/apps/web/app/components/LabelEditor.tsx
+++ b/apps/web/app/components/LabelEditor.tsx
@@ -1,13 +1,15 @@
 'use client'
 
-import { useCallback, useRef, useState, type FormEvent } from 'react'
+import { useCallback, useMemo, useRef, useState, type FormEvent } from 'react'
 import { Palette, Tag, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import { getLabelSuggestions } from '@silentsuite/core'
 import {
   getLabelColor,
   labelTextColor,
   useLabelColorStore,
 } from '@/app/stores/use-label-color-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 
 // ---------------------------------------------------------------------------
 // Shared label / category chip components (#291)
@@ -137,12 +139,19 @@ export function LabelEditor({
 }) {
   const t = useTranslations('Labels')
   const [input, setInput] = useState('')
+  const [activeSuggestion, setActiveSuggestion] = useState(0)
+  const labelIndex = useLabelSuggestionsStore((state) => state.index)
+  const suggestions = useMemo(
+    () => getLabelSuggestions(labelIndex, input, 6, labels),
+    [labelIndex, input, labels],
+  )
 
   const commit = useCallback(
     (raw: string) => {
       const next = normalizeLabels([...labels, raw])
       if (next.length !== labels.length) onChange(next)
       setInput('')
+      setActiveSuggestion(0)
     },
     [labels, onChange],
   )
@@ -158,17 +167,28 @@ export function LabelEditor({
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter' || e.key === ',') {
         e.preventDefault()
-        if (input.trim()) commit(input)
+        if (suggestions.length > 0 && (e.key === 'Enter' || !input.trim())) {
+          commit(suggestions[activeSuggestion] ?? suggestions[0]!)
+        } else if (input.trim()) commit(input)
+      } else if (e.key === 'ArrowDown' && suggestions.length > 0) {
+        e.preventDefault()
+        setActiveSuggestion((current) => (current + 1) % suggestions.length)
+      } else if (e.key === 'ArrowUp' && suggestions.length > 0) {
+        e.preventDefault()
+        setActiveSuggestion((current) => (current - 1 + suggestions.length) % suggestions.length)
+      } else if (e.key === 'Escape') {
+        setInput('')
+        setActiveSuggestion(0)
       } else if (e.key === 'Backspace' && !input && labels.length > 0) {
         // Quick-delete the last chip when the input is empty
         remove(labels[labels.length - 1]!)
       }
     },
-    [input, labels, commit, remove],
+    [input, labels, commit, remove, suggestions, activeSuggestion],
   )
 
   return (
-    <div className="flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">
+    <div className="relative flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">
       {labels.map((label, index) => (
         <LabelChip
           key={`${label}-${index}`}
@@ -183,13 +203,42 @@ export function LabelEditor({
         <input
           type="text"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={(e) => {
+            setInput(e.target.value)
+            setActiveSuggestion(0)
+          }}
           onKeyDown={handleKeyDown}
           onBlur={() => input.trim() && commit(input)}
           placeholder={labels.length === 0 ? (placeholder ?? t('addLabelPlaceholder')) : ''}
           aria-label={ariaLabel ?? t('editorAriaLabel')}
+          aria-autocomplete="list"
+          aria-expanded={suggestions.length > 0}
           className="min-w-[6rem] flex-1 bg-transparent text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none"
         />
+      )}
+      {!disabled && suggestions.length > 0 && (
+        <div
+          role="listbox"
+          aria-label={t('suggestionsAriaLabel')}
+          className="absolute left-2 right-2 top-[calc(100%+0.25rem)] z-50 max-h-48 overflow-auto rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] py-1 text-sm shadow-lg"
+        >
+          {suggestions.map((suggestion, index) => (
+            <button
+              key={suggestion}
+              type="button"
+              role="option"
+              aria-selected={index === activeSuggestion}
+              onMouseDown={(event) => {
+                event.preventDefault()
+                commit(suggestion)
+              }}
+              onMouseEnter={() => setActiveSuggestion(index)}
+              className={`block w-full px-3 py-1.5 text-left ${index === activeSuggestion ? 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300' : 'text-[rgb(var(--foreground))]'}`}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import AddCardBanner from '../add-card-banner'
+
+vi.mock('next/dynamic', () => ({
+  default: () => function MockStripePaymentForm({ mode, submitLabel }: { mode: string; submitLabel: string }) {
+    return <div data-testid="stripe-payment-form">{mode}:{submitLabel}</div>
+  },
+}))
+
+vi.mock('@/app/lib/config', () => ({
+  BILLING_API_URL: 'https://billing.example.test',
+}))
+
+vi.stubGlobal('fetch', vi.fn())
+
+describe('AddCardBanner', () => {
+  beforeEach(() => {
+    vi.mocked(fetch).mockReset()
+  })
+
+  it('offers only pay-now monthly/annual choices and requests immediate payment setup', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ clientSecret: 'pi_secret' }),
+    } as Response)
+
+    render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Add payment method'))
+
+    expect(screen.getByText('Pay now + 14 bonus days')).toBeInTheDocument()
+    expect(screen.getByText('Choose monthly or annual. Your card is charged now.')).toBeInTheDocument()
+    expect(screen.queryByText('30-day trial')).not.toBeInTheDocument()
+    expect(screen.getByText('Monthly')).toBeInTheDocument()
+    expect(screen.getByText('Annual')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Annual'))
+    fireEvent.click(screen.getByText('Continue to payment'))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      'https://billing.example.test/subscription/setup-card',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ planId: 'early_annual', trialPath: 'immediate' }),
+      }),
+    ))
+
+    expect(await screen.findByText('14 bonus days included after today\'s payment.')).toBeInTheDocument()
+    expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €36')
+  })
+})

--- a/apps/web/app/components/__tests__/EmailVerificationBanner.test.tsx
+++ b/apps/web/app/components/__tests__/EmailVerificationBanner.test.tsx
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { EmailVerificationBanner } from '../EmailVerificationBanner'
+
+let mockUser: { id: string; email: string; planId: string; emailVerified?: boolean } | null = null
+const mockRefreshSession = vi.fn(async () => true)
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      user: mockUser,
+      refreshSession: mockRefreshSession,
+    }),
+}))
+
+vi.mock('@/app/lib/self-hosted', () => ({
+  isSelfHosted: false,
+}))
+
+vi.mock('lucide-react', () => ({
+  MailWarning: () => <svg data-testid="mail-warning-icon" />,
+  Loader2: () => <svg data-testid="loader-icon" />,
+}))
+
+vi.stubGlobal('fetch', vi.fn())
+
+describe('EmailVerificationBanner', () => {
+  beforeEach(() => {
+    mockUser = { id: 'user-1', email: 'typo@gmial.com', planId: 'early_annual', emailVerified: false }
+    mockRefreshSession.mockClear()
+    vi.mocked(fetch).mockReset()
+  })
+
+  it('renders persistent unverified copy and both recovery actions', () => {
+    render(<EmailVerificationBanner />)
+
+    expect(screen.getByText('Please verify your email so you can receive account and billing messages.')).toBeInTheDocument()
+    expect(screen.getByText('Resend email')).toBeInTheDocument()
+    expect(screen.getByText('Change email')).toBeInTheDocument()
+  })
+
+  it('opens a change email form with confirmation and careful contact-email copy', () => {
+    render(<EmailVerificationBanner />)
+
+    fireEvent.click(screen.getByText('Change email'))
+
+    expect(screen.getByLabelText('New email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Confirm new email')).toBeInTheDocument()
+    expect(screen.getByText('This changes the email we use for account and billing messages. Your current login email may stay the same for now.')).toBeInTheDocument()
+  })
+
+  it('submits normalized contact email changes to billing and refreshes the session', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ email: 'correct@gmail.com', emailVerified: false }),
+    } as Response)
+    render(<EmailVerificationBanner />)
+
+    fireEvent.click(screen.getByText('Change email'))
+    fireEvent.change(screen.getByLabelText('New email'), { target: { value: ' Correct@GMail.com ' } })
+    fireEvent.change(screen.getByLabelText('Confirm new email'), { target: { value: 'correct@gmail.COM' } })
+    fireEvent.click(screen.getByText('Save email'))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/account/email/change'),
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: expect.objectContaining({ 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }),
+        body: JSON.stringify({ email: 'correct@gmail.com' }),
+      }),
+    ))
+    await waitFor(() => expect(mockRefreshSession).toHaveBeenCalled())
+    expect(await screen.findByText('Verification email sent to correct@gmail.com.')).toBeInTheDocument()
+  })
+
+  it('shows a recoverable message when billing changes the email but sending fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ email: 'correct@gmail.com', emailVerified: false, sent: false }),
+    } as Response)
+    render(<EmailVerificationBanner />)
+
+    fireEvent.click(screen.getByText('Change email'))
+    fireEvent.change(screen.getByLabelText('New email'), { target: { value: 'correct@gmail.com' } })
+    fireEvent.change(screen.getByLabelText('Confirm new email'), { target: { value: 'correct@gmail.com' } })
+    fireEvent.click(screen.getByText('Save email'))
+
+    expect(await screen.findByText('Email changed to correct@gmail.com, but the verification email could not be sent. Try Resend email in a moment.')).toBeInTheDocument()
+  })
+
+  it('blocks mismatched changed-email confirmation before calling billing', () => {
+    render(<EmailVerificationBanner />)
+
+    fireEvent.click(screen.getByText('Change email'))
+    fireEvent.change(screen.getByLabelText('New email'), { target: { value: 'one@example.com' } })
+    fireEvent.change(screen.getByLabelText('Confirm new email'), { target: { value: 'two@example.com' } })
+    fireEvent.click(screen.getByText('Save email'))
+
+    expect(screen.getByText('Email addresses do not match.')).toBeInTheDocument()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/components/__tests__/LabelEditor.test.tsx
+++ b/apps/web/app/components/__tests__/LabelEditor.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { LabelEditor, LabelChips, normalizeLabels } from '../LabelEditor'
 import { renderWithIntl } from '@/src/__tests__/render-with-intl'
 import { getLabelColor, labelTextColor, useLabelColorStore } from '@/app/stores/use-label-color-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
+import { createLabelIndex } from '@silentsuite/core'
 
 vi.mock('lucide-react', () => ({
   Palette: () => <svg data-testid="palette-icon" />,
@@ -12,6 +14,7 @@ vi.mock('lucide-react', () => ({
 
 beforeEach(() => {
   useLabelColorStore.setState({ colors: {} })
+  useLabelSuggestionsStore.getState().destroy()
   localStorage.clear()
 })
 
@@ -136,5 +139,37 @@ describe('LabelEditor', () => {
     expect(screen.queryByLabelText('Labels')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Remove label Work')).not.toBeInTheDocument()
     expect(screen.getByText('Work')).toBeInTheDocument()
+  })
+
+  it('shows synced suggestions and selects one with keyboard', () => {
+    useLabelSuggestionsStore.setState({
+      index: createLabelIndex([
+        { label: 'Work', count: 5, lastUsedAt: 10 },
+        { label: 'Workout', count: 3, lastUsedAt: 9 },
+      ], 10),
+    })
+    const onChange = vi.fn()
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} />)
+    const input = screen.getByLabelText('Labels')
+
+    fireEvent.change(input, { target: { value: 'wor' } })
+    expect(screen.getByRole('option', { name: 'Work' })).toBeInTheDocument()
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenCalledWith(['Workout'])
+  })
+
+  it('does not suggest labels that are already selected', () => {
+    useLabelSuggestionsStore.setState({
+      index: createLabelIndex([
+        { label: 'Work', count: 5, lastUsedAt: 10 },
+        { label: 'Home', count: 3, lastUsedAt: 9 },
+      ], 10),
+    })
+
+    renderWithIntl(<LabelEditor labels={['Work']} onChange={vi.fn()} />)
+    expect(screen.queryByRole('option', { name: 'Work' })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Home' })).toBeInTheDocument()
   })
 })

--- a/apps/web/app/components/add-card-banner.tsx
+++ b/apps/web/app/components/add-card-banner.tsx
@@ -17,7 +17,6 @@ const StripePaymentForm = dynamic(() => import('./stripe-payment-form'), {
 })
 
 type BillingInterval = 'monthly' | 'annual'
-type TrialPath = '30day' | 'immediate'
 
 interface AddCardBannerProps {
   daysRemaining: number
@@ -89,7 +88,6 @@ function AddCardModal({
   onCardAdded: () => void
 }) {
   const [interval, setInterval] = useState<BillingInterval>('monthly')
-  const [trialPath, setTrialPath] = useState<TrialPath>('30day')
   const [clientSecret, setClientSecret] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -104,7 +102,7 @@ function AddCardModal({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ planId, trialPath }),
+        body: JSON.stringify({ planId, trialPath: 'immediate' }),
       })
       if (!res.ok) {
         const data = await res.json().catch(() => null)
@@ -133,61 +131,24 @@ function AddCardModal({
 
         {!clientSecret ? (
           <>
-            {/* Plan selection */}
-            <div className="space-y-3">
-              {/* 30-day trial */}
-              <button
-                onClick={() => setTrialPath('30day')}
-                className={`w-full rounded-xl border p-4 text-left transition-all ${
-                  trialPath === '30day'
-                    ? 'border-emerald-500/50 bg-emerald-500/5'
-                    : 'border-[rgb(var(--border))] hover:border-slate-600/50'
-                }`}
-              >
-                <div className="flex items-start gap-3">
-                  <div className="rounded-lg bg-[rgb(var(--border))] p-2 shrink-0">
-                    <Lock className="h-4 w-4 text-amber-400" />
-                  </div>
-                  <div>
-                    <h3 className="font-medium text-[rgb(var(--foreground))]">30-day trial</h3>
-                    <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">First charge on day 30</p>
-                  </div>
-                  {trialPath === '30day' && (
-                    <div className="ml-auto shrink-0 rounded-full bg-emerald-500 p-0.5">
-                      <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-                      </svg>
-                    </div>
-                  )}
+            {/* Pay now summary */}
+            <div className="rounded-xl border border-emerald-500/50 bg-emerald-500/5 p-4 text-left">
+              <div className="flex items-start gap-3">
+                <div className="rounded-lg bg-[rgb(var(--border))] p-2 shrink-0">
+                  <Zap className="h-4 w-4 text-amber-400" />
                 </div>
-              </button>
-
-              {/* Pay now + 30 bonus days */}
-              <button
-                onClick={() => setTrialPath('immediate')}
-                className={`w-full rounded-xl border p-4 text-left transition-all ${
-                  trialPath === 'immediate'
-                    ? 'border-emerald-500/50 bg-emerald-500/5'
-                    : 'border-[rgb(var(--border))] hover:border-slate-600/50'
-                }`}
-              >
-                <div className="flex items-start gap-3">
-                  <div className="rounded-lg bg-[rgb(var(--border))] p-2 shrink-0">
-                    <Zap className="h-4 w-4 text-amber-400" />
-                  </div>
-                  <div>
-                    <h3 className="font-medium text-[rgb(var(--foreground))]">Pay now + 30 bonus days</h3>
-                    <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">Get an extra month free</p>
-                  </div>
-                  {trialPath === 'immediate' && (
-                    <div className="ml-auto shrink-0 rounded-full bg-emerald-500 p-0.5">
-                      <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-                      </svg>
-                    </div>
-                  )}
+                <div>
+                  <h3 className="font-medium text-[rgb(var(--foreground))]">Pay now + 14 bonus days</h3>
+                  <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">
+                    Choose monthly or annual. Your card is charged now.
+                  </p>
                 </div>
-              </button>
+                <div className="ml-auto shrink-0 rounded-full bg-emerald-500 p-0.5">
+                  <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                  </svg>
+                </div>
+              </div>
             </div>
 
             {/* Billing toggle + price */}
@@ -228,9 +189,7 @@ function AddCardModal({
                 <PriceDisplay interval={interval} />
               </div>
               <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-                {trialPath === '30day'
-                  ? 'First charge in 30 days. Cancel anytime before.'
-                  : '30 bonus days included. Next charge in 30 days.'}
+                14 bonus days included after today&apos;s payment.
               </p>
             </div>
 
@@ -238,8 +197,8 @@ function AddCardModal({
             <StripePaymentForm
               clientSecret={clientSecret}
               onSuccess={onCardAdded}
-              submitLabel={trialPath === '30day' ? 'Start 30-day trial' : `Pay ${interval === 'monthly' ? '\u20AC3.60' : '\u20AC36'}`}
-              mode={trialPath === '30day' ? 'setup' : 'payment'}
+              submitLabel={`Pay ${interval === 'monthly' ? '\u20AC3.60' : '\u20AC36'}`}
+              mode="payment"
             />
 
             <div className="flex items-center justify-center gap-1.5 text-xs text-[rgb(var(--muted))]">

--- a/apps/web/app/components/add-card-banner.tsx
+++ b/apps/web/app/components/add-card-banner.tsx
@@ -287,7 +287,7 @@ export default function AddCardBanner({ daysRemaining, onCardAdded }: AddCardBan
         <div className="flex items-center gap-2">
           <Button size="sm" onClick={() => setShowModal(true)}>
             <CreditCard className="h-3.5 w-3.5 mr-1.5" />
-            Add card
+            Add payment method
           </Button>
           <button onClick={() => setDismissed(true)} className="text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]">
             <X className="h-4 w-4" />

--- a/apps/web/app/components/empty-state.tsx
+++ b/apps/web/app/components/empty-state.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CalendarDays, CheckSquare, Users, Search, type LucideIcon } from 'lucide-react'
+import { AlertTriangle, CalendarDays, CheckSquare, RefreshCw, Search, Users, type LucideIcon } from 'lucide-react'
 
 interface EmptyStateProps {
   icon: LucideIcon
@@ -74,6 +74,38 @@ export function SearchEmptyState({ query }: { query: string }) {
       icon={Search}
       title="No results found"
       description={`No contacts match "${query}". Try a different search term.`}
+    />
+  )
+}
+
+export type SyncStartupStatus = 'idle' | 'restoring' | 'hydrated-cache' | 'syncing' | 'synced' | 'empty' | 'offline' | 'error' | 'no-session'
+
+export function SyncStartupState({ state, error }: { state: SyncStartupStatus; error?: string | null }) {
+  if (state === 'error') {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title="Could not restore encrypted session"
+        description={error || 'Sign in again or retry when your connection is available.'}
+      />
+    )
+  }
+
+  if (state === 'offline') {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title="Waiting to sync encrypted data"
+        description="You appear to be offline. Cached data will stay visible when available; reconnect to finish sync."
+      />
+    )
+  }
+
+  return (
+    <EmptyState
+      icon={RefreshCw}
+      title={state === 'syncing' ? 'Syncing encrypted data…' : 'Restoring encrypted data…'}
+      description="SilentSuite is checking your encrypted session before showing an empty account."
     />
   )
 }

--- a/apps/web/app/lib/__tests__/date.test.ts
+++ b/apps/web/app/lib/__tests__/date.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   endOfWeek,
+  formatDate,
   getWeekNumber,
   startOfWeek,
   weekdayLabels,
@@ -27,6 +28,20 @@ describe('weekdayLabels', () => {
 
   it('orders labels from Sunday for sunday-start', () => {
     expect(weekdayLabels('sunday')).toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'])
+  })
+})
+
+describe('formatDate', () => {
+  const date = new Date(2026, 5, 9)
+
+  it.each([
+    ['DD/MM/YYYY', '09/06/2026'],
+    ['MM/DD/YYYY', '06/09/2026'],
+    ['DD.MM.YYYY', '09.06.2026'],
+    ['YYYY/MM/DD', '2026/06/09'],
+    ['YYYY-MM-DD', '2026-06-09'],
+  ] as const)('formats %s', (format, expected) => {
+    expect(formatDate(date, format)).toBe(expected)
   })
 })
 

--- a/apps/web/app/lib/__tests__/email-recovery.test.ts
+++ b/apps/web/app/lib/__tests__/email-recovery.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  findCommonEmailDomainTypo,
+  normalizeEmailForComparison,
+  signupEmailSchema,
+} from '../email-recovery'
+
+describe('email recovery validation helpers', () => {
+  it('normalizes email case and whitespace for comparison', () => {
+    expect(normalizeEmailForComparison('  User@GMail.COM ')).toBe('user@gmail.com')
+  })
+
+  it('rejects malformed signup emails with public copy', () => {
+    const result = signupEmailSchema.safeParse({ email: 'person@', confirmEmail: 'person@' })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toBe('Enter a valid email address.')
+  })
+
+  it('rejects signup email confirmation mismatches after normalization', () => {
+    const result = signupEmailSchema.safeParse({
+      email: 'person@example.com',
+      confirmEmail: 'person@other.com',
+    })
+    expect(result.success).toBe(false)
+    expect(result.error?.issues[0]?.message).toBe('Email addresses do not match.')
+  })
+
+  it('accepts matching emails with different case and surrounding whitespace', () => {
+    const result = signupEmailSchema.safeParse({
+      email: ' Person@Example.com ',
+      confirmEmail: 'person@example.COM',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('warns when both pasted emails use a common typo domain', () => {
+    expect(findCommonEmailDomainTypo('person@gmial.com')).toEqual({
+      typedDomain: 'gmial.com',
+      suggestedDomain: 'gmail.com',
+      message: 'Did you mean gmail.com?',
+    })
+  })
+
+  it('warns for common provider TLD mistakes', () => {
+    expect(findCommonEmailDomainTypo('person@gmail.con')?.suggestedDomain).toBe('gmail.com')
+  })
+})

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -17,7 +17,7 @@
  */
 import { logger } from '@/app/lib/logger'
 
-export type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
+export type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'labelIndex'
 
 export interface CachedItem {
   itemUid: string

--- a/apps/web/app/lib/date.ts
+++ b/apps/web/app/lib/date.ts
@@ -87,10 +87,14 @@ export function formatDate(input: Date | string | number, format: DateFormat = '
   switch (format) {
     case 'YYYY-MM-DD':
       return `${y}-${m}-${d}`
+    case 'YYYY/MM/DD':
+      return `${y}/${m}/${d}`
     case 'DD/MM/YYYY':
       return `${d}/${m}/${y}`
     case 'MM/DD/YYYY':
       return `${m}/${d}/${y}`
+    case 'DD.MM.YYYY':
+      return `${d}.${m}.${y}`
     case 'system':
     default:
       return date.toLocaleDateString(locale ?? undefined, options ?? { year: 'numeric', month: 'long', day: 'numeric' })

--- a/apps/web/app/lib/email-recovery.ts
+++ b/apps/web/app/lib/email-recovery.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod'
+
+const COMMON_EMAIL_DOMAINS = [
+  'gmail.com',
+  'outlook.com',
+  'hotmail.com',
+  'yahoo.com',
+  'proton.me',
+  'protonmail.com',
+  'icloud.com',
+]
+
+const COMMON_DOMAIN_TYPOS: Record<string, string> = {
+  'gmai.com': 'gmail.com',
+  'gmail.co': 'gmail.com',
+  'gmail.con': 'gmail.com',
+  'gmail.om': 'gmail.com',
+  'gmial.com': 'gmail.com',
+  'gmal.com': 'gmail.com',
+  'hotmial.com': 'hotmail.com',
+  'hotmai.com': 'hotmail.com',
+  'hotmail.co': 'hotmail.com',
+  'hotmal.com': 'hotmail.com',
+  'outlok.com': 'outlook.com',
+  'outlook.co': 'outlook.com',
+  'outlook.con': 'outlook.com',
+  'yaho.com': 'yahoo.com',
+  'yahoo.co': 'yahoo.com',
+  'yahoo.con': 'yahoo.com',
+  'protonmail.co': 'protonmail.com',
+  'protonmail.con': 'protonmail.com',
+  'proton.me.com': 'proton.me',
+  'iclould.com': 'icloud.com',
+  'icoud.com': 'icloud.com',
+  'icloud.co': 'icloud.com',
+  'icloud.con': 'icloud.com',
+}
+
+export type EmailDomainTypoWarning = {
+  typedDomain: string
+  suggestedDomain: string
+  message: string
+}
+
+export function normalizeEmailForComparison(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+function domainFromEmail(email: string): string | null {
+  const normalized = normalizeEmailForComparison(email)
+  const atIndex = normalized.lastIndexOf('@')
+  if (atIndex < 0 || atIndex === normalized.length - 1) return null
+  return normalized.slice(atIndex + 1)
+}
+
+function oneEditAway(left: string, right: string): boolean {
+  if (left === right) return false
+  if (Math.abs(left.length - right.length) > 1) return false
+
+  let edits = 0
+  let i = 0
+  let j = 0
+  while (i < left.length && j < right.length) {
+    if (left[i] === right[j]) {
+      i += 1
+      j += 1
+      continue
+    }
+    edits += 1
+    if (edits > 1) return false
+    if (left.length > right.length) {
+      i += 1
+    } else if (right.length > left.length) {
+      j += 1
+    } else {
+      i += 1
+      j += 1
+    }
+  }
+
+  if (i < left.length || j < right.length) edits += 1
+  return edits === 1
+}
+
+export function findCommonEmailDomainTypo(email: string): EmailDomainTypoWarning | null {
+  const typedDomain = domainFromEmail(email)
+  if (!typedDomain) return null
+
+  const suggestedDomain = COMMON_DOMAIN_TYPOS[typedDomain]
+    ?? COMMON_EMAIL_DOMAINS.find((domain) => oneEditAway(typedDomain, domain))
+
+  if (!suggestedDomain || suggestedDomain === typedDomain) return null
+
+  return {
+    typedDomain,
+    suggestedDomain,
+    message: `Did you mean ${suggestedDomain}?`,
+  }
+}
+
+export const signupEmailSchema = z
+  .object({
+    email: z.string().trim().toLowerCase().pipe(z.email('Enter a valid email address.')),
+    confirmEmail: z.string().trim().toLowerCase().pipe(z.email('Enter a valid email address.')),
+  })
+  .refine((data) => normalizeEmailForComparison(data.email) === normalizeEmailForComparison(data.confirmEmail), {
+    message: 'Email addresses do not match.',
+    path: ['confirmEmail'],
+  })

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -5,7 +5,7 @@
  */
 import { logger } from '@/app/lib/logger'
 
-type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
+type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'labelIndex'
 type MutationType = 'create' | 'update' | 'delete' | 'move'
 
 export interface QueueEntry {

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -9,6 +9,7 @@ import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { usePreferencesSyncStore } from '@/app/stores/use-preferences-sync-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 import {
   getItemsByType as cacheGetItemsByType,
   replaceItemsForType as cacheReplaceItemsForType,
@@ -439,6 +440,17 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         reportSyncError('initialize preferences sync', err)
       }
 
+      // Load the encrypted label suggestion index from its dedicated Etebase
+      // collection. Plaintext labels only exist inside decrypted item content.
+      try {
+        const labelIndexStartedAt = nowMs()
+        await useLabelSuggestionsStore.getState().initialize()
+        logSyncTiming('label-index-initialize', labelIndexStartedAt)
+      } catch (err) {
+        hadErrors = true
+        reportSyncError('initialize label suggestions', err)
+      }
+
       return hadErrors
     }
 
@@ -496,6 +508,13 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           } catch (err) {
             reportSyncError('sync preferences', err)
           }
+        } else if (collectionType === 'silentsuite.labelindex') {
+          try {
+            const labelIndexItems = await refresher('labelIndex', event.collectionUid)
+            await useLabelSuggestionsStore.getState().loadFromRemote(labelIndexItems)
+          } catch (err) {
+            reportSyncError('sync label suggestions', err)
+          }
         }
 
         setLastSynced(new Date())
@@ -521,6 +540,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       if (unsubChange) unsubChange()
       if (unsubStatus) unsubStatus()
       usePreferencesSyncStore.getState().destroy()
+      useLabelSuggestionsStore.getState().destroy()
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -125,6 +125,7 @@ async function deserializeCalendarItemsIncrementally(
 export function SyncProvider({ children }: { children: React.ReactNode }) {
   const initializeSync = useSyncStore((s) => s.initializeSync)
   const setSyncStatus = useSyncStore((s) => s.setSyncStatus)
+  const setInitialSyncState = useSyncStore((s) => s.setInitialSyncState)
   const setLastSynced = useSyncStore((s) => s.setLastSynced)
   const setError = useSyncStore((s) => s.setError)
 
@@ -154,6 +155,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       const initStartedAt = markCalendarSyncStart()
       try {
         setSyncStatus('syncing')
+        setInitialSyncState('restoring')
         const cacheStatus = getCacheCapabilityStatus()
         logSyncTiming('cache-capability', initStartedAt, { ...cacheStatus })
 
@@ -161,13 +163,37 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         // from IndexedDB before the network sync starts. This is best-effort
         // — failures are logged and the normal init path proceeds.
         if (isLocalCacheEnabled()) {
-          await hydrateFromCache()
+          const hydrated = await hydrateFromCache()
+          if (hydrated) setInitialSyncState('hydrated-cache')
         }
 
         // Restore session, create/fetch collections, load items, start SyncEngine
         const etebaseInitStartedAt = nowMs()
-        await etebaseInitialize()
+        const initOutcome = await etebaseInitialize()
         logSyncTiming('etebase-initialize', etebaseInitStartedAt)
+
+        if (initOutcome.status === 'no-session') {
+          setInitialSyncState('no-session')
+          setSyncStatus('synced')
+          setError(null)
+          return
+        }
+
+        if (initOutcome.status === 'offline') {
+          setInitialSyncState('offline')
+          setSyncStatus('offline')
+          setError('Offline. Showing any cached encrypted data until sync can resume.')
+          return
+        }
+
+        if (initOutcome.status === 'error') {
+          setInitialSyncState('error')
+          setSyncStatus('error')
+          setError('Could not restore encrypted session')
+          return
+        }
+
+        setInitialSyncState('syncing')
 
         // Now load items from each collection into the data stores
         const loadHadErrors = await loadItemsIntoStores()
@@ -180,9 +206,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
         if (loadHadErrors) {
           setSyncStatus('error')
+          setInitialSyncState('error')
           setError('Some synced items could not be loaded')
         } else {
           setSyncStatus('synced')
+          setInitialSyncState(hasVisibleDomainData() ? 'synced' : 'empty')
           setError(null)
         }
         setLastSynced(new Date())
@@ -190,6 +218,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       } catch (err) {
         reportSyncError('init', err)
         setSyncStatus('error')
+        setInitialSyncState('error')
         setError('Sync initialization failed')
       }
     }
@@ -204,8 +233,15 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
      * Cheap (~10-50ms for a typical vault) and fully off the network path.
      * Failures here are non-fatal; we just skip the optimistic paint.
      */
-    async function hydrateFromCache() {
+    function hasVisibleDomainData(): boolean {
+      return useCalendarStore.getState().events.length > 0
+        || useTaskStore.getState().tasks.length > 0
+        || useContactStore.getState().contacts.length > 0
+    }
+
+    async function hydrateFromCache(): Promise<boolean> {
       const cacheHydrateStartedAt = nowMs()
+      let hydratedAny = false
       try {
         const [taskItems, contactItems, eventItems, core] = await Promise.all([
           cacheGetItemsByType('tasks'),
@@ -221,6 +257,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
               return { ...task, id: it.itemUid, listId: it.collectionUid }
             })
             useTaskStore.getState().syncFromRemote(tasks)
+            hydratedAny = tasks.length > 0 || hydratedAny
             logger.log(`[sync-provider] Hydrated ${tasks.length} tasks from cache`)
           } catch (err) {
             logger.warn('[sync-provider] Failed to hydrate tasks from cache', getSafeErrorDetails(err))
@@ -234,6 +271,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
               return { ...contact, id: it.itemUid, listId: it.collectionUid }
             })
             useContactStore.getState().syncFromRemote(contacts)
+            hydratedAny = contacts.length > 0 || hydratedAny
             logger.log(`[sync-provider] Hydrated ${contacts.length} contacts from cache`)
           } catch (err) {
             logger.warn('[sync-provider] Failed to hydrate contacts from cache', getSafeErrorDetails(err))
@@ -262,6 +300,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
               setError('Some cached calendar events could not be loaded')
               reportSyncError('hydrate cached calendar events', errors[0])
             } else {
+              hydratedAny = events.length > 0 || hydratedAny
               logger.log(`[sync-provider] Hydrated ${events.length} events from cache`)
             }
           } catch (err) {
@@ -277,6 +316,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         logger.warn('[sync-provider] Cache hydration failed', getSafeErrorDetails(err))
         logSyncTiming('cache-hydrate-failed', cacheHydrateStartedAt)
       }
+      return hydratedAny
     }
 
     async function loadItemsIntoStores(): Promise<boolean> {
@@ -331,6 +371,8 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             reportSyncError('load calendar event chunk', errors[0])
           }
           await mirrorToCache('calendar', eventItems)
+        } else {
+          useCalendarStore.getState().syncFromRemote([])
         }
       } catch (err) {
         hadErrors = true
@@ -354,6 +396,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: taskItems.length, taskCount: tasks.length })
           await mirrorToCache('tasks', taskItems)
         } else {
+          useTaskStore.getState().syncFromRemote([])
           logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: 0, taskCount: 0 })
         }
       } catch (err) {
@@ -376,6 +419,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: contactItems.length, contactCount: contacts.length })
           await mirrorToCache('contacts', contactItems)
         } else {
+          useContactStore.getState().syncFromRemote([])
           logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: 0, contactCount: 0 })
         }
       } catch (err) {

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -95,7 +95,7 @@ function setupStoreWithMocks(itemManager: MockItemManager, syncEngine: MockSyncE
   }
   useEtebaseStore.setState({
     account: account as any,
-    collections: { calendar: [collection as any], tasks: [], contacts: [], preferences: [] },
+    collections: { calendar: [collection as any], tasks: [], contacts: [], preferences: [], labelIndex: [] },
     itemCache: new Map(),
     itemTypeMap: new Map(),
     itemCollectionMap: new Map(),
@@ -113,7 +113,7 @@ function setupStoreWithCollections(itemManagerByUid: Record<string, MockItemMana
   }
   useEtebaseStore.setState({
     account: account as any,
-    collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [] },
+    collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
     itemCache: new Map(),
     itemTypeMap: new Map(),
     itemCollectionMap: new Map(),
@@ -200,7 +200,7 @@ describe('useEtebaseStore.createItemsBatch', () => {
     })
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -373,7 +373,7 @@ describe('useEtebaseStore.moveItem', () => {
     offlineQueueMock.isOfflineError.mockReset().mockReturnValue(false)
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -392,7 +392,7 @@ describe('useEtebaseStore.moveItem', () => {
     coreMock.deleteItem.mockResolvedValue(undefined)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [sourceCollection, targetCollection] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [sourceCollection, targetCollection] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([['item-old', sourceItem]]),
       itemTypeMap: new Map([['item-old', 'calendar']]),
       itemCollectionMap: new Map([['item-old', 'col-1']]),
@@ -426,7 +426,7 @@ describe('useEtebaseStore.moveItem', () => {
     offlineQueueMock.isOfflineError.mockReturnValue(true)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [sourceCollection, targetCollection] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [sourceCollection, targetCollection] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([['item-old', sourceItem]]),
       itemTypeMap: new Map([['item-old', 'calendar']]),
       itemCollectionMap: new Map([['item-old', 'col-1']]),
@@ -457,7 +457,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
   beforeEach(() => {
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -479,7 +479,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [{ uid: 'col-1' }, { uid: 'col-2' }] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [{ uid: 'col-1' }, { uid: 'col-2' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([
         ['item-1', deleteItemOne],
         ['item-2', deleteItemTwo],
@@ -535,7 +535,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -573,7 +573,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(items.map((item) => [item.uid, item])),
       itemTypeMap: new Map(items.map((item) => [item.uid, 'calendar' as const])),
       itemCollectionMap: new Map(items.map((item) => [item.uid, 'col-1'])),
@@ -604,7 +604,7 @@ describe('useEtebaseStore.refreshCollection', () => {
   beforeEach(() => {
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -635,7 +635,7 @@ describe('useEtebaseStore.refreshCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([
         ['old-col-1', staleItem],
         ['keep-col-2', survivorItem],
@@ -677,7 +677,7 @@ describe('useEtebaseStore.refreshCollection', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map([['existing', existingItem]]),
       itemTypeMap: new Map([['existing', 'calendar']]),
       itemCollectionMap: new Map([['existing', 'col-1']]),
@@ -721,7 +721,7 @@ describe('useEtebaseStore.reconcileCollections', () => {
     })
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -753,7 +753,7 @@ describe('useEtebaseStore.reconcileCollections', () => {
 
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [deletedCalendar] as any[], tasks: [taskCollection] as any[], contacts: [contactCollection] as any[], preferences: [] },
+      collections: { calendar: [deletedCalendar] as any[], tasks: [taskCollection] as any[], contacts: [contactCollection] as any[], preferences: [], labelIndex: [] },
       itemCache: new Map([['event-1', mockItem('event-1', 'deleted event')]]),
       itemTypeMap: new Map([['event-1', 'calendar']]),
       itemCollectionMap: new Map([['event-1', 'deleted-cal']]),
@@ -799,7 +799,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
     })
     useEtebaseStore.setState({
       account: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -823,7 +823,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
     coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [collection] as any[], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [collection] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       isInitialized: true,
     })
 
@@ -859,7 +859,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
     coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [], tasks: [collection] as any[], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [collection] as any[], contacts: [], preferences: [], labelIndex: [] },
       isInitialized: true,
     })
 
@@ -895,7 +895,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
     coreMock.updateCollectionMeta.mockResolvedValue(updatedCollection)
     useEtebaseStore.setState({
       account: account as any,
-      collections: { calendar: [], tasks: [], contacts: [collection] as any[], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [collection] as any[], preferences: [], labelIndex: [] },
       isInitialized: true,
     })
 
@@ -934,7 +934,7 @@ describe('useEtebaseStore.updateCollectionMeta', () => {
         calendar: type === 'calendar' ? [collection] as any[] : [],
         tasks: type === 'tasks' ? [collection] as any[] : [],
         contacts: type === 'contacts' ? [collection] as any[] : [],
-        preferences: [],
+        preferences: [], labelIndex: [],
       },
       isInitialized: true,
     })

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { secureGet } from '@/app/lib/secure-storage'
 import { useEtebaseStore } from '../use-etebase-store'
 import { useCalendarStore } from '../use-calendar-store'
 import { useCalendarListStore } from '../use-calendar-list-store'
@@ -18,6 +19,10 @@ const coreMock = vi.hoisted(() => ({
   createItem: vi.fn(),
   deleteItem: vi.fn(),
   updateCollectionMeta: vi.fn(),
+  restoreSession: vi.fn(),
+  getAccountFingerprint: vi.fn(),
+  listItems: vi.fn(),
+  SyncEngine: vi.fn(),
 }))
 
 const toastStoreMock = vi.hoisted(() => ({
@@ -49,6 +54,10 @@ beforeEach(() => {
   coreMock.createItem.mockReset()
   coreMock.deleteItem.mockReset()
   coreMock.updateCollectionMeta.mockReset()
+  coreMock.restoreSession.mockReset()
+  coreMock.getAccountFingerprint.mockReset()
+  coreMock.listItems.mockReset()
+  coreMock.SyncEngine.mockReset()
   toastStoreMock.showErrorToast.mockReset()
 })
 
@@ -112,6 +121,68 @@ function setupStoreWithCollections(itemManagerByUid: Record<string, MockItemMana
     syncEngine: syncEngine as any,
   })
 }
+
+describe('useEtebaseStore.initialize outcomes', () => {
+  beforeEach(() => {
+    vi.mocked(secureGet).mockReset().mockResolvedValue(null)
+    useEtebaseStore.setState({
+      account: null,
+      accountFingerprint: null,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('returns no-session without marking Etebase initialized', async () => {
+    vi.mocked(secureGet).mockResolvedValue(null)
+
+    const outcome = await useEtebaseStore.getState().initialize()
+
+    expect(outcome).toEqual({ status: 'no-session' })
+    expect(useEtebaseStore.getState().isInitialized).toBe(false)
+    expect(coreMock.restoreSession).not.toHaveBeenCalled()
+  })
+
+  it('returns success after restoring a saved session and loading collections', async () => {
+    vi.mocked(secureGet).mockResolvedValue('saved-session')
+    const account = { id: 'account' }
+    coreMock.restoreSession.mockResolvedValue(account)
+    coreMock.getAccountFingerprint.mockReturnValue('fingerprint')
+    coreMock.listCollections.mockImplementation(async (_account: unknown, type: string) => [mockCollection(`${type}-col`)])
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+    const engine = {
+      trackCollection: vi.fn(),
+      onStokenAdvance: vi.fn(),
+      start: vi.fn(async () => {}),
+      stop: vi.fn(),
+    }
+    coreMock.SyncEngine.mockImplementation(function MockSyncEngine() {
+      return engine
+    })
+
+    const outcome = await useEtebaseStore.getState().initialize()
+
+    expect(outcome).toEqual({ status: 'success', itemCount: 0 })
+    expect(useEtebaseStore.getState().isInitialized).toBe(true)
+    expect(useEtebaseStore.getState().accountFingerprint).toBe('fingerprint')
+    expect(engine.start).toHaveBeenCalledWith(account)
+  })
+
+  it('returns error without marking initialized on restore failure', async () => {
+    vi.mocked(secureGet).mockResolvedValue('saved-session')
+    coreMock.restoreSession.mockRejectedValue(new Error('bad session'))
+
+    const outcome = await useEtebaseStore.getState().initialize()
+
+    expect(outcome.status).toBe('error')
+    expect(useEtebaseStore.getState().isInitialized).toBe(false)
+    expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith('Failed to restore session. Please try signing in again.')
+  })
+})
 
 describe('useEtebaseStore.createItemsBatch', () => {
   beforeEach(() => {

--- a/apps/web/app/stores/__tests__/use-label-suggestions-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-label-suggestions-store.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createLabelIndex, serializeLabelIndex } from '@silentsuite/core'
+import { useEtebaseStore } from '../use-etebase-store'
+import { useLabelSuggestionsStore } from '../use-label-suggestions-store'
+
+vi.mock('@/app/lib/secure-storage', () => ({
+  secureGet: vi.fn(async () => null),
+  secureSet: vi.fn(async () => {}),
+  secureRemove: vi.fn(async () => {}),
+  secureClear: vi.fn(async () => {}),
+  migrateFromLocalStorage: vi.fn(async () => {}),
+}))
+
+vi.mock('@/app/stores/use-toast-store', () => ({
+  showErrorToast: vi.fn(),
+}))
+
+vi.mock('@/app/lib/offline-queue', () => ({
+  enqueue: vi.fn(async () => {}),
+  getAll: vi.fn(async () => []),
+  remove: vi.fn(async () => {}),
+  isOfflineError: vi.fn(() => false),
+}))
+
+function resetStores() {
+  useLabelSuggestionsStore.getState().destroy()
+  useEtebaseStore.setState({
+    account: null,
+    collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+    itemCache: new Map(),
+    itemTypeMap: new Map(),
+    itemCollectionMap: new Map(),
+    isInitialized: false,
+    syncEngine: null,
+  })
+}
+
+describe('useLabelSuggestionsStore', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    resetStores()
+  })
+
+  it('creates label index in a dedicated encrypted labelIndex collection', async () => {
+    const createItem = vi.fn(async () => 'label-index-1')
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [{ uid: 'label-col' }] as any[] },
+      isInitialized: true,
+      createItem: createItem as any,
+    })
+
+    await useLabelSuggestionsStore.getState().recordLabelsUsed(['Work'])
+    await useLabelSuggestionsStore.getState().syncLocalToRemote()
+
+    expect(createItem).toHaveBeenCalledTimes(1)
+    expect(createItem.mock.calls[0]?.[0]).toBe('labelIndex')
+    expect(createItem.mock.calls[0]?.[3]).toBe('label-col')
+    const content = createItem.mock.calls[0]?.[1] as string
+    expect(content).toContain('silentsuite.labelindex.v1')
+    expect(content).toContain('Work')
+    expect(useLabelSuggestionsStore.getState().remoteItemUid).toBe('label-index-1')
+  })
+
+  it('merges remote indexes idempotently and suggests by rank', async () => {
+    const updateItem = vi.fn(async () => {})
+    const remote = serializeLabelIndex(createLabelIndex([
+      { label: 'Work', count: 4, lastUsedAt: 10 },
+      { label: 'Home', count: 1, lastUsedAt: 9 },
+    ], 10))
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [{ uid: 'label-col' }] as any[] },
+      isInitialized: true,
+      fetchAllItems: vi.fn(async () => [{ uid: 'remote-1', content: remote, collectionUid: 'label-col' }]) as any,
+      updateItem: updateItem as any,
+    })
+
+    await useLabelSuggestionsStore.getState().recordLabelsUsed(['work', 'Urgent'])
+    await useLabelSuggestionsStore.getState().loadFromRemote()
+    await useLabelSuggestionsStore.getState().loadFromRemote()
+
+    expect(useLabelSuggestionsStore.getState().suggestionsFor('', [], 3)).toEqual(['Work', 'Urgent', 'Home'])
+    expect(useLabelSuggestionsStore.getState().index.labels.work.count).toBe(4)
+  })
+})

--- a/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
@@ -22,7 +22,7 @@ function resetStores() {
   usePreferencesStore.setState({ notificationSound: true })
   useEtebaseStore.setState({
     account: null,
-    collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+    collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
     itemCache: new Map(),
     itemTypeMap: new Map(),
     itemCollectionMap: new Map(),

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -77,6 +77,7 @@ function resetStore() {
   calendarStoreMock.syncFromRemote.mockReset()
   useSyncStore.setState({
     syncStatus: 'synced',
+    initialSyncState: 'synced',
     lastSyncedAt: null,
     isOnline: true,
     error: null,
@@ -111,6 +112,16 @@ describe('useSyncStore', () => {
 
     useSyncStore.getState().setError(null)
     expect(useSyncStore.getState().error).toBeNull()
+  })
+
+  it('tracks explicit initial sync state transitions', () => {
+    expect(useSyncStore.getState().initialSyncState).toBe('synced')
+
+    useSyncStore.getState().setInitialSyncState('restoring')
+    expect(useSyncStore.getState().initialSyncState).toBe('restoring')
+
+    useSyncStore.getState().setInitialSyncState('empty')
+    expect(useSyncStore.getState().initialSyncState).toBe('empty')
   })
 
   it('simulateSyncCycle transitions synced→syncing→synced', async () => {

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -80,6 +80,12 @@ type EtebaseCore = typeof import('@silentsuite/core')
 
 type CachedContentItem = { uid: string; content: string; collectionUid: string }
 
+export type EtebaseInitializeOutcome =
+  | { status: 'no-session' }
+  | { status: 'success'; itemCount: number }
+  | { status: 'offline'; error: unknown }
+  | { status: 'error'; error: unknown }
+
 const COLLECTION_DEFINITIONS: [CollectionTypeKey, string, string][] = [
   ['calendar', COLLECTION_TYPE_CALENDAR, 'Personal Calendar'],
   ['tasks', COLLECTION_TYPE_TASKS, 'Personal Tasks'],
@@ -344,7 +350,7 @@ interface EtebaseActions {
    * Restore Etebase session from localStorage, initialize collections,
    * load all items into data stores, and start the SyncEngine.
    */
-  initialize: () => Promise<void>
+  initialize: () => Promise<EtebaseInitializeOutcome>
 
   /**
    * Create an item in the given collection type.
@@ -493,7 +499,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const savedSession = await secureGet('etebase_session')
     if (!savedSession) {
       logger.debug('[etebase-store] No saved session, skipping initialization')
-      return
+      set({ isInitialized: false })
+      return { status: 'no-session' }
     }
 
     try {
@@ -584,14 +591,16 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       await engine.start(account)
       set({ syncEngine: engine, isInitialized: true })
       logger.debug('[etebase-store] SyncEngine started')
+      return { status: 'success', itemCount: itemCache.size }
     } catch (err) {
       console.error('[etebase-store] Initialization failed', getSafeErrorDetails(err))
       // Don't clear the session -- the user might be offline
       // They can retry on next page load
-      set({ isInitialized: true })
+      set({ isInitialized: false })
       if (!isOfflineError(err)) {
         showErrorToast('Failed to restore session. Please try signing in again.')
       }
+      return isOfflineError(err) ? { status: 'offline', error: err } : { status: 'error', error: err }
     }
   },
 
@@ -1359,8 +1368,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
         const collectionUid = itemCollectionMap.get(uid)
         if (collectionUid) results.push({ uid, content: contentStr, collectionUid })
-      } catch {
-        // Skip items that fail to decode
+      } catch (err) {
+        logger.warn(`[etebase-store] Failed to decode cached ${type} item`, getSafeErrorDetails(err))
       }
     }
 
@@ -1372,7 +1381,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const targetCollections = collectionUid
       ? [resolveCollection(collections, type, collectionUid)].filter(Boolean)
       : collections[type]
-    if (!account || targetCollections.length === 0) return []
+    if (!account || targetCollections.length === 0) {
+      logger.warn(`[etebase-store] Cannot refresh ${type}: missing account or collection`)
+      return get().fetchAllItems(type)
+    }
 
     try {
       const colManager = account.getCollectionManager()
@@ -1386,6 +1398,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         // Fetch ALL items (no stoken = full fetch)
         const itemManager = colManager.getItemManager(freshCollection)
         const collectionItems: { item: any; content: string }[] = []
+        let skippedDecodeCount = 0
 
         // Paginate through all items
         let stoken: string | undefined = undefined
@@ -1399,13 +1412,18 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
                 const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
                 collectionItems.push({ item, content: contentStr })
                 allResults.push({ uid: item.uid, content: contentStr, collectionUid: freshCollection.uid })
-              } catch {
-                // Skip items that fail to decode
+              } catch (err) {
+                skippedDecodeCount++
+                logger.warn(`[etebase-store] Failed to decode refreshed ${type} item`, getSafeErrorDetails(err))
               }
             }
           }
           stoken = response.stoken || undefined
           done = response.done
+        }
+
+        if (skippedDecodeCount > 0 && collectionItems.length === 0) {
+          throw new Error(`Refreshed ${type} collection contained only undecodable items`)
         }
 
         refreshed.push({ collection: freshCollection, items: collectionItems })

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -73,8 +73,9 @@ const COLLECTION_TYPE_CALENDAR = 'etebase.vevent'
 const COLLECTION_TYPE_TASKS = 'etebase.vtodo'
 const COLLECTION_TYPE_CONTACTS = 'etebase.vcard'
 const COLLECTION_TYPE_PREFERENCES = 'silentsuite.preferences'
+const COLLECTION_TYPE_LABEL_INDEX = 'silentsuite.labelindex'
 
-type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
+type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'labelIndex'
 type CollectionMetaUpdates = { name?: string; description?: string; color?: string }
 type EtebaseCore = typeof import('@silentsuite/core')
 
@@ -91,6 +92,7 @@ const COLLECTION_DEFINITIONS: [CollectionTypeKey, string, string][] = [
   ['tasks', COLLECTION_TYPE_TASKS, 'Personal Tasks'],
   ['contacts', COLLECTION_TYPE_CONTACTS, 'Personal Contacts'],
   ['preferences', COLLECTION_TYPE_PREFERENCES, 'Preferences'],
+  ['labelIndex', COLLECTION_TYPE_LABEL_INDEX, 'Label Suggestions'],
 ]
 
 function collectionTypeToKey(ct: string): CollectionTypeKey | null {
@@ -98,6 +100,7 @@ function collectionTypeToKey(ct: string): CollectionTypeKey | null {
   if (ct === COLLECTION_TYPE_TASKS) return 'tasks'
   if (ct === COLLECTION_TYPE_CONTACTS) return 'contacts'
   if (ct === COLLECTION_TYPE_PREFERENCES) return 'preferences'
+  if (ct === COLLECTION_TYPE_LABEL_INDEX) return 'labelIndex'
   return null
 }
 
@@ -105,6 +108,7 @@ function keyToCollectionType(type: CollectionTypeKey): string {
   if (type === 'calendar') return COLLECTION_TYPE_CALENDAR
   if (type === 'tasks') return COLLECTION_TYPE_TASKS
   if (type === 'contacts') return COLLECTION_TYPE_CONTACTS
+  if (type === 'labelIndex') return COLLECTION_TYPE_LABEL_INDEX
   return COLLECTION_TYPE_PREFERENCES
 }
 
@@ -117,6 +121,7 @@ async function ensureCollectionsForAccount(
     tasks: [],
     contacts: [],
     preferences: [],
+    labelIndex: [],
   }
 
   for (const [key, colType, defaultName] of COLLECTION_DEFINITIONS) {
@@ -242,7 +247,7 @@ async function hydrateListStores(collections: Record<CollectionTypeKey, any[]>):
 }
 
 async function removeItemsFromDomainStore(type: CollectionTypeKey, collectionUid: string, itemUids?: string[]): Promise<number> {
-  if (type === 'preferences') return 0
+  if (type === 'preferences' || type === 'labelIndex') return 0
 
   const itemUidSet = itemUids ? new Set(itemUids) : null
 
@@ -316,6 +321,7 @@ function collectionItemNoun(type: CollectionTypeKey): string {
   if (type === 'calendar') return 'events'
   if (type === 'tasks') return 'tasks'
   if (type === 'preferences') return 'preferences'
+  if (type === 'labelIndex') return 'label suggestions'
   return 'contacts'
 }
 
@@ -323,7 +329,25 @@ function collectionDisplayName(type: CollectionTypeKey): string {
   if (type === 'calendar') return 'calendar'
   if (type === 'tasks') return 'task list'
   if (type === 'contacts') return 'address book'
+  if (type === 'labelIndex') return 'label suggestions'
   return 'preferences'
+}
+
+async function recordLabelsFromContent(type: CollectionTypeKey, content: string): Promise<void> {
+  if (type !== 'calendar' && type !== 'tasks' && type !== 'contacts') return
+  try {
+    const core = await import('@silentsuite/core')
+    const labels = type === 'calendar'
+      ? core.deserializeCalendarEvent(content).categories
+      : type === 'tasks'
+        ? core.deserializeTask(content).categories
+        : core.deserializeContact(content).categories
+    if (!labels || labels.length === 0) return
+    const { useLabelSuggestionsStore } = await import('@/app/stores/use-label-suggestions-store')
+    await useLabelSuggestionsStore.getState().recordLabelsUsed(labels)
+  } catch (err) {
+    logger.warn(`[etebase-store] Failed to record ${type} label suggestions`, err)
+  }
 }
 
 interface EtebaseState {
@@ -488,7 +512,7 @@ interface EtebaseActions {
 export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) => ({
   account: null,
   accountFingerprint: null,
-  collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+  collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
   itemCache: new Map(),
   itemTypeMap: new Map(),
   itemCollectionMap: new Map(),
@@ -1076,6 +1100,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       set({ itemCache, itemTypeMap, itemCollectionMap })
       // Write through to the local persistence cache so a reload paints it.
       void writeItemToCache(type, collection.uid, item.uid, content)
+      void recordLabelsFromContent(type, content)
       return item.uid
     } catch (err) {
       if (isOfflineError(err)) {
@@ -1249,6 +1274,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       newCache.set(itemUid, updated)
       set({ itemCache: newCache })
       void writeItemToCache(type, collection.uid, itemUid, content)
+      void recordLabelsFromContent(type, content)
     } catch (err) {
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
@@ -1490,7 +1516,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     set({
       account: null,
       accountFingerprint: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),

--- a/apps/web/app/stores/use-label-suggestions-store.ts
+++ b/apps/web/app/stores/use-label-suggestions-store.ts
@@ -1,0 +1,177 @@
+'use client'
+
+import { create } from 'zustand'
+import {
+  createLabelIndex,
+  deserializeLabelIndex,
+  getLabelSuggestions,
+  mergeLabelIndexes,
+  recordLabelsUsed as recordLabelsUsedInIndex,
+  serializeLabelIndex,
+  type LabelIndexV1,
+} from '@silentsuite/core'
+import { enqueue } from '@/app/lib/offline-queue'
+import { logger } from '@/app/lib/logger'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+
+const LABEL_INDEX_TEMP_ID = 'silentsuite-label-index'
+const WRITE_DEBOUNCE_MS = 500
+
+interface RemoteLabelIndexItem {
+  uid: string
+  index: LabelIndexV1
+}
+
+interface LabelSuggestionsState {
+  index: LabelIndexV1
+  remoteItemUid: string | null
+  pendingCreateTempId: string | null
+  isInitialized: boolean
+  isApplyingRemote: boolean
+  writeTimer: ReturnType<typeof setTimeout> | null
+}
+
+interface LabelSuggestionsActions {
+  initialize: () => Promise<void>
+  loadFromRemote: (items?: { uid: string; content: string }[]) => Promise<void>
+  syncLocalToRemote: () => Promise<void>
+  scheduleUpload: () => void
+  recordLabelsUsed: (labels: string[]) => Promise<void>
+  suggestionsFor: (query?: string, excluded?: string[], limit?: number) => string[]
+  destroy: () => void
+}
+
+function parseRemoteItems(items: { uid: string; content: string }[]): RemoteLabelIndexItem[] {
+  const parsed: RemoteLabelIndexItem[] = []
+  for (const item of items) {
+    try {
+      parsed.push({ uid: item.uid, index: deserializeLabelIndex(item.content) })
+    } catch (err) {
+      logger.warn(`[label-suggestions] Ignoring invalid label-index item ${item.uid}`, err)
+    }
+  }
+  return parsed
+}
+
+function chooseCanonical(items: RemoteLabelIndexItem[]): RemoteLabelIndexItem | null {
+  if (items.length === 0) return null
+  return [...items].sort((a, b) => b.index.updatedAt - a.index.updatedAt)[0] ?? null
+}
+
+function labelIndexCollectionUid(): string | undefined {
+  return useEtebaseStore.getState().collections.labelIndex[0]?.uid
+}
+
+export const useLabelSuggestionsStore = create<LabelSuggestionsState & LabelSuggestionsActions>((set, get) => ({
+  index: createLabelIndex([], 0),
+  remoteItemUid: null,
+  pendingCreateTempId: null,
+  isInitialized: false,
+  isApplyingRemote: false,
+  writeTimer: null,
+
+  initialize: async () => {
+    if (get().isInitialized) return
+    if (!useEtebaseStore.getState().account) return
+    await get().loadFromRemote()
+    set({ isInitialized: true })
+  },
+
+  loadFromRemote: async (itemsFromRefresh) => {
+    const etebase = useEtebaseStore.getState()
+    if (!etebase.account) return
+
+    const items = itemsFromRefresh ?? await etebase.fetchAllItems('labelIndex')
+    const remoteItems = parseRemoteItems(items)
+    const canonical = chooseCanonical(remoteItems)
+
+    if (!canonical) {
+      await get().syncLocalToRemote()
+      return
+    }
+
+    const merged = mergeLabelIndexes([get().index, ...remoteItems.map((item) => item.index)])
+    set({ index: merged, remoteItemUid: canonical.uid, pendingCreateTempId: null })
+
+    const mergedContent = serializeLabelIndex(merged)
+    const canonicalContent = serializeLabelIndex(canonical.index)
+    if (remoteItems.length > 1 || mergedContent !== canonicalContent) {
+      await etebase.updateItem('labelIndex', canonical.uid, mergedContent)
+    }
+  },
+
+  syncLocalToRemote: async () => {
+    if (get().isApplyingRemote) return
+    const etebase = useEtebaseStore.getState()
+    if (!etebase.account) return
+
+    const content = serializeLabelIndex(get().index)
+    const remoteItemUid = get().remoteItemUid
+
+    if (remoteItemUid && etebase.itemCache.has(remoteItemUid)) {
+      await etebase.updateItem('labelIndex', remoteItemUid, content)
+      return
+    }
+
+    const existing = parseRemoteItems(await etebase.fetchAllItems('labelIndex'))
+    const canonical = chooseCanonical(existing)
+    if (canonical) {
+      const merged = mergeLabelIndexes([get().index, ...existing.map((item) => item.index)])
+      set({ index: merged, remoteItemUid: canonical.uid, pendingCreateTempId: null })
+      await etebase.updateItem('labelIndex', canonical.uid, serializeLabelIndex(merged))
+      return
+    }
+
+    const collectionUid = labelIndexCollectionUid()
+    const pendingCreateTempId = get().pendingCreateTempId
+    if (pendingCreateTempId && collectionUid) {
+      await enqueue({
+        type: 'create',
+        collectionType: 'labelIndex',
+        collectionUid,
+        content,
+        tempId: pendingCreateTempId,
+      })
+      return
+    }
+
+    const itemUid = await etebase.createItem('labelIndex', content, LABEL_INDEX_TEMP_ID, collectionUid)
+    if (itemUid) {
+      set({ remoteItemUid: itemUid, pendingCreateTempId: null })
+    } else if (typeof navigator !== 'undefined' && !navigator.onLine) {
+      set({ pendingCreateTempId: LABEL_INDEX_TEMP_ID })
+    }
+  },
+
+  scheduleUpload: () => {
+    const existingTimer = get().writeTimer
+    if (existingTimer) clearTimeout(existingTimer)
+    const writeTimer = setTimeout(() => {
+      set({ writeTimer: null })
+      void get().syncLocalToRemote()
+    }, WRITE_DEBOUNCE_MS)
+    set({ writeTimer })
+  },
+
+  recordLabelsUsed: async (labels) => {
+    if (labels.length === 0) return
+    const next = recordLabelsUsedInIndex(get().index, labels)
+    set({ index: next })
+    get().scheduleUpload()
+  },
+
+  suggestionsFor: (query = '', excluded = [], limit = 8) => getLabelSuggestions(get().index, query, limit, excluded),
+
+  destroy: () => {
+    const { writeTimer } = get()
+    if (writeTimer) clearTimeout(writeTimer)
+    set({
+      index: createLabelIndex([], 0),
+      remoteItemUid: null,
+      pendingCreateTempId: null,
+      isInitialized: false,
+      isApplyingRemote: false,
+      writeTimer: null,
+    })
+  },
+}))

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -7,8 +7,11 @@ import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
 
+export type InitialSyncState = 'idle' | 'restoring' | 'hydrated-cache' | 'syncing' | 'synced' | 'empty' | 'offline' | 'error' | 'no-session'
+
 interface SyncState {
   syncStatus: SyncStatus
+  initialSyncState: InitialSyncState
   lastSyncedAt: Date | null
   isOnline: boolean
   error: string | null
@@ -18,6 +21,7 @@ interface SyncState {
 
 interface SyncActions {
   setSyncStatus: (status: SyncStatus) => void
+  setInitialSyncState: (state: InitialSyncState) => void
   setLastSynced: (date: Date) => void
   setOnline: (online: boolean) => void
   setError: (error: string | null) => void
@@ -32,7 +36,8 @@ interface SyncActions {
 }
 
 export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
-  syncStatus: 'synced',
+  syncStatus: 'syncing',
+  initialSyncState: 'idle',
   lastSyncedAt: null,
   isOnline: typeof navigator !== 'undefined' ? navigator.onLine : true,
   error: null,
@@ -40,6 +45,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
   failedQueueCount: 0,
 
   setSyncStatus: (status) => set({ syncStatus: status }),
+  setInitialSyncState: (initialSyncState) => set({ initialSyncState }),
   setLastSynced: (date) => set({ lastSyncedAt: date }),
   setOnline: (online) => set({ isOnline: online }),
   setError: (error) => set({ error }),
@@ -258,7 +264,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       // Refresh counts to ensure UI is accurate after sync
       const pc = await getPendingCount()
       const fc = await getFailedCount()
-      set({ syncStatus: 'synced', lastSyncedAt: new Date(), error: null, pendingQueueCount: pc, failedQueueCount: fc })
+      set({ syncStatus: 'synced', initialSyncState: 'synced', lastSyncedAt: new Date(), error: null, pendingQueueCount: pc, failedQueueCount: fc })
     }).catch((err) => {
       console.error('[sync-store] Manual sync failed', getSafeErrorDetails(err))
       set({ syncStatus: 'error', error: 'Sync failed' })

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -38,6 +38,7 @@
     "editorAriaLabel": "Labels",
     "changeLabelColor": "Change label {label} color",
     "removeLabel": "Remove label {label}",
+    "suggestionsAriaLabel": "Label suggestions",
     "eventLabels": "Event labels",
     "taskLabels": "Task labels",
     "contactLabels": "Contact labels",

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -11,7 +11,7 @@ A privacy-focused, end-to-end encrypted sync service for calendar, contacts, and
 The v0.1.0-beta release covers:
 
 - **Web app** at [app.silentsuite.io](https://app.silentsuite.io) — calendar, contacts, tasks, import/export, settings, admin
-- **Android** — signed APK for sideloading (download via QR code in the app's *Settings → Mobile*)
+- **Android** — Google Play plus signed APK channels such as GitHub Releases, Zapstore, and F-Droid
 - **Desktop bridge** — CalDAV/CardDAV bridge for Thunderbird, Apple Calendar, Evolution, etc., on Linux / macOS / Windows
 - **Self-hosting** — two-container Docker stack (PostgreSQL + SilentSuite server)
 
@@ -22,7 +22,6 @@ See the [v0.1.0-beta release notes](https://github.com/silent-suite/silentsuite/
 On the roadmap, not yet shipped:
 
 - Native iOS app (the [EteSync iOS app](https://www.etesync.com/) works against your account in the meantime — same Etebase protocol)
-- Google Play / F-Droid listings (Android ships as a sideload APK)
 - OAuth-based one-click import from Google / iCloud
 - Push notifications
 - Multiple collections per account ([#88](https://github.com/silent-suite/silentsuite/issues/88))
@@ -68,13 +67,23 @@ No — an account belongs to a single server. Pick one when you sign up. To migr
 
 ## Apps & Devices
 
-### How do I get the Android APK?
+### How do I install the Android app?
 
-Sign in to [app.silentsuite.io](https://app.silentsuite.io) on a device with a screen, open *Settings → Mobile*, and either scan the QR code or use the direct download link to the latest GitHub Release.
+Use the same channel for install and updates:
 
-### Why is the Android app not on Google Play?
+- **Google Play** - recommended if you installed from Play and want Play-managed updates.
+- **GitHub Releases / Zapstore / F-Droid** - direct APK channels for sideloading and open app-store distribution. To get the direct APK, sign in to [app.silentsuite.io](https://app.silentsuite.io) on a device with a screen, open *Settings → Mobile*, and either scan the QR code or use the direct download link to the latest GitHub Release.
 
-Distribution channels (Google Play, F-Droid) are on the roadmap — see [#58](https://github.com/silent-suite/silentsuite-internal/issues/58) and [#59](https://github.com/silent-suite/silentsuite-internal/issues/59). For now it's a signed sideloadable APK.
+### Why do I see a certificate mismatch when switching Android install channels?
+
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+
+SilentSuite's known Android signing certificate SHA-256 hashes are:
+
+- **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
+- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+
+If you installed from Google Play, update through Google Play. If you installed from a direct APK channel, update through that same channel. Switching channels may require uninstalling and reinstalling the app. A mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 
 ### How does the desktop bridge work?
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -35,9 +35,19 @@ Open [app.silentsuite.io](https://app.silentsuite.io/login) on the second device
 
 ### Android
 
-In **Settings → Mobile** there's a QR code that links to the latest signed APK on GitHub Releases. Scan it from your phone or download manually. Sideload, open the app, log in. The Android app supports a custom server URL in advanced settings if you self-host.
+Install SilentSuite from the channel you want to keep using for updates:
 
-> Currently distributed as a sideloadable APK. Google Play and F-Droid listings are on the roadmap.
+- **Google Play** - use the Play listing if you installed from Play or want Play-managed updates.
+- **GitHub Releases / Zapstore / F-Droid** - use these direct APK channels if you prefer sideloading or open app-store distribution. In **Settings → Mobile** there is a QR code that links to the latest signed APK on GitHub Releases.
+
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching between Google Play and direct APK channels may require uninstalling and reinstalling the app.
+
+SilentSuite's known Android signing certificate SHA-256 hashes are:
+
+- **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
+- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+
+A certificate mismatch warning while switching install channels is expected and does not by itself indicate a compromised build. The Android app supports a custom server URL in advanced settings if you self-host.
 
 ### Desktop (CalDAV / CardDAV via the bridge)
 

--- a/packages/core/src/etebase/constants.ts
+++ b/packages/core/src/etebase/constants.ts
@@ -2,9 +2,11 @@ export const COLLECTION_TYPE_CALENDAR = 'etebase.vevent' as const;
 export const COLLECTION_TYPE_TASKS = 'etebase.vtodo' as const;
 export const COLLECTION_TYPE_CONTACTS = 'etebase.vcard' as const;
 export const COLLECTION_TYPE_PREFERENCES = 'silentsuite.preferences' as const;
+export const COLLECTION_TYPE_LABEL_INDEX = 'silentsuite.labelindex' as const;
 
 export type CollectionType =
   | typeof COLLECTION_TYPE_CALENDAR
   | typeof COLLECTION_TYPE_TASKS
   | typeof COLLECTION_TYPE_CONTACTS
-  | typeof COLLECTION_TYPE_PREFERENCES;
+  | typeof COLLECTION_TYPE_PREFERENCES
+  | typeof COLLECTION_TYPE_LABEL_INDEX;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export {
   COLLECTION_TYPE_TASKS,
   COLLECTION_TYPE_CONTACTS,
   COLLECTION_TYPE_PREFERENCES,
+  COLLECTION_TYPE_LABEL_INDEX,
 } from './etebase/constants.js';
 export type { CollectionType } from './etebase/constants.js';
 
@@ -128,6 +129,21 @@ export type {
   VersionedPreference,
   SyncedPreferencesV1,
 } from './models/preferences.js';
+
+// Synced encrypted label suggestion index
+export {
+  LABEL_INDEX_KIND,
+  createLabelIndex,
+  normalizeLabel,
+  normalizeLabelKey,
+  normalizeLabelIndex,
+  mergeLabelIndexes,
+  recordLabelsUsed,
+  getLabelSuggestions,
+  serializeLabelIndex,
+  deserializeLabelIndex,
+} from './models/label-index.js';
+export type { LabelIndexEntry, LabelIndexV1 } from './models/label-index.js';
 
 // iCal parser
 export {

--- a/packages/core/src/models/calendar-event.test.ts
+++ b/packages/core/src/models/calendar-event.test.ts
@@ -4,6 +4,8 @@ import {
   fromVEvent,
   serializeCalendarEvent,
   deserializeCalendarEvent,
+  buildAlarmTrigger,
+  parseAlarmTriggerMinutes,
 } from './calendar-event.js';
 import type { CalendarEvent } from './calendar-event.js';
 import { expandRecurrence } from '../utils/recurrence.js';
@@ -277,6 +279,15 @@ describe('recurring event', () => {
     expect(restored.allDay).toBe(true);
     expect(restored.recurrenceRule).toBe('FREQ=DAILY;COUNT=7');
     expect(restored.exceptions).toHaveLength(2);
+  });
+});
+
+// ── CalendarEvent with all fields populated ──
+
+describe('alarm trigger helpers', () => {
+  it('roundtrips custom minute offsets as simple negative-duration VALARMs', () => {
+    expect(parseAlarmTriggerMinutes('-PT11M')).toBe(11);
+    expect(buildAlarmTrigger(11)).toBe('-PT11M');
   });
 });
 

--- a/packages/core/src/models/label-index.test.ts
+++ b/packages/core/src/models/label-index.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createLabelIndex,
+  deserializeLabelIndex,
+  getLabelSuggestions,
+  mergeLabelIndexes,
+  recordLabelsUsed,
+  serializeLabelIndex,
+} from './label-index.js';
+
+describe('label index', () => {
+  it('normalizes, serializes, and deserializes labels by case-insensitive key', () => {
+    const index = createLabelIndex([
+      { label: ' Work ', count: 2, lastUsedAt: 10 },
+      { label: 'work', count: 5, lastUsedAt: 5 },
+      { label: 'Personal', count: 1, lastUsedAt: 20 },
+    ], 30);
+
+    const restored = deserializeLabelIndex(serializeLabelIndex(index));
+
+    expect(Object.keys(restored.labels)).toEqual(['work', 'personal']);
+    expect(restored.labels.work).toMatchObject({ label: 'Work', count: 5, lastUsedAt: 10 });
+    expect(restored.labels.personal).toMatchObject({ label: 'Personal', count: 1, lastUsedAt: 20 });
+  });
+
+  it('records label use without duplicating keys', () => {
+    const recorded = recordLabelsUsed(createLabelIndex([], 0), ['Work', ' work ', '', 'Home'], 100);
+
+    expect(recorded.labels.work).toMatchObject({ label: 'work', count: 2, lastUsedAt: 100 });
+    expect(recorded.labels.home).toMatchObject({ label: 'Home', count: 1, lastUsedAt: 100 });
+  });
+
+  it('merges idempotently with union/max/last-used semantics', () => {
+    const first = createLabelIndex([
+      { label: 'Work', count: 4, lastUsedAt: 10 },
+      { label: 'Home', count: 1, lastUsedAt: 5 },
+    ], 10);
+    const second = createLabelIndex([
+      { label: 'work', count: 2, lastUsedAt: 20 },
+      { label: 'Urgent', count: 3, lastUsedAt: 15 },
+    ], 20);
+
+    const once = mergeLabelIndexes([first, second]);
+    const twice = mergeLabelIndexes([once, first, second]);
+
+    expect(twice.labels.work).toMatchObject({ label: 'Work', count: 4, lastUsedAt: 20 });
+    expect(twice.labels.home).toMatchObject({ label: 'Home', count: 1, lastUsedAt: 5 });
+    expect(twice.labels.urgent).toMatchObject({ label: 'Urgent', count: 3, lastUsedAt: 15 });
+    expect(twice).toEqual(once);
+  });
+
+  it('ranks suggestions by count, recency, and excludes selected labels', () => {
+    const index = createLabelIndex([
+      { label: 'Work', count: 2, lastUsedAt: 10 },
+      { label: 'Workout', count: 5, lastUsedAt: 2 },
+      { label: 'Personal', count: 10, lastUsedAt: 20 },
+    ], 20);
+
+    expect(getLabelSuggestions(index, 'wor', 5, ['Workout'])).toEqual(['Work']);
+    expect(getLabelSuggestions(index, '', 2)).toEqual(['Personal', 'Workout']);
+  });
+
+  it('rejects documents with a different explicit kind', () => {
+    expect(() => deserializeLabelIndex(JSON.stringify({ kind: 'silentsuite.preferences.v1' }))).toThrow(/kind/);
+  });
+});

--- a/packages/core/src/models/label-index.ts
+++ b/packages/core/src/models/label-index.ts
@@ -1,0 +1,140 @@
+export const LABEL_INDEX_KIND = 'silentsuite.labelindex.v1';
+
+export interface LabelIndexEntry {
+  label: string;
+  count: number;
+  lastUsedAt: number;
+}
+
+export interface LabelIndexV1 {
+  kind: typeof LABEL_INDEX_KIND;
+  schemaVersion: 1;
+  updatedAt: number;
+  labels: Record<string, LabelIndexEntry>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function timestamp(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function count(value: unknown, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+export function normalizeLabel(label: string): string {
+  return label.trim().replace(/\s+/g, ' ');
+}
+
+export function normalizeLabelKey(label: string): string {
+  return normalizeLabel(label).toLocaleLowerCase();
+}
+
+export function createLabelIndex(entries: LabelIndexEntry[] = [], now = Date.now()): LabelIndexV1 {
+  const index: LabelIndexV1 = {
+    kind: LABEL_INDEX_KIND,
+    schemaVersion: 1,
+    updatedAt: 0,
+    labels: {},
+  };
+  for (const entry of entries) {
+    const label = normalizeLabel(entry.label);
+    if (!label) continue;
+    const key = normalizeLabelKey(label);
+    const lastUsedAt = timestamp(entry.lastUsedAt, now);
+    const existing = index.labels[key];
+    index.labels[key] = {
+      label: existing?.lastUsedAt && existing.lastUsedAt > lastUsedAt ? existing.label : label,
+      count: Math.max(existing?.count ?? 0, count(entry.count)),
+      lastUsedAt: Math.max(existing?.lastUsedAt ?? 0, lastUsedAt),
+    };
+  }
+  index.updatedAt = Math.max(now, ...Object.values(index.labels).map((entry) => entry.lastUsedAt), 0);
+  return index;
+}
+
+export function normalizeLabelIndex(input: unknown): LabelIndexV1 {
+  const root = isRecord(input) ? input : {};
+  if ('kind' in root && root.kind !== LABEL_INDEX_KIND) {
+    throw new Error('Invalid label index kind');
+  }
+  const labels = isRecord(root.labels) ? root.labels : {};
+  const entries: LabelIndexEntry[] = [];
+  for (const value of Object.values(labels)) {
+    if (!isRecord(value) || typeof value.label !== 'string') continue;
+    const label = normalizeLabel(value.label);
+    if (!label) continue;
+    entries.push({
+      label,
+      count: count(value.count, 0),
+      lastUsedAt: timestamp(value.lastUsedAt, timestamp(root.updatedAt, 0)),
+    });
+  }
+  const normalized = createLabelIndex(entries, timestamp(root.updatedAt, 0));
+  normalized.updatedAt = Math.max(timestamp(root.updatedAt, 0), ...Object.values(normalized.labels).map((entry) => entry.lastUsedAt), 0);
+  return normalized;
+}
+
+export function mergeLabelIndexes(indexes: LabelIndexV1[]): LabelIndexV1 {
+  const merged = createLabelIndex([], 0);
+  for (const index of indexes) {
+    const normalized = normalizeLabelIndex(index);
+    for (const [key, incoming] of Object.entries(normalized.labels)) {
+      const existing = merged.labels[key];
+      const shouldUseIncomingLabel = !existing
+        || incoming.count > existing.count
+        || (incoming.count === existing.count && incoming.lastUsedAt >= existing.lastUsedAt);
+      merged.labels[key] = {
+        label: shouldUseIncomingLabel ? incoming.label : existing.label,
+        // Counts are approximate ranking signals. Use max rather than summing so
+        // repeated cold-start merges are idempotent.
+        count: Math.max(existing?.count ?? 0, incoming.count),
+        lastUsedAt: Math.max(existing?.lastUsedAt ?? 0, incoming.lastUsedAt),
+      };
+    }
+    merged.updatedAt = Math.max(merged.updatedAt, normalized.updatedAt);
+  }
+  merged.updatedAt = Math.max(merged.updatedAt, ...Object.values(merged.labels).map((entry) => entry.lastUsedAt), 0);
+  return merged;
+}
+
+export function recordLabelsUsed(index: LabelIndexV1, labels: string[], now = Date.now()): LabelIndexV1 {
+  const next = mergeLabelIndexes([index]);
+  for (const raw of labels) {
+    const label = normalizeLabel(raw);
+    if (!label) continue;
+    const key = normalizeLabelKey(label);
+    const existing = next.labels[key];
+    next.labels[key] = {
+      label,
+      count: (existing?.count ?? 0) + 1,
+      lastUsedAt: Math.max(existing?.lastUsedAt ?? 0, now),
+    };
+  }
+  next.updatedAt = Math.max(next.updatedAt, now);
+  return next;
+}
+
+export function getLabelSuggestions(index: LabelIndexV1, query = '', limit = 8, excluded: string[] = []): string[] {
+  const normalized = normalizeLabelIndex(index);
+  const q = normalizeLabelKey(query);
+  const excludedKeys = new Set(excluded.map(normalizeLabelKey));
+  return Object.entries(normalized.labels)
+    .filter(([key]) => !excludedKeys.has(key) && (!q || key.includes(q)))
+    .sort(([, a], [, b]) => (b.count - a.count) || (b.lastUsedAt - a.lastUsedAt) || a.label.localeCompare(b.label))
+    .slice(0, limit)
+    .map(([, entry]) => entry.label);
+}
+
+export function serializeLabelIndex(index: LabelIndexV1): string {
+  return JSON.stringify(normalizeLabelIndex(index));
+}
+
+export function deserializeLabelIndex(content: string): LabelIndexV1 {
+  return normalizeLabelIndex(JSON.parse(content) as unknown);
+}

--- a/packages/core/src/models/preferences.test.ts
+++ b/packages/core/src/models/preferences.test.ts
@@ -6,6 +6,7 @@ import {
   mergeSyncedPreferences,
   serializePreferences,
 } from './preferences.js';
+import { createLabelIndex, serializeLabelIndex } from './label-index.js';
 
 describe('synced preferences', () => {
   it('serializes only synced account preferences', () => {
@@ -64,6 +65,14 @@ describe('synced preferences', () => {
       dayStartHour: 7,
       dayEndHour: 23,
     });
+  });
+
+  it('rejects label-index content instead of treating it as preferences', () => {
+    const labelIndexContent = serializeLabelIndex(createLabelIndex([
+      { label: 'Work', count: 1, lastUsedAt: 1 },
+    ], 1));
+
+    expect(() => deserializePreferences(labelIndexContent)).toThrow(/preferences kind/);
   });
 
   it.each(['DD/MM/YYYY', 'MM/DD/YYYY', 'DD.MM.YYYY', 'YYYY/MM/DD', 'YYYY-MM-DD', 'system'] as const)(

--- a/packages/core/src/models/preferences.test.ts
+++ b/packages/core/src/models/preferences.test.ts
@@ -66,6 +66,14 @@ describe('synced preferences', () => {
     });
   });
 
+  it.each(['DD/MM/YYYY', 'MM/DD/YYYY', 'DD.MM.YYYY', 'YYYY/MM/DD', 'YYYY-MM-DD', 'system'] as const)(
+    'accepts %s as a synced date format',
+    (dateFormat) => {
+      const preferences = createSyncedPreferences({ dateFormat }, {}, 42);
+
+      expect(getSyncedPreferenceValues(preferences).dateFormat).toBe(dateFormat);
+    },
+  );
 
   it('accepts valid day bounds and falls back when start is not before end', () => {
     const valid = createSyncedPreferences({ dayStartHour: 7, dayEndHour: 19 }, {}, 42);

--- a/packages/core/src/models/preferences.ts
+++ b/packages/core/src/models/preferences.ts
@@ -12,7 +12,7 @@ export type SyncedPreferenceKey = typeof SYNCED_PREFERENCE_KEYS[number];
 export type TimeFormat = '12h' | '24h';
 export type FirstDayOfWeek = 'monday' | 'sunday';
 export type DefaultReminder = 'none' | '5' | '15' | '30' | '60' | '1440';
-export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'YYYY-MM-DD' | 'system'
+export type DateFormat = 'DD/MM/YYYY' | 'MM/DD/YYYY' | 'DD.MM.YYYY' | 'YYYY/MM/DD' | 'YYYY-MM-DD' | 'system'
 export type DayBoundaryHour = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24;
 
 export interface SyncedPreferenceValues {
@@ -93,7 +93,14 @@ function defaultTimezone(value: unknown, fallback: string): string {
 }
 
 function dateFormat(value: unknown, fallback: DateFormat): DateFormat {
-  return value === 'DD/MM/YYYY' || value === 'MM/DD/YYYY' || value === 'YYYY-MM-DD' || value === 'system' ? value : fallback
+  return value === 'DD/MM/YYYY'
+    || value === 'MM/DD/YYYY'
+    || value === 'DD.MM.YYYY'
+    || value === 'YYYY/MM/DD'
+    || value === 'YYYY-MM-DD'
+    || value === 'system'
+    ? value
+    : fallback
 }
 
 function dayBoundaryHour(value: unknown, fallback: DayBoundaryHour): DayBoundaryHour {

--- a/packages/core/src/models/preferences.ts
+++ b/packages/core/src/models/preferences.ts
@@ -1,3 +1,5 @@
+export const PREFERENCES_KIND = 'silentsuite.preferences.v1';
+
 export const SYNCED_PREFERENCE_KEYS = [
   'timeFormat',
   'firstDayOfWeek',
@@ -31,6 +33,7 @@ export interface VersionedPreference<T> {
 }
 
 export interface SyncedPreferencesV1 {
+  kind: typeof PREFERENCES_KIND;
   schemaVersion: 1;
   updatedAt: number;
   fields: {
@@ -150,6 +153,7 @@ export function createSyncedPreferences(
   const updatedAt = Math.max(...SYNCED_PREFERENCE_KEYS.map((key) => normalizedTimestamps[key]));
 
   return {
+    kind: PREFERENCES_KIND,
     schemaVersion: 1,
     updatedAt,
     fields: {
@@ -166,6 +170,9 @@ export function createSyncedPreferences(
 
 export function normalizeSyncedPreferences(input: unknown): SyncedPreferencesV1 {
   const root = isRecord(input) ? input : {};
+  if ('kind' in root && root.kind !== PREFERENCES_KIND) {
+    throw new Error('Invalid preferences kind');
+  }
   const fields = isRecord(root.fields) ? root.fields : {};
   const rootUpdatedAt = timestamp(root.updatedAt, 0);
 


### PR DESCRIPTION
## Summary
- Promote current `dev` into `main`.
- Includes web signup/contact-email recovery, startup sync empty-state safeguards, encrypted label suggestions, calendar date/reminder polish, billing recovery UI, pay-now payment flow simplification, and Android signing documentation updates.

## Verification
- `dev` CI passed at `3c101686ae2cbfab1b52110d63adc6affa1a9378`.
- Preview deployment for `dev` completed successfully.
- Promotion merge dry-run from `main` was clean.
- Promotion review completed against `origin/main...origin/dev`.
