### PR TITLE
feat: add shared payment choice panel

### DIFF
--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -78,7 +78,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     vi.unstubAllGlobals()
   })
 
-  it('shows add payment method for active no-card trials without making cancel the only action', async () => {
+  it('shows choose payment for active no-card trials without making cancel the only action', async () => {
     mockSubscription({
       status: 'trialing',
       trial: { active: true, endsAt: '2026-07-03T00:00:00.000Z', daysRemaining: 3 },
@@ -94,7 +94,8 @@ describe('SubscriptionPage billing recovery CTAs', () => {
 
     render(<SubscriptionPage />)
 
-    expect(await screen.findByRole('button', { name: /add payment method/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /choose payment/i })).toBeInTheDocument()
+    expect(screen.getByText(/Subscribe by card or annual Bitcoin and get 14 bonus days/)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /cancel subscription/i })).not.toBeInTheDocument()
   })
 

--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -14,40 +14,81 @@ vi.mock('@/app/lib/config', () => ({
 
 vi.stubGlobal('fetch', vi.fn())
 
+const monthlyOptions = {
+  selectedInterval: 'monthly',
+  options: [
+    { id: 'stripe_pay_now', provider: 'stripe', planIds: ['early_monthly'], billingIntervals: ['monthly'], enabled: true },
+    { id: 'bitcoin_annual_switch', provider: 'notice', planIds: ['early_annual'], billingIntervals: ['annual'], enabled: true },
+  ],
+}
+
+const annualOptions = {
+  selectedInterval: 'annual',
+  options: [
+    { id: 'stripe_pay_now', provider: 'stripe', planIds: ['early_annual'], billingIntervals: ['annual'], enabled: true },
+    { id: 'btcpay_annual', provider: 'btcpay', planIds: ['early_annual'], billingIntervals: ['annual'], enabled: true },
+  ],
+}
+
 describe('AddCardBanner', () => {
   beforeEach(() => {
     vi.mocked(fetch).mockReset()
+    vi.stubGlobal('location', { href: 'https://app.example.test/settings/subscription' })
   })
 
-  it('offers only pay-now monthly/annual choices and requests immediate payment setup', async () => {
-    vi.mocked(fetch).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ clientSecret: 'pi_secret' }),
-    } as Response)
+  it('uses shared payment options and starts Stripe pay-now through payment-flows', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: true, json: async () => monthlyOptions } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ clientSecret: 'pi_secret', flowKind: 'stripe_pay_now' }) } as Response)
 
     render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
 
-    fireEvent.click(screen.getByText('Add payment method'))
+    expect(screen.getByText(/Subscribe by card or annual Bitcoin and get 14 bonus days/)).toBeInTheDocument()
+    expect(screen.queryByText(/Add a card to continue/)).not.toBeInTheDocument()
 
-    expect(screen.getByText('Pay now + 14 bonus days')).toBeInTheDocument()
-    expect(screen.getByText('Choose monthly or annual. Your card is charged now.')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Choose payment'))
+
+    expect(await screen.findByText('Pay now + 14 bonus days')).toBeInTheDocument()
+    expect(screen.getByText('Prefer Bitcoin?')).toBeInTheDocument()
     expect(screen.queryByText('30-day trial')).not.toBeInTheDocument()
-    expect(screen.getByText('Monthly')).toBeInTheDocument()
-    expect(screen.getByText('Annual')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByText('Annual'))
-    fireEvent.click(screen.getByText('Continue to payment'))
+    fireEvent.click(screen.getByText('Continue to card payment'))
 
     await waitFor(() => expect(fetch).toHaveBeenCalledWith(
-      'https://billing.example.test/subscription/setup-card',
+      'https://billing.example.test/subscription/payment-flows',
       expect.objectContaining({
         method: 'POST',
         credentials: 'include',
-        body: JSON.stringify({ planId: 'early_annual', trialPath: 'immediate' }),
+        body: JSON.stringify({ flowKind: 'stripe_pay_now', planId: 'early_monthly' }),
       }),
     ))
 
     expect(await screen.findByText('14 bonus days included after today\'s payment.')).toBeInTheDocument()
-    expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €36')
+    expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €3.60')
+  })
+
+  it('switches monthly Bitcoin banner to annual and starts annual BTCPay flow', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: true, json: async () => monthlyOptions } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => annualOptions } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => annualOptions } as Response)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ checkoutUrl: 'https://btcpay.silentsuite.io/i/inv_123' }) } as Response)
+
+    render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
+    fireEvent.click(screen.getByText('Choose payment'))
+
+    fireEvent.click(await screen.findByText('Prefer Bitcoin?'))
+    expect(await screen.findByText('Pay annual with Bitcoin')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Pay annual with Bitcoin'))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      'https://billing.example.test/subscription/payment-flows',
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ flowKind: 'btcpay_annual', planId: 'early_annual', returnUrl: '/settings/subscription' }),
+      }),
+    ))
   })
 })

--- a/apps/web/app/components/add-card-banner.tsx
+++ b/apps/web/app/components/add-card-banner.tsx
@@ -1,84 +1,14 @@
 'use client'
 
 import { useState } from 'react'
-import { CreditCard, Clock, X, Lock, Zap, Crown } from 'lucide-react'
+import { CreditCard, Clock, X } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
-import dynamic from 'next/dynamic'
-import { BILLING_API_URL } from '@/app/lib/config'
-
-const StripePaymentForm = dynamic(() => import('./stripe-payment-form'), {
-  loading: () => (
-    <div className="flex flex-col items-center justify-center py-8">
-      <div className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
-      <p className="mt-3 text-sm text-[rgb(var(--muted))]">Loading payment form...</p>
-    </div>
-  ),
-  ssr: false,
-})
-
-type BillingInterval = 'monthly' | 'annual'
+import PaymentChoicePanel from './payment-choice-panel'
 
 interface AddCardBannerProps {
   daysRemaining: number
   onCardAdded: () => void
 }
-
-// ---------------------------------------------------------------------------
-// Billing toggle (compact)
-// ---------------------------------------------------------------------------
-
-function BillingToggle({
-  interval,
-  onChange,
-}: {
-  interval: BillingInterval
-  onChange: (interval: BillingInterval) => void
-}) {
-  return (
-    <div className="flex items-center gap-1 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-0.5">
-      <button
-        onClick={() => onChange('monthly')}
-        className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-          interval === 'monthly'
-            ? 'bg-[rgb(var(--primary))] text-white'
-            : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
-        }`}
-      >
-        Monthly
-      </button>
-      <button
-        onClick={() => onChange('annual')}
-        className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-          interval === 'annual'
-            ? 'bg-[rgb(var(--primary))] text-white'
-            : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
-        }`}
-      >
-        Annual
-      </button>
-    </div>
-  )
-}
-
-function PriceDisplay({ interval }: { interval: BillingInterval }) {
-  if (interval === 'monthly') {
-    return (
-      <span className="text-sm font-medium text-[rgb(var(--foreground))]">
-        &euro;3.60<span className="text-[rgb(var(--muted))]">/mo</span>
-      </span>
-    )
-  }
-  return (
-    <span className="text-sm font-medium text-[rgb(var(--foreground))]">
-      &euro;36<span className="text-[rgb(var(--muted))]">/yr</span>
-      <span className="ml-1 text-xs text-emerald-600 dark:text-emerald-500">(&euro;3/mo)</span>
-    </span>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Full-screen modal for adding card
-// ---------------------------------------------------------------------------
 
 function AddCardModal({
   onClose,
@@ -87,141 +17,20 @@ function AddCardModal({
   onClose: () => void
   onCardAdded: () => void
 }) {
-  const [interval, setInterval] = useState<BillingInterval>('monthly')
-  const [clientSecret, setClientSecret] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const planId = interval === 'monthly' ? 'early_monthly' : 'early_annual'
-
-  const handleContinue = async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const res = await fetch(`${BILLING_API_URL}/subscription/setup-card`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ planId, trialPath: 'immediate' }),
-      })
-      if (!res.ok) {
-        const data = await res.json().catch(() => null)
-        throw new Error(data?.detail ?? 'Failed to set up payment')
-      }
-      const data = await res.json()
-      setClientSecret(data.clientSecret)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Something went wrong')
-    } finally {
-      setLoading(false)
-    }
-  }
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgb(var(--background))]/80 backdrop-blur-sm">
       <div className="mx-4 w-full max-w-md rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-6 space-y-5">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">
-            Continue with silentsuite.io
-          </h2>
-          <button onClick={onClose} className="text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
+          <span className="sr-only">Payment options</span>
+          <button onClick={onClose} className="ml-auto text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
             <X className="h-5 w-5" />
           </button>
         </div>
-
-        {!clientSecret ? (
-          <>
-            {/* Pay now summary */}
-            <div className="rounded-xl border border-emerald-500/50 bg-emerald-500/5 p-4 text-left">
-              <div className="flex items-start gap-3">
-                <div className="rounded-lg bg-[rgb(var(--border))] p-2 shrink-0">
-                  <Zap className="h-4 w-4 text-amber-400" />
-                </div>
-                <div>
-                  <h3 className="font-medium text-[rgb(var(--foreground))]">Pay now + 14 bonus days</h3>
-                  <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">
-                    Choose monthly or annual. Your card is charged now.
-                  </p>
-                </div>
-                <div className="ml-auto shrink-0 rounded-full bg-emerald-500 p-0.5">
-                  <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" strokeWidth={3} stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-                  </svg>
-                </div>
-              </div>
-            </div>
-
-            {/* Billing toggle + price */}
-            <div className="flex items-center justify-between">
-              <BillingToggle interval={interval} onChange={setInterval} />
-              <div className="flex items-center gap-2">
-                <Crown className="h-3.5 w-3.5 text-amber-400" />
-                <PriceDisplay interval={interval} />
-              </div>
-            </div>
-
-            {error && (
-              <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
-                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
-              </div>
-            )}
-
-            <Button onClick={handleContinue} disabled={loading} className="w-full">
-              {loading ? (
-                <span className="flex items-center justify-center gap-2">
-                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                  Setting up...
-                </span>
-              ) : (
-                'Continue to payment'
-              )}
-            </Button>
-          </>
-        ) : (
-          <>
-            {/* Payment summary */}
-            <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Crown className="h-4 w-4 text-amber-400" />
-                  <span className="text-sm font-medium text-[rgb(var(--foreground))]">Early Adopter</span>
-                </div>
-                <PriceDisplay interval={interval} />
-              </div>
-              <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-                14 bonus days included after today&apos;s payment.
-              </p>
-            </div>
-
-            {/* Stripe form */}
-            <StripePaymentForm
-              clientSecret={clientSecret}
-              onSuccess={onCardAdded}
-              submitLabel={`Pay ${interval === 'monthly' ? '\u20AC3.60' : '\u20AC36'}`}
-              mode="payment"
-            />
-
-            <div className="flex items-center justify-center gap-1.5 text-xs text-[rgb(var(--muted))]">
-              <Lock className="h-3 w-3 text-emerald-500" />
-              <span>Secured by Stripe. We never see your card details.</span>
-            </div>
-
-            <button
-              onClick={() => setClientSecret(null)}
-              className="w-full text-center text-xs text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors"
-            >
-              &larr; Back to options
-            </button>
-          </>
-        )}
+        <PaymentChoicePanel onSuccess={onCardAdded} title="Continue with silentsuite.io" />
       </div>
     </div>
   )
 }
-
-// ---------------------------------------------------------------------------
-// Banner component (shown in settings/subscription)
-// ---------------------------------------------------------------------------
 
 export default function AddCardBanner({ daysRemaining, onCardAdded }: AddCardBannerProps) {
   const [showModal, setShowModal] = useState(false)
@@ -239,14 +48,14 @@ export default function AddCardBanner({ daysRemaining, onCardAdded }: AddCardBan
               {daysRemaining} day{daysRemaining !== 1 ? 's' : ''} left in your trial
             </p>
             <p className="text-xs text-[rgb(var(--muted))]">
-              Add a card to continue with silentsuite.io
+              Subscribe by card or annual Bitcoin and get 14 bonus days. If you do nothing, your account becomes read-only when the trial ends.
             </p>
           </div>
         </div>
         <div className="flex items-center gap-2">
           <Button size="sm" onClick={() => setShowModal(true)}>
             <CreditCard className="h-3.5 w-3.5 mr-1.5" />
-            Add payment method
+            Choose payment
           </Button>
           <button onClick={() => setDismissed(true)} className="text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]">
             <X className="h-4 w-4" />

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -1,0 +1,282 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import dynamic from 'next/dynamic'
+import { Crown, Lock, Zap } from 'lucide-react'
+import { Button } from '@silentsuite/ui'
+import { BILLING_API_URL } from '@/app/lib/config'
+
+const StripePaymentForm = dynamic(() => import('./stripe-payment-form'), {
+  loading: () => (
+    <div className="flex flex-col items-center justify-center py-8">
+      <div className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
+      <p className="mt-3 text-sm text-[rgb(var(--muted))]">Loading payment form...</p>
+    </div>
+  ),
+  ssr: false,
+})
+
+type BillingInterval = 'monthly' | 'annual'
+
+type PaymentOption = {
+  id: string
+  provider: 'stripe' | 'btcpay' | 'notice'
+  planIds?: string[]
+  billingIntervals?: BillingInterval[]
+  entitlementPreview?: string
+  enabled: boolean
+  disabledReason?: string
+}
+
+interface PaymentChoicePanelProps {
+  onSuccess: () => void | Promise<void>
+  onCancel?: () => void
+  initialInterval?: BillingInterval
+  title?: string
+  successPoll?: () => void | Promise<void>
+}
+
+function BillingToggle({ interval, onChange }: { interval: BillingInterval; onChange: (interval: BillingInterval) => void }) {
+  return (
+    <div className="flex items-center gap-1 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-0.5">
+      <button
+        onClick={() => onChange('monthly')}
+        className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+          interval === 'monthly' ? 'bg-[rgb(var(--primary))] text-white' : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
+        }`}
+      >
+        Monthly
+      </button>
+      <button
+        onClick={() => onChange('annual')}
+        className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+          interval === 'annual' ? 'bg-[rgb(var(--primary))] text-white' : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
+        }`}
+      >
+        Annual
+      </button>
+    </div>
+  )
+}
+
+function PriceDisplay({ interval }: { interval: BillingInterval }) {
+  if (interval === 'monthly') {
+    return (
+      <span className="text-sm font-medium text-[rgb(var(--foreground))]">
+        &euro;3.60<span className="text-[rgb(var(--muted))]">/mo</span>
+      </span>
+    )
+  }
+  return (
+    <span className="text-sm font-medium text-[rgb(var(--foreground))]">
+      &euro;36<span className="text-[rgb(var(--muted))]">/yr</span>
+      <span className="ml-1 text-xs text-emerald-600 dark:text-emerald-500">(&euro;3/mo)</span>
+    </span>
+  )
+}
+
+function safeBtcpayUrl(rawUrl: string): string {
+  const checkoutUrl = new URL(rawUrl)
+  if (checkoutUrl.protocol !== 'https:' || checkoutUrl.origin !== 'https://btcpay.silentsuite.io') {
+    throw new Error('Bitcoin checkout returned an unexpected payment URL.')
+  }
+  return checkoutUrl.toString()
+}
+
+export default function PaymentChoicePanel({
+  onSuccess,
+  onCancel,
+  initialInterval = 'monthly',
+  title = 'Continue with silentsuite.io',
+  successPoll,
+}: PaymentChoicePanelProps) {
+  const [interval, setInterval] = useState<BillingInterval>(initialInterval)
+  const [clientSecret, setClientSecret] = useState<string | null>(null)
+  const [loading, setLoading] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [options, setOptions] = useState<PaymentOption[]>([])
+  const [optionsLoaded, setOptionsLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    async function loadOptions() {
+      setOptionsLoaded(false)
+      try {
+        const res = await fetch(`${BILLING_API_URL}/subscription/payment-options?interval=${interval}`, { credentials: 'include' })
+        if (!res.ok) {
+          if (!cancelled) setOptions([])
+          return
+        }
+        const data = await res.json()
+        if (!cancelled) setOptions(Array.isArray(data.options) ? data.options : [])
+      } catch {
+        if (!cancelled) setOptions([])
+      } finally {
+        if (!cancelled) setOptionsLoaded(true)
+      }
+    }
+    void loadOptions()
+    return () => { cancelled = true }
+  }, [interval])
+
+  const stripeOption = useMemo(() => options.find(option => option.id === 'stripe_pay_now' && option.enabled), [options])
+  const btcpayAnnualOption = useMemo(() => options.find(option => option.id === 'btcpay_annual' && option.enabled), [options])
+  const bitcoinSwitchOption = useMemo(() => options.find(option => option.id === 'bitcoin_annual_switch' && option.enabled), [options])
+  const planId = stripeOption?.planIds?.[0] ?? (interval === 'monthly' ? 'early_monthly' : 'early_annual')
+
+  const startStripe = async () => {
+    setLoading('stripe')
+    setError(null)
+    try {
+      const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ flowKind: 'stripe_pay_now', planId }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.detail ?? 'Failed to set up payment')
+      }
+      const data = await res.json()
+      setClientSecret(data.clientSecret)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  const startBtcpay = async () => {
+    setLoading('btcpay')
+    setError(null)
+    try {
+      const annualRes = await fetch(`${BILLING_API_URL}/subscription/payment-options?interval=annual`, { credentials: 'include' })
+      if (!annualRes.ok) throw new Error('Bitcoin checkout is not available for this account state.')
+      const annualData = await annualRes.json()
+      const annualOptions = Array.isArray(annualData.options) ? annualData.options as PaymentOption[] : []
+      const option = annualOptions.find(candidate => candidate.id === 'btcpay_annual' && candidate.enabled)
+      if (!option) throw new Error('Bitcoin checkout is not available for this account state.')
+      const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ flowKind: 'btcpay_annual', planId: option.planIds?.[0] ?? 'early_annual', returnUrl: '/settings/subscription' }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.detail ?? 'Bitcoin checkout is not available.')
+      }
+      const data = await res.json()
+      window.location.href = safeBtcpayUrl(data.checkoutUrl)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to start Bitcoin checkout.')
+    } finally {
+      setLoading(null)
+    }
+  }
+
+  if (clientSecret) {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Crown className="h-4 w-4 text-amber-400" />
+              <span className="text-sm font-medium text-[rgb(var(--foreground))]">Early Adopter</span>
+            </div>
+            <PriceDisplay interval={interval} />
+          </div>
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">14 bonus days included after today&apos;s payment.</p>
+        </div>
+        <StripePaymentForm
+          clientSecret={clientSecret}
+          onSuccess={async () => {
+            await onSuccess()
+            await successPoll?.()
+          }}
+          submitLabel={`Pay ${interval === 'monthly' ? '\u20AC3.60' : '\u20AC36'}`}
+          mode="payment"
+        />
+        <div className="flex items-center justify-center gap-1.5 text-xs text-[rgb(var(--muted))]">
+          <Lock className="h-3 w-3 text-emerald-500" />
+          <span>Secured by Stripe. We never see your card details.</span>
+        </div>
+        <button
+          onClick={() => setClientSecret(null)}
+          className="w-full text-center text-xs text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors"
+        >
+          &larr; Back to options
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-5">
+      <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">{title}</h2>
+      <div className="rounded-xl border border-emerald-500/50 bg-emerald-500/5 p-4 text-left">
+        <div className="flex items-start gap-3">
+          <div className="rounded-lg bg-[rgb(var(--border))] p-2 shrink-0">
+            <Zap className="h-4 w-4 text-amber-400" />
+          </div>
+          <div>
+            <h3 className="font-medium text-[rgb(var(--foreground))]">Pay now + 14 bonus days</h3>
+            <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">Choose monthly card, annual card, or annual Bitcoin when available.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <BillingToggle interval={interval} onChange={setInterval} />
+        <div className="flex items-center gap-2">
+          <Crown className="h-3.5 w-3.5 text-amber-400" />
+          <PriceDisplay interval={interval} />
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        </div>
+      )}
+
+      {bitcoinSwitchOption && interval === 'monthly' && (
+        <button
+          type="button"
+          onClick={() => setInterval('annual')}
+          className="w-full rounded-xl border border-amber-500/25 bg-amber-500/5 p-4 text-left transition-colors hover:bg-amber-500/10"
+        >
+          <h3 className="font-medium text-[rgb(var(--foreground))]">Prefer Bitcoin?</h3>
+          <p className="mt-0.5 text-xs text-[rgb(var(--muted))]">Bitcoin payments are annual only. Switch to annual billing to pay with Bitcoin.</p>
+        </button>
+      )}
+
+      {interval === 'annual' && btcpayAnnualOption && (
+        <Button onClick={startBtcpay} disabled={loading !== null} variant="outline" className="w-full">
+          {loading === 'btcpay' ? 'Opening Bitcoin checkout...' : 'Pay annual with Bitcoin'}
+        </Button>
+      )}
+
+      {!optionsLoaded ? (
+        <Button disabled className="w-full">
+          Loading payment options...
+        </Button>
+      ) : stripeOption ? (
+        <Button onClick={startStripe} disabled={loading !== null} className="w-full">
+          {loading === 'stripe' ? 'Setting up...' : 'Continue to card payment'}
+        </Button>
+      ) : (
+        <p className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3 text-sm text-[rgb(var(--muted))]">
+          Payment options are not available for this account state.
+        </p>
+      )}
+
+      {onCancel && (
+        <Button variant="outline" size="sm" onClick={onCancel} disabled={loading !== null} className="w-full">
+          Cancel
+        </Button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a reusable payment choice panel for card and annual Bitcoin payment flows.
- Update the 7-day no-card trial banner and subscription-page copy to use “Choose payment” and 14 bonus-day language.
- Route card and Bitcoin starts through the shared billing payment-flows API.

## Verification
- Ad-hoc focused web tests for `AddCardBanner` and subscription-page CTA behavior.
- Web typecheck.
- Paired backend focused tests/typecheck run against the companion billing worktree.
- Stale positive-copy scan for old 30-day/add-card language.

## Dependency
- Requires the companion billing API changes in silent-suite/silentsuite-internal#181.
