### PR TITLE
Fix encrypted restore sync recovery

### DIFF
--- a/apps/web/app/providers/__tests__/sync-provider.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
+import { deserializeCalendarEvent, deserializeContact, deserializeTask } from '@silentsuite/core'
 import { SyncProvider } from '../sync-provider'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 
@@ -21,6 +22,28 @@ const calendarStore = vi.hoisted(() => ({
   upsertFromRemote: vi.fn(),
 }))
 
+const taskStore = vi.hoisted(() => ({
+  tasks: [] as unknown[],
+  syncFromRemote: vi.fn(),
+}))
+
+const contactStore = vi.hoisted(() => ({
+  contacts: [] as unknown[],
+  syncFromRemote: vi.fn(),
+}))
+
+const preferencesSyncStore = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  loadFromRemote: vi.fn(),
+  destroy: vi.fn(),
+}))
+
+const labelSuggestionsStore = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  loadFromRemote: vi.fn(),
+  destroy: vi.fn(),
+}))
+
 vi.mock('@sentry/nextjs', () => ({
   captureException: vi.fn(),
 }))
@@ -33,11 +56,11 @@ vi.mock('@/app/stores/use-etebase-store', () => ({
 }))
 
 vi.mock('@/app/stores/use-task-store', () => ({
-  useTaskStore: { getState: () => ({ tasks: [], syncFromRemote: vi.fn() }) },
+  useTaskStore: { getState: () => taskStore },
 }))
 
 vi.mock('@/app/stores/use-contact-store', () => ({
-  useContactStore: { getState: () => ({ contacts: [], syncFromRemote: vi.fn() }) },
+  useContactStore: { getState: () => contactStore },
 }))
 
 vi.mock('@/app/stores/use-calendar-store', () => ({
@@ -51,11 +74,11 @@ vi.mock('@/app/stores/use-calendar-store', () => ({
 }))
 
 vi.mock('@/app/stores/use-preferences-sync-store', () => ({
-  usePreferencesSyncStore: { getState: () => ({ initialize: vi.fn(), loadFromRemote: vi.fn(), destroy: vi.fn() }) },
+  usePreferencesSyncStore: { getState: () => preferencesSyncStore },
 }))
 
 vi.mock('@/app/stores/use-label-suggestions-store', () => ({
-  useLabelSuggestionsStore: { getState: () => ({ initialize: vi.fn(), loadFromRemote: vi.fn(), destroy: vi.fn() }) },
+  useLabelSuggestionsStore: { getState: () => labelSuggestionsStore },
 }))
 
 vi.mock('@/app/lib/offline-queue', () => ({
@@ -69,6 +92,8 @@ vi.mock('@/app/lib/offline-queue', () => ({
 
 vi.mock('@/app/stores/use-toast-store', () => ({
   showErrorToast: vi.fn(),
+  beginPassiveStartupToastCycle: vi.fn(),
+  endPassiveStartupToastCycle: vi.fn(),
 }))
 
 vi.mock('@/app/lib/data-cache', () => ({
@@ -112,18 +137,62 @@ function resetSyncStore() {
   })
 }
 
+function incrementalResult(items: { uid: string; content: string; collectionUid: string }[] = []) {
+  return {
+    type: 'calendar',
+    attemptedCount: items.length,
+    decodedCount: items.length,
+    decodeFailureCount: 0,
+    enumerationErrorCount: 0,
+    items,
+    collections: [],
+    trustworthyForFullReplacement: true,
+  }
+}
+
 describe('SyncProvider restore recovery blockers', () => {
   beforeEach(() => {
     resetSyncStore()
     calendarStore.events = []
     calendarStore.syncFromRemote.mockClear()
     calendarStore.upsertFromRemote.mockClear()
+    taskStore.tasks = []
+    taskStore.syncFromRemote.mockClear()
+    contactStore.contacts = []
+    contactStore.syncFromRemote.mockClear()
+    vi.mocked(deserializeCalendarEvent).mockReset().mockImplementation((content) => ({
+      id: String(content),
+      title: String(content),
+      startDate: new Date('2026-01-01T00:00:00Z'),
+      endDate: new Date('2026-01-01T01:00:00Z'),
+      allDay: false,
+      calendarId: 'calendar-1',
+    }))
+    vi.mocked(deserializeTask).mockReset().mockImplementation((content) => ({
+      id: String(content),
+      uid: String(content),
+      title: String(content),
+      completed: false,
+      status: 'needs-action',
+      percent_complete: 0,
+    }))
+    vi.mocked(deserializeContact).mockReset().mockImplementation((content) => ({
+      id: String(content),
+      uid: String(content),
+      displayName: String(content),
+    }))
     etebase.state.initialize.mockReset().mockResolvedValue({ status: 'success' })
     etebase.state.fetchAllItems.mockReset().mockResolvedValue([])
-    etebase.state.loadCollectionItemsIncrementally.mockReset().mockResolvedValue([])
+    etebase.state.loadCollectionItemsIncrementally.mockReset().mockResolvedValue(incrementalResult())
     etebase.state.startSyncEngine.mockReset().mockResolvedValue(undefined)
     etebase.state.onSyncChange.mockClear()
     etebase.state.onStatusChange.mockClear()
+    preferencesSyncStore.initialize.mockReset().mockResolvedValue(undefined)
+    preferencesSyncStore.loadFromRemote.mockReset().mockResolvedValue(undefined)
+    preferencesSyncStore.destroy.mockClear()
+    labelSuggestionsStore.initialize.mockReset().mockResolvedValue(undefined)
+    labelSuggestionsStore.loadFromRemote.mockReset().mockResolvedValue(undefined)
+    labelSuggestionsStore.destroy.mockClear()
   })
 
   it('sets the recovery blocker for a missing encrypted session', async () => {
@@ -162,9 +231,98 @@ describe('SyncProvider restore recovery blockers', () => {
 
     render(<SyncProvider><div>content</div></SyncProvider>)
 
-    await waitFor(() => expect(useSyncStore.getState().error).toBe('Some synced items could not be loaded'))
-    expect(useSyncStore.getState().initialSyncState).toBe('empty')
+    await waitFor(() => expect(useSyncStore.getState().error).toBe('Calendar data could not be loaded'))
+    expect(useSyncStore.getState().initialSyncState).toBe('error')
     expect(useSyncStore.getState().initialSyncBlocker).toBeNull()
     expect(useSyncStore.getState().initialSyncProgress.active).toBe(false)
+    expect(etebase.state.startSyncEngine).not.toHaveBeenCalled()
+  })
+
+  it('wires SyncEngine when calendar loads but preferences startup fails', async () => {
+    etebase.state.initialize.mockResolvedValueOnce({ status: 'success' })
+    preferencesSyncStore.initialize.mockRejectedValueOnce(new Error('preferences write failed'))
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(etebase.state.startSyncEngine).toHaveBeenCalledTimes(1))
+    expect(etebase.state.onSyncChange).toHaveBeenCalledTimes(1)
+    expect(etebase.state.onStatusChange).toHaveBeenCalledTimes(1)
+    expect(useSyncStore.getState().initialSyncBlocker).toBeNull()
+    expect(useSyncStore.getState().error).toBe('Some synced metadata could not be loaded')
+  })
+
+  it('upserts successfully decoded calendar events when enumeration is partial and untrustworthy', async () => {
+    const calendarItem = { uid: 'event-1', content: 'VEVENT', collectionUid: 'calendar-1' }
+    etebase.state.loadCollectionItemsIncrementally.mockImplementation(async (type: string, options?: { onItems?: (items: typeof calendarItem[], progress: { loaded: number; done: boolean; collectionUid: string }) => Promise<void> | void }) => {
+      if (type !== 'calendar') return incrementalResult()
+      await options?.onItems?.([calendarItem], { loaded: 1, done: true, collectionUid: 'calendar-1' })
+      return {
+        ...incrementalResult([calendarItem]),
+        enumerationErrorCount: 1,
+        trustworthyForFullReplacement: false,
+      }
+    })
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(calendarStore.upsertFromRemote).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(etebase.state.startSyncEngine).toHaveBeenCalledTimes(1))
+    expect(calendarStore.syncFromRemote).not.toHaveBeenCalled()
+    expect(calendarStore.upsertFromRemote).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'event-1', calendarId: 'calendar-1' }),
+    ])
+  })
+
+  it('keeps SyncEngine wired when one calendar item fails to deserialize', async () => {
+    const calendarItem = { uid: 'broken-event', content: 'BROKEN', collectionUid: 'calendar-1' }
+    vi.mocked(deserializeCalendarEvent).mockImplementationOnce(() => {
+      throw new Error('broken calendar item')
+    })
+    etebase.state.loadCollectionItemsIncrementally.mockImplementation(async (type: string, options?: { onItems?: (items: typeof calendarItem[], progress: { loaded: number; done: boolean; collectionUid: string }) => Promise<void> | void }) => {
+      if (type !== 'calendar') return incrementalResult()
+      await options?.onItems?.([calendarItem], { loaded: 1, done: true, collectionUid: 'calendar-1' })
+      return incrementalResult([calendarItem])
+    })
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(etebase.state.startSyncEngine).toHaveBeenCalledTimes(1))
+    expect(calendarStore.syncFromRemote).not.toHaveBeenCalled()
+    expect(useSyncStore.getState().error).toBe('Some synced items could not be loaded')
+  })
+
+  it('merges visible task and contact items instead of full-replacing on partial enumeration', async () => {
+    taskStore.tasks = [{ id: 'existing-task', title: 'Existing task' }]
+    contactStore.contacts = [{ id: 'existing-contact', displayName: 'Existing contact' }]
+    etebase.state.loadCollectionItemsIncrementally.mockImplementation(async (type: string) => {
+      if (type === 'tasks') {
+        return {
+          ...incrementalResult([{ uid: 'task-new', content: 'Task new', collectionUid: 'tasks-1' }]),
+          enumerationErrorCount: 1,
+          trustworthyForFullReplacement: false,
+        }
+      }
+      if (type === 'contacts') {
+        return {
+          ...incrementalResult([{ uid: 'contact-new', content: 'Contact new', collectionUid: 'contacts-1' }]),
+          enumerationErrorCount: 1,
+          trustworthyForFullReplacement: false,
+        }
+      }
+      return incrementalResult()
+    })
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(etebase.state.startSyncEngine).toHaveBeenCalledTimes(1))
+    expect(taskStore.syncFromRemote).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ id: 'existing-task' }),
+      expect.objectContaining({ id: 'task-new', listId: 'tasks-1' }),
+    ]))
+    expect(contactStore.syncFromRemote).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ id: 'existing-contact' }),
+      expect.objectContaining({ id: 'contact-new', listId: 'contacts-1' }),
+    ]))
+    expect(useSyncStore.getState().error).toBe('Some synced items could not be loaded')
   })
 })

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -11,6 +11,10 @@ import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { usePreferencesSyncStore } from '@/app/stores/use-preferences-sync-store'
 import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 import {
+  beginPassiveStartupToastCycle,
+  endPassiveStartupToastCycle,
+} from '@/app/stores/use-toast-store'
+import {
   getItemsByType as cacheGetItemsByType,
   replaceItemsForType as cacheReplaceItemsForType,
   isCacheEnabled as isLocalCacheEnabled,
@@ -34,6 +38,44 @@ import { readLocalSyncSummary, writeLocalSyncSummary } from '@/app/lib/sync-summ
 import type { CalendarEvent } from '@silentsuite/core'
 
 const CALENDAR_DESERIALIZE_CHUNK_SIZE = 50
+
+type InitialDomainLoadResult = {
+  domain: 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'labelIndex'
+  visibility: 'visible' | 'internal'
+  status: 'loaded' | 'empty' | 'warning' | 'failed'
+  itemCount: number
+  decodedCount: number
+  decodeFailureCount: number
+  errorCategory?: string
+}
+
+type InitialLoadClassification = {
+  accountRestored: true
+  domains: InitialDomainLoadResult[]
+  visibleFatal: boolean
+  visibleWarnings: InitialDomainLoadResult[]
+  internalWarnings: InitialDomainLoadResult[]
+  safeToWireSyncEngine: boolean
+}
+
+function errorCategoryFrom(err: unknown): string {
+  const details = getSafeErrorDetails(err) as { name?: unknown; code?: unknown; status?: unknown }
+  if (typeof details.status === 'number') return `http-${details.status}`
+  if (typeof details.code === 'string') return details.code
+  if (typeof details.name === 'string') return details.name
+  return 'unknown'
+}
+
+function shouldWireSyncEngine(classification: Pick<InitialLoadClassification, 'visibleFatal'>): boolean {
+  return !classification.visibleFatal
+}
+
+function mergeById<T extends { id: string }>(current: T[], incoming: T[]): T[] {
+  if (incoming.length === 0) return current
+  const byId = new Map(current.map((item) => [item.id, item]))
+  for (const item of incoming) byId.set(item.id, item)
+  return Array.from(byId.values())
+}
 
 function yieldToBrowser(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0))
@@ -144,7 +186,6 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
   const etebaseLoadIncrementally = useEtebaseStore((s) => s.loadCollectionItemsIncrementally)
   const etebaseOnSyncChange = useEtebaseStore((s) => s.onSyncChange)
   const etebaseOnStatusChange = useEtebaseStore((s) => s.onStatusChange)
-  const etebaseIsInitialized = useEtebaseStore((s) => s.isInitialized)
 
   const didInit = useRef(false)
 
@@ -182,7 +223,10 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         // Restore session, create/fetch collections, load items, start SyncEngine
         const etebaseInitStartedAt = nowMs()
         const initOutcome = await etebaseInitialize()
-        logSyncTiming('etebase-initialize', etebaseInitStartedAt)
+        logSyncTiming('etebase-initialize', etebaseInitStartedAt, {
+          syncEnginePrepared: Boolean(useEtebaseStore.getState().syncEngine),
+          etebaseStoreInitialized: useEtebaseStore.getState().isInitialized,
+        })
 
         if (initOutcome.status === 'no-session') {
           setInitialSyncProgressPhase('blocked')
@@ -221,22 +265,17 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         } : undefined)
 
         // Now load items from each collection into the data stores
-        const loadHadErrors = await loadItemsIntoStores()
+        const classification = await loadItemsIntoStores()
 
-        if (loadHadErrors) {
+        if (!classification.safeToWireSyncEngine) {
           setSyncStatus('error')
-          // A post-restore item or optional metadata load error should not
-          // put the app back into the encrypted-session recovery/blocked UI.
-          // Keep the visible domain stores usable and surface the problem via
-          // the sync indicator instead of hiding the calendar behind a false
-          // restore error screen.
-          setInitialSyncState(hasVisibleDomainData() ? 'synced' : 'empty')
+          setInitialSyncState(hasVisibleDomainData() ? 'synced' : 'error')
           setInitialSyncBlocker(null)
           finishInitialSyncProgress()
-          setError('Some synced items could not be loaded')
+          setError('Calendar data could not be loaded')
         } else {
-          // Start SyncEngine only after initial enumeration has completed, so
-          // change handlers cannot full-replace stores from a partial item cache.
+          // Start SyncEngine after safe initial enumeration. Internal encrypted
+          // metadata warnings must not block visible calendar recovery.
           await useEtebaseStore.getState().startSyncEngine()
 
           // Wire SyncEngine change events
@@ -244,11 +283,23 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
           // Wire SyncEngine status
           unsubStatus = wireStatusHandler()
+          logSyncTiming('sync-engine-start', initStartedAt, {
+            syncEngineStarted: true,
+            changeHandlerWired: Boolean(unsubChange),
+            statusHandlerWired: Boolean(unsubStatus),
+            visibleWarningCount: classification.visibleWarnings.length,
+            internalWarningCount: classification.internalWarnings.length,
+          })
 
-          setSyncStatus('synced')
+          const hasWarnings = classification.visibleWarnings.length > 0 || classification.internalWarnings.length > 0
+          setSyncStatus(hasWarnings ? 'error' : 'synced')
           setInitialSyncState(hasVisibleDomainData() ? 'synced' : 'empty')
           setInitialSyncBlocker(null)
-          setError(null)
+          setError(classification.visibleWarnings.length > 0
+            ? 'Some synced items could not be loaded'
+            : classification.internalWarnings.length > 0
+              ? 'Some synced metadata could not be loaded'
+              : null)
           finishInitialSyncProgress()
           const currentFingerprint = useEtebaseStore.getState().accountFingerprint
           if (currentFingerprint) {
@@ -260,7 +311,12 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           }
           setLastSynced(new Date())
         }
-        logSyncTiming('initial-sync-complete', initStartedAt, { hadErrors: loadHadErrors })
+        logSyncTiming('initial-sync-complete', initStartedAt, {
+          visibleFatal: classification.visibleFatal,
+          visibleWarningCount: classification.visibleWarnings.length,
+          internalWarningCount: classification.internalWarnings.length,
+          safeToWireSyncEngine: classification.safeToWireSyncEngine,
+        })
       } catch (err) {
         reportSyncError('init', err)
         setSyncStatus('error')
@@ -368,9 +424,22 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       return hydratedAny
     }
 
-    async function loadItemsIntoStores(): Promise<boolean> {
+    async function loadItemsIntoStores(): Promise<InitialLoadClassification> {
       const cacheEnabled = isLocalCacheEnabled()
-      let hadErrors = false
+      const domains: InitialDomainLoadResult[] = []
+
+      const addDomain = (result: InitialDomainLoadResult) => {
+        domains.push(result)
+        logSyncTiming('initial-domain-load', nowMs(), {
+          domain: result.domain,
+          visibility: result.visibility,
+          status: result.status,
+          itemCount: result.itemCount,
+          decodedCount: result.decodedCount,
+          decodeFailureCount: result.decodeFailureCount,
+          errorCategory: result.errorCategory ?? null,
+        })
+      }
 
       async function mirrorToCache(
         type: 'tasks' | 'contacts' | 'calendar',
@@ -402,7 +471,8 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         const calendarFetchStartedAt = nowMs()
         const { deserializeCalendarEvent } = await import('@silentsuite/core')
         const allEvents: CalendarEvent[] = []
-        const eventItems = await etebaseLoadIncrementally('calendar', {
+        let calendarDeserializeErrorCount = 0
+        const eventLoad = await etebaseLoadIncrementally('calendar', {
           onItems: async (pageItems, progress) => {
             if (pageItems.length > 0) {
               const { events, errors } = await deserializeCalendarItemsIncrementally(
@@ -413,106 +483,167 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
               )
               allEvents.push(...events)
               calendarEventCount = allEvents.length
+              calendarDeserializeErrorCount += errors.length
               if (errors.length > 0) {
-                hadErrors = true
                 reportSyncError('load calendar event chunk', errors[0])
               }
             }
             updateInitialSyncProgress('calendar', calendarEventCount, undefined, progress.done)
           },
         })
-        useCalendarStore.getState().syncFromRemote(allEvents)
+        const decodeFailureCount = eventLoad.decodeFailureCount + calendarDeserializeErrorCount
+        const trustworthyCalendar = eventLoad.trustworthyForFullReplacement && calendarDeserializeErrorCount === 0
+        if (trustworthyCalendar) {
+          useCalendarStore.getState().syncFromRemote(allEvents)
+        }
         updateInitialSyncProgress('calendar', calendarEventCount, undefined, true)
-        logSyncTiming('calendar-fetch', calendarFetchStartedAt, { itemCount: eventItems.length, eventCount: allEvents.length })
+        const status = eventLoad.enumerationErrorCount > 0 && allEvents.length === 0
+          ? 'failed'
+          : decodeFailureCount > 0 || eventLoad.enumerationErrorCount > 0
+            ? 'warning'
+            : eventLoad.attemptedCount === 0
+              ? 'empty'
+              : 'loaded'
+        addDomain({
+          domain: 'calendar',
+          visibility: 'visible',
+          status,
+          itemCount: eventLoad.attemptedCount,
+          decodedCount: allEvents.length,
+          decodeFailureCount,
+          errorCategory: eventLoad.enumerationErrorCount > 0 ? 'enumeration-failed' : decodeFailureCount > 0 ? 'decode-failed' : undefined,
+        })
+        logSyncTiming('calendar-fetch', calendarFetchStartedAt, {
+          itemCount: eventLoad.attemptedCount,
+          decodedItemCount: eventLoad.decodedCount,
+          decodeFailureCount,
+          enumerationErrorCount: eventLoad.enumerationErrorCount,
+          eventCount: allEvents.length,
+          trustworthyForFullReplacement: trustworthyCalendar,
+        })
         logger.log(`[sync-provider] Loaded ${allEvents.length} calendar events from server`)
-        await mirrorToCache('calendar', eventItems)
+        if (trustworthyCalendar) await mirrorToCache('calendar', eventLoad.items)
       } catch (err) {
-        hadErrors = true
         reportSyncError('load calendar events', err)
+        addDomain({
+          domain: 'calendar',
+          visibility: 'visible',
+          status: 'failed',
+          itemCount: 0,
+          decodedCount: 0,
+          decodeFailureCount: 0,
+          errorCategory: errorCategoryFrom(err),
+        })
       }
 
       // Load tasks
       try {
         setInitialSyncProgressPhase('tasks')
         const taskLoadStartedAt = nowMs()
-        const taskItems = await etebaseLoadIncrementally('tasks')
+        const taskLoad = await etebaseLoadIncrementally('tasks')
         const { deserializeTask } = await import('@silentsuite/core')
-        const tasks = taskItems.map((item) => {
+        const tasks = taskLoad.items.map((item) => {
           const task = deserializeTask(item.content)
           // Use the Etebase item UID only as the local id so updates/deletes
           // can address the item without changing the stable iCalendar UID.
           return { ...task, id: item.uid, listId: item.collectionUid }
         })
-        useTaskStore.getState().syncFromRemote(tasks)
+        const taskStore = useTaskStore.getState()
+        taskStore.syncFromRemote(taskLoad.trustworthyForFullReplacement
+          ? tasks
+          : mergeById(taskStore.tasks, tasks))
         updateInitialSyncProgress('tasks', tasks.length, undefined, true)
         logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
-        logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: taskItems.length, taskCount: tasks.length })
-        await mirrorToCache('tasks', taskItems)
+        logSyncTiming('tasks-load', taskLoadStartedAt, { itemCount: taskLoad.attemptedCount, taskCount: tasks.length, decodeFailureCount: taskLoad.decodeFailureCount, enumerationErrorCount: taskLoad.enumerationErrorCount })
+        addDomain({ domain: 'tasks', visibility: 'visible', status: taskLoad.decodeFailureCount || taskLoad.enumerationErrorCount ? 'warning' : taskLoad.attemptedCount === 0 ? 'empty' : 'loaded', itemCount: taskLoad.attemptedCount, decodedCount: tasks.length, decodeFailureCount: taskLoad.decodeFailureCount, errorCategory: taskLoad.enumerationErrorCount ? 'enumeration-failed' : taskLoad.decodeFailureCount ? 'decode-failed' : undefined })
+        if (taskLoad.trustworthyForFullReplacement) await mirrorToCache('tasks', taskLoad.items)
       } catch (err) {
-        hadErrors = true
         reportSyncError('load tasks', err)
+        addDomain({ domain: 'tasks', visibility: 'visible', status: 'warning', itemCount: 0, decodedCount: 0, decodeFailureCount: 0, errorCategory: errorCategoryFrom(err) })
       }
 
       // Load contacts
       try {
         setInitialSyncProgressPhase('contacts')
         const contactLoadStartedAt = nowMs()
-        const contactItems = await etebaseLoadIncrementally('contacts')
+        const contactLoad = await etebaseLoadIncrementally('contacts')
         const { deserializeContact } = await import('@silentsuite/core')
-        const contacts = contactItems.map((item) => {
+        const contacts = contactLoad.items.map((item) => {
           const contact = deserializeContact(item.content)
           return { ...contact, id: item.uid, listId: item.collectionUid }
         })
-        useContactStore.getState().syncFromRemote(contacts)
+        const contactStore = useContactStore.getState()
+        contactStore.syncFromRemote(contactLoad.trustworthyForFullReplacement
+          ? contacts
+          : mergeById(contactStore.contacts, contacts))
         updateInitialSyncProgress('contacts', contacts.length, undefined, true)
         logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
-        logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: contactItems.length, contactCount: contacts.length })
-        await mirrorToCache('contacts', contactItems)
+        logSyncTiming('contacts-load', contactLoadStartedAt, { itemCount: contactLoad.attemptedCount, contactCount: contacts.length, decodeFailureCount: contactLoad.decodeFailureCount, enumerationErrorCount: contactLoad.enumerationErrorCount })
+        addDomain({ domain: 'contacts', visibility: 'visible', status: contactLoad.decodeFailureCount || contactLoad.enumerationErrorCount ? 'warning' : contactLoad.attemptedCount === 0 ? 'empty' : 'loaded', itemCount: contactLoad.attemptedCount, decodedCount: contacts.length, decodeFailureCount: contactLoad.decodeFailureCount, errorCategory: contactLoad.enumerationErrorCount ? 'enumeration-failed' : contactLoad.decodeFailureCount ? 'decode-failed' : undefined })
+        if (contactLoad.trustworthyForFullReplacement) await mirrorToCache('contacts', contactLoad.items)
       } catch (err) {
-        hadErrors = true
         reportSyncError('load contacts', err)
+        addDomain({ domain: 'contacts', visibility: 'visible', status: 'warning', itemCount: 0, decodedCount: 0, decodeFailureCount: 0, errorCategory: errorCategoryFrom(err) })
       }
 
       // Load non-visible encrypted collections into itemCache before their
       // stores initialize through fetchAllItems().
       setInitialSyncProgressPhase('preferences')
       try {
-        await etebaseLoadIncrementally('preferences')
+        const preferencesLoad = await etebaseLoadIncrementally('preferences')
+        addDomain({ domain: 'preferences', visibility: 'internal', status: preferencesLoad.decodeFailureCount || preferencesLoad.enumerationErrorCount ? 'warning' : preferencesLoad.attemptedCount === 0 ? 'empty' : 'loaded', itemCount: preferencesLoad.attemptedCount, decodedCount: preferencesLoad.decodedCount, decodeFailureCount: preferencesLoad.decodeFailureCount, errorCategory: preferencesLoad.enumerationErrorCount ? 'enumeration-failed' : preferencesLoad.decodeFailureCount ? 'decode-failed' : undefined })
       } catch (err) {
-        hadErrors = true
         reportSyncError('load preferences items', err)
+        addDomain({ domain: 'preferences', visibility: 'internal', status: 'warning', itemCount: 0, decodedCount: 0, decodeFailureCount: 0, errorCategory: errorCategoryFrom(err) })
       }
       try {
-        await etebaseLoadIncrementally('labelIndex')
+        const labelIndexLoad = await etebaseLoadIncrementally('labelIndex')
+        addDomain({ domain: 'labelIndex', visibility: 'internal', status: labelIndexLoad.decodeFailureCount || labelIndexLoad.enumerationErrorCount ? 'warning' : labelIndexLoad.attemptedCount === 0 ? 'empty' : 'loaded', itemCount: labelIndexLoad.attemptedCount, decodedCount: labelIndexLoad.decodedCount, decodeFailureCount: labelIndexLoad.decodeFailureCount, errorCategory: labelIndexLoad.enumerationErrorCount ? 'enumeration-failed' : labelIndexLoad.decodeFailureCount ? 'decode-failed' : undefined })
       } catch (err) {
-        hadErrors = true
         reportSyncError('load label suggestion items', err)
+        addDomain({ domain: 'labelIndex', visibility: 'internal', status: 'warning', itemCount: 0, decodedCount: 0, decodeFailureCount: 0, errorCategory: errorCategoryFrom(err) })
       }
 
-      // Load and subscribe account-level preferences after the Etebase item
-      // cache is ready. Preferences stay in their own local store because one
-      // field, notificationSound, is intentionally device-local.
+      beginPassiveStartupToastCycle()
       try {
         const preferencesStartedAt = nowMs()
         await usePreferencesSyncStore.getState().initialize()
-        logSyncTiming('preferences-initialize', preferencesStartedAt)
+        logSyncTiming('preferences-initialize', preferencesStartedAt, { createOrUpdateAttempted: true })
       } catch (err) {
-        hadErrors = true
         reportSyncError('initialize preferences sync', err)
+        addDomain({ domain: 'preferences', visibility: 'internal', status: 'warning', itemCount: 0, decodedCount: 0, decodeFailureCount: 0, errorCategory: errorCategoryFrom(err) })
       }
 
-      // Load the encrypted label suggestion index from its dedicated Etebase
-      // collection. Plaintext labels only exist inside decrypted item content.
       try {
         const labelIndexStartedAt = nowMs()
         await useLabelSuggestionsStore.getState().initialize()
-        logSyncTiming('label-index-initialize', labelIndexStartedAt)
+        logSyncTiming('label-index-initialize', labelIndexStartedAt, { createOrUpdateAttempted: true })
       } catch (err) {
-        hadErrors = true
         reportSyncError('initialize label suggestions', err)
+        addDomain({ domain: 'labelIndex', visibility: 'internal', status: 'warning', itemCount: 0, decodedCount: 0, decodeFailureCount: 0, errorCategory: errorCategoryFrom(err) })
+      } finally {
+        endPassiveStartupToastCycle()
       }
 
-      return hadErrors
+      const visibleFatal = domains.some((domain) => domain.domain === 'calendar' && domain.status === 'failed')
+      const visibleWarnings = domains.filter((domain) => domain.visibility === 'visible' && domain.status === 'warning')
+      const internalWarnings = domains.filter((domain) => domain.visibility === 'internal' && (domain.status === 'warning' || domain.status === 'failed'))
+      const classification: InitialLoadClassification = {
+        accountRestored: true,
+        domains,
+        visibleFatal,
+        visibleWarnings,
+        internalWarnings,
+        safeToWireSyncEngine: shouldWireSyncEngine({ visibleFatal }),
+      }
+      logSyncTiming('initial-load-classification', nowMs(), {
+        domainCount: domains.length,
+        visibleFatal,
+        visibleWarningCount: visibleWarnings.length,
+        internalWarningCount: internalWarnings.length,
+        safeToWireSyncEngine: classification.safeToWireSyncEngine,
+      })
+      return classification
     }
 
     function wireChangeHandler(): (() => void) | null {

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -255,7 +255,14 @@ describe('useEtebaseStore.initialize outcomes', () => {
     expect(coreMock.listItems).toHaveBeenCalledTimes(2)
     expect(pages).toEqual([['event-1'], ['event-2']])
     expect(progress).toEqual([1, 2])
-    expect(items.map((item) => item.uid)).toEqual(['event-1', 'event-2'])
+    expect(items.items.map((item) => item.uid)).toEqual(['event-1', 'event-2'])
+    expect(items).toMatchObject({
+      attemptedCount: 2,
+      decodedCount: 2,
+      decodeFailureCount: 0,
+      enumerationErrorCount: 0,
+      trustworthyForFullReplacement: true,
+    })
     expect(useEtebaseStore.getState().itemCache.has('deleted-event')).toBe(false)
     await expect(useEtebaseStore.getState().fetchAllItems('calendar')).resolves.toHaveLength(2)
   })
@@ -290,6 +297,130 @@ describe('useEtebaseStore.initialize outcomes', () => {
     expect(await useEtebaseStore.getState().fetchAllItems('labelIndex')).toEqual([
       { uid: 'labels-1', content: 'LABELS', collectionUid: 'label-index-col' },
     ])
+  })
+
+  it('reports all-item decode failure without treating the collection as trustworthy empty', async () => {
+    const account = { id: 'account' }
+    const calendarCollection = mockCollection('calendar-col')
+    const existingItem = mockItem('existing-event', 'OLD VEVENT')
+    const brokenItem = {
+      uid: 'broken-event',
+      isDeleted: false,
+      getContent: vi.fn(async () => {
+        throw new Error('decode failed')
+      }),
+    }
+    useEtebaseStore.setState({
+      account,
+      collections: { calendar: [calendarCollection], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+      itemCache: new Map([['existing-event', existingItem]]),
+      itemTypeMap: new Map([['existing-event', 'calendar']]),
+      itemCollectionMap: new Map([['existing-event', 'calendar-col']]),
+      isInitialized: true,
+      syncEngine: null,
+    })
+    coreMock.listItems.mockResolvedValueOnce({ items: [brokenItem], stoken: null, done: true })
+
+    const result = await useEtebaseStore.getState().loadCollectionItemsIncrementally('calendar')
+
+    expect(result.items).toEqual([])
+    expect(result).toMatchObject({
+      attemptedCount: 1,
+      decodedCount: 0,
+      decodeFailureCount: 1,
+      trustworthyForFullReplacement: false,
+    })
+    expect(useEtebaseStore.getState().itemCache.get('existing-event')).toBe(existingItem)
+  })
+
+  it('keeps successful calendar collection results when another collection fails enumeration', async () => {
+    const account = { id: 'account' }
+    const okCollection = mockCollection('ok-col')
+    const failedCollection = mockCollection('failed-col')
+    useEtebaseStore.setState({
+      account,
+      collections: { calendar: [okCollection, failedCollection], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: true,
+      syncEngine: null,
+    })
+    coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => {
+      if (collection.uid === 'failed-col') throw new Error('list failed')
+      return { items: [mockItem('event-ok', 'VEVENT OK')], stoken: null, done: true }
+    })
+
+    const result = await useEtebaseStore.getState().loadCollectionItemsIncrementally('calendar')
+
+    expect(result.items).toEqual([{ uid: 'event-ok', content: 'VEVENT OK', collectionUid: 'ok-col' }])
+    expect(result.enumerationErrorCount).toBe(1)
+    expect(result.trustworthyForFullReplacement).toBe(false)
+    expect(result.collections.map((collection) => collection.trustworthyForReplacement)).toEqual([true, false])
+  })
+
+  it('allows trustworthy empty enumeration to remove stale cached items', async () => {
+    const account = { id: 'account' }
+    const calendarCollection = mockCollection('calendar-col')
+    useEtebaseStore.setState({
+      account,
+      collections: { calendar: [calendarCollection], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+      itemCache: new Map([['stale-event', mockItem('stale-event', 'OLD')]]),
+      itemTypeMap: new Map([['stale-event', 'calendar']]),
+      itemCollectionMap: new Map([['stale-event', 'calendar-col']]),
+      isInitialized: true,
+      syncEngine: null,
+    })
+    coreMock.listItems.mockResolvedValueOnce({ items: [], stoken: null, done: true })
+
+    const result = await useEtebaseStore.getState().loadCollectionItemsIncrementally('calendar')
+
+    expect(result).toMatchObject({
+      attemptedCount: 0,
+      decodedCount: 0,
+      decodeFailureCount: 0,
+      enumerationErrorCount: 0,
+      trustworthyForFullReplacement: true,
+    })
+    expect(useEtebaseStore.getState().itemCache.has('stale-event')).toBe(false)
+  })
+})
+
+describe('useEtebaseStore.createItem', () => {
+  beforeEach(() => {
+    offlineQueueMock.isOfflineError.mockReset().mockReturnValue(false)
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('routes labelIndex save failures to label-suggestion copy instead of preferences copy', async () => {
+    const account = { id: 'account' }
+    const labelCollection = { uid: 'label-col' }
+    coreMock.createItem.mockRejectedValueOnce(new Error('write failed'))
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [labelCollection] as any[] },
+      isInitialized: true,
+    })
+
+    const result = await useEtebaseStore.getState().createItem('labelIndex', 'LABELS')
+
+    expect(result).toBeNull()
+    expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith(
+      'Failed to save label suggestions. Please try again.',
+      { source: 'labelIndex' },
+    )
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalledWith(
+      'Failed to save preferences. Please try again.',
+      expect.anything(),
+    )
   })
 })
 

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -54,6 +54,10 @@ vi.mock('@/app/stores/use-preferences-sync-store', () => ({
   usePreferencesSyncStore: { getState: () => ({ loadFromRemote: vi.fn(), setRemoteItemUid: vi.fn() }) },
 }))
 
+vi.mock('@/app/stores/use-label-suggestions-store', () => ({
+  useLabelSuggestionsStore: { getState: () => ({ loadFromRemote: vi.fn() }) },
+}))
+
 vi.mock('@/app/lib/offline-queue', () => ({
   replay: vi.fn().mockResolvedValue([]),
   getPendingCount: vi.fn().mockResolvedValue(0),
@@ -211,11 +215,12 @@ describe('useSyncStore', () => {
     await flushPromises()
     expect(etebaseMock.state.reconcileCollections).toHaveBeenCalledTimes(1)
     expect(syncNow).toHaveBeenCalledTimes(1)
-    expect(etebaseMock.state.refreshCollection).toHaveBeenCalledTimes(4)
+    expect(etebaseMock.state.refreshCollection).toHaveBeenCalledTimes(5)
     expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('tasks')
     expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('contacts')
     expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('calendar')
     expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('preferences')
+    expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('labelIndex')
 
     const reconcileOrder = etebaseMock.state.reconcileCollections.mock.invocationCallOrder[0]!
     const firstRefreshOrder = etebaseMock.state.refreshCollection.mock.invocationCallOrder[0]!

--- a/apps/web/app/stores/__tests__/use-toast-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-toast-store.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  beginPassiveStartupToastCycle,
+  endPassiveStartupToastCycle,
+  showErrorToast,
+  useToastStore,
+} from '../use-toast-store'
+
+beforeEach(() => {
+  vi.stubGlobal('crypto', { randomUUID: vi.fn(() => `toast-${Math.random()}`) })
+  endPassiveStartupToastCycle()
+  useToastStore.setState({ toasts: [] })
+})
+
+describe('useToastStore passive startup coalescing', () => {
+  it('coalesces duplicate passive startup errors per source and cycle', () => {
+    beginPassiveStartupToastCycle()
+
+    showErrorToast('Failed to save preferences. Please try again.', { source: 'preferences' })
+    showErrorToast('Failed to save preferences. Please try again.', { source: 'preferences' })
+    showErrorToast('Failed to save preferences. Please try again.', { source: 'labelIndex' })
+
+    expect(useToastStore.getState().toasts.map((toast) => toast.message)).toEqual([
+      'Failed to save preferences. Please try again.',
+      'Failed to save preferences. Please try again.',
+    ])
+  })
+
+  it('allows a later explicit action-scoped failure after the passive cycle ends', () => {
+    beginPassiveStartupToastCycle()
+    showErrorToast('Failed to save preferences. Please try again.', { source: 'preferences' })
+    showErrorToast('Failed to save preferences. Please try again.', { source: 'preferences' })
+    endPassiveStartupToastCycle()
+
+    showErrorToast('Failed to save preferences. Please try again.', { source: 'preferences' })
+
+    expect(useToastStore.getState().toasts).toHaveLength(2)
+  })
+})

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -81,6 +81,25 @@ type EtebaseCore = typeof import('@silentsuite/core')
 
 export type CachedContentItem = { uid: string; content: string; collectionUid: string }
 export type IncrementalCollectionProgress = { loaded: number; done: boolean; collectionUid: string }
+export type IncrementalCollectionResult = {
+  attemptedCount: number
+  decodedCount: number
+  decodeFailureCount: number
+  enumerationErrorCount: number
+  items: CachedContentItem[]
+  trustworthyForReplacement: boolean
+  errorCategory?: string
+}
+export type IncrementalLoadResult = {
+  type: CollectionTypeKey
+  attemptedCount: number
+  decodedCount: number
+  decodeFailureCount: number
+  enumerationErrorCount: number
+  items: CachedContentItem[]
+  collections: IncrementalCollectionResult[]
+  trustworthyForFullReplacement: boolean
+}
 
 export type EtebaseInitializeOutcome =
   | { status: 'no-session' }
@@ -334,6 +353,27 @@ function collectionDisplayName(type: CollectionTypeKey): string {
   return 'preferences'
 }
 
+function saveItemNoun(type: CollectionTypeKey): string {
+  if (type === 'calendar') return 'event'
+  if (type === 'tasks') return 'task'
+  if (type === 'contacts') return 'contact'
+  if (type === 'labelIndex') return 'label suggestions'
+  return 'preferences'
+}
+
+function toastSourceForType(type: CollectionTypeKey): 'preferences' | 'labelIndex' | undefined {
+  if (type === 'preferences') return 'preferences'
+  if (type === 'labelIndex') return 'labelIndex'
+  return undefined
+}
+
+function showSaveFailureToast(type: CollectionTypeKey): void {
+  const source = toastSourceForType(type)
+  const message = `Failed to save ${saveItemNoun(type)}. Please try again.`
+  if (source) showErrorToast(message, { source })
+  else showErrorToast(message)
+}
+
 async function recordLabelsFromContent(type: CollectionTypeKey, content: string): Promise<void> {
   if (type !== 'calendar' && type !== 'tasks' && type !== 'contacts') return
   try {
@@ -492,7 +532,7 @@ interface EtebaseActions {
   loadCollectionItemsIncrementally: (
     type: CollectionTypeKey,
     options?: { onItems?: (items: CachedContentItem[], progress: IncrementalCollectionProgress) => Promise<void> | void },
-  ) => Promise<CachedContentItem[]>
+  ) => Promise<IncrementalLoadResult>
 
   /** Start the SyncEngine after initial page-at-a-time enumeration is complete. */
   startSyncEngine: () => Promise<void>
@@ -1096,7 +1136,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         }
       } else {
         console.error(`[etebase-store] Failed to create ${type} item`, getSafeErrorDetails(err))
-        showErrorToast(`Failed to save ${type === 'calendar' ? 'event' : type === 'tasks' ? 'task' : type === 'contacts' ? 'contact' : 'preferences'}. Please try again.`)
+        showSaveFailureToast(type)
       }
       return null
     }
@@ -1268,7 +1308,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         }
       } else {
         console.error(`[etebase-store] Failed to update ${type} item`, getSafeErrorDetails(err))
-        showErrorToast(`Failed to save ${type === 'calendar' ? 'event' : type === 'tasks' ? 'task' : type === 'contacts' ? 'contact' : 'preferences'}. Please try again.`)
+        showSaveFailureToast(type)
       }
     }
   },
@@ -1395,62 +1435,122 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
   loadCollectionItemsIncrementally: async (type, options: { onItems?: (items: CachedContentItem[], progress: IncrementalCollectionProgress) => Promise<void> | void } = {}) => {
     const { account, collections } = get()
+    const emptyResult = (): IncrementalLoadResult => ({
+      type,
+      attemptedCount: 0,
+      decodedCount: 0,
+      decodeFailureCount: 0,
+      enumerationErrorCount: 0,
+      items: [],
+      collections: [],
+      trustworthyForFullReplacement: Boolean(account && collections[type].length > 0),
+    })
     if (!account || collections[type].length === 0) {
       logger.warn(`[etebase-store] Cannot load ${type}: missing account or collection`)
-      return get().fetchAllItems(type)
+      const fallbackItems = await get().fetchAllItems(type)
+      return {
+        ...emptyResult(),
+        attemptedCount: fallbackItems.length,
+        decodedCount: fallbackItems.length,
+        items: fallbackItems,
+        trustworthyForFullReplacement: false,
+      }
     }
 
     const core = await import('@silentsuite/core')
-    const newItemCache = new Map(get().itemCache)
-    const newItemTypeMap = new Map(get().itemTypeMap)
-    const newItemCollectionMap = new Map(get().itemCollectionMap)
-    const targetCollectionUids = new Set(collections[type].map((collection) => collection.uid))
-
-    for (const [uid, collectionUid] of newItemCollectionMap.entries()) {
-      if (targetCollectionUids.has(collectionUid)) {
-        newItemCache.delete(uid)
-        newItemTypeMap.delete(uid)
-        newItemCollectionMap.delete(uid)
-      }
-    }
-
     let loaded = 0
     const results: CachedContentItem[] = []
+    const collectionResults: IncrementalCollectionResult[] = []
 
     for (const collection of collections[type]) {
+      const collectionItems: CachedContentItem[] = []
+      const collectionItemObjects: any[] = []
+      let attemptedCount = 0
+      let decodeFailureCount = 0
+      let enumerationErrorCount = 0
       let stoken: string | null = null
       let done = false
 
-      while (!done) {
-        const response = await core.listItems(account, collection, stoken)
-        const pageItems = response.items.filter((item: any) => !item.isDeleted)
-        const pageResults: CachedContentItem[] = []
+      try {
+        while (!done) {
+          const response = await core.listItems(account, collection, stoken)
+          const pageItems = response.items.filter((item: any) => !item.isDeleted)
+          const pageResults: CachedContentItem[] = []
 
-        for (const item of pageItems) {
+          for (const item of pageItems) {
+            attemptedCount++
+            collectionItemObjects.push(item)
+            try {
+              const content = await item.getContent()
+              const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
+              const cached = { uid: item.uid, content: contentStr, collectionUid: collection.uid }
+              pageResults.push(cached)
+              collectionItems.push(cached)
+              results.push(cached)
+            } catch (err) {
+              decodeFailureCount++
+              logger.warn(`[etebase-store] Failed to decode incremental ${type} item`, getSafeErrorDetails(err))
+            }
+          }
+
+          loaded += pageResults.length
+          stoken = response.stoken
+          done = response.done
+          await options.onItems?.(pageResults, { loaded, done, collectionUid: collection.uid })
+        }
+      } catch (err) {
+        enumerationErrorCount++
+        logger.warn(`[etebase-store] Failed to enumerate incremental ${type} collection`, getSafeErrorDetails(err))
+      }
+
+      const trustworthyForReplacement = enumerationErrorCount === 0 && decodeFailureCount === 0
+      if (trustworthyForReplacement) {
+        const newItemCache = new Map(get().itemCache)
+        const newItemTypeMap = new Map(get().itemTypeMap)
+        const newItemCollectionMap = new Map(get().itemCollectionMap)
+        for (const [uid, mappedCollectionUid] of newItemCollectionMap.entries()) {
+          if (mappedCollectionUid === collection.uid) {
+            newItemCache.delete(uid)
+            newItemTypeMap.delete(uid)
+            newItemCollectionMap.delete(uid)
+          }
+        }
+        for (const item of collectionItemObjects) {
           newItemCache.set(item.uid, item)
           newItemTypeMap.set(item.uid, type)
           newItemCollectionMap.set(item.uid, collection.uid)
-          try {
-            const content = await item.getContent()
-            const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
-            const cached = { uid: item.uid, content: contentStr, collectionUid: collection.uid }
-            pageResults.push(cached)
-            results.push(cached)
-          } catch (err) {
-            logger.warn(`[etebase-store] Failed to decode incremental ${type} item`, getSafeErrorDetails(err))
-          }
         }
-
-        loaded += pageResults.length
         set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, itemCollectionMap: newItemCollectionMap })
-        stoken = response.stoken
-        done = response.done
-        await options.onItems?.(pageResults, { loaded, done, collectionUid: collection.uid })
       }
+
+      collectionResults.push({
+        attemptedCount,
+        decodedCount: collectionItems.length,
+        decodeFailureCount,
+        enumerationErrorCount,
+        items: collectionItems,
+        trustworthyForReplacement,
+        errorCategory: enumerationErrorCount > 0 ? 'enumeration-failed' : decodeFailureCount > 0 ? 'decode-failed' : undefined,
+      })
     }
 
+    const attemptedCount = collectionResults.reduce((sum, result) => sum + result.attemptedCount, 0)
+    const decodedCount = collectionResults.reduce((sum, result) => sum + result.decodedCount, 0)
+    const decodeFailureCount = collectionResults.reduce((sum, result) => sum + result.decodeFailureCount, 0)
+    const enumerationErrorCount = collectionResults.reduce((sum, result) => sum + result.enumerationErrorCount, 0)
+    const trustworthyForFullReplacement = collectionResults.every((result) => result.trustworthyForReplacement)
+
     logger.debug(`[etebase-store] Incrementally loaded ${results.length} ${type} items`)
-    return results
+    return {
+      type,
+      attemptedCount,
+      decodedCount,
+      decodeFailureCount,
+      enumerationErrorCount,
+      items: results,
+      collections: collectionResults,
+      trustworthyForFullReplacement,
+    }
   },
 
   startSyncEngine: async () => {

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -303,11 +303,12 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       }
 
       // Then refresh every collection of each type from the server
-      const [taskItems, contactItems, eventItems, preferenceItems] = await Promise.all([
+      const [taskItems, contactItems, eventItems, preferenceItems, labelIndexItems] = await Promise.all([
         reconciledEtebase.refreshCollection('tasks'),
         reconciledEtebase.refreshCollection('contacts'),
         reconciledEtebase.refreshCollection('calendar'),
         reconciledEtebase.refreshCollection('preferences'),
+        reconciledEtebase.refreshCollection('labelIndex'),
       ])
 
       // Push fresh data into stores
@@ -315,6 +316,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       const { useContactStore } = await import('@/app/stores/use-contact-store')
       const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
       const { usePreferencesSyncStore } = await import('@/app/stores/use-preferences-sync-store')
+      const { useLabelSuggestionsStore } = await import('@/app/stores/use-label-suggestions-store')
 
       const tasks = taskItems.map((item) => {
         const task = core.deserializeTask(item.content)
@@ -334,6 +336,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       })
       useCalendarStore.getState().syncFromRemote(events)
       await usePreferencesSyncStore.getState().loadFromRemote(preferenceItems)
+      await useLabelSuggestionsStore.getState().loadFromRemote(labelIndexItems)
 
       // Purge stale queue entries (older than 24h) that may cause phantom indicators
       const stale = await getStaleEntries()

--- a/apps/web/app/stores/use-toast-store.ts
+++ b/apps/web/app/stores/use-toast-store.ts
@@ -19,6 +19,17 @@ interface ToastActions {
   removeToast: (id: string) => void
 }
 
+export type ToastCoalesceSource = 'preferences' | 'labelIndex' | 'internal-sync'
+
+interface ToastOptions {
+  source?: ToastCoalesceSource
+  passiveStartup?: boolean
+}
+
+let passiveStartupCycle = 0
+let passiveStartupCycleActive = false
+const shownPassiveStartupToasts = new Set<string>()
+
 export const useToastStore = create<ToastState & ToastActions>((set) => ({
   toasts: [],
 
@@ -37,7 +48,23 @@ export const useToastStore = create<ToastState & ToastActions>((set) => ({
 }))
 
 /** Show an error toast from anywhere (including non-React code like stores). */
-export function showErrorToast(message: string) {
+export function beginPassiveStartupToastCycle() {
+  passiveStartupCycle += 1
+  passiveStartupCycleActive = true
+  shownPassiveStartupToasts.clear()
+}
+
+export function endPassiveStartupToastCycle() {
+  passiveStartupCycleActive = false
+  shownPassiveStartupToasts.clear()
+}
+
+export function showErrorToast(message: string, options: ToastOptions = {}) {
+  if ((options.passiveStartup || passiveStartupCycleActive) && options.source) {
+    const key = `${passiveStartupCycle}:${options.source}:${message}`
+    if (shownPassiveStartupToasts.has(key)) return
+    shownPassiveStartupToasts.add(key)
+  }
   useToastStore.getState().addToast(message, 'error')
 }
 


### PR DESCRIPTION
## Summary
- classify initial encrypted data loads by visible/internal domain before wiring SyncEngine
- preserve successfully decoded calendar data when enumeration is partial, and only full-replace after trustworthy enumeration
- add privacy-safe sync timing diagnostics plus scoped startup toast coalescing for preferences/label suggestions

## Verification
- pnpm --filter @silentsuite/web test -- app/providers/__tests__/sync-provider.test.tsx app/stores/__tests__/use-etebase-store.test.ts app/stores/__tests__/use-sync-store.test.ts app/stores/__tests__/use-preferences-store.test.ts app/stores/__tests__/use-label-suggestions-store.test.ts app/stores/__tests__/use-toast-store.test.ts app/components/__tests__/SyncIndicator.test.tsx app/components/__tests__/InitialSyncProgress.test.tsx 'app/(app)/calendar/__tests__/page.test.tsx' app/lib/__tests__/sync-timing.test.ts\n- pnpm --filter @silentsuite/web type-check\n- git diff --check\n\nRefs #446\n\n## Follow-up\n- requires deployed preview smoke with a known non-empty encrypted account before merge/closeout.