### PR TITLE
fix: upgrade FastAPI and Starlette for security

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-django ruff
+          pip install -r requirements-dev.txt
 
       - name: Compile check (smoke test)
         working-directory: server

--- a/server/etebase_server/fastapi/msgpack.py
+++ b/server/etebase_server/fastapi/msgpack.py
@@ -45,6 +45,8 @@ class MsgpackRoute(APIRoute):
         super().__init__(path, endpoint, *args, **kwargs)
 
     def _get_media_type_route_handler(self, media_type):
+        # This calls FastAPI's internal request handler factory; keep FastAPI pinned
+        # and exercise msgpack routes when upgrading FastAPI/Starlette.
         return get_request_handler(
             dependant=self.dependant,
             body_field=self.body_field,

--- a/server/requirements-dev.txt
+++ b/server/requirements-dev.txt
@@ -4,50 +4,100 @@
 #
 #    pip-compile --output-file=requirements-dev.txt requirements.in/development.txt
 #
-asgiref==3.8.1
+anyio==4.14.1
     # via
+    #   -c requirements.txt
+    #   httpx2
+asgiref==3.11.1
+    # via
+    #   -c requirements.txt
     #   django
-    #   django-stubs
-build==1.2.1
+ast-serialize==0.6.0
+    # via mypy
+build==1.5.0
     # via pip-tools
-click==8.1.7
-    # via pip-tools
-coverage==7.5.3
-    # via -r requirements.in/development.txt
-django==5.0.6
+click==8.4.2
     # via
+    #   -c requirements.txt
+    #   pip-tools
+coverage==7.14.3
+    # via -r requirements.in/development.txt
+django==5.2.15
+    # via
+    #   -c requirements.txt
     #   django-stubs
     #   django-stubs-ext
-django-stubs==5.0.2
+django-stubs==6.0.6
     # via -r requirements.in/development.txt
-django-stubs-ext==5.0.2
+django-stubs-ext==6.0.6
     # via django-stubs
-mypy==1.10.0
+h11==0.16.0
+    # via
+    #   -c requirements.txt
+    #   httpcore2
+httpcore2==2.5.0
+    # via httpx2
+httpx2==2.5.0
     # via -r requirements.in/development.txt
-mypy-extensions==1.0.0
+idna==3.18
+    # via
+    #   -c requirements.txt
+    #   anyio
+    #   httpx2
+iniconfig==2.3.0
+    # via pytest
+librt==0.12.0
     # via mypy
-packaging==24.0
-    # via build
-pip-tools==7.4.1
+mypy==2.1.0
     # via -r requirements.in/development.txt
-pyproject-hooks==1.1.0
+mypy-extensions==1.1.0
+    # via mypy
+packaging==26.2
+    # via
+    #   build
+    #   pytest
+    #   wheel
+pathspec==1.1.1
+    # via mypy
+pip-tools==7.5.3
+    # via -r requirements.in/development.txt
+pluggy==1.6.0
+    # via pytest
+pygments==2.20.0
+    # via pytest
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pywatchman==2.0.0
-    # via -r requirements.in/development.txt
-ruff==0.4.8
-    # via -r requirements.in/development.txt
-sqlparse==0.5.0
-    # via django
-types-pyyaml==6.0.12.20240311
-    # via django-stubs
-typing-extensions==4.12.2
+pytest==9.1.1
     # via
+    #   -r requirements.in/development.txt
+    #   pytest-django
+pytest-django==4.12.0
+    # via -r requirements.in/development.txt
+pywatchman==4.0.0
+    # via -r requirements.in/development.txt
+ruff==0.15.20
+    # via -r requirements.in/development.txt
+sqlparse==0.5.5
+    # via
+    #   -c requirements.txt
+    #   django
+truststore==0.10.4
+    # via
+    #   httpcore2
+    #   httpx2
+types-pyyaml==6.0.12.20260518
+    # via django-stubs
+typing-extensions==4.15.0
+    # via
+    #   -c requirements.txt
+    #   anyio
     #   django-stubs
     #   django-stubs-ext
+    #   httpx2
     #   mypy
-wheel==0.43.0
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/server/requirements.in/base.txt
+++ b/server/requirements.in/base.txt
@@ -1,7 +1,7 @@
 django>=5.2,<6.0
 msgpack
 pynacl
-fastapi>=0.104
+fastapi==0.138.2
 pydantic>=2.0.0
 typing_extensions
 uvicorn[standard]

--- a/server/requirements.in/development.txt
+++ b/server/requirements.in/development.txt
@@ -1,3 +1,4 @@
+--constraint ../requirements.txt
 coverage
 pip-tools
 pywatchman
@@ -6,3 +7,4 @@ mypy
 django-stubs
 pytest
 pytest-django
+httpx2==2.5.0

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,118 +4,74 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in/base.txt
 #
-aiofiles==23.2.1
+aiofiles==25.1.0
     # via -r requirements.in/base.txt
+annotated-doc==0.0.4
+    # via fastapi
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
+anyio==4.14.1
     # via
-    #   httpx
     #   starlette
     #   watchfiles
-asgiref==3.8.1
+asgiref==3.11.1
     # via django
-certifi==2024.6.2
-    # via
-    #   httpcore
-    #   httpx
-cffi==1.16.0
+cffi==2.0.0
     # via pynacl
-click==8.1.7
-    # via
-    #   typer
-    #   uvicorn
-django==5.2.12
-    # via -r requirements.in/base.txt
-dnspython==2.6.1
-    # via email-validator
-email-validator==2.1.1
-    # via fastapi
-fastapi==0.111.0
-    # via -r requirements.in/base.txt
-fastapi-cli==0.0.4
-    # via fastapi
-h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
+click==8.4.2
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-idna==3.7
-    # via
-    #   anyio
-    #   email-validator
-    #   httpx
-jinja2==3.1.4
-    # via fastapi
-markdown-it-py==3.0.0
-    # via rich
-markupsafe==2.1.5
-    # via jinja2
-mdurl==0.1.2
-    # via markdown-it-py
-msgpack==1.0.8
+django==5.2.15
     # via -r requirements.in/base.txt
-orjson==3.10.3
-    # via fastapi
-pycparser==2.22
+fastapi==0.138.2
+    # via -r requirements.in/base.txt
+h11==0.16.0
+    # via uvicorn
+httptools==0.8.0
+    # via uvicorn
+idna==3.18
+    # via anyio
+msgpack==1.2.1
+    # via -r requirements.in/base.txt
+psycopg2-binary==2.9.12
+    # via -r requirements.in/base.txt
+pycparser==3.0
     # via cffi
-pydantic==2.7.3
+pydantic==2.13.4
     # via
     #   -r requirements.in/base.txt
     #   fastapi
-pydantic-core==2.18.4
+pydantic-core==2.46.4
     # via pydantic
-pygments==2.18.0
-    # via rich
-pynacl==1.5.0
+pynacl==1.6.2
     # via -r requirements.in/base.txt
-python-dotenv==1.0.1
+python-dotenv==1.2.2
     # via uvicorn
-python-multipart==0.0.9
-    # via fastapi
-pyyaml==6.0.1
+pyyaml==6.0.3
     # via uvicorn
-redis==5.1.0b6
+redis==8.0.1
     # via -r requirements.in/base.txt
-rich==13.7.1
-    # via typer
-shellingham==1.5.4
-    # via typer
-sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
-sqlparse==0.5.0
+sqlparse==0.5.5
     # via django
-starlette==0.37.2
+starlette==1.3.1
     # via fastapi
-typer==0.12.3
-    # via fastapi-cli
-typing-extensions==4.12.2
+typing-extensions==4.15.0
     # via
     #   -r requirements.in/base.txt
+    #   anyio
     #   fastapi
     #   pydantic
     #   pydantic-core
-    #   typer
-ujson==5.10.0
-    # via fastapi
-uvicorn[standard]==0.30.1
+    #   starlette
+    #   typing-inspection
+typing-inspection==0.4.2
     # via
-    #   -r requirements.in/base.txt
     #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-watchfiles==0.22.0
-    # via uvicorn
-websockets==12.0
-    # via uvicorn
-
-# PostgreSQL adapter
-psycopg2-binary==2.9.10
+    #   pydantic
+uvicorn[standard]==0.49.0
     # via -r requirements.in/base.txt
+uvloop==0.22.1
+    # via uvicorn
+watchfiles==1.2.0
+    # via uvicorn
+websockets==16.0
+    # via uvicorn


### PR DESCRIPTION
## Summary

- Upgrades the server FastAPI pin to `0.138.2`, resolving to Starlette `1.3.1` so the reported Starlette CVE fixes are included.
- Refreshes the server runtime and dev requirement locks as a coherent dependency set.
- Adds the pinned Starlette 1.x test-client dependency `httpx2==2.5.0` to dev requirements and constrains dev requirements against runtime pins.
- Updates server CI to install the committed dev requirements instead of loose pytest/ruff packages.
- Documents the FastAPI internal handler dependency in the msgpack route helper.

Fixes #425

## Validation

- `python -m pip check` -> `No broken requirements found.`
- `python -m py_compile manage.py etebase_server/settings.py etebase_server/urls.py etebase_server/utils.py etebase_server/myauth/tests.py` -> OK
- `python -c "import django; django.setup(); print('Django loaded OK')"` with `DJANGO_SETTINGS_MODULE=etebase_server.settings` -> OK
- Docker secret exclusion checks -> OK
- `python -m pytest etebase_server/ -q --tb=short` -> `50 passed, 46 warnings`

Known note: the workflow's ruff step remains `continue-on-error`; with the newer committed dev ruff, it reports pre-existing import-format/unused-import findings in `etebase_server/myauth/tests.py`.