### PR TITLE
Clean up rolled-back data cache schema

### DIFF
--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -239,6 +239,39 @@ describe('data-cache', () => {
       expect(ok).toBe(true)
       expect(await getStoken('col-tasks')).toBe('stk-a')
     })
+
+    it('upgrades and clears the rolled-back v3 encrypted cache schema', async () => {
+      await _resetForTests()
+      const v3Db = await new Promise<IDBDatabase>((resolve, reject) => {
+        const req = indexedDB.open('silentsuite-data-cache', 3)
+        req.onupgradeneeded = () => {
+          const db = req.result
+          const items = db.createObjectStore('items', { keyPath: 'itemUid' })
+          items.createIndex('byCollectionType', 'collectionType', { unique: false })
+          items.createIndex('byCollectionUid', 'collectionUid', { unique: false })
+          db.createObjectStore('collections', { keyPath: 'collectionUid' })
+          db.createObjectStore('meta')
+          db.createObjectStore('crypto')
+        }
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error)
+      })
+      v3Db.close()
+
+      await ensureFingerprint('alice@example.com')
+      await _resetForTests()
+
+      const upgradedDb = await new Promise<IDBDatabase>((resolve, reject) => {
+        const req = indexedDB.open('silentsuite-data-cache')
+        req.onsuccess = () => resolve(req.result)
+        req.onerror = () => reject(req.error)
+      })
+
+      expect(upgradedDb.version).toBe(4)
+      expect(upgradedDb.objectStoreNames.contains('crypto')).toBe(false)
+      expect(upgradedDb.objectStoreNames.contains('items')).toBe(true)
+      upgradedDb.close()
+    })
   })
 
   describe('clearAll', () => {

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -46,13 +46,14 @@ export interface CacheMeta {
 }
 
 /** Bumped on shape changes to the cached records. */
-export const CACHE_SCHEMA_VERSION = 2
+export const CACHE_SCHEMA_VERSION = 4
 
 const DB_NAME = 'silentsuite-data-cache'
-const DB_VERSION = 2
+const DB_VERSION = 4
 const STORE_ITEMS = 'items'
 const STORE_COLLECTIONS = 'collections'
 const STORE_META = 'meta'
+const STORE_CRYPTO = 'crypto'
 
 const META_KEY = 'singleton'
 
@@ -80,6 +81,15 @@ function openDB(): Promise<IDBDatabase> {
     const request = indexedDB.open(DB_NAME, DB_VERSION)
     request.onupgradeneeded = (event) => {
       const db = request.result
+      // v4 intentionally rolls back the encrypted local item cache. Browsers
+      // that already opened the v3 database cannot be downgraded to v2; clear
+      // all prior stores, including the v3 crypto key store, then recreate the
+      // minimal fail-closed cache schema used by this build.
+      if (event.oldVersion > 0 && event.oldVersion < 4) {
+        for (const storeName of [STORE_ITEMS, STORE_COLLECTIONS, STORE_META, STORE_CRYPTO]) {
+          if (db.objectStoreNames.contains(storeName)) db.deleteObjectStore(storeName)
+        }
+      }
       if (!db.objectStoreNames.contains(STORE_ITEMS)) {
         const items = db.createObjectStore(STORE_ITEMS, { keyPath: 'itemUid' })
         items.createIndex('byCollectionType', 'collectionType', { unique: false })


### PR DESCRIPTION
## Summary

Fix a production-promotion review finding in the rolled-back web data cache schema:

- keep the data-cache IndexedDB version monotonic after the v3 encrypted-cache rollback
- clear prior v3 stores, including the old crypto key store, during the v4 upgrade
- add a regression test that verifies a v3 database upgrades to v4 without the crypto store

## Verification

- `pnpm --filter @silentsuite/web test -- app/lib/__tests__/data-cache.test.ts app/lib/__tests__/sync-restore-diagnostics.test.ts app/stores/__tests__/use-etebase-store.test.ts app/stores/__tests__/use-auth-store.test.ts app/components/__tests__/SyncIndicator.test.tsx`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint`
- `pnpm --filter @silentsuite/web build`
- `git diff --check`
