### PR TITLE
fix(web): ignore hidden label suggestions on keyboard input

### DIFF
--- a/apps/web/app/components/LabelEditor.tsx
+++ b/apps/web/app/components/LabelEditor.tsx
@@ -165,17 +165,19 @@ export function LabelEditor({
     [labels, onChange],
   )
 
+  const showSuggestions = !disabled && isSuggestionOpen && suggestions.length > 0
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === 'Enter' || e.key === ',') {
         e.preventDefault()
-        if (suggestions.length > 0 && (e.key === 'Enter' || !input.trim())) {
+        if (showSuggestions && (e.key === 'Enter' || !input.trim())) {
           commit(suggestions[activeSuggestion] ?? suggestions[0]!)
         } else if (input.trim()) commit(input)
-      } else if (e.key === 'ArrowDown' && suggestions.length > 0) {
+      } else if (e.key === 'ArrowDown' && showSuggestions) {
         e.preventDefault()
         setActiveSuggestion((current) => (current + 1) % suggestions.length)
-      } else if (e.key === 'ArrowUp' && suggestions.length > 0) {
+      } else if (e.key === 'ArrowUp' && showSuggestions) {
         e.preventDefault()
         setActiveSuggestion((current) => (current - 1 + suggestions.length) % suggestions.length)
       } else if (e.key === 'Escape') {
@@ -187,10 +189,8 @@ export function LabelEditor({
         remove(labels[labels.length - 1]!)
       }
     },
-    [input, labels, commit, remove, suggestions, activeSuggestion],
+    [input, labels, commit, remove, suggestions, activeSuggestion, showSuggestions],
   )
-
-  const showSuggestions = !disabled && isSuggestionOpen && suggestions.length > 0
 
   return (
     <div className="relative flex flex-1 flex-wrap items-center gap-1.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-2 py-1.5 focus-within:ring-2 focus-within:ring-emerald-500">

--- a/apps/web/app/components/__tests__/LabelEditor.test.tsx
+++ b/apps/web/app/components/__tests__/LabelEditor.test.tsx
@@ -222,4 +222,24 @@ describe('LabelEditor', () => {
     expect(screen.queryByRole('option', { name: 'Work' })).not.toBeInTheDocument()
     expect(screen.getByRole('option', { name: 'Home' })).toBeInTheDocument()
   })
+
+  it('does not commit hidden suggestions after Escape closes the listbox', () => {
+    useLabelSuggestionsStore.setState({
+      index: createLabelIndex([
+        { label: 'Work', count: 5, lastUsedAt: 10 },
+      ], 10),
+    })
+    const onChange = vi.fn()
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} />)
+    const input = screen.getByLabelText('Labels')
+
+    fireEvent.focus(input)
+    expect(screen.getByRole('option', { name: 'Work' })).toBeInTheDocument()
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByRole('listbox', { name: 'Label suggestions' })).not.toBeInTheDocument()
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onChange).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- Prevent hidden label suggestions from being committed after Escape closes the suggestion list.
- Keep ArrowUp/ArrowDown navigation scoped to the visible suggestions list.
- Add regression coverage for Escape followed by Enter.

## Test Plan
- `pnpm --filter @silentsuite/web test -- LabelEditor.test.tsx`
- `pnpm --filter @silentsuite/web type-check`
- `git diff --check`
