### PR TITLE
Add web sync restore diagnostics

### DIFF
--- a/apps/web/app/components/SyncIndicator.tsx
+++ b/apps/web/app/components/SyncIndicator.tsx
@@ -5,6 +5,11 @@ import { RefreshCw } from 'lucide-react'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 import { formatTimeAgo } from '@/app/lib/format-time-ago'
 import type { SyncStatus } from '@silentsuite/core'
+import {
+  buildRestoreDiagnosticsCopyText,
+  readRestoreDiagnostics,
+  shouldExposeRestoreDiagnostics,
+} from '@/app/lib/sync-restore-diagnostics'
 
 const dotStyles: Record<SyncStatus, string> = {
   synced: 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.5)]',
@@ -47,11 +52,19 @@ export function SyncIndicator() {
   const isSyncing = syncStatus === 'syncing'
   const isOffline = syncStatus === 'offline'
   const isError = syncStatus === 'error'
+  const canCopyDiagnostics = isError && shouldExposeRestoreDiagnostics()
 
   const handleSync = useCallback(() => {
     if (isSyncing || isOffline) return
     simulateSyncCycle()
   }, [isSyncing, isOffline, simulateSyncCycle])
+
+  const handleCopyDiagnostics = useCallback(async () => {
+    const copyText = buildRestoreDiagnosticsCopyText(readRestoreDiagnostics())
+    await navigator.clipboard?.writeText(copyText)
+    setTooltipText('Restore diagnostics copied')
+    setShowTooltip(true)
+  }, [])
 
   // Update tooltip text on an interval while visible so relative times stay fresh
   useEffect(() => {
@@ -93,6 +106,16 @@ export function SyncIndicator() {
           className="hidden text-xs text-rose-400 hover:text-rose-300 md:inline"
         >
           Sync error
+        </button>
+      )}
+      {canCopyDiagnostics && (
+        <button
+          onClick={handleCopyDiagnostics}
+          className="hidden rounded border border-rose-500/40 px-1.5 py-0.5 text-[10px] text-rose-300 hover:border-rose-400 hover:text-rose-200 md:inline"
+          aria-label="Copy sync restore diagnostics"
+          type="button"
+        >
+          Copy diagnostics
         </button>
       )}
 

--- a/apps/web/app/components/__tests__/SyncIndicator.test.tsx
+++ b/apps/web/app/components/__tests__/SyncIndicator.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { SyncIndicator } from '../SyncIndicator'
 import type { SyncStatus } from '@silentsuite/core'
 
@@ -8,6 +8,8 @@ const mockSyncState = {
   syncStatus: 'synced' as SyncStatus,
   lastSyncedAt: null as Date | null,
   error: null as string | null,
+  pendingQueueCount: 0,
+  simulateSyncCycle: vi.fn(),
 }
 
 vi.mock('@/app/stores/use-sync-store', () => ({
@@ -23,6 +25,9 @@ describe('SyncIndicator', () => {
     mockSyncState.syncStatus = 'synced'
     mockSyncState.lastSyncedAt = null
     mockSyncState.error = null
+    mockSyncState.pendingQueueCount = 0
+    mockSyncState.simulateSyncCycle.mockClear()
+    sessionStorage.clear()
   })
 
   it('renders synced status with emerald color', () => {
@@ -55,5 +60,31 @@ describe('SyncIndicator', () => {
     const dot = screen.getByRole('status')
     expect(dot).toHaveAttribute('aria-label', 'Sync status: error')
     expect(dot.className).toContain('bg-red-500')
+  })
+
+  it('copies redacted restore diagnostics on preview/local sync errors', async () => {
+    const writeText = vi.fn(async () => {})
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    mockSyncState.syncStatus = 'error'
+    sessionStorage.setItem('silentsuite.restore-diagnostics.v1', JSON.stringify({
+      version: 1,
+      source: 'restore',
+      generatedAtMs: 1,
+      etebaseHost: 'server.silentsuite.io',
+      billingHost: 'api.silentsuite.io',
+      failedPhase: 'restoreSession',
+      entries: [{ phase: 'restoreSession', status: 'failed', errorName: 'Error' }],
+    }))
+
+    render(<SyncIndicator />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy sync restore diagnostics' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    const copied = writeText.mock.calls[0]![0] as string
+    expect(copied).toContain('"failedPhase":"restoreSession"')
+    expect(copied).not.toContain('session-secret')
   })
 })

--- a/apps/web/app/lib/__tests__/sync-restore-diagnostics.test.ts
+++ b/apps/web/app/lib/__tests__/sync-restore-diagnostics.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  RESTORE_DIAGNOSTICS_STORAGE_KEY,
+  RestoreDiagnosticsRecorder,
+  buildRestoreDiagnosticsCopyText,
+  classifySessionPersistence,
+  createLoginSessionPersistenceDiagnostics,
+  readRestoreDiagnostics,
+  shouldExposeRestoreDiagnostics,
+} from '../sync-restore-diagnostics'
+
+describe('sync restore diagnostics', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    localStorage.clear()
+    vi.unstubAllGlobals()
+  })
+
+  it('classifies session persistence without exposing the saved session value', () => {
+    const classification = classifySessionPersistence('{"secret":"session-token-value"}')
+
+    expect(classification).toEqual({ present: true, parseableJson: true, shape: 'json' })
+    expect(JSON.stringify(classification)).not.toContain('session-token-value')
+  })
+
+  it('stores only hostnames, phase codes, counts, durations, and safe error names', () => {
+    const recorder = new RestoreDiagnosticsRecorder({
+      source: 'restore',
+      etebaseServerUrl: 'https://server.silentsuite.io/private/path?token=secret',
+      billingApiUrl: 'https://api.silentsuite.io/auth/token-exchange?email=user@example.com',
+      now: () => 1_000,
+    })
+
+    recorder.completePhase('sessionRead', {
+      session: classifySessionPersistence('raw-session-secret'),
+    })
+    recorder.startPhase('listItems:calendar')
+    recorder.completePhase('listItems:calendar', {
+      collectionCount: 2,
+      itemCount: 42,
+      pageCount: 3,
+      now: 1_075,
+    })
+    recorder.startPhase('syncEngineStart')
+    recorder.failActivePhase(new Error('contains raw-session-secret and user@example.com'), 1_090)
+    recorder.persist()
+
+    const copyText = buildRestoreDiagnosticsCopyText(readRestoreDiagnostics())
+    expect(copyText).toContain('"etebaseHost":"server.silentsuite.io"')
+    expect(copyText).toContain('"billingHost":"api.silentsuite.io"')
+    expect(copyText).toContain('"phase":"syncEngineStart"')
+    expect(copyText).toContain('"errorName":"Error"')
+    expect(copyText).toContain('"itemCount":42')
+    expect(copyText).not.toContain('raw-session-secret')
+    expect(copyText).not.toContain('user@example.com')
+    expect(copyText).not.toContain('/private/path')
+    expect(copyText).not.toContain('token=secret')
+  })
+
+  it('records login session roundtrip diagnostics without persisting the session blob', () => {
+    createLoginSessionPersistenceDiagnostics({
+      etebaseServerUrl: 'https://server.silentsuite.io',
+      billingApiUrl: 'https://api.silentsuite.io',
+      savedSession: 'login-session-secret',
+      rereadSession: 'login-session-secret',
+      now: () => 2_000,
+    }).persist()
+
+    const raw = sessionStorage.getItem(RESTORE_DIAGNOSTICS_STORAGE_KEY) ?? ''
+    expect(raw).toContain('"phase":"sessionPersistence"')
+    expect(raw).toContain('"status":"ok"')
+    expect(raw).toContain('"roundtripMatch":true')
+    expect(raw).not.toContain('login-session-secret')
+  })
+
+  it('exposes copy UI only on preview/local or explicit syncDebug opt-in', () => {
+    vi.stubGlobal('window', {
+      location: { hostname: 'app.silentsuite.io', search: '' },
+      localStorage,
+    })
+    expect(shouldExposeRestoreDiagnostics()).toBe(false)
+
+    vi.stubGlobal('window', {
+      location: { hostname: 'previewapp.silentsuite.io', search: '' },
+      localStorage,
+    })
+    expect(shouldExposeRestoreDiagnostics()).toBe(true)
+
+    vi.stubGlobal('window', {
+      location: { hostname: 'app.silentsuite.io', search: '?syncDebug=1' },
+      localStorage,
+    })
+    expect(shouldExposeRestoreDiagnostics()).toBe(true)
+  })
+})

--- a/apps/web/app/lib/sync-restore-diagnostics.ts
+++ b/apps/web/app/lib/sync-restore-diagnostics.ts
@@ -1,0 +1,233 @@
+import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
+import { getSafeErrorName } from '@/app/lib/privacy-safe-errors'
+
+export const RESTORE_DIAGNOSTICS_STORAGE_KEY = 'silentsuite.restore-diagnostics.v1'
+
+export type RestoreDiagnosticPhase =
+  | 'sessionRead'
+  | 'sessionPersistence'
+  | 'restoreSession'
+  | 'ensureCollections'
+  | 'hydrateLists'
+  | 'listItems:calendar'
+  | 'listItems:tasks'
+  | 'listItems:contacts'
+  | 'syncEngineTrackCollections'
+  | 'syncEngineStart'
+  | 'unknown'
+
+export type RestoreDiagnosticStatus = 'ok' | 'failed' | 'skipped'
+
+export interface SessionPersistenceShape {
+  present: boolean
+  parseableJson: boolean
+  shape: 'missing' | 'empty' | 'json' | 'string'
+}
+
+export interface RestoreDiagnosticEntry {
+  phase: RestoreDiagnosticPhase
+  status: RestoreDiagnosticStatus
+  durationMs?: number
+  errorName?: string
+  session?: SessionPersistenceShape
+  roundtripMatch?: boolean
+  collectionType?: 'calendar' | 'tasks' | 'contacts'
+  collectionCount?: number
+  itemCount?: number
+  pageCount?: number
+}
+
+export interface RestoreDiagnosticsSnapshot {
+  version: 1
+  source: 'login' | 'restore'
+  generatedAtMs: number
+  etebaseHost: string
+  billingHost: string
+  failedPhase: RestoreDiagnosticPhase | null
+  entries: RestoreDiagnosticEntry[]
+}
+
+interface RecorderInit {
+  source: 'login' | 'restore'
+  etebaseServerUrl?: string
+  billingApiUrl?: string
+  now?: () => number
+}
+
+interface PhaseStart {
+  phase: RestoreDiagnosticPhase
+  startedAtMs: number
+}
+
+function safeHostname(url: string | undefined, fallback: string): string {
+  if (!url) return fallback
+  try {
+    return new URL(url).hostname || fallback
+  } catch {
+    return fallback
+  }
+}
+
+function safeStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.sessionStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+function safeLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage ?? null
+  } catch {
+    return null
+  }
+}
+
+export function classifySessionPersistence(value: string | null | undefined): SessionPersistenceShape {
+  if (value == null) return { present: false, parseableJson: false, shape: 'missing' }
+  if (value === '') return { present: false, parseableJson: false, shape: 'empty' }
+  try {
+    JSON.parse(value)
+    return { present: true, parseableJson: true, shape: 'json' }
+  } catch {
+    return { present: true, parseableJson: false, shape: 'string' }
+  }
+}
+
+export class RestoreDiagnosticsRecorder {
+  private readonly now: () => number
+  private readonly entries: RestoreDiagnosticEntry[] = []
+  private readonly source: 'login' | 'restore'
+  private readonly etebaseHost: string
+  private readonly billingHost: string
+  private generatedAtMs: number
+  private activePhase: PhaseStart | null = null
+  private failedPhase: RestoreDiagnosticPhase | null = null
+
+  constructor(init: RecorderInit) {
+    this.now = init.now ?? (() => Date.now())
+    this.generatedAtMs = this.now()
+    this.source = init.source
+    this.etebaseHost = safeHostname(init.etebaseServerUrl ?? ETEBASE_SERVER_URL, 'unknown')
+    this.billingHost = safeHostname(init.billingApiUrl ?? BILLING_API_URL, 'unknown')
+  }
+
+  startPhase(phase: RestoreDiagnosticPhase, now = this.now()): void {
+    this.activePhase = { phase, startedAtMs: now }
+  }
+
+  completePhase(
+    phase: RestoreDiagnosticPhase,
+    details: Omit<RestoreDiagnosticEntry, 'phase' | 'status' | 'durationMs'> & { now?: number } = {},
+  ): void {
+    const { now, ...safeDetails } = details
+    const finishedAtMs = now ?? this.now()
+    const active = this.activePhase?.phase === phase ? this.activePhase : null
+    const durationMs = active ? Math.max(0, Math.round(finishedAtMs - active.startedAtMs)) : undefined
+    this.entries.push({
+      phase,
+      status: 'ok',
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      ...safeDetails,
+    })
+    if (active) this.activePhase = null
+    this.generatedAtMs = finishedAtMs
+  }
+
+  skipPhase(phase: RestoreDiagnosticPhase, details: Omit<RestoreDiagnosticEntry, 'phase' | 'status'> = {}): void {
+    this.entries.push({ phase, status: 'skipped', ...details })
+  }
+
+  failActivePhase(error: unknown, now = this.now()): void {
+    const active = this.activePhase ?? { phase: 'unknown' as RestoreDiagnosticPhase, startedAtMs: now }
+    const durationMs = Math.max(0, Math.round(now - active.startedAtMs))
+    this.failedPhase = active.phase
+    this.entries.push({
+      phase: active.phase,
+      status: 'failed',
+      durationMs,
+      errorName: getSafeErrorName(error),
+    })
+    this.activePhase = null
+    this.generatedAtMs = now
+  }
+
+  snapshot(): RestoreDiagnosticsSnapshot {
+    return {
+      version: 1,
+      source: this.source,
+      generatedAtMs: this.generatedAtMs,
+      etebaseHost: this.etebaseHost,
+      billingHost: this.billingHost,
+      failedPhase: this.failedPhase,
+      entries: [...this.entries],
+    }
+  }
+
+  persist(): void {
+    persistRestoreDiagnostics(this.snapshot())
+  }
+}
+
+export function createLoginSessionPersistenceDiagnostics(init: {
+  etebaseServerUrl?: string
+  billingApiUrl?: string
+  savedSession: string | null | undefined
+  rereadSession: string | null | undefined
+  now?: () => number
+}): RestoreDiagnosticsRecorder {
+  const recorder = new RestoreDiagnosticsRecorder({
+    source: 'login',
+    etebaseServerUrl: init.etebaseServerUrl,
+    billingApiUrl: init.billingApiUrl,
+    now: init.now,
+  })
+  recorder.completePhase('sessionPersistence', {
+    session: classifySessionPersistence(init.rereadSession),
+    roundtripMatch: Boolean(init.savedSession) && init.savedSession === init.rereadSession,
+  })
+  return recorder
+}
+
+export function persistRestoreDiagnostics(snapshot: RestoreDiagnosticsSnapshot): void {
+  const storage = safeStorage()
+  if (!storage) return
+  try {
+    storage.setItem(RESTORE_DIAGNOSTICS_STORAGE_KEY, buildRestoreDiagnosticsCopyText(snapshot))
+  } catch {
+    // Diagnostics are best-effort only.
+  }
+}
+
+export function readRestoreDiagnostics(): RestoreDiagnosticsSnapshot | null {
+  const storage = safeStorage()
+  if (!storage) return null
+  try {
+    const raw = storage.getItem(RESTORE_DIAGNOSTICS_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as RestoreDiagnosticsSnapshot
+    if (parsed?.version !== 1 || !Array.isArray(parsed.entries)) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function buildRestoreDiagnosticsCopyText(snapshot: RestoreDiagnosticsSnapshot | null): string {
+  if (!snapshot) return JSON.stringify({ version: 1, error: 'no_restore_diagnostics_recorded' })
+  return JSON.stringify(snapshot)
+}
+
+export function shouldExposeRestoreDiagnostics(): boolean {
+  if (typeof window === 'undefined') return false
+  const hostname = window.location.hostname
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === 'previewapp.silentsuite.io') {
+    return true
+  }
+  const params = new URLSearchParams(window.location.search)
+  if (params.get('syncDebug') === '1') return true
+  return safeLocalStorage()?.getItem('silentsuite-sync-debug') === '1'
+}

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -522,6 +522,37 @@ describe('useAuthStore', () => {
     expect(secureStore.etebase_session).toBe('mock-saved-session')
   })
 
+  it('login records a redacted Etebase session persistence diagnostic after storing the session', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'user-1', email: 'test@example.com', planId: 'pro', isAdmin: false }),
+    } as Response)
+
+    await useAuthStore.getState().login('test@example.com', 'password123')
+
+    const raw = sessionStorage.getItem('silentsuite.restore-diagnostics.v1') ?? ''
+    expect(raw).toContain('"phase":"sessionPersistence"')
+    expect(raw).toContain('"roundtripMatch":true')
+    expect(raw).not.toContain('mock-saved-session')
+    expect(raw).not.toContain('test@example.com')
+  })
+
+  it('login still succeeds if the best-effort persistence diagnostic read fails', async () => {
+    const { secureGet } = await import('@/app/lib/secure-storage')
+    vi.mocked(secureGet).mockRejectedValueOnce(new Error('diagnostic read failed'))
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'user-1', email: 'test@example.com', planId: 'pro', isAdmin: false }),
+    } as Response)
+
+    await useAuthStore.getState().login('test@example.com', 'password123')
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+    expect(useAuthStore.getState().error).toBeNull()
+  })
+
   it('login does not clear the current offline queue when Etebase authentication fails', async () => {
     const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
     vi.mocked(etebaseLogIn).mockRejectedValueOnce(new Error('unauthorized'))

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -13,8 +13,12 @@ const offlineQueueMock = vi.hoisted(() => ({
 }))
 
 const coreMock = vi.hoisted(() => ({
+  restoreSession: vi.fn(),
+  getAccountFingerprint: vi.fn(),
   listCollections: vi.fn(),
   createCollection: vi.fn(),
+  listItems: vi.fn(),
+  SyncEngine: vi.fn(),
   createItem: vi.fn(),
   deleteItem: vi.fn(),
   updateCollectionMeta: vi.fn(),
@@ -46,10 +50,15 @@ beforeEach(() => {
   offlineQueueMock.isOfflineError.mockReset().mockReturnValue(false)
   coreMock.listCollections.mockReset()
   coreMock.createCollection.mockReset()
+  coreMock.restoreSession.mockReset()
+  coreMock.getAccountFingerprint.mockReset()
+  coreMock.listItems.mockReset()
+  coreMock.SyncEngine.mockReset()
   coreMock.createItem.mockReset()
   coreMock.deleteItem.mockReset()
   coreMock.updateCollectionMeta.mockReset()
   toastStoreMock.showErrorToast.mockReset()
+  sessionStorage.clear()
 })
 
 interface MockItemManager {
@@ -112,6 +121,51 @@ function setupStoreWithCollections(itemManagerByUid: Record<string, MockItemMana
     syncEngine: syncEngine as any,
   })
 }
+
+describe('useEtebaseStore.initialize restore diagnostics', () => {
+  beforeEach(() => {
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      syncEngine: null,
+    })
+  })
+
+  it('records a redacted failed restoreSession phase diagnostic', async () => {
+    const { secureGet } = await import('@/app/lib/secure-storage')
+    vi.mocked(secureGet).mockResolvedValueOnce('raw-session-secret')
+    coreMock.restoreSession.mockRejectedValueOnce(new Error('raw-session-secret user@example.com'))
+
+    await useEtebaseStore.getState().initialize()
+
+    const raw = sessionStorage.getItem('silentsuite.restore-diagnostics.v1') ?? ''
+    expect(raw).toContain('"phase":"restoreSession"')
+    expect(raw).toContain('"status":"failed"')
+    expect(raw).toContain('"errorName":"Error"')
+    expect(raw).not.toContain('raw-session-secret')
+    expect(raw).not.toContain('user@example.com')
+    expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith('Failed to restore session. Please try signing in again.')
+  })
+
+  it('records a failed sessionRead phase diagnostic when secure session read throws', async () => {
+    const { secureGet } = await import('@/app/lib/secure-storage')
+    vi.mocked(secureGet).mockRejectedValueOnce(new Error('raw-session-secret user@example.com'))
+
+    await useEtebaseStore.getState().initialize()
+
+    const raw = sessionStorage.getItem('silentsuite.restore-diagnostics.v1') ?? ''
+    expect(raw).toContain('"phase":"sessionRead"')
+    expect(raw).toContain('"status":"failed"')
+    expect(raw).toContain('"failedPhase":"sessionRead"')
+    expect(raw).not.toContain('raw-session-secret')
+    expect(raw).not.toContain('user@example.com')
+    expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith('Failed to restore session. Please try signing in again.')
+  })
+})
 
 describe('useEtebaseStore.createItemsBatch', () => {
   beforeEach(() => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -3,11 +3,13 @@
 import { create } from 'zustand'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { logger } from '@/app/lib/logger'
-import { BILLING_API_URL } from '@/app/lib/config'
+import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
 import { COOKIE_MAX_AGE_SELF_HOSTED, COOKIE_MAX_AGE_HOSTED } from '@/app/lib/constants'
 import { secureGet, secureSet, secureRemove, secureClear, migrateFromLocalStorage } from '@/app/lib/secure-storage'
 import { clearAll as clearLocalDataCache } from '@/app/lib/data-cache'
 import { clearAll as clearOfflineQueue } from '@/app/lib/offline-queue'
+import { createLoginSessionPersistenceDiagnostics } from '@/app/lib/sync-restore-diagnostics'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 
 export interface User {
   isAdmin?: boolean
@@ -429,6 +431,17 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // and queued work from one account cannot replay into another account.
       await clearOfflineQueue()
       await secureSet('etebase_session', savedSession)
+      try {
+        const persistedSession = await secureGet('etebase_session')
+        createLoginSessionPersistenceDiagnostics({
+          etebaseServerUrl: serverUrl ?? ETEBASE_SERVER_URL,
+          billingApiUrl: BILLING_API_URL,
+          savedSession,
+          rereadSession: persistedSession,
+        }).persist()
+      } catch (diagErr) {
+        logger.warn('[auth-store] Session persistence diagnostics failed', getSafeErrorDetails(diagErr))
+      }
 
       if (isSelfHosted || isCustomServer(serverUrl)) {
         if (serverUrl) localStorage.setItem('silentsuite-server-url', serverUrl)

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { create } from 'zustand'
-import { ETEBASE_SERVER_URL } from '@/app/lib/config'
+import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
 import type {
   CollectionAccessLevel,
   CollectionType,
@@ -28,6 +28,7 @@ import {
   type CachedItem,
 } from '@/app/lib/data-cache'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { RestoreDiagnosticsRecorder, classifySessionPersistence } from '@/app/lib/sync-restore-diagnostics'
 
 /**
  * Holds live Etebase SDK objects (Account, Collections, Items, SyncEngine).
@@ -74,12 +75,13 @@ const COLLECTION_TYPE_TASKS = 'etebase.vtodo'
 const COLLECTION_TYPE_CONTACTS = 'etebase.vcard'
 
 type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
+type VisibleCollectionTypeKey = Exclude<CollectionTypeKey, 'preferences'>
 type CollectionMetaUpdates = { name?: string; description?: string; color?: string }
 type EtebaseCore = typeof import('@silentsuite/core')
 
 type CachedContentItem = { uid: string; content: string; collectionUid: string }
 
-const COLLECTION_DEFINITIONS: [CollectionTypeKey, string, string][] = [
+const COLLECTION_DEFINITIONS: [VisibleCollectionTypeKey, string, string][] = [
   ['calendar', COLLECTION_TYPE_CALENDAR, 'Personal Calendar'],
   ['tasks', COLLECTION_TYPE_TASKS, 'Personal Tasks'],
   ['contacts', COLLECTION_TYPE_CONTACTS, 'Personal Contacts'],
@@ -487,21 +489,35 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   syncEngine: null,
 
   initialize: async () => {
-    const savedSession = await secureGet('etebase_session')
-    if (!savedSession) {
-      logger.debug('[etebase-store] No saved session, skipping initialization')
-      return
-    }
+    const serverUrl = getServerUrl()
+    const diagnostics = new RestoreDiagnosticsRecorder({
+      source: 'restore',
+      etebaseServerUrl: serverUrl,
+      billingApiUrl: BILLING_API_URL,
+    })
 
     try {
+      diagnostics.startPhase('sessionRead')
+      const savedSession = await secureGet('etebase_session')
+      diagnostics.completePhase('sessionRead', {
+        session: classifySessionPersistence(savedSession),
+      })
+      if (!savedSession) {
+        diagnostics.skipPhase('restoreSession')
+        diagnostics.persist()
+        logger.debug('[etebase-store] No saved session, skipping initialization')
+        return
+      }
+
       // Dynamic import to avoid SSR issues with etebase WASM
       const core = await import('@silentsuite/core')
 
       // 1. Restore the Account
       logger.debug('[etebase-store] Restoring Etebase session...')
-      const serverUrl = getServerUrl()
+      diagnostics.startPhase('restoreSession')
       const account = await core.restoreSession(serverUrl, savedSession)
       const accountFingerprint = core.getAccountFingerprint(account)
+      diagnostics.completePhase('restoreSession')
       set({ account, accountFingerprint })
       logger.debug('[etebase-store] Session restored')
 
@@ -518,10 +534,16 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       }
 
       // 2. Ensure collections exist (create if first login, fetch if returning)
+      diagnostics.startPhase('ensureCollections')
       const collections = await ensureCollectionsForAccount(account, core)
+      diagnostics.completePhase('ensureCollections', {
+        collectionCount: COLLECTION_DEFINITIONS.reduce((count, [key]) => count + collections[key].length, 0),
+      })
 
       set({ collections })
+      diagnostics.startPhase('hydrateLists')
       await hydrateListStores(collections)
+      diagnostics.completePhase('hydrateLists')
 
       // 3. Load all items from each collection into the cache
       const itemCache = new Map<string, any>()
@@ -529,7 +551,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const itemCollectionMap = new Map<string, string>()
 
       for (const [key] of COLLECTION_DEFINITIONS) {
+        const phase = `listItems:${key}` as const
+        diagnostics.startPhase(phase)
         const typedCollections = collections[key]
+        let itemCount = 0
+        let pageCount = 0
 
         for (const collection of typedCollections) {
           let stoken: string | null = null
@@ -537,17 +563,25 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
           while (!done) {
             const response = await core.listItems(account, collection, stoken)
+            pageCount += 1
             for (const item of response.items) {
               if (!item.isDeleted) {
                 itemCache.set(item.uid, item)
                 itemTypeMap.set(item.uid, key)
                 itemCollectionMap.set(item.uid, collection.uid)
+                itemCount += 1
               }
             }
             stoken = response.stoken
             done = response.done
           }
         }
+        diagnostics.completePhase(phase, {
+          collectionType: key,
+          collectionCount: typedCollections.length,
+          itemCount,
+          pageCount,
+        })
       }
 
       set({ itemCache, itemTypeMap, itemCollectionMap })
@@ -560,11 +594,15 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       })
 
       // Track all collections
+      diagnostics.startPhase('syncEngineTrackCollections')
       for (const [key, colType] of COLLECTION_DEFINITIONS) {
         for (const collection of collections[key]) {
           await trackCollectionWithSyncEngine(engine, colType, key, collection.uid)
         }
       }
+      diagnostics.completePhase('syncEngineTrackCollections', {
+        collectionCount: COLLECTION_DEFINITIONS.reduce((count, [key]) => count + collections[key].length, 0),
+      })
 
       // Seed persisted stokens before starting so the first sync round
       // pulls only deltas instead of refetching the whole vault. Wire the
@@ -578,10 +616,15 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         })
       }
 
+      diagnostics.startPhase('syncEngineStart')
       await engine.start(account)
+      diagnostics.completePhase('syncEngineStart')
       set({ syncEngine: engine, isInitialized: true })
+      diagnostics.persist()
       logger.debug('[etebase-store] SyncEngine started')
     } catch (err) {
+      diagnostics.failActivePhase(err)
+      diagnostics.persist()
       console.error('[etebase-store] Initialization failed', getSafeErrorDetails(err))
       // Don't clear the session -- the user might be offline
       // They can retry on next page load


### PR DESCRIPTION
## Summary

- add privacy-safe restore diagnostics for the web Etebase session initialization path
- record post-login encrypted-session persistence roundtrip status without storing session values
- expose a preview/local-only copy diagnostics action from the sync indicator when sync is in error state

## Diagnostics captured

Only safe metadata is recorded:

- failing phase code such as `restoreSession`, `ensureCollections`, `listItems:calendar`, or `syncEngineStart`
- Etebase and billing hostnames only
- booleans for session presence/parseability and post-login roundtrip match
- collection/item/page counts and phase durations
- safe error names only

The diagnostics intentionally do not include credentials, raw session blobs, auth tokens, emails, item IDs, collection IDs, item contents, full URLs, query strings, or error messages.

## Verification

- `pnpm --filter @silentsuite/web test -- app/lib/__tests__/sync-restore-diagnostics.test.ts app/stores/__tests__/use-auth-store.test.ts app/stores/__tests__/use-etebase-store.test.ts app/components/__tests__/SyncIndicator.test.tsx`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint` (passes with existing warnings)
- `pnpm --filter @silentsuite/web build` (passes with existing Sentry/PWA warnings)
- `git diff --check`
