### PR TITLE
Improve encrypted restore and initial sync UX

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -7,18 +7,22 @@ import { Header } from '@/app/components/header'
 import { BottomNav } from '@/app/components/bottom-nav'
 import { ReadOnlyBanner, DegradedModeBanner } from '@/app/components/read-only-overlay'
 import { PendingSyncBanner } from '@/app/components/PendingSyncBanner'
+import { InitialSyncProgress } from '@/app/components/InitialSyncProgress'
 import { OfflineToast } from '@/app/components/OfflineToast'
 import { ToastContainer } from '@/app/components/Toast'
 import { EmailVerificationBanner } from '@/app/components/EmailVerificationBanner'
 import { SyncProvider } from '@/app/providers/sync-provider'
 import { NotificationProvider } from '@/app/providers/notification-provider'
+import { EncryptedSessionRecoveryScreen } from '@/app/components/EncryptedSessionRecoveryScreen'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+import { useSyncStore } from '@/app/stores/use-sync-store'
 import { isSelfHosted } from '@/app/lib/self-hosted'
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const t = useTranslations('Navigation')
   const readOnly = useAuthStore((s) => s.isReadOnly())
   const degraded = useAuthStore((s) => s.isDegraded())
+  const initialSyncBlocker = useSyncStore((s) => s.initialSyncBlocker)
 
   return (
     <ProtectedRoute>
@@ -39,8 +43,9 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               {!isSelfHosted && degraded && <DegradedModeBanner />}
               {!isSelfHosted && readOnly && <ReadOnlyBanner />}
               <PendingSyncBanner />
+              <InitialSyncProgress />
               <main id="main-content" className="relative z-0 flex-1 overflow-auto p-3 pb-20 md:p-4 md:pb-4 page-transition">
-                {children}
+                {initialSyncBlocker ? <EncryptedSessionRecoveryScreen /> : children}
               </main>
             </div>
             <BottomNav />

--- a/apps/web/app/(auth)/login/__tests__/page.test.tsx
+++ b/apps/web/app/(auth)/login/__tests__/page.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import LoginPage from '../page'
+
+const routerReplace = vi.fn()
+const search = vi.hoisted(() => ({ value: new URLSearchParams() }))
+const auth = vi.hoisted(() => ({
+  state: {
+    login: vi.fn(async () => {}),
+    isLoading: false,
+    error: null as string | null,
+    clearError: vi.fn(),
+    isAuthenticated: false,
+  },
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: routerReplace }),
+  useSearchParams: () => search.value,
+}))
+
+vi.mock('@/app/stores/use-auth-store', () => {
+  const useAuthStore = () => auth.state
+  useAuthStore.getState = () => auth.state
+  return { useAuthStore }
+})
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  normalizeServerUrl: (url: string) => url.replace(/\/+$/, ''),
+}))
+
+vi.mock('lucide-react', () => ({
+  ChevronRight: () => <svg data-testid="chevron-right" />,
+}))
+
+describe('LoginPage unlock mode', () => {
+  beforeEach(() => {
+    routerReplace.mockClear()
+    auth.state.login.mockReset().mockResolvedValue(undefined)
+    auth.state.clearError.mockClear()
+    auth.state.isLoading = false
+    auth.state.error = null
+    auth.state.isAuthenticated = false
+    search.value = new URLSearchParams()
+    localStorage.clear()
+  })
+
+  it('bypasses the authenticated redirect and renders the credential form for unlock mode', () => {
+    auth.state.isAuthenticated = true
+    search.value = new URLSearchParams('reason=unlock&returnTo=%2Ftasks')
+
+    render(<LoginPage />)
+
+    expect(routerReplace).not.toHaveBeenCalled()
+    expect(screen.getByRole('heading', { name: 'Unlock your encrypted data' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Email address')).toBeInTheDocument()
+    expect(screen.getByLabelText('Password')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Unlock data' })).toBeInTheDocument()
+  })
+
+  it('submits through login and navigates to the safe return target after unlock succeeds', async () => {
+    search.value = new URLSearchParams('reason=unlock&returnTo=%2Ftasks')
+    auth.state.login.mockImplementationOnce(async () => {
+      auth.state.isAuthenticated = true
+    })
+
+    render(<LoginPage />)
+
+    fireEvent.change(screen.getByLabelText('Email address'), { target: { value: 'user@example.com' } })
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'correct horse battery staple' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Unlock data' }))
+
+    await waitFor(() => expect(auth.state.login).toHaveBeenCalledWith('user@example.com', 'correct horse battery staple', undefined))
+    await waitFor(() => expect(routerReplace).toHaveBeenCalledWith('/tasks'))
+  })
+
+  it('falls back to /calendar for unsafe return targets after unlock succeeds', async () => {
+    search.value = new URLSearchParams('reason=unlock&returnTo=https%3A%2F%2Fevil.example')
+    auth.state.login.mockImplementationOnce(async () => {
+      auth.state.isAuthenticated = true
+    })
+
+    render(<LoginPage />)
+
+    fireEvent.change(screen.getByLabelText('Email address'), { target: { value: 'user@example.com' } })
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Unlock data' }))
+
+    await waitFor(() => expect(routerReplace).toHaveBeenCalledWith('/calendar'))
+  })
+})

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -19,11 +19,17 @@ const loginSchema = z.object({
 
 type LoginFormData = z.infer<typeof loginSchema>
 
+function getSafeReturnTo(raw: string | null): string {
+  return raw && raw.startsWith('/') && !raw.includes('://') && !raw.includes('//') ? raw : '/calendar'
+}
+
 export default function LoginPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { login, isLoading, error, clearError, isAuthenticated } = useAuthStore()
   const [serverUrl, setServerUrl] = useState('')
+  const isUnlockMode = searchParams.get('reason') === 'unlock'
+  const returnTo = getSafeReturnTo(searchParams.get('returnTo'))
 
   const {
     register,
@@ -35,13 +41,10 @@ export default function LoginPage() {
   })
 
   useEffect(() => {
-    if (isAuthenticated) {
-      const raw = searchParams.get('returnTo') ?? '/calendar'
-      // Validate returnTo to prevent open redirect: must be a relative path
-      const returnTo = raw.startsWith('/') && !raw.includes('://') && !raw.includes('//') ? raw : '/calendar'
+    if (isAuthenticated && !isUnlockMode) {
       router.replace(returnTo)
     }
-  }, [isAuthenticated, router, searchParams])
+  }, [isAuthenticated, isUnlockMode, returnTo, router])
 
   useEffect(() => {
     return () => clearError()
@@ -55,14 +58,21 @@ export default function LoginPage() {
       localStorage.removeItem('silentsuite-server-url')
     }
     await login(data.email, data.password, normalizedUrl)
+    if (useAuthStore.getState().isAuthenticated) {
+      router.replace(returnTo)
+    }
   }
 
   return (
     <div className="max-w-md mx-auto space-y-6">
       <div className="space-y-2 text-center">
-        <h2 className="text-xl font-semibold text-[rgb(var(--foreground))]">Welcome back</h2>
+        <h2 className="text-xl font-semibold text-[rgb(var(--foreground))]">
+          {isUnlockMode ? 'Unlock your encrypted data' : 'Welcome back'}
+        </h2>
         <p className="text-sm text-[rgb(var(--muted))]">
-          Log in to your encrypted workspace
+          {isUnlockMode
+            ? 'Sign in again to recreate the encrypted session for this browser.'
+            : 'Log in to your encrypted workspace'}
         </p>
       </div>
 
@@ -115,7 +125,7 @@ export default function LoginPage() {
         </div>
 
         <Button type="submit" disabled={isLoading} className="w-full">
-          {isLoading ? 'Logging in...' : 'Log in'}
+          {isLoading ? 'Logging in...' : isUnlockMode ? 'Unlock data' : 'Log in'}
         </Button>
 
         {/* Advanced Settings */}

--- a/apps/web/app/components/EncryptedSessionRecoveryScreen.tsx
+++ b/apps/web/app/components/EncryptedSessionRecoveryScreen.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { LockKeyhole, LogOut } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { Button } from '@silentsuite/ui'
+import { useAuthStore } from '@/app/stores/use-auth-store'
+import { useSyncStore } from '@/app/stores/use-sync-store'
+
+export function EncryptedSessionRecoveryScreen() {
+  const router = useRouter()
+  const blocker = useSyncStore((s) => s.initialSyncBlocker)
+  const error = useSyncStore((s) => s.error)
+  const logout = useAuthStore((s) => s.logout)
+
+  if (!blocker) return null
+
+  const detail = blocker === 'missing-encrypted-session'
+    ? 'This browser could not find the encrypted vault keys needed to read your calendars, tasks, and contacts.'
+    : 'This browser could not restore the encrypted vault keys needed to read your calendars, tasks, and contacts.'
+
+  const unlock = () => {
+    router.push(`/login?reason=unlock&returnTo=${encodeURIComponent('/calendar')}`)
+  }
+
+  return (
+    <section
+      aria-labelledby="encrypted-session-recovery-title"
+      className="mx-auto flex min-h-full max-w-2xl flex-col items-center justify-center px-4 py-12 text-center"
+    >
+      <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-400">
+        <LockKeyhole className="h-7 w-7" aria-hidden="true" />
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-sm font-medium uppercase tracking-wide text-emerald-400">You are signed in</p>
+        <h1 id="encrypted-session-recovery-title" className="text-2xl font-semibold text-[rgb(var(--foreground))] md:text-3xl">
+          Unlock your encrypted data
+        </h1>
+        <p className="text-base text-[rgb(var(--muted))]">
+          {detail} Your data has not been deleted. Sign in again to unlock it on this browser.
+        </p>
+        {error && (
+          <p className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <div className="mt-7 flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:justify-center">
+        <Button type="button" onClick={unlock} className="w-full sm:w-auto">
+          Sign in again to unlock data
+        </Button>
+        <Button type="button" variant="outline" onClick={() => void logout()} className="w-full gap-2 sm:w-auto">
+          <LogOut className="h-4 w-4" aria-hidden="true" />
+          Sign out
+        </Button>
+      </div>
+
+      <p className="mt-6 max-w-xl text-sm text-[rgb(var(--muted))]">
+        Encryption keys stay local to this browser or device. Signing in again recreates the local encrypted session so SilentSuite can decrypt your data here.
+      </p>
+    </section>
+  )
+}

--- a/apps/web/app/components/InitialSyncProgress.tsx
+++ b/apps/web/app/components/InitialSyncProgress.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useSyncStore, type DomainSyncProgress, type InitialSyncDomain } from '@/app/stores/use-sync-store'
+import { boundedSyncPercentage } from '@/app/lib/sync-summary'
+
+const domainLabels: Record<InitialSyncDomain, { label: string; noun: string }> = {
+  calendar: { label: 'Calendar', noun: 'events' },
+  tasks: { label: 'Tasks', noun: 'tasks' },
+  contacts: { label: 'Contacts', noun: 'contacts' },
+}
+
+const phaseLabels: Record<string, string> = {
+  restoring: 'Restoring encrypted session',
+  calendar: 'Loading calendar',
+  tasks: 'Loading tasks',
+  contacts: 'Loading contacts',
+  preferences: 'Finishing encrypted settings',
+  error: 'Sync needs attention',
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat().format(value)
+}
+
+export function formatInitialSyncCount(domain: InitialSyncDomain, progress: DomainSyncProgress): string {
+  const { noun } = domainLabels[domain]
+  const loaded = formatNumber(progress.loaded)
+  const percentage = boundedSyncPercentage(progress.loaded, progress.knownTotal)
+
+  if (progress.knownTotal === null || progress.knownTotal <= 0 || percentage === null) {
+    return `${loaded} ${noun} loaded so far`
+  }
+
+  const known = formatNumber(progress.knownTotal)
+  const overLastSync = progress.loaded > progress.knownTotal ? ' — more than last sync' : ''
+  return `${loaded} / about ${known} ${noun} loaded (${percentage}%)${overLastSync}`
+}
+
+export function InitialSyncProgress() {
+  const progress = useSyncStore((s) => s.initialSyncProgress)
+
+  if (!progress.active || progress.phase === 'blocked') return null
+
+  const activeDomain: InitialSyncDomain = progress.phase === 'tasks'
+    ? 'tasks'
+    : progress.phase === 'contacts'
+      ? 'contacts'
+      : 'calendar'
+  const activeProgress = progress[activeDomain]
+  const percent = boundedSyncPercentage(activeProgress.loaded, activeProgress.knownTotal)
+
+  return (
+    <section
+      aria-label="Initial encrypted data sync progress"
+      className="border-b border-[rgb(var(--border))] bg-emerald-500/10 px-4 py-3 text-sm text-[rgb(var(--foreground))]"
+    >
+      <div className="mx-auto flex max-w-5xl flex-col gap-2">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="font-medium">{phaseLabels[progress.phase] ?? 'Loading encrypted data'}</p>
+            <p className="text-xs text-[rgb(var(--muted))]">
+              Encrypted data is loading and decrypting locally in this browser.
+            </p>
+          </div>
+          <p className="text-xs tabular-nums text-[rgb(var(--muted))]">
+            {formatInitialSyncCount(activeDomain, activeProgress)}
+          </p>
+        </div>
+        {percent !== null && (
+          <div className="h-1.5 overflow-hidden rounded-full bg-[rgb(var(--surface))]" aria-hidden="true">
+            <div className="h-full rounded-full bg-emerald-500 transition-all" style={{ width: `${percent}%` }} />
+          </div>
+        )}
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[rgb(var(--muted))]">
+          {(Object.keys(domainLabels) as InitialSyncDomain[]).map((domain) => (
+            <span key={domain}>
+              {domainLabels[domain].label}: {formatInitialSyncCount(domain, progress[domain])}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/app/components/SyncIndicator.tsx
+++ b/apps/web/app/components/SyncIndicator.tsx
@@ -5,6 +5,7 @@ import { RefreshCw } from 'lucide-react'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 import { formatTimeAgo } from '@/app/lib/format-time-ago'
 import type { SyncStatus } from '@silentsuite/core'
+import type { InitialSyncProgressState } from '@/app/stores/use-sync-store'
 
 const dotStyles: Record<SyncStatus, string> = {
   synced: 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.5)]',
@@ -20,7 +21,18 @@ const ariaLabels: Record<SyncStatus, string> = {
   error: 'Sync status: error',
 }
 
-function getTooltipText(status: SyncStatus, lastSyncedAt: Date | null, error: string | null, pendingCount: number): string {
+function getProgressTooltip(progress: InitialSyncProgressState): string | null {
+  if (!progress.active) return null
+  if (progress.phase === 'calendar') return `Loading encrypted calendar data locally (${progress.calendar.loaded} events)`
+  if (progress.phase === 'tasks') return `Loading encrypted tasks locally (${progress.tasks.loaded} tasks)`
+  if (progress.phase === 'contacts') return `Loading encrypted contacts locally (${progress.contacts.loaded} contacts)`
+  if (progress.phase === 'preferences') return 'Finishing encrypted settings locally'
+  return 'Loading encrypted data locally in this browser'
+}
+
+function getTooltipText(status: SyncStatus, lastSyncedAt: Date | null, error: string | null, pendingCount: number, progress: InitialSyncProgressState): string {
+  const progressText = getProgressTooltip(progress)
+  if (progressText) return progressText
   const queueSuffix = pendingCount > 0 ? ` (${pendingCount} queued)` : ''
   switch (status) {
     case 'synced':
@@ -40,6 +52,7 @@ export function SyncIndicator() {
   const error = useSyncStore((s) => s.error)
   const simulateSyncCycle = useSyncStore((s) => s.simulateSyncCycle)
   const pendingQueueCount = useSyncStore((s) => s.pendingQueueCount)
+  const initialSyncProgress = useSyncStore((s) => s.initialSyncProgress)
   const [showTooltip, setShowTooltip] = useState(false)
   const [tooltipText, setTooltipText] = useState('')
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -56,15 +69,15 @@ export function SyncIndicator() {
   // Update tooltip text on an interval while visible so relative times stay fresh
   useEffect(() => {
     if (showTooltip) {
-      setTooltipText(getTooltipText(syncStatus, lastSyncedAt, error, pendingQueueCount))
+      setTooltipText(getTooltipText(syncStatus, lastSyncedAt, error, pendingQueueCount, initialSyncProgress))
       intervalRef.current = setInterval(() => {
-        setTooltipText(getTooltipText(syncStatus, lastSyncedAt, error, pendingQueueCount))
+        setTooltipText(getTooltipText(syncStatus, lastSyncedAt, error, pendingQueueCount, initialSyncProgress))
       }, 1000)
     }
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current)
     }
-  }, [showTooltip, syncStatus, lastSyncedAt, error, pendingQueueCount])
+  }, [showTooltip, syncStatus, lastSyncedAt, error, pendingQueueCount, initialSyncProgress])
 
   return (
     <div

--- a/apps/web/app/components/__tests__/EncryptedSessionRecoveryScreen.test.tsx
+++ b/apps/web/app/components/__tests__/EncryptedSessionRecoveryScreen.test.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { EncryptedSessionRecoveryScreen } from '../EncryptedSessionRecoveryScreen'
+import { useSyncStore } from '@/app/stores/use-sync-store'
+
+const routerPush = vi.fn()
+const logout = vi.fn()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPush }),
+}))
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: (selector: (state: { logout: typeof logout }) => unknown) => selector({ logout }),
+}))
+
+vi.mock('lucide-react', () => ({
+  LockKeyhole: () => <svg data-testid="lock-icon" />,
+  LogOut: () => <svg data-testid="logout-icon" />,
+}))
+
+describe('EncryptedSessionRecoveryScreen', () => {
+  beforeEach(() => {
+    routerPush.mockClear()
+    logout.mockClear()
+    useSyncStore.setState({ initialSyncBlocker: null, error: null })
+  })
+
+  it('renders recovery copy and unlock CTA for a missing encrypted session', () => {
+    useSyncStore.setState({
+      initialSyncBlocker: 'missing-encrypted-session',
+      error: 'Encrypted session was not restored. Sign in again to unlock your data.',
+    })
+
+    render(<EncryptedSessionRecoveryScreen />)
+
+    expect(screen.getByRole('heading', { name: 'Unlock your encrypted data' })).toBeInTheDocument()
+    expect(screen.getByText('You are signed in')).toBeInTheDocument()
+    expect(screen.getByText(/could not find the encrypted vault keys/i)).toBeInTheDocument()
+    expect(screen.getByText(/Your data has not been deleted/i)).toBeInTheDocument()
+    expect(screen.getByText(/Encryption keys stay local to this browser or device/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in again to unlock data' }))
+    expect(routerPush).toHaveBeenCalledWith('/login?reason=unlock&returnTo=%2Fcalendar')
+  })
+
+  it('calls the existing logout action from the secondary CTA', () => {
+    useSyncStore.setState({ initialSyncBlocker: 'encrypted-session-restore-failed' })
+
+    render(<EncryptedSessionRecoveryScreen />)
+    fireEvent.click(screen.getByRole('button', { name: /Sign out/i }))
+
+    expect(logout).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/app/components/__tests__/InitialSyncProgress.test.tsx
+++ b/apps/web/app/components/__tests__/InitialSyncProgress.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { InitialSyncProgress, formatInitialSyncCount } from '../InitialSyncProgress'
+import type { InitialSyncProgressState } from '@/app/stores/use-sync-store'
+
+const mockState: { initialSyncProgress: InitialSyncProgressState } = {
+  initialSyncProgress: {
+    active: true,
+    phase: 'calendar',
+    calendar: { loaded: 600, knownTotal: null, done: false },
+    tasks: { loaded: 0, knownTotal: null, done: false },
+    contacts: { loaded: 0, knownTotal: null, done: false },
+    message: null,
+  },
+}
+
+vi.mock('@/app/stores/use-sync-store', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/app/stores/use-sync-store')>()),
+  useSyncStore: (selector: (state: typeof mockState) => unknown) => selector(mockState),
+}))
+
+describe('InitialSyncProgress', () => {
+  beforeEach(() => {
+    mockState.initialSyncProgress = {
+      active: true,
+      phase: 'calendar',
+      calendar: { loaded: 600, knownTotal: null, done: false },
+      tasks: { loaded: 0, knownTotal: null, done: false },
+      contacts: { loaded: 0, knownTotal: null, done: false },
+      message: null,
+    }
+  })
+
+  it('shows first-sync counts without a percentage when totals are unknown', () => {
+    render(<InitialSyncProgress />)
+
+    expect(screen.getByText(/Encrypted data is loading and decrypting locally in this browser/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/600 events loaded so far/).length).toBeGreaterThan(0)
+    expect(screen.queryByText(/600 \/ about/)).not.toBeInTheDocument()
+  })
+
+  it('shows approximate totals and bounded percentage for later syncs', () => {
+    mockState.initialSyncProgress.calendar = { loaded: 600, knownTotal: 3000, done: false }
+
+    render(<InitialSyncProgress />)
+
+    expect(screen.getAllByText(/600 \/ about 3,000 events loaded \(20%\)/).length).toBeGreaterThan(0)
+  })
+
+  it('handles zero and over-last-sync totals safely', () => {
+    expect(formatInitialSyncCount('calendar', { loaded: 5, knownTotal: 0, done: false })).toBe('5 events loaded so far')
+    expect(formatInitialSyncCount('tasks', { loaded: 12, knownTotal: 10, done: false })).toBe('12 / about 10 tasks loaded (100%) — more than last sync')
+  })
+
+  it('does not render when inactive or blocked', () => {
+    mockState.initialSyncProgress.active = false
+    const { rerender } = render(<InitialSyncProgress />)
+    expect(screen.queryByLabelText('Initial encrypted data sync progress')).not.toBeInTheDocument()
+
+    mockState.initialSyncProgress.active = true
+    mockState.initialSyncProgress.phase = 'blocked'
+    rerender(<InitialSyncProgress />)
+    expect(screen.queryByLabelText('Initial encrypted data sync progress')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/app/components/__tests__/SyncIndicator.test.tsx
+++ b/apps/web/app/components/__tests__/SyncIndicator.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { SyncIndicator } from '../SyncIndicator'
 import type { SyncStatus } from '@silentsuite/core'
 
@@ -8,6 +8,16 @@ const mockSyncState = {
   syncStatus: 'synced' as SyncStatus,
   lastSyncedAt: null as Date | null,
   error: null as string | null,
+  pendingQueueCount: 0,
+  initialSyncProgress: {
+    active: false,
+    phase: 'idle' as any,
+    calendar: { loaded: 0, knownTotal: null, done: false },
+    tasks: { loaded: 0, knownTotal: null, done: false },
+    contacts: { loaded: 0, knownTotal: null, done: false },
+    message: null,
+  },
+  simulateSyncCycle: vi.fn(),
 }
 
 vi.mock('@/app/stores/use-sync-store', () => ({
@@ -23,6 +33,15 @@ describe('SyncIndicator', () => {
     mockSyncState.syncStatus = 'synced'
     mockSyncState.lastSyncedAt = null
     mockSyncState.error = null
+    mockSyncState.pendingQueueCount = 0
+    mockSyncState.initialSyncProgress = {
+      active: false,
+      phase: 'idle',
+      calendar: { loaded: 0, knownTotal: null, done: false },
+      tasks: { loaded: 0, knownTotal: null, done: false },
+      contacts: { loaded: 0, knownTotal: null, done: false },
+      message: null,
+    }
   })
 
   it('renders synced status with emerald color', () => {
@@ -55,5 +74,20 @@ describe('SyncIndicator', () => {
     const dot = screen.getByRole('status')
     expect(dot).toHaveAttribute('aria-label', 'Sync status: error')
     expect(dot.className).toContain('bg-red-500')
+  })
+
+  it('shows initial sync progress in the tooltip', async () => {
+    mockSyncState.syncStatus = 'syncing'
+    mockSyncState.initialSyncProgress = {
+      ...mockSyncState.initialSyncProgress,
+      active: true,
+      phase: 'calendar',
+      calendar: { loaded: 42, knownTotal: 100, done: false },
+    }
+    render(<SyncIndicator />)
+
+    fireEvent.mouseEnter(screen.getByRole('status').closest('div')!.parentElement!)
+
+    expect(await screen.findByText('Loading encrypted calendar data locally (42 events)')).toBeInTheDocument()
   })
 })

--- a/apps/web/app/lib/__tests__/sync-summary.test.ts
+++ b/apps/web/app/lib/__tests__/sync-summary.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { clearLocalSyncSummary, readLocalSyncSummary, writeLocalSyncSummary, boundedSyncPercentage } from '../sync-summary'
+
+describe('sync-summary', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('stores only aggregate counts scoped to the account fingerprint', () => {
+    writeLocalSyncSummary('fingerprint-a', { calendarCount: 12, taskCount: 3, contactCount: 4 })
+
+    const summary = readLocalSyncSummary('fingerprint-a')
+
+    expect(summary).toMatchObject({
+      schemaVersion: 1,
+      accountFingerprint: 'fingerprint-a',
+      calendarCount: 12,
+      taskCount: 3,
+      contactCount: 4,
+    })
+    expect(Object.keys(summary!)).toEqual([
+      'schemaVersion',
+      'accountFingerprint',
+      'savedAt',
+      'calendarCount',
+      'taskCount',
+      'contactCount',
+    ])
+  })
+
+  it('ignores and clears summaries for a different fingerprint', () => {
+    writeLocalSyncSummary('fingerprint-a', { calendarCount: 1, taskCount: 2, contactCount: 3 })
+
+    expect(readLocalSyncSummary('fingerprint-b')).toBeNull()
+    expect(localStorage.getItem('silentsuite-sync-summary')).toBeNull()
+  })
+
+  it('clears the local summary', () => {
+    writeLocalSyncSummary('fingerprint-a', { calendarCount: 1, taskCount: 2, contactCount: 3 })
+    clearLocalSyncSummary()
+
+    expect(readLocalSyncSummary('fingerprint-a')).toBeNull()
+  })
+
+  it('bounds progress percentages', () => {
+    expect(boundedSyncPercentage(20, 100)).toBe(20)
+    expect(boundedSyncPercentage(150, 100)).toBe(100)
+    expect(boundedSyncPercentage(-5, 100)).toBe(0)
+    expect(boundedSyncPercentage(5, 0)).toBeNull()
+    expect(boundedSyncPercentage(5, null)).toBeNull()
+  })
+})

--- a/apps/web/app/lib/sync-summary.ts
+++ b/apps/web/app/lib/sync-summary.ts
@@ -1,0 +1,81 @@
+'use client'
+
+const STORAGE_KEY = 'silentsuite-sync-summary'
+
+export interface LocalSyncSummary {
+  schemaVersion: 1
+  accountFingerprint: string
+  savedAt: number
+  calendarCount: number
+  taskCount: number
+  contactCount: number
+}
+
+export interface SyncSummaryCounts {
+  calendarCount: number
+  taskCount: number
+  contactCount: number
+}
+
+function storage(): Storage | null {
+  return typeof window === 'undefined' ? null : window.localStorage
+}
+
+function isSummary(value: unknown): value is LocalSyncSummary {
+  if (!value || typeof value !== 'object') return false
+  const summary = value as Record<string, unknown>
+  return summary.schemaVersion === 1
+    && typeof summary.accountFingerprint === 'string'
+    && typeof summary.savedAt === 'number'
+    && typeof summary.calendarCount === 'number'
+    && typeof summary.taskCount === 'number'
+    && typeof summary.contactCount === 'number'
+}
+
+export function readLocalSyncSummary(accountFingerprint: string | null): LocalSyncSummary | null {
+  if (!accountFingerprint) return null
+  const store = storage()
+  if (!store) return null
+  try {
+    const raw = store.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (!isSummary(parsed)) {
+      store.removeItem(STORAGE_KEY)
+      return null
+    }
+    if (parsed.accountFingerprint !== accountFingerprint) {
+      store.removeItem(STORAGE_KEY)
+      return null
+    }
+    return parsed
+  } catch {
+    store.removeItem(STORAGE_KEY)
+    return null
+  }
+}
+
+export function writeLocalSyncSummary(accountFingerprint: string, counts: SyncSummaryCounts): LocalSyncSummary | null {
+  const store = storage()
+  if (!store) return null
+  const summary: LocalSyncSummary = {
+    schemaVersion: 1,
+    accountFingerprint,
+    savedAt: Date.now(),
+    calendarCount: Math.max(0, Math.trunc(counts.calendarCount)),
+    taskCount: Math.max(0, Math.trunc(counts.taskCount)),
+    contactCount: Math.max(0, Math.trunc(counts.contactCount)),
+  }
+  store.setItem(STORAGE_KEY, JSON.stringify(summary))
+  return summary
+}
+
+export function clearLocalSyncSummary(): void {
+  storage()?.removeItem(STORAGE_KEY)
+}
+
+export function boundedSyncPercentage(loaded: number, knownTotal: number | null): number | null {
+  if (knownTotal === null || knownTotal <= 0) return null
+  const safeLoaded = Math.max(0, loaded)
+  return Math.min(100, Math.max(0, Math.floor((safeLoaded / knownTotal) * 100)))
+}

--- a/apps/web/app/providers/__tests__/sync-provider.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.test.tsx
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { SyncProvider } from '../sync-provider'
+import { useSyncStore } from '@/app/stores/use-sync-store'
+
+const etebase = vi.hoisted(() => ({
+  state: {
+    initialize: vi.fn(),
+    fetchAllItems: vi.fn(),
+    onSyncChange: vi.fn(() => vi.fn()),
+    onStatusChange: vi.fn(() => vi.fn()),
+    isInitialized: false,
+  },
+}))
+
+const calendarStore = vi.hoisted(() => ({
+  events: [] as unknown[],
+  syncFromRemote: vi.fn(),
+  upsertFromRemote: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: Object.assign(
+    (selector: (state: typeof etebase.state) => unknown) => selector(etebase.state),
+    { getState: () => etebase.state },
+  ),
+}))
+
+vi.mock('@/app/stores/use-task-store', () => ({
+  useTaskStore: { getState: () => ({ tasks: [], syncFromRemote: vi.fn() }) },
+}))
+
+vi.mock('@/app/stores/use-contact-store', () => ({
+  useContactStore: { getState: () => ({ contacts: [], syncFromRemote: vi.fn() }) },
+}))
+
+vi.mock('@/app/stores/use-calendar-store', () => ({
+  useCalendarStore: {
+    getState: () => ({
+      events: calendarStore.events,
+      syncFromRemote: calendarStore.syncFromRemote,
+      upsertFromRemote: calendarStore.upsertFromRemote,
+    }),
+  },
+}))
+
+vi.mock('@/app/stores/use-preferences-sync-store', () => ({
+  usePreferencesSyncStore: { getState: () => ({ initialize: vi.fn(), loadFromRemote: vi.fn(), destroy: vi.fn() }) },
+}))
+
+vi.mock('@/app/stores/use-label-suggestions-store', () => ({
+  useLabelSuggestionsStore: { getState: () => ({ initialize: vi.fn(), loadFromRemote: vi.fn(), destroy: vi.fn() }) },
+}))
+
+vi.mock('@/app/lib/offline-queue', () => ({
+  replay: vi.fn().mockResolvedValue([]),
+  getPendingCount: vi.fn().mockResolvedValue(0),
+  getFailedCount: vi.fn().mockResolvedValue(0),
+  onCountChange: vi.fn().mockReturnValue(() => {}),
+  getStaleEntries: vi.fn().mockResolvedValue([]),
+  remove: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/app/stores/use-toast-store', () => ({
+  showErrorToast: vi.fn(),
+}))
+
+vi.mock('@/app/lib/data-cache', () => ({
+  getItemsByType: vi.fn().mockResolvedValue([]),
+  replaceItemsForType: vi.fn().mockResolvedValue(undefined),
+  isCacheEnabled: vi.fn(() => false),
+  getCacheCapabilityStatus: vi.fn(() => ({ enabled: false })),
+}))
+
+vi.mock('@/app/lib/sync-timing', () => ({
+  logSyncTiming: vi.fn(),
+  markCalendarSyncStart: vi.fn(() => 0),
+  nowMs: vi.fn(() => 0),
+}))
+
+vi.mock('@/app/lib/privacy-safe-errors', () => ({
+  createSafeOperationalError: vi.fn((component: string, operation: string) => new Error(`${component}:${operation}`)),
+  getSafeErrorDetails: vi.fn(() => ({ message: 'safe error' })),
+}))
+
+vi.mock('@/app/lib/calendar-loading', () => ({
+  partitionCalendarItemsForFastPaint: vi.fn((items: unknown[]) => ({ priority: items, backlog: [] })),
+}))
+
+vi.mock('@silentsuite/core', () => ({
+  deserializeCalendarEvent: vi.fn(),
+  deserializeTask: vi.fn(),
+  deserializeContact: vi.fn(),
+}))
+
+function resetSyncStore() {
+  useSyncStore.setState({
+    syncStatus: 'synced',
+    initialSyncState: 'synced',
+    initialSyncBlocker: null,
+    lastSyncedAt: null,
+    isOnline: true,
+    error: null,
+    pendingQueueCount: 0,
+    failedQueueCount: 0,
+  })
+}
+
+describe('SyncProvider restore recovery blockers', () => {
+  beforeEach(() => {
+    resetSyncStore()
+    calendarStore.events = []
+    calendarStore.syncFromRemote.mockClear()
+    calendarStore.upsertFromRemote.mockClear()
+    etebase.state.initialize.mockReset().mockResolvedValue({ status: 'success' })
+    etebase.state.fetchAllItems.mockReset().mockResolvedValue([])
+    etebase.state.onSyncChange.mockClear()
+    etebase.state.onStatusChange.mockClear()
+  })
+
+  it('sets the recovery blocker for a missing encrypted session', async () => {
+    etebase.state.initialize.mockResolvedValueOnce({ status: 'no-session' })
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(useSyncStore.getState().initialSyncBlocker).toBe('missing-encrypted-session'))
+    expect(useSyncStore.getState().initialSyncState).toBe('no-session')
+    expect(useSyncStore.getState().syncStatus).toBe('error')
+  })
+
+  it('sets the recovery blocker for a restore failure', async () => {
+    etebase.state.initialize.mockResolvedValueOnce({ status: 'error', error: new Error('restore failed') })
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(useSyncStore.getState().initialSyncBlocker).toBe('encrypted-session-restore-failed'))
+    expect(useSyncStore.getState().initialSyncState).toBe('error')
+  })
+
+  it('does not set a recovery blocker when restore reports offline', async () => {
+    etebase.state.initialize.mockResolvedValueOnce({ status: 'offline' })
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(useSyncStore.getState().initialSyncState).toBe('offline'))
+    expect(useSyncStore.getState().initialSyncBlocker).toBeNull()
+    expect(useSyncStore.getState().syncStatus).toBe('offline')
+  })
+
+  it('clears the recovery blocker for post-restore load errors', async () => {
+    useSyncStore.setState({ initialSyncBlocker: 'missing-encrypted-session' })
+    etebase.state.initialize.mockResolvedValueOnce({ status: 'success' })
+    etebase.state.fetchAllItems.mockRejectedValueOnce(new Error('calendar load failed'))
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(useSyncStore.getState().error).toBe('Some synced items could not be loaded'))
+    expect(useSyncStore.getState().initialSyncState).toBe('error')
+    expect(useSyncStore.getState().initialSyncBlocker).toBeNull()
+  })
+})

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -30,6 +30,7 @@ import {
   partitionCalendarItemsForFastPaint,
   type CalendarContentItem,
 } from '@/app/lib/calendar-loading'
+import { readLocalSyncSummary, writeLocalSyncSummary } from '@/app/lib/sync-summary'
 import type { CalendarEvent } from '@silentsuite/core'
 
 const CALENDAR_DESERIALIZE_CHUNK_SIZE = 50
@@ -50,6 +51,7 @@ async function deserializeCalendarItemsIncrementally(
   items: CalendarContentItem[],
   deserializeCalendarEvent: (content: string) => CalendarEvent,
   source: 'cache' | 'server',
+  options: { finalReplace?: boolean } = {},
 ): Promise<{ events: CalendarEvent[]; errors: unknown[] }> {
   const startedAt = nowMs()
   const { priority, backlog } = partitionCalendarItemsForFastPaint(items)
@@ -103,7 +105,9 @@ async function deserializeCalendarItemsIncrementally(
 
   // Final replace is still required: it preserves full-history search while
   // dropping items that were deleted remotely after the previous local state.
-  useCalendarStore.getState().syncFromRemote(allEvents)
+  if (options.finalReplace !== false) {
+    useCalendarStore.getState().syncFromRemote(allEvents)
+  }
   logSyncTiming('calendar-deserialize-complete', startedAt, {
     source,
     totalItemCount: items.length,
@@ -127,11 +131,17 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
   const initializeSync = useSyncStore((s) => s.initializeSync)
   const setSyncStatus = useSyncStore((s) => s.setSyncStatus)
   const setInitialSyncState = useSyncStore((s) => s.setInitialSyncState)
+  const setInitialSyncBlocker = useSyncStore((s) => s.setInitialSyncBlocker)
   const setLastSynced = useSyncStore((s) => s.setLastSynced)
   const setError = useSyncStore((s) => s.setError)
+  const startInitialSyncProgress = useSyncStore((s) => s.startInitialSyncProgress)
+  const setInitialSyncProgressPhase = useSyncStore((s) => s.setInitialSyncProgressPhase)
+  const updateInitialSyncProgress = useSyncStore((s) => s.updateInitialSyncProgress)
+  const finishInitialSyncProgress = useSyncStore((s) => s.finishInitialSyncProgress)
+  const resetInitialSyncProgress = useSyncStore((s) => s.resetInitialSyncProgress)
 
   const etebaseInitialize = useEtebaseStore((s) => s.initialize)
-  const etebaseFetchAllItems = useEtebaseStore((s) => s.fetchAllItems)
+  const etebaseLoadIncrementally = useEtebaseStore((s) => s.loadCollectionItemsIncrementally)
   const etebaseOnSyncChange = useEtebaseStore((s) => s.onSyncChange)
   const etebaseOnStatusChange = useEtebaseStore((s) => s.onStatusChange)
   const etebaseIsInitialized = useEtebaseStore((s) => s.isInitialized)
@@ -157,6 +167,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       try {
         setSyncStatus('syncing')
         setInitialSyncState('restoring')
+        setInitialSyncBlocker(null)
         const cacheStatus = getCacheCapabilityStatus()
         logSyncTiming('cache-capability', initStartedAt, { ...cacheStatus })
 
@@ -174,52 +185,84 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         logSyncTiming('etebase-initialize', etebaseInitStartedAt)
 
         if (initOutcome.status === 'no-session') {
+          setInitialSyncProgressPhase('blocked')
           setInitialSyncState('no-session')
+          setInitialSyncBlocker('missing-encrypted-session')
           setSyncStatus('error')
           setError('Encrypted session was not restored. Sign in again to unlock your data.')
           return
         }
 
         if (initOutcome.status === 'offline') {
+          resetInitialSyncProgress()
           setInitialSyncState('offline')
+          setInitialSyncBlocker(null)
           setSyncStatus('offline')
           setError('Offline. Showing any cached encrypted data until sync can resume.')
           return
         }
 
         if (initOutcome.status === 'error') {
+          setInitialSyncProgressPhase('blocked')
           setInitialSyncState('error')
+          setInitialSyncBlocker('encrypted-session-restore-failed')
           setSyncStatus('error')
           setError('Could not restore encrypted session')
           return
         }
 
         setInitialSyncState('syncing')
+        const fingerprint = useEtebaseStore.getState().accountFingerprint
+        const summary = readLocalSyncSummary(fingerprint)
+        startInitialSyncProgress(summary ? {
+          calendar: summary.calendarCount,
+          tasks: summary.taskCount,
+          contacts: summary.contactCount,
+        } : undefined)
 
         // Now load items from each collection into the data stores
         const loadHadErrors = await loadItemsIntoStores()
 
-        // Wire SyncEngine change events
-        unsubChange = wireChangeHandler()
-
-        // Wire SyncEngine status
-        unsubStatus = wireStatusHandler()
-
         if (loadHadErrors) {
           setSyncStatus('error')
           setInitialSyncState('error')
+          setInitialSyncBlocker(null)
+          setInitialSyncProgressPhase('error')
           setError('Some synced items could not be loaded')
         } else {
+          // Start SyncEngine only after initial enumeration has completed, so
+          // change handlers cannot full-replace stores from a partial item cache.
+          await useEtebaseStore.getState().startSyncEngine()
+
+          // Wire SyncEngine change events
+          unsubChange = wireChangeHandler()
+
+          // Wire SyncEngine status
+          unsubStatus = wireStatusHandler()
+
           setSyncStatus('synced')
           setInitialSyncState(hasVisibleDomainData() ? 'synced' : 'empty')
+          setInitialSyncBlocker(null)
           setError(null)
+          finishInitialSyncProgress()
+          const currentFingerprint = useEtebaseStore.getState().accountFingerprint
+          if (currentFingerprint) {
+            writeLocalSyncSummary(currentFingerprint, {
+              calendarCount: useCalendarStore.getState().events.length,
+              taskCount: useTaskStore.getState().tasks.length,
+              contactCount: useContactStore.getState().contacts.length,
+            })
+          }
+          setLastSynced(new Date())
         }
-        setLastSynced(new Date())
         logSyncTiming('initial-sync-complete', initStartedAt, { hadErrors: loadHadErrors })
       } catch (err) {
         reportSyncError('init', err)
         setSyncStatus('error')
         setInitialSyncState('error')
+        const hasRestoredAccount = Boolean(useEtebaseStore.getState().account)
+        setInitialSyncBlocker(hasRestoredAccount ? null : 'encrypted-session-restore-failed')
+        setInitialSyncProgressPhase('error')
         setError('Sync initialization failed')
       }
     }
@@ -321,7 +364,6 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     }
 
     async function loadItemsIntoStores(): Promise<boolean> {
-      const etebase = useEtebaseStore.getState()
       const cacheEnabled = isLocalCacheEnabled()
       let hadErrors = false
 
@@ -349,32 +391,36 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
       // Load calendar events first so the calendar can paint before unrelated
       // task/contact deserialization work on large accounts.
+      let calendarEventCount = 0
       try {
+        setInitialSyncProgressPhase('calendar')
         const calendarFetchStartedAt = nowMs()
-        const eventItems = await etebase.fetchAllItems('calendar')
-        logSyncTiming('calendar-fetch', calendarFetchStartedAt, { itemCount: eventItems.length })
-        if (eventItems.length > 0) {
-          const calendarImportStartedAt = nowMs()
-          const { deserializeCalendarEvent } = await import('@silentsuite/core')
-          const { events, errors } = await deserializeCalendarItemsIncrementally(
-            eventItems,
-            deserializeCalendarEvent,
-            'server',
-          )
-          logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
-          logSyncTiming('calendar-load', calendarImportStartedAt, {
-            itemCount: eventItems.length,
-            eventCount: events.length,
-            errorCount: errors.length,
-          })
-          if (errors.length > 0) {
-            hadErrors = true
-            reportSyncError('load calendar event chunk', errors[0])
-          }
-          await mirrorToCache('calendar', eventItems)
-        } else {
-          useCalendarStore.getState().syncFromRemote([])
-        }
+        const { deserializeCalendarEvent } = await import('@silentsuite/core')
+        const allEvents: CalendarEvent[] = []
+        const eventItems = await etebaseLoadIncrementally('calendar', {
+          onItems: async (pageItems, progress) => {
+            if (pageItems.length > 0) {
+              const { events, errors } = await deserializeCalendarItemsIncrementally(
+                pageItems,
+                deserializeCalendarEvent,
+                'server',
+                { finalReplace: false },
+              )
+              allEvents.push(...events)
+              calendarEventCount = allEvents.length
+              if (errors.length > 0) {
+                hadErrors = true
+                reportSyncError('load calendar event chunk', errors[0])
+              }
+            }
+            updateInitialSyncProgress('calendar', calendarEventCount, undefined, progress.done)
+          },
+        })
+        useCalendarStore.getState().syncFromRemote(allEvents)
+        updateInitialSyncProgress('calendar', calendarEventCount, undefined, true)
+        logSyncTiming('calendar-fetch', calendarFetchStartedAt, { itemCount: eventItems.length, eventCount: allEvents.length })
+        logger.log(`[sync-provider] Loaded ${allEvents.length} calendar events from server`)
+        await mirrorToCache('calendar', eventItems)
       } catch (err) {
         hadErrors = true
         reportSyncError('load calendar events', err)
@@ -382,24 +428,21 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
       // Load tasks
       try {
+        setInitialSyncProgressPhase('tasks')
         const taskLoadStartedAt = nowMs()
-        const taskItems = await etebase.fetchAllItems('tasks')
-        if (taskItems.length > 0) {
-          const { deserializeTask } = await import('@silentsuite/core')
-          const tasks = taskItems.map((item) => {
-            const task = deserializeTask(item.content)
-            // Use the Etebase item UID only as the local id so updates/deletes
-            // can address the item without changing the stable iCalendar UID.
-            return { ...task, id: item.uid, listId: item.collectionUid }
-          })
-          useTaskStore.getState().syncFromRemote(tasks)
-          logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
-          logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: taskItems.length, taskCount: tasks.length })
-          await mirrorToCache('tasks', taskItems)
-        } else {
-          useTaskStore.getState().syncFromRemote([])
-          logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: 0, taskCount: 0 })
-        }
+        const taskItems = await etebaseLoadIncrementally('tasks')
+        const { deserializeTask } = await import('@silentsuite/core')
+        const tasks = taskItems.map((item) => {
+          const task = deserializeTask(item.content)
+          // Use the Etebase item UID only as the local id so updates/deletes
+          // can address the item without changing the stable iCalendar UID.
+          return { ...task, id: item.uid, listId: item.collectionUid }
+        })
+        useTaskStore.getState().syncFromRemote(tasks)
+        updateInitialSyncProgress('tasks', tasks.length, undefined, true)
+        logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
+        logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: taskItems.length, taskCount: tasks.length })
+        await mirrorToCache('tasks', taskItems)
       } catch (err) {
         hadErrors = true
         reportSyncError('load tasks', err)
@@ -407,25 +450,38 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
       // Load contacts
       try {
+        setInitialSyncProgressPhase('contacts')
         const contactLoadStartedAt = nowMs()
-        const contactItems = await etebase.fetchAllItems('contacts')
-        if (contactItems.length > 0) {
-          const { deserializeContact } = await import('@silentsuite/core')
-          const contacts = contactItems.map((item) => {
-            const contact = deserializeContact(item.content)
-            return { ...contact, id: item.uid, listId: item.collectionUid }
-          })
-          useContactStore.getState().syncFromRemote(contacts)
-          logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
-          logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: contactItems.length, contactCount: contacts.length })
-          await mirrorToCache('contacts', contactItems)
-        } else {
-          useContactStore.getState().syncFromRemote([])
-          logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: 0, contactCount: 0 })
-        }
+        const contactItems = await etebaseLoadIncrementally('contacts')
+        const { deserializeContact } = await import('@silentsuite/core')
+        const contacts = contactItems.map((item) => {
+          const contact = deserializeContact(item.content)
+          return { ...contact, id: item.uid, listId: item.collectionUid }
+        })
+        useContactStore.getState().syncFromRemote(contacts)
+        updateInitialSyncProgress('contacts', contacts.length, undefined, true)
+        logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
+        logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: contactItems.length, contactCount: contacts.length })
+        await mirrorToCache('contacts', contactItems)
       } catch (err) {
         hadErrors = true
         reportSyncError('load contacts', err)
+      }
+
+      // Load non-visible encrypted collections into itemCache before their
+      // stores initialize through fetchAllItems().
+      setInitialSyncProgressPhase('preferences')
+      try {
+        await etebaseLoadIncrementally('preferences')
+      } catch (err) {
+        hadErrors = true
+        reportSyncError('load preferences items', err)
+      }
+      try {
+        await etebaseLoadIncrementally('labelIndex')
+      } catch (err) {
+        hadErrors = true
+        reportSyncError('load label suggestion items', err)
       }
 
       // Load and subscribe account-level preferences after the Etebase item

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -128,7 +128,7 @@ describe('useEtebaseStore.initialize outcomes', () => {
     useEtebaseStore.setState({
       account: null,
       accountFingerprint: null,
-      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
       itemCache: new Map(),
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
@@ -169,10 +169,12 @@ describe('useEtebaseStore.initialize outcomes', () => {
     expect(outcome).toEqual({ status: 'success', itemCount: 0 })
     expect(useEtebaseStore.getState().isInitialized).toBe(true)
     expect(useEtebaseStore.getState().accountFingerprint).toBe('fingerprint')
+    expect(engine.start).not.toHaveBeenCalled()
+    await useEtebaseStore.getState().startSyncEngine()
     expect(engine.start).toHaveBeenCalledWith(account)
   })
 
-  it('restores remote collections and items into cold-start caches and list stores', async () => {
+  it('restores remote collections without blocking on item enumeration and hydrates list stores', async () => {
     vi.mocked(secureGet).mockResolvedValue('saved-session')
     const account = { id: 'account' }
     const calendarCollection = mockCollection('calendar-col', { name: 'Personal', color: '#10b981' })
@@ -207,10 +209,8 @@ describe('useEtebaseStore.initialize outcomes', () => {
 
     const outcome = await useEtebaseStore.getState().initialize()
 
-    expect(outcome).toEqual({ status: 'success', itemCount: 1 })
-    expect(useEtebaseStore.getState().itemCache.has('event-1')).toBe(true)
-    expect(useEtebaseStore.getState().itemTypeMap.get('event-1')).toBe('calendar')
-    expect(useEtebaseStore.getState().itemCollectionMap.get('event-1')).toBe('calendar-col')
+    expect(outcome).toEqual({ status: 'success', itemCount: 0 })
+    expect(coreMock.listItems).not.toHaveBeenCalled()
     expect(useCalendarListStore.getState().calendars.map((calendar) => calendar.id)).toEqual(['calendar-col'])
     expect(useTaskListStore.getState().lists.map((list) => list.id)).toEqual(['tasks-col'])
     expect(useContactListStore.getState().lists.map((list) => list.id)).toEqual(['contacts-col'])
@@ -225,6 +225,71 @@ describe('useEtebaseStore.initialize outcomes', () => {
     expect(outcome.status).toBe('error')
     expect(useEtebaseStore.getState().isInitialized).toBe(false)
     expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith('Failed to restore session. Please try signing in again.')
+  })
+
+  it('incrementally loads a collection page-at-a-time and filters deleted items before callbacks', async () => {
+    const account = { id: 'account' }
+    const calendarCollection = mockCollection('calendar-col')
+    useEtebaseStore.setState({
+      account,
+      collections: { calendar: [calendarCollection], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: true,
+      syncEngine: null,
+    })
+    coreMock.listItems
+      .mockResolvedValueOnce({ items: [mockItem('event-1', 'VEVENT 1'), mockItem('deleted-event', 'DELETED', true)], stoken: 'next', done: false })
+      .mockResolvedValueOnce({ items: [mockItem('event-2', 'VEVENT 2')], stoken: null, done: true })
+    const pages: string[][] = []
+    const progress: number[] = []
+
+    const items = await useEtebaseStore.getState().loadCollectionItemsIncrementally('calendar', {
+      onItems: (pageItems, pageProgress) => {
+        pages.push(pageItems.map((item) => item.uid))
+        progress.push(pageProgress.loaded)
+      },
+    })
+
+    expect(coreMock.listItems).toHaveBeenCalledTimes(2)
+    expect(pages).toEqual([['event-1'], ['event-2']])
+    expect(progress).toEqual([1, 2])
+    expect(items.map((item) => item.uid)).toEqual(['event-1', 'event-2'])
+    expect(useEtebaseStore.getState().itemCache.has('deleted-event')).toBe(false)
+    await expect(useEtebaseStore.getState().fetchAllItems('calendar')).resolves.toHaveLength(2)
+  })
+
+  it('incrementally preserves preferences and labelIndex items for fetchAllItems', async () => {
+    const account = { id: 'account' }
+    const preferencesCollection = mockCollection('preferences-col')
+    const labelIndexCollection = mockCollection('label-index-col')
+    useEtebaseStore.setState({
+      account,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [preferencesCollection], labelIndex: [labelIndexCollection] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: true,
+      syncEngine: null,
+    })
+    coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => ({
+      items: collection.uid === 'preferences-col'
+        ? [mockItem('prefs-1', 'PREFS')]
+        : [mockItem('labels-1', 'LABELS')],
+      stoken: null,
+      done: true,
+    }))
+
+    await useEtebaseStore.getState().loadCollectionItemsIncrementally('preferences')
+    await useEtebaseStore.getState().loadCollectionItemsIncrementally('labelIndex')
+
+    expect(await useEtebaseStore.getState().fetchAllItems('preferences')).toEqual([
+      { uid: 'prefs-1', content: 'PREFS', collectionUid: 'preferences-col' },
+    ])
+    expect(await useEtebaseStore.getState().fetchAllItems('labelIndex')).toEqual([
+      { uid: 'labels-1', content: 'LABELS', collectionUid: 'label-index-col' },
+    ])
   })
 })
 

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -78,11 +78,20 @@ function resetStore() {
   useSyncStore.setState({
     syncStatus: 'synced',
     initialSyncState: 'synced',
+    initialSyncBlocker: null,
     lastSyncedAt: null,
     isOnline: true,
     error: null,
     pendingQueueCount: 0,
     failedQueueCount: 0,
+    initialSyncProgress: {
+      active: false,
+      phase: 'idle',
+      calendar: { loaded: 0, knownTotal: null, done: false },
+      tasks: { loaded: 0, knownTotal: null, done: false },
+      contacts: { loaded: 0, knownTotal: null, done: false },
+      message: null,
+    },
   })
 }
 
@@ -122,6 +131,39 @@ describe('useSyncStore', () => {
 
     useSyncStore.getState().setInitialSyncState('empty')
     expect(useSyncStore.getState().initialSyncState).toBe('empty')
+  })
+
+  it('tracks explicit initial sync blocker transitions', () => {
+    expect(useSyncStore.getState().initialSyncBlocker).toBeNull()
+
+    useSyncStore.getState().setInitialSyncBlocker('missing-encrypted-session')
+    expect(useSyncStore.getState().initialSyncBlocker).toBe('missing-encrypted-session')
+
+    useSyncStore.getState().setInitialSyncBlocker('encrypted-session-restore-failed')
+    expect(useSyncStore.getState().initialSyncBlocker).toBe('encrypted-session-restore-failed')
+
+    useSyncStore.getState().setInitialSyncBlocker(null)
+    expect(useSyncStore.getState().initialSyncBlocker).toBeNull()
+  })
+
+  it('tracks initial sync progress phases and counts', () => {
+    useSyncStore.getState().startInitialSyncProgress({ calendar: 3000 })
+    expect(useSyncStore.getState().initialSyncProgress.active).toBe(true)
+    expect(useSyncStore.getState().initialSyncProgress.calendar.knownTotal).toBe(3000)
+
+    useSyncStore.getState().setInitialSyncProgressPhase('calendar')
+    useSyncStore.getState().updateInitialSyncProgress('calendar', 600, undefined, false)
+    expect(useSyncStore.getState().initialSyncProgress.phase).toBe('calendar')
+    expect(useSyncStore.getState().initialSyncProgress.calendar.loaded).toBe(600)
+    expect(useSyncStore.getState().initialSyncProgress.calendar.done).toBe(false)
+
+    useSyncStore.getState().finishInitialSyncProgress()
+    expect(useSyncStore.getState().initialSyncProgress.active).toBe(false)
+    expect(useSyncStore.getState().initialSyncProgress.phase).toBe('complete')
+    expect(useSyncStore.getState().initialSyncProgress.contacts.done).toBe(true)
+
+    useSyncStore.getState().resetInitialSyncProgress()
+    expect(useSyncStore.getState().initialSyncProgress.phase).toBe('idle')
   })
 
   it('simulateSyncCycle transitions synced→syncing→synced', async () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -8,6 +8,7 @@ import { COOKIE_MAX_AGE_SELF_HOSTED, COOKIE_MAX_AGE_HOSTED } from '@/app/lib/con
 import { secureGet, secureSet, secureRemove, secureClear, migrateFromLocalStorage } from '@/app/lib/secure-storage'
 import { clearAll as clearLocalDataCache } from '@/app/lib/data-cache'
 import { clearAll as clearOfflineQueue } from '@/app/lib/offline-queue'
+import { clearLocalSyncSummary } from '@/app/lib/sync-summary'
 
 export interface User {
   isAdmin?: boolean
@@ -526,6 +527,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     } catch (err) {
       logger.warn('[auth-store] Failed to clear offline queue during logout:', err)
     }
+
+    clearLocalSyncSummary()
 
     // Clear signup-in-progress flag
     if (typeof window !== 'undefined') {

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -79,7 +79,8 @@ type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'la
 type CollectionMetaUpdates = { name?: string; description?: string; color?: string }
 type EtebaseCore = typeof import('@silentsuite/core')
 
-type CachedContentItem = { uid: string; content: string; collectionUid: string }
+export type CachedContentItem = { uid: string; content: string; collectionUid: string }
+export type IncrementalCollectionProgress = { loaded: number; done: boolean; collectionUid: string }
 
 export type EtebaseInitializeOutcome =
   | { status: 'no-session' }
@@ -486,6 +487,17 @@ interface EtebaseActions {
   fetchAllItems: (type: CollectionTypeKey) => Promise<CachedContentItem[]>
 
   /**
+   * Page through a collection type and update the local item cache as pages arrive.
+   */
+  loadCollectionItemsIncrementally: (
+    type: CollectionTypeKey,
+    options?: { onItems?: (items: CachedContentItem[], progress: IncrementalCollectionProgress) => Promise<void> | void },
+  ) => Promise<CachedContentItem[]>
+
+  /** Start the SyncEngine after initial page-at-a-time enumeration is complete. */
+  startSyncEngine: () => Promise<void>
+
+  /**
    * Re-fetch all items from the Etebase server for a collection type.
    * Updates the local cache and returns fresh content.
    * This is what the sync change handler should call.
@@ -557,37 +569,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       set({ collections })
       await hydrateListStores(collections)
 
-      // 3. Load all items from each collection into the cache
-      const itemCache = new Map<string, any>()
-      const itemTypeMap = new Map<string, CollectionTypeKey>()
-      const itemCollectionMap = new Map<string, string>()
-
-      for (const [key] of COLLECTION_DEFINITIONS) {
-        const typedCollections = collections[key]
-
-        for (const collection of typedCollections) {
-          let stoken: string | null = null
-          let done = false
-
-          while (!done) {
-            const response = await core.listItems(account, collection, stoken)
-            for (const item of response.items) {
-              if (!item.isDeleted) {
-                itemCache.set(item.uid, item)
-                itemTypeMap.set(item.uid, key)
-                itemCollectionMap.set(item.uid, collection.uid)
-              }
-            }
-            stoken = response.stoken
-            done = response.done
-          }
-        }
-      }
-
-      set({ itemCache, itemTypeMap, itemCollectionMap })
-      logger.debug(`[etebase-store] Loaded ${itemCache.size} items into cache`)
-
-      // 4. Start SyncEngine
+      // 3. Prepare SyncEngine, but do not start polling yet. Initial item
+      // enumeration happens page-at-a-time in SyncProvider so visible calendar
+      // data can render before tasks/contacts/non-visible collections finish.
       const engine = new core.SyncEngine({
         serverUrl: serverUrl,
         pollIntervalMs: 30_000,
@@ -612,10 +596,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         })
       }
 
-      await engine.start(account)
       set({ syncEngine: engine, isInitialized: true })
-      logger.debug('[etebase-store] SyncEngine started')
-      return { status: 'success', itemCount: itemCache.size }
+      logger.debug('[etebase-store] SyncEngine prepared')
+      return { status: 'success', itemCount: 0 }
     } catch (err) {
       console.error('[etebase-store] Initialization failed', getSafeErrorDetails(err))
       // Don't clear the session -- the user might be offline
@@ -1408,6 +1391,73 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     }
 
     return results
+  },
+
+  loadCollectionItemsIncrementally: async (type, options: { onItems?: (items: CachedContentItem[], progress: IncrementalCollectionProgress) => Promise<void> | void } = {}) => {
+    const { account, collections } = get()
+    if (!account || collections[type].length === 0) {
+      logger.warn(`[etebase-store] Cannot load ${type}: missing account or collection`)
+      return get().fetchAllItems(type)
+    }
+
+    const core = await import('@silentsuite/core')
+    const newItemCache = new Map(get().itemCache)
+    const newItemTypeMap = new Map(get().itemTypeMap)
+    const newItemCollectionMap = new Map(get().itemCollectionMap)
+    const targetCollectionUids = new Set(collections[type].map((collection) => collection.uid))
+
+    for (const [uid, collectionUid] of newItemCollectionMap.entries()) {
+      if (targetCollectionUids.has(collectionUid)) {
+        newItemCache.delete(uid)
+        newItemTypeMap.delete(uid)
+        newItemCollectionMap.delete(uid)
+      }
+    }
+
+    let loaded = 0
+    const results: CachedContentItem[] = []
+
+    for (const collection of collections[type]) {
+      let stoken: string | null = null
+      let done = false
+
+      while (!done) {
+        const response = await core.listItems(account, collection, stoken)
+        const pageItems = response.items.filter((item: any) => !item.isDeleted)
+        const pageResults: CachedContentItem[] = []
+
+        for (const item of pageItems) {
+          newItemCache.set(item.uid, item)
+          newItemTypeMap.set(item.uid, type)
+          newItemCollectionMap.set(item.uid, collection.uid)
+          try {
+            const content = await item.getContent()
+            const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
+            const cached = { uid: item.uid, content: contentStr, collectionUid: collection.uid }
+            pageResults.push(cached)
+            results.push(cached)
+          } catch (err) {
+            logger.warn(`[etebase-store] Failed to decode incremental ${type} item`, getSafeErrorDetails(err))
+          }
+        }
+
+        loaded += pageResults.length
+        set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, itemCollectionMap: newItemCollectionMap })
+        stoken = response.stoken
+        done = response.done
+        await options.onItems?.(pageResults, { loaded, done, collectionUid: collection.uid })
+      }
+    }
+
+    logger.debug(`[etebase-store] Incrementally loaded ${results.length} ${type} items`)
+    return results
+  },
+
+  startSyncEngine: async () => {
+    const { account, syncEngine } = get()
+    if (!account || !syncEngine) return
+    await syncEngine.start(account)
+    logger.debug('[etebase-store] SyncEngine started')
   },
 
   refreshCollection: async (type: CollectionTypeKey, collectionUid?: string) => {

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -8,10 +8,45 @@ import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
 
 export type InitialSyncState = 'idle' | 'restoring' | 'hydrated-cache' | 'syncing' | 'synced' | 'empty' | 'offline' | 'error' | 'no-session'
+export type InitialSyncBlocker = null | 'missing-encrypted-session' | 'encrypted-session-restore-failed'
+export type InitialSyncDomain = 'calendar' | 'tasks' | 'contacts'
+export type InitialSyncProgressPhase = 'idle' | 'restoring' | 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'complete' | 'blocked' | 'error'
+
+export interface DomainSyncProgress {
+  loaded: number
+  knownTotal: number | null
+  done: boolean
+}
+
+export interface InitialSyncProgressState {
+  active: boolean
+  phase: InitialSyncProgressPhase
+  calendar: DomainSyncProgress
+  tasks: DomainSyncProgress
+  contacts: DomainSyncProgress
+  message: string | null
+}
+
+export type InitialSyncKnownTotals = Partial<Record<InitialSyncDomain, number | null>>
+
+const emptyDomainProgress: DomainSyncProgress = { loaded: 0, knownTotal: null, done: false }
+
+export function createInitialSyncProgressState(): InitialSyncProgressState {
+  return {
+    active: false,
+    phase: 'idle',
+    calendar: { ...emptyDomainProgress },
+    tasks: { ...emptyDomainProgress },
+    contacts: { ...emptyDomainProgress },
+    message: null,
+  }
+}
 
 interface SyncState {
   syncStatus: SyncStatus
   initialSyncState: InitialSyncState
+  initialSyncBlocker: InitialSyncBlocker
+  initialSyncProgress: InitialSyncProgressState
   lastSyncedAt: Date | null
   isOnline: boolean
   error: string | null
@@ -22,6 +57,12 @@ interface SyncState {
 interface SyncActions {
   setSyncStatus: (status: SyncStatus) => void
   setInitialSyncState: (state: InitialSyncState) => void
+  setInitialSyncBlocker: (blocker: InitialSyncBlocker) => void
+  startInitialSyncProgress: (knownTotals?: InitialSyncKnownTotals) => void
+  setInitialSyncProgressPhase: (phase: InitialSyncProgressPhase, message?: string | null) => void
+  updateInitialSyncProgress: (domain: InitialSyncDomain, loaded: number, knownTotal?: number | null, done?: boolean) => void
+  finishInitialSyncProgress: () => void
+  resetInitialSyncProgress: () => void
   setLastSynced: (date: Date) => void
   setOnline: (online: boolean) => void
   setError: (error: string | null) => void
@@ -38,6 +79,8 @@ interface SyncActions {
 export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
   syncStatus: 'syncing',
   initialSyncState: 'idle',
+  initialSyncBlocker: null,
+  initialSyncProgress: createInitialSyncProgressState(),
   lastSyncedAt: null,
   isOnline: typeof navigator !== 'undefined' ? navigator.onLine : true,
   error: null,
@@ -46,6 +89,43 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
 
   setSyncStatus: (status) => set({ syncStatus: status }),
   setInitialSyncState: (initialSyncState) => set({ initialSyncState }),
+  setInitialSyncBlocker: (initialSyncBlocker) => set({ initialSyncBlocker }),
+  startInitialSyncProgress: (knownTotals = {}) => set({
+    initialSyncProgress: {
+      active: true,
+      phase: 'restoring',
+      calendar: { loaded: 0, knownTotal: knownTotals.calendar ?? null, done: false },
+      tasks: { loaded: 0, knownTotal: knownTotals.tasks ?? null, done: false },
+      contacts: { loaded: 0, knownTotal: knownTotals.contacts ?? null, done: false },
+      message: null,
+    },
+  }),
+  setInitialSyncProgressPhase: (phase, message = null) => set((state) => ({
+    initialSyncProgress: { ...state.initialSyncProgress, active: phase !== 'idle' && phase !== 'complete', phase, message },
+  })),
+  updateInitialSyncProgress: (domain, loaded, knownTotal, done) => set((state) => ({
+    initialSyncProgress: {
+      ...state.initialSyncProgress,
+      [domain]: {
+        ...state.initialSyncProgress[domain],
+        loaded: Math.max(0, loaded),
+        knownTotal: knownTotal === undefined ? state.initialSyncProgress[domain].knownTotal : knownTotal,
+        done: done ?? state.initialSyncProgress[domain].done,
+      },
+    },
+  })),
+  finishInitialSyncProgress: () => set((state) => ({
+    initialSyncProgress: {
+      ...state.initialSyncProgress,
+      active: false,
+      phase: 'complete',
+      calendar: { ...state.initialSyncProgress.calendar, done: true },
+      tasks: { ...state.initialSyncProgress.tasks, done: true },
+      contacts: { ...state.initialSyncProgress.contacts, done: true },
+      message: null,
+    },
+  })),
+  resetInitialSyncProgress: () => set({ initialSyncProgress: createInitialSyncProgressState() }),
   setLastSynced: (date) => set({ lastSyncedAt: date }),
   setOnline: (online) => set({ isOnline: online }),
   setError: (error) => set({ error }),
@@ -264,7 +344,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       // Refresh counts to ensure UI is accurate after sync
       const pc = await getPendingCount()
       const fc = await getFailedCount()
-      set({ syncStatus: 'synced', initialSyncState: 'synced', lastSyncedAt: new Date(), error: null, pendingQueueCount: pc, failedQueueCount: fc })
+      set({ syncStatus: 'synced', initialSyncState: 'synced', initialSyncBlocker: null, lastSyncedAt: new Date(), error: null, pendingQueueCount: pc, failedQueueCount: fc })
     }).catch((err) => {
       console.error('[sync-store] Manual sync failed', getSafeErrorDetails(err))
       set({ syncStatus: 'error', error: 'Sync failed' })


### PR DESCRIPTION
## Summary
- Add an encrypted-session recovery screen when hosted auth is still signed in but the browser cannot restore local vault keys.
- Let `/login?reason=unlock` render the credential form even for hosted-authenticated users so the browser can recreate `etebase_session` without a confusing logout loop.
- Load initial encrypted data calendar-first with page-at-a-time enumeration, live browser-local progress counts, and fingerprint-scoped last-sync summaries for approximate later-session percentages.
- Defer SyncEngine startup until initial enumeration completes, and still enumerate preferences plus label suggestions after visible data so non-visible stores restore correctly.

## Testing
- `pnpm --filter @silentsuite/web test -- app/stores/__tests__/use-sync-store.test.ts app/components/__tests__/EncryptedSessionRecoveryScreen.test.tsx 'app/(auth)/login/__tests__/page.test.tsx' app/providers/__tests__/sync-provider.test.tsx app/lib/__tests__/sync-summary.test.ts app/components/__tests__/InitialSyncProgress.test.tsx app/stores/__tests__/use-etebase-store.test.ts app/components/__tests__/SyncIndicator.test.tsx` (Vitest ran 47 files / 451 tests)
- `pnpm --filter @silentsuite/web type-check`
- `git diff --cached --check`

Closes #446
