### PR TITLE
Promote dev to main

### DIFF
--- a/apps/web/app/(app)/calendar/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/calendar/__tests__/page.test.tsx
@@ -285,6 +285,16 @@ describe('CalendarPage mobile reachability', () => {
     expect(screen.queryByTestId('mobile-agenda')).not.toBeInTheDocument()
   })
 
+  it('does not render the calendar as empty when the encrypted session is missing', () => {
+    storeMock.calendarState.isLoading = false
+    storeMock.syncState.initialSyncState = 'no-session'
+
+    renderWithIntl(<CalendarPage />)
+
+    expect(screen.getByText('Encrypted session needs to be restored')).toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-agenda')).not.toBeInTheDocument()
+  })
+
   it('exposes a mobile collection switcher with a 44px touch target', () => {
     renderWithIntl(<CalendarPage />)
 

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -199,7 +199,7 @@ export default function CalendarPage() {
     () => events.filter((event) => visibleCalendarIds.has(event.calendarId ?? 'default')),
     [events, visibleCalendarIds],
   )
-  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty'
   const shouldShowStartupState = !isLoading && visibleEvents.length === 0 && !initialLoadComplete
 
   // Search

--- a/apps/web/app/(app)/contacts/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/contacts/__tests__/page.test.tsx
@@ -94,6 +94,16 @@ describe('ContactsPage mobile reachability', () => {
     expect(screen.queryByText('No contacts yet')).not.toBeInTheDocument()
   })
 
+  it('does not show an empty contact state when the encrypted session is missing', () => {
+    storeMock.contactState.isLoading = false
+    storeMock.syncState.initialSyncState = 'no-session'
+
+    renderWithIntl(<ContactsPage />)
+
+    expect(screen.getByText('Encrypted session needs to be restored')).toBeInTheDocument()
+    expect(screen.queryByText('No contacts yet')).not.toBeInTheDocument()
+  })
+
   it('exposes a mobile collection switcher with a 44px touch target', () => {
     renderWithIntl(<ContactsPage />)
     const folderButton = screen.getByRole('button', { name: manageAddressBooks })

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -1104,7 +1104,7 @@ export default function ContactsPage() {
     [contacts, selectedId],
   )
 
-  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty'
   const shouldShowStartupState = listFilteredContacts.length === 0 && !isLoading && !initialLoadComplete
   const isEmpty = listFilteredContacts.length === 0 && !isLoading && initialLoadComplete
   const isEmptySearch = filtered.length === 0 && searchQuery.trim() !== '' && !isLoading && initialLoadComplete

--- a/apps/web/app/(app)/tasks/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/tasks/__tests__/page.test.tsx
@@ -95,6 +95,16 @@ describe('TasksPage mobile reachability', () => {
     expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument()
   })
 
+  it('does not show an empty task state when the encrypted session is missing', () => {
+    storeMock.taskState.isLoading = false
+    storeMock.syncState.initialSyncState = 'no-session'
+
+    renderWithIntl(<TasksPage />)
+
+    expect(screen.getByText('Encrypted session needs to be restored')).toBeInTheDocument()
+    expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument()
+  })
+
   it('exposes a mobile collection switcher with a 44px touch target', () => {
     renderWithIntl(<TasksPage />)
     const folderButton = screen.getByRole('button', { name: manageTaskLists })

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -862,7 +862,7 @@ export default function TasksPage() {
     [tasks, visibleListIds],
   )
   const sortedTasks = useMemo(() => sortTasks(filteredTasks), [filteredTasks])
-  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty' || initialSyncState === 'no-session'
+  const initialLoadComplete = initialSyncState === 'synced' || initialSyncState === 'empty'
   const shouldShowStartupState = tasks.length === 0 && !isLoading && !initialLoadComplete
   const isEmpty = tasks.length === 0 && !isLoading && initialLoadComplete
 

--- a/apps/web/app/components/LabelEditor.tsx
+++ b/apps/web/app/components/LabelEditor.tsx
@@ -139,6 +139,7 @@ export function LabelEditor({
 }) {
   const t = useTranslations('Labels')
   const [input, setInput] = useState('')
+  const [isSuggestionOpen, setSuggestionOpen] = useState(false)
   const [activeSuggestion, setActiveSuggestion] = useState(0)
   const labelIndex = useLabelSuggestionsStore((state) => state.index)
   const suggestions = useMemo(
@@ -152,6 +153,7 @@ export function LabelEditor({
       if (next.length !== labels.length) onChange(next)
       setInput('')
       setActiveSuggestion(0)
+      setSuggestionOpen(false)
     },
     [labels, onChange],
   )
@@ -179,6 +181,7 @@ export function LabelEditor({
       } else if (e.key === 'Escape') {
         setInput('')
         setActiveSuggestion(0)
+        setSuggestionOpen(false)
       } else if (e.key === 'Backspace' && !input && labels.length > 0) {
         // Quick-delete the last chip when the input is empty
         remove(labels[labels.length - 1]!)
@@ -186,6 +189,8 @@ export function LabelEditor({
     },
     [input, labels, commit, remove, suggestions, activeSuggestion],
   )
+
+  const showSuggestions = !disabled && isSuggestionOpen && suggestions.length > 0
 
   return (
     <div className="relative flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">
@@ -206,17 +211,22 @@ export function LabelEditor({
           onChange={(e) => {
             setInput(e.target.value)
             setActiveSuggestion(0)
+            setSuggestionOpen(true)
           }}
           onKeyDown={handleKeyDown}
-          onBlur={() => input.trim() && commit(input)}
+          onFocus={() => setSuggestionOpen(true)}
+          onBlur={() => {
+            if (input.trim()) commit(input)
+            else setSuggestionOpen(false)
+          }}
           placeholder={labels.length === 0 ? (placeholder ?? t('addLabelPlaceholder')) : ''}
           aria-label={ariaLabel ?? t('editorAriaLabel')}
           aria-autocomplete="list"
-          aria-expanded={suggestions.length > 0}
+          aria-expanded={showSuggestions}
           className="min-w-[6rem] flex-1 bg-transparent text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none"
         />
       )}
-      {!disabled && suggestions.length > 0 && (
+      {showSuggestions && (
         <div
           role="listbox"
           aria-label={t('suggestionsAriaLabel')}

--- a/apps/web/app/components/__tests__/LabelEditor.test.tsx
+++ b/apps/web/app/components/__tests__/LabelEditor.test.tsx
@@ -160,6 +160,55 @@ describe('LabelEditor', () => {
     expect(onChange).toHaveBeenCalledWith(['Workout'])
   })
 
+  it('opens recent suggestions on focus even before typing', () => {
+    useLabelSuggestionsStore.setState({
+      index: createLabelIndex([
+        { label: 'Work', count: 5, lastUsedAt: 10 },
+        { label: 'Home', count: 3, lastUsedAt: 9 },
+      ], 10),
+    })
+    renderWithIntl(<LabelEditor labels={[]} onChange={vi.fn()} />)
+
+    expect(screen.queryByRole('listbox', { name: 'Label suggestions' })).not.toBeInTheDocument()
+
+    fireEvent.focus(screen.getByLabelText('Labels'))
+
+    expect(screen.getByRole('option', { name: 'Work' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Home' })).toBeInTheDocument()
+  })
+
+  it('filters focused suggestions as the user types', () => {
+    useLabelSuggestionsStore.setState({
+      index: createLabelIndex([
+        { label: 'Work', count: 5, lastUsedAt: 10 },
+        { label: 'Home', count: 3, lastUsedAt: 9 },
+      ], 10),
+    })
+    renderWithIntl(<LabelEditor labels={[]} onChange={vi.fn()} />)
+    const input = screen.getByLabelText('Labels')
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'ho' } })
+
+    expect(screen.queryByRole('option', { name: 'Work' })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Home' })).toBeInTheDocument()
+  })
+
+  it('selects a focused suggestion by click', () => {
+    useLabelSuggestionsStore.setState({
+      index: createLabelIndex([
+        { label: 'Home', count: 3, lastUsedAt: 9 },
+      ], 10),
+    })
+    const onChange = vi.fn()
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} />)
+
+    fireEvent.focus(screen.getByLabelText('Labels'))
+    fireEvent.mouseDown(screen.getByRole('option', { name: 'Home' }))
+
+    expect(onChange).toHaveBeenCalledWith(['Home'])
+  })
+
   it('does not suggest labels that are already selected', () => {
     useLabelSuggestionsStore.setState({
       index: createLabelIndex([
@@ -169,6 +218,7 @@ describe('LabelEditor', () => {
     })
 
     renderWithIntl(<LabelEditor labels={['Work']} onChange={vi.fn()} />)
+    fireEvent.focus(screen.getByLabelText('Labels'))
     expect(screen.queryByRole('option', { name: 'Work' })).not.toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Home' })).toBeInTheDocument()
   })

--- a/apps/web/app/components/empty-state.tsx
+++ b/apps/web/app/components/empty-state.tsx
@@ -101,6 +101,16 @@ export function SyncStartupState({ state, error }: { state: SyncStartupStatus; e
     )
   }
 
+  if (state === 'no-session') {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title="Encrypted session needs to be restored"
+        description="You are signed in, but this browser has not restored the encrypted vault session yet. Sign in again to unlock your data instead of showing an empty workspace."
+      />
+    )
+  }
+
   return (
     <EmptyState
       icon={RefreshCw}

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -175,8 +175,8 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
         if (initOutcome.status === 'no-session') {
           setInitialSyncState('no-session')
-          setSyncStatus('synced')
-          setError(null)
+          setSyncStatus('error')
+          setError('Encrypted session was not restored. Sign in again to unlock your data.')
           return
         }
 

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -172,6 +172,50 @@ describe('useEtebaseStore.initialize outcomes', () => {
     expect(engine.start).toHaveBeenCalledWith(account)
   })
 
+  it('restores remote collections and items into cold-start caches and list stores', async () => {
+    vi.mocked(secureGet).mockResolvedValue('saved-session')
+    const account = { id: 'account' }
+    const calendarCollection = mockCollection('calendar-col', { name: 'Personal', color: '#10b981' })
+    const taskCollection = mockCollection('tasks-col', { name: 'Tasks', color: '#3b82f6' })
+    const contactCollection = mockCollection('contacts-col', { name: 'Contacts', color: '#8b5cf6' })
+    const preferencesCollection = mockCollection('preferences-col')
+    const labelIndexCollection = mockCollection('label-index-col')
+    coreMock.restoreSession.mockResolvedValue(account)
+    coreMock.getAccountFingerprint.mockReturnValue('fingerprint')
+    coreMock.listCollections.mockImplementation(async (_account: unknown, type: string) => {
+      if (type === 'etebase.vevent') return [calendarCollection]
+      if (type === 'etebase.vtodo') return [taskCollection]
+      if (type === 'etebase.vcard') return [contactCollection]
+      if (type === 'silentsuite.preferences') return [preferencesCollection]
+      if (type === 'silentsuite.labelindex') return [labelIndexCollection]
+      return []
+    })
+    coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => ({
+      items: collection.uid === 'calendar-col' ? [mockItem('event-1', 'VEVENT')] : [],
+      stoken: null,
+      done: true,
+    }))
+    const engine = {
+      trackCollection: vi.fn(),
+      onStokenAdvance: vi.fn(),
+      start: vi.fn(async () => {}),
+      stop: vi.fn(),
+    }
+    coreMock.SyncEngine.mockImplementation(function MockSyncEngine() {
+      return engine
+    })
+
+    const outcome = await useEtebaseStore.getState().initialize()
+
+    expect(outcome).toEqual({ status: 'success', itemCount: 1 })
+    expect(useEtebaseStore.getState().itemCache.has('event-1')).toBe(true)
+    expect(useEtebaseStore.getState().itemTypeMap.get('event-1')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('event-1')).toBe('calendar-col')
+    expect(useCalendarListStore.getState().calendars.map((calendar) => calendar.id)).toEqual(['calendar-col'])
+    expect(useTaskListStore.getState().lists.map((list) => list.id)).toEqual(['tasks-col'])
+    expect(useContactListStore.getState().lists.map((list) => list.id)).toEqual(['contacts-col'])
+  })
+
   it('returns error without marking initialized on restore failure', async () => {
     vi.mocked(secureGet).mockResolvedValue('saved-session')
     coreMock.restoreSession.mockRejectedValue(new Error('bad session'))
@@ -692,6 +736,26 @@ describe('useEtebaseStore.refreshCollection', () => {
     expect(state.itemCache.get('existing')).toBe(existingItem)
     expect(state.itemCollectionMap.get('existing')).toBe('col-1')
     errorSpy.mockRestore()
+  })
+
+  it('throws when cached item content cannot be decoded instead of returning a false empty list', async () => {
+    const brokenItem = {
+      uid: 'broken-1',
+      getContent: vi.fn(async () => {
+        throw new Error('decode failed')
+      }),
+    }
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+      itemCache: new Map([['broken-1', brokenItem]]),
+      itemTypeMap: new Map([['broken-1', 'calendar']]),
+      itemCollectionMap: new Map([['broken-1', 'col-1']]),
+      isInitialized: true,
+      syncEngine: null,
+    })
+
+    await expect(useEtebaseStore.getState().fetchAllItems('calendar')).rejects.toThrow('Could not decode cached events')
   })
 })
 

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -1386,17 +1386,25 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   fetchAllItems: async (type: CollectionTypeKey) => {
     const { itemCache, itemTypeMap, itemCollectionMap } = get()
     const results: CachedContentItem[] = []
+    let matchingItemCount = 0
+    let failedDecodeCount = 0
 
     for (const [uid, item] of itemCache.entries()) {
       if (itemTypeMap.get(uid) !== type) continue
+      matchingItemCount++
       try {
         const content = await item.getContent()
         const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
         const collectionUid = itemCollectionMap.get(uid)
         if (collectionUid) results.push({ uid, content: contentStr, collectionUid })
       } catch (err) {
+        failedDecodeCount++
         logger.warn(`[etebase-store] Failed to decode cached ${type} item`, getSafeErrorDetails(err))
       }
+    }
+
+    if (failedDecodeCount > 0) {
+      throw new Error(`Could not decode cached ${collectionItemNoun(type)} (${failedDecodeCount}/${matchingItemCount} failed)`)
     }
 
     return results


### PR DESCRIPTION
## Summary
- Promote the latest `dev` web restore and label suggestions fixes to production.
- Includes the post-dev QA-verified cold-start encrypted restore guard and label suggestion UX updates.

## Validation
- `dev` CI passed for 712b208d0413bb20d52d592943fa60b113c95aef.
- `dev` preview deployment passed for 712b208d0413bb20d52d592943fa60b113c95aef.
- Browser QA on the deployed preview passed with restart/restore and label-suggestion screenshots.
- Known CSP/libsodium console follow-up remains tracked separately in #44.
