### PR TITLE
Keep sync recoverable after degraded calendar loads

### DIFF
--- a/apps/web/app/providers/__tests__/sync-provider.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.test.tsx
@@ -9,6 +9,7 @@ const etebase = vi.hoisted(() => ({
     initialize: vi.fn(),
     fetchAllItems: vi.fn(),
     loadCollectionItemsIncrementally: vi.fn(),
+    refreshCollection: vi.fn(),
     startSyncEngine: vi.fn(),
     onSyncChange: vi.fn(() => vi.fn()),
     onStatusChange: vi.fn(() => vi.fn()),
@@ -184,6 +185,7 @@ describe('SyncProvider restore recovery blockers', () => {
     etebase.state.initialize.mockReset().mockResolvedValue({ status: 'success' })
     etebase.state.fetchAllItems.mockReset().mockResolvedValue([])
     etebase.state.loadCollectionItemsIncrementally.mockReset().mockResolvedValue(incrementalResult())
+    etebase.state.refreshCollection.mockReset().mockResolvedValue([])
     etebase.state.startSyncEngine.mockReset().mockResolvedValue(undefined)
     etebase.state.onSyncChange.mockClear()
     etebase.state.onStatusChange.mockClear()
@@ -224,18 +226,51 @@ describe('SyncProvider restore recovery blockers', () => {
     expect(useSyncStore.getState().syncStatus).toBe('offline')
   })
 
-  it('keeps the app usable and clears the recovery blocker for post-restore load errors', async () => {
+  it('keeps the app usable and wires recovery when calendar enumeration fails', async () => {
     useSyncStore.setState({ initialSyncBlocker: 'missing-encrypted-session' })
+    calendarStore.events = [{ id: 'existing-event', title: 'Existing event' }]
     etebase.state.initialize.mockResolvedValueOnce({ status: 'success' })
     etebase.state.loadCollectionItemsIncrementally.mockRejectedValueOnce(new Error('calendar load failed'))
 
     render(<SyncProvider><div>content</div></SyncProvider>)
 
-    await waitFor(() => expect(useSyncStore.getState().error).toBe('Calendar data could not be loaded'))
-    expect(useSyncStore.getState().initialSyncState).toBe('error')
+    await waitFor(() => expect(etebase.state.startSyncEngine).toHaveBeenCalledTimes(1))
+    expect(useSyncStore.getState().error).toBe('Some synced items could not be loaded')
+    expect(useSyncStore.getState().initialSyncState).toBe('synced')
     expect(useSyncStore.getState().initialSyncBlocker).toBeNull()
     expect(useSyncStore.getState().initialSyncProgress.active).toBe(false)
-    expect(etebase.state.startSyncEngine).not.toHaveBeenCalled()
+    expect(etebase.state.onSyncChange).toHaveBeenCalledTimes(1)
+    expect(etebase.state.onStatusChange).toHaveBeenCalledTimes(1)
+    expect(calendarStore.syncFromRemote).not.toHaveBeenCalledWith([])
+  })
+
+  it('can recover a degraded calendar after a later SyncEngine change', async () => {
+    let syncHandler: ((event: { changeType: string; collectionType: string; collectionUid: string; itemUids: string[] }) => Promise<void>) | null = null
+    etebase.state.onSyncChange.mockImplementation((handler) => {
+      syncHandler = handler
+      return vi.fn()
+    })
+    etebase.state.initialize.mockResolvedValueOnce({ status: 'success' })
+    etebase.state.loadCollectionItemsIncrementally.mockImplementation(async (type: string) => {
+      if (type !== 'calendar') return incrementalResult()
+      return {
+        ...incrementalResult(),
+        enumerationErrorCount: 1,
+        trustworthyForFullReplacement: false,
+      }
+    })
+    etebase.state.refreshCollection.mockResolvedValueOnce([{ uid: 'event-1', content: 'VEVENT', collectionUid: 'calendar-1' }])
+    etebase.state.fetchAllItems.mockResolvedValueOnce([{ uid: 'event-1', content: 'VEVENT', collectionUid: 'calendar-1' }])
+
+    render(<SyncProvider><div>content</div></SyncProvider>)
+
+    await waitFor(() => expect(etebase.state.startSyncEngine).toHaveBeenCalledTimes(1))
+    expect(syncHandler).toBeTruthy()
+    await syncHandler!({ changeType: 'update', collectionType: 'etebase.vevent', collectionUid: 'calendar-1', itemUids: ['event-1'] })
+
+    expect(calendarStore.syncFromRemote).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 'event-1', calendarId: 'calendar-1' }),
+    ])
   })
 
   it('wires SyncEngine when calendar loads but preferences startup fails', async () => {

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -42,7 +42,7 @@ const CALENDAR_DESERIALIZE_CHUNK_SIZE = 50
 type InitialDomainLoadResult = {
   domain: 'calendar' | 'tasks' | 'contacts' | 'preferences' | 'labelIndex'
   visibility: 'visible' | 'internal'
-  status: 'loaded' | 'empty' | 'warning' | 'failed'
+  status: 'loaded' | 'empty' | 'warning' | 'degraded' | 'failed'
   itemCount: number
   decodedCount: number
   decodeFailureCount: number
@@ -66,8 +66,8 @@ function errorCategoryFrom(err: unknown): string {
   return 'unknown'
 }
 
-function shouldWireSyncEngine(classification: Pick<InitialLoadClassification, 'visibleFatal'>): boolean {
-  return !classification.visibleFatal
+function shouldWireSyncEngine(_classification: Pick<InitialLoadClassification, 'visibleFatal'>): boolean {
+  return true
 }
 
 function mergeById<T extends { id: string }>(current: T[], incoming: T[]): T[] {
@@ -498,7 +498,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         }
         updateInitialSyncProgress('calendar', calendarEventCount, undefined, true)
         const status = eventLoad.enumerationErrorCount > 0 && allEvents.length === 0
-          ? 'failed'
+          ? 'degraded'
           : decodeFailureCount > 0 || eventLoad.enumerationErrorCount > 0
             ? 'warning'
             : eventLoad.attemptedCount === 0
@@ -528,7 +528,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         addDomain({
           domain: 'calendar',
           visibility: 'visible',
-          status: 'failed',
+          status: 'degraded',
           itemCount: 0,
           decodedCount: 0,
           decodeFailureCount: 0,
@@ -625,8 +625,8 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         endPassiveStartupToastCycle()
       }
 
-      const visibleFatal = domains.some((domain) => domain.domain === 'calendar' && domain.status === 'failed')
-      const visibleWarnings = domains.filter((domain) => domain.visibility === 'visible' && domain.status === 'warning')
+      const visibleFatal = domains.some((domain) => domain.visibility === 'visible' && domain.status === 'failed')
+      const visibleWarnings = domains.filter((domain) => domain.visibility === 'visible' && (domain.status === 'warning' || domain.status === 'degraded'))
       const internalWarnings = domains.filter((domain) => domain.visibility === 'internal' && (domain.status === 'warning' || domain.status === 'failed'))
       const classification: InitialLoadClassification = {
         accountRestored: true,

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -415,7 +415,7 @@ describe('useEtebaseStore.createItem', () => {
     expect(result).toBeNull()
     expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith(
       'Failed to save label suggestions. Please try again.',
-      { source: 'labelIndex' },
+      { source: 'labelIndex', suppressDuringPassiveStartup: true },
     )
     expect(toastStoreMock.showErrorToast).not.toHaveBeenCalledWith(
       'Failed to save preferences. Please try again.',

--- a/apps/web/app/stores/__tests__/use-toast-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-toast-store.test.ts
@@ -13,6 +13,21 @@ beforeEach(() => {
 })
 
 describe('useToastStore passive startup coalescing', () => {
+  it('suppresses internal save failures during passive startup', () => {
+    beginPassiveStartupToastCycle()
+
+    showErrorToast('Failed to save preferences. Please try again.', {
+      source: 'preferences',
+      suppressDuringPassiveStartup: true,
+    })
+    showErrorToast('Failed to save label suggestions. Please try again.', {
+      source: 'labelIndex',
+      suppressDuringPassiveStartup: true,
+    })
+
+    expect(useToastStore.getState().toasts).toHaveLength(0)
+  })
+
   it('coalesces duplicate passive startup errors per source and cycle', () => {
     beginPassiveStartupToastCycle()
 
@@ -28,12 +43,17 @@ describe('useToastStore passive startup coalescing', () => {
 
   it('allows a later explicit action-scoped failure after the passive cycle ends', () => {
     beginPassiveStartupToastCycle()
-    showErrorToast('Failed to save preferences. Please try again.', { source: 'preferences' })
-    showErrorToast('Failed to save preferences. Please try again.', { source: 'preferences' })
+    showErrorToast('Failed to save preferences. Please try again.', {
+      source: 'preferences',
+      suppressDuringPassiveStartup: true,
+    })
     endPassiveStartupToastCycle()
 
-    showErrorToast('Failed to save preferences. Please try again.', { source: 'preferences' })
+    showErrorToast('Failed to save preferences. Please try again.', {
+      source: 'preferences',
+      suppressDuringPassiveStartup: true,
+    })
 
-    expect(useToastStore.getState().toasts).toHaveLength(2)
+    expect(useToastStore.getState().toasts).toHaveLength(1)
   })
 })

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -370,7 +370,7 @@ function toastSourceForType(type: CollectionTypeKey): 'preferences' | 'labelInde
 function showSaveFailureToast(type: CollectionTypeKey): void {
   const source = toastSourceForType(type)
   const message = `Failed to save ${saveItemNoun(type)}. Please try again.`
-  if (source) showErrorToast(message, { source })
+  if (source) showErrorToast(message, { source, suppressDuringPassiveStartup: true })
   else showErrorToast(message)
 }
 

--- a/apps/web/app/stores/use-toast-store.ts
+++ b/apps/web/app/stores/use-toast-store.ts
@@ -24,6 +24,7 @@ export type ToastCoalesceSource = 'preferences' | 'labelIndex' | 'internal-sync'
 interface ToastOptions {
   source?: ToastCoalesceSource
   passiveStartup?: boolean
+  suppressDuringPassiveStartup?: boolean
 }
 
 let passiveStartupCycle = 0
@@ -60,7 +61,9 @@ export function endPassiveStartupToastCycle() {
 }
 
 export function showErrorToast(message: string, options: ToastOptions = {}) {
-  if ((options.passiveStartup || passiveStartupCycleActive) && options.source) {
+  const isPassiveStartup = options.passiveStartup || passiveStartupCycleActive
+  if (isPassiveStartup && options.suppressDuringPassiveStartup) return
+  if (isPassiveStartup && options.source) {
     const key = `${passiveStartupCycle}:${options.source}:${message}`
     if (shownPassiveStartupToasts.has(key)) return
     shownPassiveStartupToasts.add(key)


### PR DESCRIPTION
## Summary
- keep SyncEngine wired after degraded calendar item enumeration so the app can recover instead of staying terminally stuck
- preserve anti-wipe guards by treating degraded enumeration as non-trustworthy and avoiding empty full replacement
- suppress passive-startup internal preferences/labelIndex save toasts while keeping explicit post-startup save failures visible
- add regression coverage for degraded calendar recovery and passive-startup toast suppression

## Verification
- pnpm --filter @silentsuite/web test -- app/providers/__tests__/sync-provider.test.tsx app/stores/__tests__/use-toast-store.test.ts app/stores/__tests__/use-etebase-store.test.ts
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web lint
- git diff --check

Refs #446