### PR TITLE
Show pay-now bonus access date

### DIFF
--- a/apps/web/app/(app)/settings/subscription/__tests__/subscription-page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/subscription-page.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { getPaidBonusAccessDate, type SubscriptionBonusAccessData } from '../bonus-access'
+
+const baseSubscription: SubscriptionBonusAccessData = {
+  status: 'active',
+  trial: {
+    endsAt: null,
+  },
+  trialPath: null,
+}
+
+describe('subscription page paid bonus access date', () => {
+  it('shows the stored pay-now bonus date after an immediate payment becomes active', () => {
+    const data: SubscriptionBonusAccessData = {
+      ...baseSubscription,
+      trialPath: 'immediate',
+      trial: {
+        endsAt: '2026-07-07T18:25:00.000Z',
+      },
+    }
+
+    expect(getPaidBonusAccessDate(data, new Date('2026-06-30T18:25:00.000Z'))).toBe('2026-07-07T18:25:00.000Z')
+  })
+
+  it('does not treat normal active subscriptions as pay-now bonus access', () => {
+    const data: SubscriptionBonusAccessData = {
+      ...baseSubscription,
+      trial: {
+        endsAt: null,
+      },
+    }
+
+    expect(getPaidBonusAccessDate(data)).toBeNull()
+  })
+
+  it('hides the pay-now bonus date after the bonus access window has passed', () => {
+    const data: SubscriptionBonusAccessData = {
+      ...baseSubscription,
+      trialPath: 'immediate',
+      trial: {
+        endsAt: '2026-07-07T18:25:00.000Z',
+      },
+    }
+
+    expect(getPaidBonusAccessDate(data, new Date('2026-07-08T00:00:00.000Z'))).toBeNull()
+  })
+})

--- a/apps/web/app/(app)/settings/subscription/bonus-access.ts
+++ b/apps/web/app/(app)/settings/subscription/bonus-access.ts
@@ -1,0 +1,16 @@
+export interface SubscriptionBonusAccessData {
+  status: 'none' | 'trialing' | 'active' | 'past_due' | 'cancelled' | 'expired'
+  trialPath: '7day' | '30day' | 'immediate' | null
+  trial: {
+    endsAt: string | null
+  }
+}
+
+export function getPaidBonusAccessDate(data: SubscriptionBonusAccessData, now = new Date()): string | null {
+  if (data.status !== 'active') return null
+  if (data.trialPath !== 'immediate') return null
+  if (!data.trial.endsAt) return null
+  if (new Date(data.trial.endsAt) <= now) return null
+
+  return data.trial.endsAt
+}

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -7,6 +7,7 @@ import dynamic from 'next/dynamic'
 import { BILLING_API_URL } from '@/app/lib/config'
 import { formatDate as formatDateUtil } from '@/app/lib/date'
 import AddCardBanner from '@/app/components/add-card-banner'
+import { getPaidBonusAccessDate } from './bonus-access'
 
 const StripePaymentForm = dynamic(() => import('@/app/components/stripe-payment-form'), {
   loading: () => (
@@ -347,6 +348,7 @@ export default function SubscriptionPage() {
       ? 'Reactivate'
       : 'Subscribe'
   const accessUntilFormatted = data.renewalDate ? formatDateStr(data.renewalDate) : 'the end of your current period'
+  const paidBonusAccessDate = getPaidBonusAccessDate(data)
   // Only show Early Adopter plans — Standard plans will be enabled later
   const availablePlans = REACTIVATION_PLANS.filter((p) => p.earlyOnly)
 
@@ -421,6 +423,14 @@ export default function SubscriptionPage() {
               <p className="text-sm text-[rgb(var(--foreground))]">
                 {data.trialPath === '7day' ? '7-day trial (no card)' : data.trialPath === '30day' ? '30-day trial' : 'Paid + 14-day bonus'}
               </p>
+            </div>
+          )}
+
+          {/* Paid bonus/access date */}
+          {paidBonusAccessDate && (
+            <div>
+              <p className="text-xs text-[rgb(var(--muted))]">Bonus access</p>
+              <p className="text-sm text-[rgb(var(--foreground))]">Included until {formatDateStr(paidBonusAccessDate)}</p>
             </div>
           )}
 


### PR DESCRIPTION
## Summary
- show the stored pay-now bonus/access date on the subscription page after an immediate payment becomes active
- add a regression helper test for immediate pay-now accounts where `trial.endsAt` carries the bonus access date

## Tests
- `pnpm exec vitest run 'app/(app)/settings/subscription/__tests__/subscription-page.test.tsx'`
- `pnpm exec vitest run 'app/(app)/settings/subscription/__tests__/page.test.tsx' 'app/(app)/settings/subscription/__tests__/subscription-page.test.tsx'`
- `pnpm type-check`
