### PR TITLE
Recover abandoned payment flows in Settings

### DIFF
--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -37,9 +37,13 @@ describe('AddCardBanner', () => {
   })
 
   it('uses shared payment options and starts Stripe pay-now through payment-flows', async () => {
-    vi.mocked(fetch)
-      .mockResolvedValueOnce({ ok: true, json: async () => monthlyOptions } as Response)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ clientSecret: 'pi_secret', flowKind: 'stripe_pay_now' }) } as Response)
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/subscription/payment-flows/current')) return { ok: true, json: async () => ({ flow: null }) } as Response
+      if (url.includes('/subscription/payment-options?interval=monthly')) return { ok: true, json: async () => monthlyOptions } as Response
+      if (url.includes('/subscription/payment-flows')) return { ok: true, json: async () => ({ clientSecret: 'pi_secret', flowKind: 'stripe_pay_now' }) } as Response
+      return { ok: false, json: async () => ({}) } as Response
+    })
 
     render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
 
@@ -68,11 +72,16 @@ describe('AddCardBanner', () => {
   })
 
   it('switches monthly Bitcoin banner to annual and starts annual BTCPay flow', async () => {
-    vi.mocked(fetch)
-      .mockResolvedValueOnce({ ok: true, json: async () => monthlyOptions } as Response)
-      .mockResolvedValueOnce({ ok: true, json: async () => annualOptions } as Response)
-      .mockResolvedValueOnce({ ok: true, json: async () => annualOptions } as Response)
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ checkoutUrl: 'https://btcpay.silentsuite.io/i/inv_123' }) } as Response)
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/subscription/payment-flows/current')) return { ok: true, json: async () => ({ flow: null }) } as Response
+      if (url.includes('/subscription/payment-options?interval=monthly')) return { ok: true, json: async () => monthlyOptions } as Response
+      if (url.includes('/subscription/payment-options?interval=annual')) return { ok: true, json: async () => annualOptions } as Response
+      if (url.includes('/subscription/crypto/invoice/inv_123/payment-methods')) return { ok: true, json: async () => ({ paymentMethods: [{ id: 'btc', label: 'BTC', qrValue: 'bitcoin:test', address: 'bc1test', amountDue: '0.001', cryptoCode: 'BTC' }] }) } as Response
+      if (url.includes('/subscription/crypto/invoice/inv_123')) return { ok: true, json: async () => ({ status: 'pending' }) } as Response
+      if (url.includes('/subscription/payment-flows')) return { ok: true, json: async () => ({ checkoutUrl: 'https://btcpay.silentsuite.io/i/inv_123', invoiceId: 'inv_123', invoiceLookupToken: 'lookup_123' }) } as Response
+      return { ok: false, json: async () => ({}) } as Response
+    })
 
     render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
     fireEvent.click(screen.getByText('Choose payment'))

--- a/apps/web/app/components/bitcoin-payment-panel.tsx
+++ b/apps/web/app/components/bitcoin-payment-panel.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ArrowLeft, ExternalLink } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
+import { BILLING_API_URL } from '@/app/lib/config'
+
+type CryptoPaymentMethod = {
+  id: string
+  label: string
+  qrValue: string | null
+  address: string | null
+  paymentLink?: string | null
+  amountDue: string | null
+  cryptoCode: string | null
+}
+
+export type BitcoinPaymentSession = {
+  invoiceId: string
+  lookupToken: string
+  checkoutUrl: string
+}
+
+type BitcoinPaymentPanelProps = {
+  session: BitcoinPaymentSession
+  title?: string
+  description?: string
+  settledMessage?: string
+  onBack: () => void
+  onInvoiceInactive?: () => void
+  onPaymentComplete: () => void | Promise<void>
+  externalCheckoutLabel?: string
+}
+
+export default function BitcoinPaymentPanel({
+  session,
+  title = 'Pay with Bitcoin',
+  description = 'Scan the QR code or copy the payment details. Access unlocks after BTCPay settlement confirms.',
+  settledMessage = 'Payment settled. Your access is active.',
+  onBack,
+  onInvoiceInactive,
+  onPaymentComplete,
+  externalCheckoutLabel = 'Open in BTCPay instead',
+}: BitcoinPaymentPanelProps) {
+  const [paymentMethods, setPaymentMethods] = useState<CryptoPaymentMethod[]>([])
+  const [selectedMethodId, setSelectedMethodId] = useState<string | null>(null)
+  const [status, setStatus] = useState<'loading' | 'pending' | 'settled' | 'expired' | 'error'>('loading')
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadPaymentMethods() {
+      try {
+        const res = await fetch(`${BILLING_API_URL}/subscription/crypto/invoice/${session.invoiceId}/payment-methods`, {
+          credentials: 'include',
+          headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-Invoice-Lookup-Token': session.lookupToken },
+        })
+        if (!res.ok) throw new Error('Could not load Bitcoin payment details.')
+        const data = await res.json()
+        if (cancelled) return
+        const methods = Array.isArray(data.paymentMethods) ? data.paymentMethods as CryptoPaymentMethod[] : []
+        if (!methods.some((method) => method.qrValue || method.paymentLink || method.address)) {
+          throw new Error('Could not load Bitcoin payment details.')
+        }
+        setPaymentMethods(methods)
+        setSelectedMethodId(methods[0]?.id ?? null)
+        setStatus('pending')
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Could not load Bitcoin payment details.')
+          setStatus('error')
+        }
+      }
+    }
+
+    void loadPaymentMethods()
+    return () => { cancelled = true }
+  }, [session.invoiceId, session.lookupToken])
+
+  useEffect(() => {
+    let cancelled = false
+    let timer: number | undefined
+
+    async function poll() {
+      try {
+        const res = await fetch(`${BILLING_API_URL}/subscription/crypto/invoice/${session.invoiceId}`, {
+          credentials: 'include',
+          headers: { 'X-Requested-With': 'XMLHttpRequest', 'X-Invoice-Lookup-Token': session.lookupToken },
+        })
+        if (!res.ok) throw new Error('Could not check Bitcoin payment status.')
+        const data = await res.json()
+        if (cancelled) return
+        if (data.status === 'settled') {
+          setStatus('settled')
+          timer = window.setTimeout(() => { void onPaymentComplete() }, 1200)
+          return
+        }
+        if (data.status === 'expired' || data.status === 'invalid' || data.status === 'failed') {
+          setStatus('expired')
+          return
+        }
+        timer = window.setTimeout(poll, 10_000)
+      } catch {
+        if (!cancelled) timer = window.setTimeout(poll, 15_000)
+      }
+    }
+
+    void poll()
+    return () => {
+      cancelled = true
+      if (timer) window.clearTimeout(timer)
+    }
+  }, [onPaymentComplete, session.invoiceId, session.lookupToken])
+
+  const selectedMethod = paymentMethods.find((method) => method.id === selectedMethodId) ?? paymentMethods[0]
+  const qrValue = selectedMethod?.qrValue ?? selectedMethod?.paymentLink ?? selectedMethod?.address ?? ''
+
+  async function handleCopyPaymentDetails() {
+    try {
+      await navigator.clipboard.writeText(qrValue)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2500)
+    } catch {
+      setError('Could not copy payment details. Please copy them manually.')
+    }
+  }
+
+  function handleBack() {
+    if (status === 'expired' || status === 'settled' || status === 'error') onInvoiceInactive?.()
+    onBack()
+  }
+
+  return (
+    <div className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
+      <div className="space-y-2 text-center">
+        <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">{title}</h2>
+        <p className="text-sm text-[rgb(var(--muted))]">{description}</p>
+      </div>
+
+      {status === 'settled' ? (
+        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-center text-sm text-emerald-700 dark:text-emerald-300">
+          {settledMessage}
+        </div>
+      ) : status === 'expired' ? (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-700 dark:text-amber-200">
+          This Bitcoin invoice is no longer payable. Go back and start a new Bitcoin invoice.
+        </div>
+      ) : status === 'error' ? (
+        <div className="space-y-3 rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">
+          <p>{error ?? 'Could not load Bitcoin payment details.'}</p>
+          <a href={session.checkoutUrl} className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border border-red-500/30 bg-transparent px-4 py-2 text-sm font-medium text-red-700 shadow-sm transition-colors hover:bg-red-500/10 dark:text-red-200">
+            {externalCheckoutLabel}<ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      ) : selectedMethod && qrValue ? (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-2">
+            {paymentMethods.map((method) => (
+              <button
+                key={method.id}
+                type="button"
+                onClick={() => setSelectedMethodId(method.id)}
+                className={`rounded-lg border px-3 py-2 text-sm transition-colors ${
+                  selectedMethod.id === method.id
+                    ? 'border-amber-500 bg-amber-500/10 text-amber-700 dark:text-amber-200'
+                    : 'border-[rgb(var(--border))] bg-[rgb(var(--surface))] text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
+                }`}
+              >
+                {method.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="rounded-xl border border-[rgb(var(--border))] bg-white p-4">
+            <QRCodeSVG value={qrValue} size={240} className="mx-auto h-auto max-w-full" />
+          </div>
+
+          <div className="space-y-2 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3 text-left">
+            {selectedMethod.amountDue && (
+              <p className="text-sm text-[rgb(var(--foreground))]">
+                Amount due: <span className="font-medium">{selectedMethod.amountDue} {selectedMethod.cryptoCode ?? 'BTC'}</span>
+              </p>
+            )}
+            <p className="break-all text-xs text-[rgb(var(--muted))]">{selectedMethod.address ?? qrValue}</p>
+            <button type="button" onClick={handleCopyPaymentDetails} className="text-xs font-medium text-emerald-600 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300">
+              {copied ? 'Copied to clipboard' : 'Copy payment details'}
+            </button>
+          </div>
+
+          <a href={session.checkoutUrl} className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100">
+            {externalCheckoutLabel}<ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center justify-center py-8">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-[rgb(var(--primary))] border-t-transparent" />
+          <p className="mt-3 text-sm text-[rgb(var(--muted))]">Loading Bitcoin payment details...</p>
+        </div>
+      )}
+
+      <button onClick={handleBack} className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
+        <ArrowLeft className="h-4 w-4" />
+        Back to payment methods
+      </button>
+    </div>
+  )
+}

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic'
 import { Crown, Lock, Zap } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
 import { BILLING_API_URL } from '@/app/lib/config'
+import BitcoinPaymentPanel, { type BitcoinPaymentSession } from './bitcoin-payment-panel'
 
 const StripePaymentForm = dynamic(() => import('./stripe-payment-form'), {
   loading: () => (
@@ -26,6 +27,20 @@ type PaymentOption = {
   entitlementPreview?: string
   enabled: boolean
   disabledReason?: string
+}
+
+type CurrentPaymentFlow = {
+  flowKind: 'stripe_pay_now' | 'btcpay_annual'
+  provider: 'stripe' | 'btcpay'
+  status: string
+  planId: string
+  billingInterval: BillingInterval
+  amount: string
+  currency: string
+  createdAt: string
+  cancellable: boolean
+  invoiceId?: string | null
+  checkoutUrl?: string | null
 }
 
 interface PaymentChoicePanelProps {
@@ -92,30 +107,33 @@ export default function PaymentChoicePanel({
 }: PaymentChoicePanelProps) {
   const [interval, setInterval] = useState<BillingInterval>(initialInterval)
   const [clientSecret, setClientSecret] = useState<string | null>(null)
+  const [bitcoinSession, setBitcoinSession] = useState<BitcoinPaymentSession | null>(null)
+  const [currentFlow, setCurrentFlow] = useState<CurrentPaymentFlow | null>(null)
   const [loading, setLoading] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [options, setOptions] = useState<PaymentOption[]>([])
   const [optionsLoaded, setOptionsLoaded] = useState(false)
 
+  async function loadOptionsForInterval(nextInterval: BillingInterval, isCancelled: () => boolean = () => false) {
+    setOptionsLoaded(false)
+    try {
+      const res = await fetch(`${BILLING_API_URL}/subscription/payment-options?interval=${nextInterval}`, { credentials: 'include' })
+      if (!res.ok) {
+        if (!isCancelled()) setOptions([])
+        return
+      }
+      const data = await res.json()
+      if (!isCancelled()) setOptions(Array.isArray(data.options) ? data.options : [])
+    } catch {
+      if (!isCancelled()) setOptions([])
+    } finally {
+      if (!isCancelled()) setOptionsLoaded(true)
+    }
+  }
+
   useEffect(() => {
     let cancelled = false
-    async function loadOptions() {
-      setOptionsLoaded(false)
-      try {
-        const res = await fetch(`${BILLING_API_URL}/subscription/payment-options?interval=${interval}`, { credentials: 'include' })
-        if (!res.ok) {
-          if (!cancelled) setOptions([])
-          return
-        }
-        const data = await res.json()
-        if (!cancelled) setOptions(Array.isArray(data.options) ? data.options : [])
-      } catch {
-        if (!cancelled) setOptions([])
-      } finally {
-        if (!cancelled) setOptionsLoaded(true)
-      }
-    }
-    void loadOptions()
+    void loadOptionsForInterval(interval, () => cancelled)
     return () => { cancelled = true }
   }, [interval])
 
@@ -123,6 +141,50 @@ export default function PaymentChoicePanel({
   const btcpayAnnualOption = useMemo(() => options.find(option => option.id === 'btcpay_annual' && option.enabled), [options])
   const bitcoinSwitchOption = useMemo(() => options.find(option => option.id === 'bitcoin_annual_switch' && option.enabled), [options])
   const planId = stripeOption?.planIds?.[0] ?? (interval === 'monthly' ? 'early_monthly' : 'early_annual')
+
+  async function loadCurrentFlow() {
+    try {
+      const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows/current`, { credentials: 'include' })
+      if (!res.ok) return
+      const data = await res.json()
+      setCurrentFlow(data.flow ?? null)
+    } catch {
+      // Payment options still render if the recovery endpoint is temporarily unavailable.
+    }
+  }
+
+  useEffect(() => {
+    void loadCurrentFlow()
+  }, [])
+
+  async function handleFlowInProgress() {
+    await loadCurrentFlow()
+    setError(null)
+  }
+
+  const cancelCurrentFlow = async () => {
+    setLoading('cancel-flow')
+    setError(null)
+    try {
+      const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows/cancel`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => null)
+        throw new Error(data?.detail ?? 'Could not cancel the pending payment flow.')
+      }
+      setCurrentFlow(null)
+      setClientSecret(null)
+      setBitcoinSession(null)
+      await loadOptionsForInterval(interval)
+      await loadCurrentFlow()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not cancel the pending payment flow.')
+    } finally {
+      setLoading(null)
+    }
+  }
 
   const startStripe = async () => {
     setLoading('stripe')
@@ -136,6 +198,10 @@ export default function PaymentChoicePanel({
       })
       if (!res.ok) {
         const data = await res.json().catch(() => null)
+        if (res.status === 409 && String(data?.type ?? '').includes('payment_flow_in_progress')) {
+          await handleFlowInProgress()
+          return
+        }
         throw new Error(data?.detail ?? 'Failed to set up payment')
       }
       const data = await res.json()
@@ -165,15 +231,37 @@ export default function PaymentChoicePanel({
       })
       if (!res.ok) {
         const data = await res.json().catch(() => null)
+        if (res.status === 409 && String(data?.type ?? '').includes('payment_flow_in_progress')) {
+          await handleFlowInProgress()
+          return
+        }
         throw new Error(data?.detail ?? 'Bitcoin checkout is not available.')
       }
       const data = await res.json()
-      window.location.href = safeBtcpayUrl(data.checkoutUrl)
+      const checkoutUrl = safeBtcpayUrl(data.checkoutUrl)
+      if (!data.invoiceId || !data.invoiceLookupToken) throw new Error('Bitcoin checkout did not return a complete payment session.')
+      setBitcoinSession({ invoiceId: data.invoiceId, lookupToken: data.invoiceLookupToken, checkoutUrl })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unable to start Bitcoin checkout.')
     } finally {
       setLoading(null)
     }
+  }
+
+  if (bitcoinSession) {
+    return (
+      <BitcoinPaymentPanel
+        session={bitcoinSession}
+        title="Pay annual with Bitcoin"
+        description="Scan the QR code or copy the payment details. Your 14 bonus days and paid access apply after BTCPay settlement confirms."
+        settledMessage="Payment settled. Refreshing your subscription..."
+        onBack={() => setBitcoinSession(null)}
+        onPaymentComplete={async () => {
+          await onSuccess()
+          await successPoll?.()
+        }}
+      />
+    )
   }
 
   if (clientSecret) {
@@ -208,6 +296,39 @@ export default function PaymentChoicePanel({
         >
           &larr; Back to options
         </button>
+      </div>
+    )
+  }
+
+  if (currentFlow) {
+    const isBitcoin = currentFlow.flowKind === 'btcpay_annual'
+    return (
+      <div className="space-y-5">
+        <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">Payment already in progress</h2>
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-left">
+          <h3 className="font-medium text-[rgb(var(--foreground))]">
+            {isBitcoin ? 'Bitcoin invoice in progress' : 'Card payment in progress'}
+          </h3>
+          <p className="mt-1 text-sm text-[rgb(var(--muted))]">
+            To prevent double payments, only one payment flow can be active at a time. Continue the current payment or cancel it before choosing another method.
+          </p>
+          {isBitcoin && currentFlow.checkoutUrl && (
+            <a href={safeBtcpayUrl(currentFlow.checkoutUrl)} className="mt-3 inline-flex w-full items-center justify-center rounded-md border border-amber-500/30 px-4 py-2 text-sm font-medium text-amber-700 transition-colors hover:bg-amber-500/10 dark:text-amber-200">
+              Continue in BTCPay
+            </a>
+          )}
+        </div>
+        {error && (
+          <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          </div>
+        )}
+        <Button onClick={cancelCurrentFlow} disabled={loading !== null || !currentFlow.cancellable} variant="outline" className="w-full">
+          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : 'Cancel and choose another method'}
+        </Button>
+        {!currentFlow.cancellable && (
+          <p className="text-xs text-[rgb(var(--muted))]">This payment is already being confirmed. Please wait for the provider update or contact support.</p>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- add a reusable embedded Bitcoin payment panel for Settings payment conversion
- show inline BTCPay QR/details instead of immediately redirecting from Settings
- detect active pending payment flows and offer continue/cancel recovery before switching methods
- update AddCardBanner payment tests for the current-flow recovery check and embedded Bitcoin flow

## Dependency
- Requires the billing API endpoints from silent-suite/silentsuite-internal PR: Fix abandoned payment flow recovery.

## Tests
- `pnpm install --frozen-lockfile`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web test -- --run app/components/__tests__/AddCardBanner.test.tsx` (Vitest ran the full web suite: 39 files, 409 tests)
