### PR TITLE
Connect multi-day calendar bars in month view

### DIFF
--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { toScheduleXEvents, type DisplayEvent } from '../calendar-grid-events'
 
 function displayEvent(overrides: Partial<DisplayEvent> = {}): DisplayEvent {
-  const startDate = new Date('2026-06-25T22:00:00Z')
-  const endDate = new Date('2026-06-27T01:00:00Z')
+  const startDate = new Date(2026, 5, 25, 22, 0)
+  const endDate = new Date(2026, 5, 27, 1, 0)
   return {
     id: 'event-1',
     masterId: 'event-1',
@@ -25,7 +25,7 @@ function zdt(date: Date): Temporal.ZonedDateTime {
 }
 
 describe('toScheduleXEvents', () => {
-  it('splits timed multi-day events into one month-view segment per affected day', () => {
+  it('renders timed multi-day month events as one connected date-range bar', () => {
     const events = toScheduleXEvents(
       [displayEvent()],
       new Map([['cal-1', '#10b981']]),
@@ -34,22 +34,32 @@ describe('toScheduleXEvents', () => {
       zdt,
     )
 
-    expect(events).toHaveLength(3)
-    expect(events.map((event) => String(event.start))).toEqual([
-      '2026-06-25',
-      '2026-06-26',
-      '2026-06-27',
+    expect(events).toHaveLength(1)
+    expect(events[0]!.id).toBe('event-1')
+    expect(String(events[0]!.start)).toBe('2026-06-25')
+    expect(String(events[0]!.end)).toBe('2026-06-27')
+    expect(events[0]!._options?.additionalClasses).toEqual([
+      'sx-cal-color-cal-1',
+      'ss-month-multiday',
     ])
-    expect(events.map((event) => String(event.end))).toEqual([
-      '2026-06-25',
-      '2026-06-26',
-      '2026-06-27',
-    ])
-    expect(events.map((event) => event.id)).toEqual([
-      'event-1__day_2026-06-25',
-      'event-1__day_2026-06-26',
-      'event-1__day_2026-06-27',
-    ])
+  })
+
+  it('does not paint timed month bars onto a final midnight-only day', () => {
+    const events = toScheduleXEvents(
+      [displayEvent({
+        startDate: new Date(2026, 5, 25, 22, 0),
+        endDate: new Date(2026, 5, 27, 0, 0),
+      })],
+      new Map([['cal-1', '#10b981']]),
+      'UTC',
+      'month',
+      zdt,
+    )
+
+    expect(events).toHaveLength(1)
+    expect(String(events[0]!.start)).toBe('2026-06-25')
+    expect(String(events[0]!.end)).toBe('2026-06-26')
+    expect(events[0]!.id).toBe('event-1')
   })
 
   it('keeps timed multi-day events as a single timed event outside month view', () => {
@@ -70,8 +80,8 @@ describe('toScheduleXEvents', () => {
   it('keeps all-day multi-day events as one Schedule-X date range', () => {
     const event = displayEvent({
       allDay: true,
-      startDate: new Date('2026-06-25T00:00:00Z'),
-      endDate: new Date('2026-06-28T00:00:00Z'),
+      startDate: new Date(2026, 5, 25),
+      endDate: new Date(2026, 5, 28),
     })
 
     const events = toScheduleXEvents(
@@ -85,5 +95,26 @@ describe('toScheduleXEvents', () => {
     expect(events).toHaveLength(1)
     expect(String(events[0]!.start)).toBe('2026-06-25')
     expect(String(events[0]!.end)).toBe('2026-06-27')
+    expect(events[0]!._options?.additionalClasses).toEqual([
+      'sx-cal-color-cal-1',
+      'ss-month-multiday',
+    ])
+  })
+
+  it('does not mark single-day events as multi-day month bars', () => {
+    const events = toScheduleXEvents(
+      [displayEvent({
+        startDate: new Date(2026, 5, 25, 9, 0),
+        endDate: new Date(2026, 5, 25, 10, 0),
+      })],
+      new Map([['cal-1', '#10b981']]),
+      'UTC',
+      'month',
+      zdt,
+    )
+
+    expect(events).toHaveLength(1)
+    expect(String(events[0]!.start)).toContain('2026-06-25')
+    expect(events[0]!._options?.additionalClasses).toEqual(['sx-cal-color-cal-1'])
   })
 })

--- a/apps/web/app/(app)/calendar/lib/calendar-grid-events.ts
+++ b/apps/web/app/(app)/calendar/lib/calendar-grid-events.ts
@@ -90,25 +90,6 @@ export function expandEventsForRange(
   return result
 }
 
-function splitMonthTimedEvent(e: DisplayEvent): DisplayEvent[] {
-  const segments: DisplayEvent[] = []
-  const endPlainDate = toTimedMonthEndPlainDate(e.startDate, e.endDate)
-  let day = dateToPlainDate(e.startDate)
-
-  while (Temporal.PlainDate.compare(day, endPlainDate) <= 0) {
-    const segmentDate = new Date(day.year, day.month - 1, day.day, e.startDate.getHours(), e.startDate.getMinutes(), e.startDate.getSeconds(), e.startDate.getMilliseconds())
-    segments.push({
-      ...e,
-      id: `${e.id}__day_${day.toString()}`,
-      startDate: segmentDate,
-      endDate: segmentDate,
-    })
-    day = day.add({ days: 1 })
-  }
-
-  return segments
-}
-
 export function toScheduleXEvents(
   displayEvents: DisplayEvent[],
   calendarColors: Map<string, string>,
@@ -116,26 +97,39 @@ export function toScheduleXEvents(
   currentView: CalendarGridView,
   toScheduleXDateTime: (date: Date, tz: string) => Temporal.ZonedDateTime,
 ): CalendarEventExternal[] {
-  const eventsForView = currentView === 'month'
-    ? displayEvents.flatMap((e) => (!e.allDay && isMultiDayTimedRange(e.startDate, e.endDate) ? splitMonthTimedEvent(e) : [e]))
-    : displayEvents
-
-  return eventsForView.map((e) => {
+  return displayEvents.map((e) => {
     const color = calendarColors.get(e.calendarId ?? 'default') ?? '#10b981'
+    const calendarId = e.calendarId ?? 'default'
+    const colorClass = `sx-cal-color-${calendarId.replace(/[^a-zA-Z0-9_-]/g, '_')}`
+    const renderAsTimedMonthBar =
+      currentView === 'month' && !e.allDay && isMultiDayTimedRange(e.startDate, e.endDate)
+    const allDayMonthEnd = e.allDay ? toAllDayEndPlainDate(e.startDate, e.endDate) : null
+    const renderAsAllDayMonthBar =
+      currentView === 'month'
+      && e.allDay
+      && allDayMonthEnd !== null
+      && Temporal.PlainDate.compare(allDayMonthEnd, dateToPlainDate(e.startDate)) > 0
+    const additionalClasses = [colorClass]
+    if (renderAsTimedMonthBar || renderAsAllDayMonthBar) {
+      additionalClasses.push('ss-month-multiday')
+    }
+
     return {
       id: e.id,
       title: e.isRecurring ? `↻ ${e.title}` : e.title,
-      start: e.allDay ? dateToPlainDate(e.startDate) : currentView === 'month' && e.id.includes('__day_') ? dateToPlainDate(e.startDate) : toScheduleXDateTime(e.startDate, userTz),
+      start: e.allDay || renderAsTimedMonthBar
+        ? dateToPlainDate(e.startDate)
+        : toScheduleXDateTime(e.startDate, userTz),
       end: e.allDay
-        ? toAllDayEndPlainDate(e.startDate, e.endDate)
-        : currentView === 'month' && e.id.includes('__day_')
-          ? dateToPlainDate(e.startDate)
+        ? allDayMonthEnd!
+        : renderAsTimedMonthBar
+          ? toTimedMonthEndPlainDate(e.startDate, e.endDate)
           : toScheduleXDateTime(e.endDate, userTz),
       description: e.description || undefined,
       location: e.location || undefined,
-      calendarId: e.calendarId ?? 'default',
+      calendarId,
       _options: {
-        additionalClasses: [`sx-cal-color-${(e.calendarId ?? 'default').replace(/[^a-zA-Z0-9_-]/g, '_')}`],
+        additionalClasses,
       },
       _color: color,
     }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -432,6 +432,17 @@
   text-overflow: ellipsis;
 }
 
+.sx-silentsuite-calendar .sx__month-grid-event.ss-month-multiday {
+  min-height: 21px;
+  border-radius: 6px !important;
+  margin-block: 2px !important;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.08);
+}
+
+.sx-silentsuite-calendar .sx__month-grid-event.ss-month-multiday:hover {
+  box-shadow: 0 2px 6px rgb(0 0 0 / 0.12);
+}
+
 .sx-silentsuite-calendar .sx__month-grid-event * {
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Render timed multi-day events in month view as one Schedule-X date-range bar instead of repeated daily chips.
- Add a month multi-day class for connected-bar styling while preserving calendar colors.
- Update focused calendar conversion tests for timed/all-day multi-day bars and midnight-ending events.

## Validation
- `corepack pnpm --filter @silentsuite/web test -- 'app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts'` — passed (47 files / 453 tests under current Vitest invocation).
- `corepack pnpm --filter @silentsuite/web type-check` — passed.
- `corepack pnpm --filter @silentsuite/web lint` — passed with pre-existing warnings.
- `corepack pnpm --filter @silentsuite/web build` — passed with existing Sentry/standalone trace warnings.
- `git diff --check` — passed.

## Notes
- This intentionally keeps exact timed rendering unchanged outside month view.
- Branch preview should be used to visually confirm the month-grid bar rendering because Schedule-X owns the final month layout.
