### PR TITLE
Keep calendar usable after sync load warnings

### DIFF
--- a/apps/web/app/components/InitialSyncProgress.tsx
+++ b/apps/web/app/components/InitialSyncProgress.tsx
@@ -15,7 +15,6 @@ const phaseLabels: Record<string, string> = {
   tasks: 'Loading tasks',
   contacts: 'Loading contacts',
   preferences: 'Finishing encrypted settings',
-  error: 'Sync needs attention',
 }
 
 function formatNumber(value: number): string {
@@ -39,7 +38,7 @@ export function formatInitialSyncCount(domain: InitialSyncDomain, progress: Doma
 export function InitialSyncProgress() {
   const progress = useSyncStore((s) => s.initialSyncProgress)
 
-  if (!progress.active || progress.phase === 'blocked') return null
+  if (!progress.active || progress.phase === 'blocked' || progress.phase === 'error') return null
 
   const activeDomain: InitialSyncDomain = progress.phase === 'tasks'
     ? 'tasks'
@@ -52,26 +51,20 @@ export function InitialSyncProgress() {
   return (
     <section
       aria-label="Initial encrypted data sync progress"
-      className="border-b border-[rgb(var(--border))] bg-emerald-500/10 px-4 py-3 text-sm text-[rgb(var(--foreground))]"
+      className="border-b border-[rgb(var(--border))] bg-[rgb(var(--surface))]/60 px-4 py-2 text-xs text-[rgb(var(--muted))]"
     >
-      <div className="mx-auto flex max-w-5xl flex-col gap-2">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <p className="font-medium">{phaseLabels[progress.phase] ?? 'Loading encrypted data'}</p>
-            <p className="text-xs text-[rgb(var(--muted))]">
-              Encrypted data is loading and decrypting locally in this browser.
-            </p>
-          </div>
-          <p className="text-xs tabular-nums text-[rgb(var(--muted))]">
-            {formatInitialSyncCount(activeDomain, activeProgress)}
-          </p>
+      <div className="mx-auto flex max-w-5xl flex-col gap-1.5">
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span className="font-medium text-[rgb(var(--foreground))]">{phaseLabels[progress.phase] ?? 'Loading encrypted data'}</span>
+          <span>Decrypting locally in this browser.</span>
+          <span className="tabular-nums">{formatInitialSyncCount(activeDomain, activeProgress)}</span>
         </div>
         {percent !== null && (
-          <div className="h-1.5 overflow-hidden rounded-full bg-[rgb(var(--surface))]" aria-hidden="true">
+          <div className="h-1 overflow-hidden rounded-full bg-[rgb(var(--border))]" aria-hidden="true">
             <div className="h-full rounded-full bg-emerald-500 transition-all" style={{ width: `${percent}%` }} />
           </div>
         )}
-        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[rgb(var(--muted))]">
+        <div className="flex flex-wrap gap-x-3 gap-y-1">
           {(Object.keys(domainLabels) as InitialSyncDomain[]).map((domain) => (
             <span key={domain}>
               {domainLabels[domain].label}: {formatInitialSyncCount(domain, progress[domain])}

--- a/apps/web/app/components/__tests__/InitialSyncProgress.test.tsx
+++ b/apps/web/app/components/__tests__/InitialSyncProgress.test.tsx
@@ -34,7 +34,7 @@ describe('InitialSyncProgress', () => {
   it('shows first-sync counts without a percentage when totals are unknown', () => {
     render(<InitialSyncProgress />)
 
-    expect(screen.getByText(/Encrypted data is loading and decrypting locally in this browser/i)).toBeInTheDocument()
+    expect(screen.getByText(/Decrypting locally in this browser/i)).toBeInTheDocument()
     expect(screen.getAllByText(/600 events loaded so far/).length).toBeGreaterThan(0)
     expect(screen.queryByText(/600 \/ about/)).not.toBeInTheDocument()
   })
@@ -52,13 +52,17 @@ describe('InitialSyncProgress', () => {
     expect(formatInitialSyncCount('tasks', { loaded: 12, knownTotal: 10, done: false })).toBe('12 / about 10 tasks loaded (100%) — more than last sync')
   })
 
-  it('does not render when inactive or blocked', () => {
+  it('does not render when inactive, blocked, or errored', () => {
     mockState.initialSyncProgress.active = false
     const { rerender } = render(<InitialSyncProgress />)
     expect(screen.queryByLabelText('Initial encrypted data sync progress')).not.toBeInTheDocument()
 
     mockState.initialSyncProgress.active = true
     mockState.initialSyncProgress.phase = 'blocked'
+    rerender(<InitialSyncProgress />)
+    expect(screen.queryByLabelText('Initial encrypted data sync progress')).not.toBeInTheDocument()
+
+    mockState.initialSyncProgress.phase = 'error'
     rerender(<InitialSyncProgress />)
     expect(screen.queryByLabelText('Initial encrypted data sync progress')).not.toBeInTheDocument()
   })

--- a/apps/web/app/components/empty-state.tsx
+++ b/apps/web/app/components/empty-state.tsx
@@ -85,8 +85,8 @@ export function SyncStartupState({ state, error }: { state: SyncStartupStatus; e
     return (
       <EmptyState
         icon={AlertTriangle}
-        title="Could not restore encrypted session"
-        description={error || 'Sign in again or retry when your connection is available.'}
+        title="Some synced data could not be loaded"
+        description={error || 'Retry sync or refresh when your connection is available.'}
       />
     )
   }

--- a/apps/web/app/providers/__tests__/sync-provider.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.test.tsx
@@ -7,6 +7,8 @@ const etebase = vi.hoisted(() => ({
   state: {
     initialize: vi.fn(),
     fetchAllItems: vi.fn(),
+    loadCollectionItemsIncrementally: vi.fn(),
+    startSyncEngine: vi.fn(),
     onSyncChange: vi.fn(() => vi.fn()),
     onStatusChange: vi.fn(() => vi.fn()),
     isInitialized: false,
@@ -118,6 +120,8 @@ describe('SyncProvider restore recovery blockers', () => {
     calendarStore.upsertFromRemote.mockClear()
     etebase.state.initialize.mockReset().mockResolvedValue({ status: 'success' })
     etebase.state.fetchAllItems.mockReset().mockResolvedValue([])
+    etebase.state.loadCollectionItemsIncrementally.mockReset().mockResolvedValue([])
+    etebase.state.startSyncEngine.mockReset().mockResolvedValue(undefined)
     etebase.state.onSyncChange.mockClear()
     etebase.state.onStatusChange.mockClear()
   })
@@ -151,15 +155,16 @@ describe('SyncProvider restore recovery blockers', () => {
     expect(useSyncStore.getState().syncStatus).toBe('offline')
   })
 
-  it('clears the recovery blocker for post-restore load errors', async () => {
+  it('keeps the app usable and clears the recovery blocker for post-restore load errors', async () => {
     useSyncStore.setState({ initialSyncBlocker: 'missing-encrypted-session' })
     etebase.state.initialize.mockResolvedValueOnce({ status: 'success' })
-    etebase.state.fetchAllItems.mockRejectedValueOnce(new Error('calendar load failed'))
+    etebase.state.loadCollectionItemsIncrementally.mockRejectedValueOnce(new Error('calendar load failed'))
 
     render(<SyncProvider><div>content</div></SyncProvider>)
 
     await waitFor(() => expect(useSyncStore.getState().error).toBe('Some synced items could not be loaded'))
-    expect(useSyncStore.getState().initialSyncState).toBe('error')
+    expect(useSyncStore.getState().initialSyncState).toBe('empty')
     expect(useSyncStore.getState().initialSyncBlocker).toBeNull()
+    expect(useSyncStore.getState().initialSyncProgress.active).toBe(false)
   })
 })

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -225,9 +225,14 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
         if (loadHadErrors) {
           setSyncStatus('error')
-          setInitialSyncState('error')
+          // A post-restore item or optional metadata load error should not
+          // put the app back into the encrypted-session recovery/blocked UI.
+          // Keep the visible domain stores usable and surface the problem via
+          // the sync indicator instead of hiding the calendar behind a false
+          // restore error screen.
+          setInitialSyncState(hasVisibleDomainData() ? 'synced' : 'empty')
           setInitialSyncBlocker(null)
-          setInitialSyncProgressPhase('error')
+          finishInitialSyncProgress()
           setError('Some synced items could not be loaded')
         } else {
           // Start SyncEngine only after initial enumeration has completed, so


### PR DESCRIPTION
## Summary
- Keep post-restore item/metadata load warnings from pushing the calendar into the blocked startup error screen.
- Finish/hide the initial sync progress panel when load warnings occur, leaving the red sync indicator to communicate the warning.
- Make the initial sync progress strip more minimal and remove the large “Sync needs attention” banner.
- Update generic sync error empty-state copy so it no longer incorrectly says the encrypted session could not be restored.

## Testing
- `pnpm --filter @silentsuite/web test -- app/providers/__tests__/sync-provider.test.tsx app/components/__tests__/InitialSyncProgress.test.tsx 'app/(app)/calendar/__tests__/page.test.tsx' app/stores/__tests__/use-etebase-store.test.ts app/components/__tests__/SyncIndicator.test.tsx` (Vitest ran 47 files / 451 tests)
- `pnpm --filter @silentsuite/web type-check`
- `git diff --check`

Follow-up to #451 / #446 smoke test.
