### PR TITLE
Unify Settings payment recovery UX

### DIFF
--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -66,8 +66,35 @@ function mockSubscription(subscription: Record<string, unknown>) {
     if (url === 'https://billing.test/subscription' && !init?.method) {
       return { ok: true, json: async () => response }
     }
-    if (url === 'https://billing.test/subscription/reactivate') {
-      return { ok: true, json: async () => ({ clientSecret: 'cs_test' }) }
+    if (url === 'https://billing.test/subscription/payment-flows/current') {
+      return { ok: true, json: async () => ({ flow: null }) }
+    }
+    if (url === 'https://billing.test/subscription/payment-options?interval=monthly') {
+      return { ok: true, json: async () => ({
+        selectedInterval: 'monthly',
+        options: [
+          { id: 'stripe_pay_now', provider: 'stripe', planIds: ['early_monthly'], billingIntervals: ['monthly'], enabled: true },
+          { id: 'bitcoin_annual_switch', provider: 'notice', planIds: ['early_annual'], billingIntervals: ['annual'], enabled: true },
+        ],
+      }) }
+    }
+    if (url === 'https://billing.test/subscription/payment-options?interval=annual') {
+      return { ok: true, json: async () => ({
+        selectedInterval: 'annual',
+        options: [
+          { id: 'stripe_pay_now', provider: 'stripe', planIds: ['early_annual'], billingIntervals: ['annual'], enabled: true },
+          { id: 'btcpay_annual', provider: 'btcpay', planIds: ['early_annual'], billingIntervals: ['annual'], enabled: true },
+        ],
+      }) }
+    }
+    if (url === 'https://billing.test/subscription/payment-flows') {
+      return { ok: true, json: async () => ({
+        clientSecret: 'cs_test',
+        planId: 'early_monthly',
+        billingInterval: 'monthly',
+        amount: '3.60',
+        currency: 'EUR',
+      }) }
     }
     return { ok: false, status: 404, json: async () => ({ detail: 'not found' }) }
   }))
@@ -151,7 +178,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(await screen.findByRole('button', { name: /^subscribe$/i })).toBeInTheDocument()
   })
 
-  it('shows visible reactivate errors and recovers the loading state', async () => {
+  it('shows visible shared payment-flow errors and recovers the loading state', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
       if (url === 'https://billing.test/subscription' && !init?.method) {
         return { ok: true, json: async () => ({
@@ -160,7 +187,11 @@ describe('SubscriptionPage billing recovery CTAs', () => {
           capabilities: { ...baseSubscription.capabilities, canReactivate: true },
         }) }
       }
-      if (url === 'https://billing.test/subscription/reactivate') {
+      if (url === 'https://billing.test/subscription/payment-flows/current') return { ok: true, json: async () => ({ flow: null }) }
+      if (url === 'https://billing.test/subscription/payment-options?interval=monthly') {
+        return { ok: true, json: async () => ({ selectedInterval: 'monthly', options: [{ id: 'stripe_pay_now', provider: 'stripe', planIds: ['early_monthly'], billingIntervals: ['monthly'], enabled: true }] }) }
+      }
+      if (url === 'https://billing.test/subscription/payment-flows') {
         return { ok: false, status: 500, json: async () => ({ detail: 'Payment setup failed safely' }) }
       }
       return { ok: false, status: 404, json: async () => ({}) }
@@ -169,10 +200,10 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     render(<SubscriptionPage />)
 
     fireEvent.click(await screen.findByRole('button', { name: /reactivate/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /subscribe by card/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
 
     expect(await screen.findByText('Payment setup failed safely')).toBeInTheDocument()
-    await waitFor(() => expect(screen.getByRole('button', { name: /subscribe by card/i })).not.toBeDisabled())
+    await waitFor(() => expect(screen.getByRole('button', { name: /continue to card payment/i })).not.toBeDisabled())
   })
 
   it('suppresses retry CTA while payment confirmation is pending after client-side success', async () => {
@@ -192,8 +223,12 @@ describe('SubscriptionPage billing recovery CTAs', () => {
               capabilities: { ...baseSubscription.capabilities, canRetryPayment: true, canStartPaidSubscription: true },
             } }
       }
-      if (url === 'https://billing.test/subscription/reactivate') {
-        return { ok: true, json: async () => ({ clientSecret: 'cs_test' }) }
+      if (url === 'https://billing.test/subscription/payment-flows/current') return { ok: true, json: async () => ({ flow: null }) }
+      if (url === 'https://billing.test/subscription/payment-options?interval=monthly') {
+        return { ok: true, json: async () => ({ selectedInterval: 'monthly', options: [{ id: 'stripe_pay_now', provider: 'stripe', planIds: ['early_monthly'], billingIntervals: ['monthly'], enabled: true }] }) }
+      }
+      if (url === 'https://billing.test/subscription/payment-flows') {
+        return { ok: true, json: async () => ({ clientSecret: 'cs_test', planId: 'early_monthly', billingInterval: 'monthly', amount: '3.60', currency: 'EUR' }) }
       }
       return { ok: false, status: 404, json: async () => ({}) }
     }))
@@ -201,7 +236,9 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     render(<SubscriptionPage />)
 
     fireEvent.click(await screen.findByRole('button', { name: /reactivate/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /subscribe by card/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
+    expect(await screen.findByText('Amount due')).toBeInTheDocument()
+    expect(screen.getByText('Powered by Stripe')).toBeInTheDocument()
     fireEvent.click(await screen.findByRole('button', { name: /mock payment success/i }))
 
     expect(await screen.findByText(/confirming your payment/i)).toBeInTheDocument()

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -3,28 +3,11 @@
 import { useEffect, useState, useCallback } from 'react'
 import { Crown, Loader2, Check } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
-import dynamic from 'next/dynamic'
 import { BILLING_API_URL } from '@/app/lib/config'
 import { formatDate as formatDateUtil } from '@/app/lib/date'
 import AddCardBanner from '@/app/components/add-card-banner'
+import PaymentChoicePanel from '@/app/components/payment-choice-panel'
 import { getPaidBonusAccessDate } from './bonus-access'
-
-const StripePaymentForm = dynamic(() => import('@/app/components/stripe-payment-form'), {
-  loading: () => (
-    <div className="flex flex-col items-center justify-center py-8">
-      <div className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
-      <p className="mt-3 text-sm text-[rgb(var(--muted))]">Loading payment form...</p>
-    </div>
-  ),
-  ssr: false,
-})
-
-const CRYPTO_CHECKOUT_ENABLED = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED === 'true'
-const BTCPAY_CHECKOUT_ORIGIN = 'https://btcpay.silentsuite.io'
-
-interface CryptoCheckoutResponse {
-  checkoutUrl: string
-}
 
 interface SubscriptionCapabilities {
   trialActive: boolean
@@ -164,10 +147,6 @@ export default function SubscriptionPage() {
   const [showCancelDialog, setShowCancelDialog] = useState(false)
   const [cancelling, setCancelling] = useState(false)
   const [showPlanSelection, setShowPlanSelection] = useState(false)
-  const [reactivating, setReactivating] = useState<string | null>(null)
-  const [reactivateClientSecret, setReactivateClientSecret] = useState<string | null>(null)
-  const [reactivatePlanId, setReactivatePlanId] = useState<string | null>(null)
-  const [reactivateError, setReactivateError] = useState<string | null>(null)
   const [showChangePlanDialog, setShowChangePlanDialog] = useState(false)
   const [changingPlan, setChangingPlan] = useState(false)
   const [changePlanSuccess, setChangePlanSuccess] = useState<{ plan: string; effectiveDate: string; prorated: boolean } | null>(null)
@@ -175,8 +154,6 @@ export default function SubscriptionPage() {
   const [changePlanError, setChangePlanError] = useState<string | null>(null)
   const [changePlanToast, setChangePlanToast] = useState<string | null>(null)
   const [billingInterval, setBillingInterval] = useState<'monthly' | 'annual'>('monthly')
-  const [cryptoCheckoutLoading, setCryptoCheckoutLoading] = useState(false)
-  const [cryptoCheckoutError, setCryptoCheckoutError] = useState<string | null>(null)
   const [paymentConfirmationPending, setPaymentConfirmationPending] = useState(false)
 
   const fetchSubscription = useCallback(async () => {
@@ -222,31 +199,6 @@ export default function SubscriptionPage() {
     }
   }
 
-  async function handleReactivate(planId: string) {
-    setReactivating(planId)
-    setReactivateError(null)
-    try {
-      const res = await fetch(`${BILLING_API_URL}/subscription/reactivate`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ planId }),
-      })
-      if (res.ok) {
-        const { clientSecret } = await res.json()
-        setReactivateClientSecret(clientSecret)
-        setReactivatePlanId(planId)
-      } else {
-        const body = await res.json().catch(() => null)
-        setReactivateError(body?.detail ?? body?.error ?? 'Unable to set up payment. Please try again.')
-      }
-    } catch {
-      setReactivateError('Unable to reach billing service. Please try again.')
-    } finally {
-      setReactivating(null)
-    }
-  }
-
   async function handleChangePlan(newPlanId: string) {
     setChangingPlan(true)
     setChangePlanError(null)
@@ -274,41 +226,6 @@ export default function SubscriptionPage() {
       setChangePlanError('Unable to reach billing service. Please try again.')
     } finally {
       setChangingPlan(false)
-    }
-  }
-
-  async function handleCryptoCheckout(planId: string) {
-    setCryptoCheckoutLoading(true)
-    setCryptoCheckoutError(null)
-    try {
-      const res = await fetch(`${BILLING_API_URL}/subscription/crypto/checkout`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-        },
-        body: JSON.stringify({
-          planId,
-          returnUrl: `${window.location.origin}/settings/subscription`,
-        }),
-      })
-      if (!res.ok) {
-        const body = await res.json().catch(() => null)
-        throw new Error(res.status >= 500 || res.status === 404
-          ? 'Crypto checkout is not available yet.'
-          : body?.detail ?? 'Crypto checkout is not available yet.')
-      }
-      const invoice = await res.json() as CryptoCheckoutResponse
-      const checkoutUrl = new URL(invoice.checkoutUrl)
-      if (checkoutUrl.origin !== BTCPAY_CHECKOUT_ORIGIN || checkoutUrl.protocol !== 'https:') {
-        throw new Error('Crypto checkout returned an unexpected payment URL.')
-      }
-      window.location.href = checkoutUrl.toString()
-    } catch (err) {
-      setCryptoCheckoutError(err instanceof Error ? err.message : 'Unable to start crypto checkout.')
-    } finally {
-      setCryptoCheckoutLoading(false)
     }
   }
 
@@ -489,144 +406,29 @@ export default function SubscriptionPage() {
           </>
         )}
         {canOpenPaidRecovery && !capabilities.canSetupCard && !data.cancelAtPeriodEnd && (
-          <Button size="sm" onClick={() => { setReactivateError(null); setCryptoCheckoutError(null); setShowPlanSelection(true) }}>
+          <Button size="sm" onClick={() => setShowPlanSelection(true)}>
             {paidRecoveryLabel}
           </Button>
         )}
       </div>
 
-      {/* Plan selection dialog (reactivate) */}
+      {/* Shared payment dialog (subscribe/reactivate/retry) */}
       {showPlanSelection && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgb(var(--background))]/80 backdrop-blur-sm">
-          <div className="mx-4 w-full max-w-md rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-6 space-y-4">
-            {reactivateClientSecret && reactivatePlanId ? (
-              <>
-                <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">Complete payment</h2>
-                <StripePaymentForm
-                  clientSecret={reactivateClientSecret}
-                  onSuccess={async () => {
-                    setPaymentConfirmationPending(true)
-                    setReactivateClientSecret(null)
-                    setReactivatePlanId(null)
-                    setShowPlanSelection(false)
-                    await fetchSubscription()
-                    for (const delayMs of [2000, 5000, 10000]) {
-                      window.setTimeout(() => { void fetchSubscription() }, delayMs)
-                    }
-                  }}
-                  submitLabel="Reactivate subscription"
-                  mode="payment"
-                />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => { setReactivateClientSecret(null); setReactivatePlanId(null) }}
-                  className="w-full"
-                >
-                  Back
-                </Button>
-              </>
-            ) : (
-              <>
-                <h2 className="text-lg font-semibold text-[rgb(var(--foreground))]">Choose your plan</h2>
-                {/* Billing interval toggle */}
-                <div className="flex items-center justify-center gap-1 rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-1">
-                  <button
-                    onClick={() => setBillingInterval('monthly')}
-                    className={`rounded-full min-h-[44px] px-4 py-2 text-sm font-medium transition-colors ${
-                      billingInterval === 'monthly'
-                        ? 'bg-emerald-600 text-white'
-                        : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
-                    }`}
-                  >
-                    Monthly
-                  </button>
-                  <button
-                    onClick={() => setBillingInterval('annual')}
-                    className={`rounded-full min-h-[44px] px-4 py-2 text-sm font-medium transition-colors ${
-                      billingInterval === 'annual'
-                        ? 'bg-emerald-600 text-white'
-                        : 'text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))]'
-                    }`}
-                  >
-                    Annual
-                  </button>
-                </div>
-                {/* Selected plan card */}
-                {(() => {
-                  const plan = billingInterval === 'monthly'
-                    ? availablePlans.find(p => p.id === 'early_monthly')!
-                    : availablePlans.find(p => p.id === 'early_annual')!
-                  const Icon = plan.icon
-                  const cryptoAnnualPrice = (Number(plan.price) * 0.9).toFixed(2)
-                  return (
-                    <div className="rounded-lg border border-emerald-500/30 bg-[rgb(var(--surface))] p-5">
-                      <div className="flex items-start justify-between">
-                        <div className="flex items-start gap-3">
-                          <div className="mt-0.5 rounded-lg bg-emerald-500/10 p-2">
-                            <Icon className="h-5 w-5 text-emerald-400" />
-                          </div>
-                          <div>
-                            <div className="flex items-center gap-2">
-                              <h3 className="font-medium text-[rgb(var(--foreground))]">{plan.name}</h3>
-                              {'badge' in plan && plan.badge && (
-                                <span className="rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                                  {plan.badge}
-                                </span>
-                              )}
-                            </div>
-                            <p className="mt-0.5 text-sm text-[rgb(var(--muted))]">{plan.description}</p>
-                          </div>
-                        </div>
-                        <div className="text-right">
-                          <span className="text-2xl font-bold text-[rgb(var(--foreground))]">&euro;{plan.price}</span>
-                          <span className="text-sm text-[rgb(var(--muted))]">{plan.period}</span>
-                        </div>
-                      </div>
-                      <button
-                        onClick={() => handleReactivate(plan.id)}
-                        disabled={reactivating !== null}
-                        className="mt-5 w-full rounded-lg bg-emerald-600 px-6 py-3 text-base font-semibold text-white shadow-lg shadow-emerald-600/25 transition-colors hover:bg-emerald-500 disabled:opacity-50"
-                      >
-                        {reactivating === plan.id ? 'Setting up...' : 'Subscribe by card'}
-                      </button>
-                      {reactivateError && (
-                        <p className="mt-2 text-sm text-red-600 dark:text-red-400">{reactivateError}</p>
-                      )}
-                      {billingInterval === 'annual' && CRYPTO_CHECKOUT_ENABLED && (
-                        <div className="mt-3 rounded-lg border border-amber-500/25 bg-amber-500/5 p-3">
-                          <div className="flex items-center justify-between gap-3">
-                            <div>
-                              <p className="text-sm font-medium text-[rgb(var(--foreground))]">Pay annual with crypto</p>
-                              <p className="text-xs text-[rgb(var(--muted))]">Prepaid once via BTCPay: &euro;{cryptoAnnualPrice}/year.</p>
-                            </div>
-                            <button
-                              onClick={() => handleCryptoCheckout(plan.id)}
-                              disabled={cryptoCheckoutLoading || reactivating !== null}
-                              className="rounded-lg border border-amber-500/40 px-3 py-2 text-sm font-medium text-amber-700 dark:text-amber-400 transition-colors hover:bg-amber-500/10 disabled:opacity-50"
-                            >
-                              {cryptoCheckoutLoading ? 'Opening...' : 'Pay crypto'}
-                            </button>
-                          </div>
-                          {cryptoCheckoutError && (
-                            <p className="mt-2 text-xs text-red-600 dark:text-red-400">{cryptoCheckoutError}</p>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  )
-                })()}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowPlanSelection(false)}
-                  disabled={reactivating !== null}
-                  className="w-full"
-                >
-                  Cancel
-                </Button>
-              </>
-            )}
+          <div className="mx-4 w-full max-w-md rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-6">
+            <PaymentChoicePanel
+              onSuccess={async () => {
+                setPaymentConfirmationPending(true)
+                setShowPlanSelection(false)
+                await fetchSubscription()
+                for (const delayMs of [2000, 5000, 10000]) {
+                  window.setTimeout(() => { void fetchSubscription() }, delayMs)
+                }
+              }}
+              onCancel={() => setShowPlanSelection(false)}
+              title="Continue with silentsuite.io"
+              successPoll={fetchSubscription}
+            />
           </div>
         </div>
       )}

--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -41,7 +41,7 @@ describe('AddCardBanner', () => {
       const url = String(input)
       if (url.includes('/subscription/payment-flows/current')) return { ok: true, json: async () => ({ flow: null }) } as Response
       if (url.includes('/subscription/payment-options?interval=monthly')) return { ok: true, json: async () => monthlyOptions } as Response
-      if (url.includes('/subscription/payment-flows')) return { ok: true, json: async () => ({ clientSecret: 'pi_secret', flowKind: 'stripe_pay_now' }) } as Response
+      if (url.includes('/subscription/payment-flows')) return { ok: true, json: async () => ({ clientSecret: 'pi_secret', flowKind: 'stripe_pay_now', planId: 'early_monthly', billingInterval: 'monthly', amount: '3.60', currency: 'EUR' }) } as Response
       return { ok: false, json: async () => ({}) } as Response
     })
 
@@ -68,6 +68,8 @@ describe('AddCardBanner', () => {
     ))
 
     expect(await screen.findByText('14 bonus days included after today\'s payment.')).toBeInTheDocument()
+    expect(screen.getByText('Amount due')).toBeInTheDocument()
+    expect(screen.getByText('Powered by Stripe')).toBeInTheDocument()
     expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €3.60')
   })
 
@@ -98,6 +100,29 @@ describe('AddCardBanner', () => {
         credentials: 'include',
         body: JSON.stringify({ flowKind: 'btcpay_annual', planId: 'early_annual', returnUrl: '/settings/subscription' }),
       }),
+    ))
+  })
+
+  it('cancels a pending card payment flow when backing out of the card form', async () => {
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/subscription/payment-flows/current')) return { ok: true, json: async () => ({ flow: null }) } as Response
+      if (url.includes('/subscription/payment-options?interval=monthly')) return { ok: true, json: async () => monthlyOptions } as Response
+      if (url.includes('/subscription/payment-flows/cancel')) return { ok: true, json: async () => ({ cancelled: true, flowKind: 'stripe_pay_now' }) } as Response
+      if (url.includes('/subscription/payment-flows') && init?.method === 'POST') return { ok: true, json: async () => ({ clientSecret: 'pi_secret', flowKind: 'stripe_pay_now', planId: 'early_monthly', billingInterval: 'monthly', amount: '3.60', currency: 'EUR' }) } as Response
+      return { ok: false, json: async () => ({}) } as Response
+    })
+
+    render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
+    fireEvent.click(screen.getByText('Choose payment'))
+    fireEvent.click(await screen.findByText('Continue to card payment'))
+
+    expect(await screen.findByText('Powered by Stripe')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('← Back to options'))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      'https://billing.example.test/subscription/payment-flows/cancel',
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
     ))
   })
 })

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -43,6 +43,13 @@ type CurrentPaymentFlow = {
   checkoutUrl?: string | null
 }
 
+type StripePaymentSummary = {
+  planId: string
+  billingInterval: BillingInterval
+  amount: string
+  currency: string
+}
+
 interface PaymentChoicePanelProps {
   onSuccess: () => void | Promise<void>
   onCancel?: () => void
@@ -90,6 +97,28 @@ function PriceDisplay({ interval }: { interval: BillingInterval }) {
   )
 }
 
+function amountForInterval(interval: BillingInterval) {
+  return interval === 'monthly' ? '3.60' : '36.00'
+}
+
+function formatAmount(amount: string, currency = 'EUR') {
+  const numeric = Number(amount)
+  if (!Number.isFinite(numeric)) return `${amount} ${currency}`
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(numeric)
+}
+
+function StripeTrustNote() {
+  return (
+    <div className="space-y-1.5 text-center text-xs text-[rgb(var(--muted))]">
+      <p className="font-medium text-[rgb(var(--foreground))]">Powered by Stripe</p>
+      <div className="flex items-center justify-center gap-1.5">
+        <Lock className="h-3 w-3 text-emerald-500" />
+        <span>Secured by Stripe. We never see your card details.</span>
+      </div>
+    </div>
+  )
+}
+
 function safeBtcpayUrl(rawUrl: string): string {
   const checkoutUrl = new URL(rawUrl)
   if (checkoutUrl.protocol !== 'https:' || checkoutUrl.origin !== 'https://btcpay.silentsuite.io') {
@@ -107,6 +136,7 @@ export default function PaymentChoicePanel({
 }: PaymentChoicePanelProps) {
   const [interval, setInterval] = useState<BillingInterval>(initialInterval)
   const [clientSecret, setClientSecret] = useState<string | null>(null)
+  const [stripePaymentSummary, setStripePaymentSummary] = useState<StripePaymentSummary | null>(null)
   const [bitcoinSession, setBitcoinSession] = useState<BitcoinPaymentSession | null>(null)
   const [currentFlow, setCurrentFlow] = useState<CurrentPaymentFlow | null>(null)
   const [loading, setLoading] = useState<string | null>(null)
@@ -176,6 +206,7 @@ export default function PaymentChoicePanel({
       }
       setCurrentFlow(null)
       setClientSecret(null)
+      setStripePaymentSummary(null)
       setBitcoinSession(null)
       await loadOptionsForInterval(interval)
       await loadCurrentFlow()
@@ -206,6 +237,12 @@ export default function PaymentChoicePanel({
       }
       const data = await res.json()
       setClientSecret(data.clientSecret)
+      setStripePaymentSummary({
+        planId: typeof data.planId === 'string' ? data.planId : planId,
+        billingInterval: data.billingInterval === 'annual' ? 'annual' : interval,
+        amount: typeof data.amount === 'string' ? data.amount : amountForInterval(interval),
+        currency: typeof data.currency === 'string' ? data.currency : 'EUR',
+      })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
     } finally {
@@ -267,34 +304,40 @@ export default function PaymentChoicePanel({
   if (clientSecret) {
     return (
       <div className="space-y-4">
-        <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3">
-          <div className="flex items-center justify-between">
+        <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
+          <div className="flex items-center justify-between gap-4">
             <div className="flex items-center gap-2">
               <Crown className="h-4 w-4 text-amber-400" />
-              <span className="text-sm font-medium text-[rgb(var(--foreground))]">Early Adopter</span>
+              <div>
+                <span className="text-sm font-medium text-[rgb(var(--foreground))]">Early Adopter</span>
+                <p className="text-xs text-[rgb(var(--muted))]">{stripePaymentSummary?.billingInterval === 'annual' ? 'Annual card payment' : 'Monthly card payment'}</p>
+              </div>
             </div>
-            <PriceDisplay interval={interval} />
+            <div className="text-right">
+              <p className="text-xs text-[rgb(var(--muted))]">Amount due</p>
+              <p className="text-sm font-semibold text-[rgb(var(--foreground))]">
+                {formatAmount(stripePaymentSummary?.amount ?? amountForInterval(interval), stripePaymentSummary?.currency ?? 'EUR')}
+              </p>
+            </div>
           </div>
-          <p className="mt-1 text-xs text-[rgb(var(--muted))]">14 bonus days included after today&apos;s payment.</p>
+          <p className="mt-2 text-xs text-[rgb(var(--muted))]">14 bonus days included after today&apos;s payment.</p>
         </div>
+        <StripeTrustNote />
         <StripePaymentForm
           clientSecret={clientSecret}
           onSuccess={async () => {
             await onSuccess()
             await successPoll?.()
           }}
-          submitLabel={`Pay ${interval === 'monthly' ? '\u20AC3.60' : '\u20AC36'}`}
+          submitLabel={`Pay ${formatAmount(stripePaymentSummary?.amount ?? amountForInterval(interval), stripePaymentSummary?.currency ?? 'EUR')}`}
           mode="payment"
         />
-        <div className="flex items-center justify-center gap-1.5 text-xs text-[rgb(var(--muted))]">
-          <Lock className="h-3 w-3 text-emerald-500" />
-          <span>Secured by Stripe. We never see your card details.</span>
-        </div>
         <button
-          onClick={() => setClientSecret(null)}
-          className="w-full text-center text-xs text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors"
+          onClick={() => { void cancelCurrentFlow() }}
+          disabled={loading !== null}
+          className="w-full text-center text-xs text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors disabled:opacity-50"
         >
-          &larr; Back to options
+          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : '← Back to options'}
         </button>
       </div>
     )
@@ -394,8 +437,20 @@ export default function PaymentChoicePanel({
       )}
 
       {onCancel && (
-        <Button variant="outline" size="sm" onClick={onCancel} disabled={loading !== null} className="w-full">
-          Cancel
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            if (clientSecret || bitcoinSession || currentFlow) {
+              void cancelCurrentFlow().then(() => onCancel())
+            } else {
+              onCancel()
+            }
+          }}
+          disabled={loading !== null}
+          className="w-full"
+        >
+          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : 'Cancel'}
         </Button>
       )}
     </div>


### PR DESCRIPTION
## Summary
- replace the Settings reactivation modal with the shared payment choice panel so trial, retry, and reactivation states use the same billing box
- show an explicit Amount due line and Powered by Stripe on every card payment form
- cancel pending payment flows when the user backs out of the card form to avoid stale flow errors when switching monthly/annual/Bitcoin

## Evidence
- GPT-5.5 vision review of user screenshots: confirmed divergent boxes, missing amount, missing Stripe branding, and stale-flow error state
- GLM 5.2 NanoGPT investigation: confirmed split UI surfaces and pending-flow back-out root cause

## Tests
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web test -- --run app/components/__tests__/AddCardBanner.test.tsx 'app/(app)/settings/subscription/__tests__/page.test.tsx' (Vitest ran 39 files, 410 tests)
- /tmp/hermes-verify-billing-payment-ux-web-* targeted script

## Dependency
- Requires billing API payment-flow recovery endpoints already on internal dev, plus silent-suite/silentsuite-internal PR returning payment flow amounts.