### PR TITLE
Make billing payment method switching explicit

### DIFF
--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -81,6 +81,7 @@ describe('AddCardBanner', () => {
       if (url.includes('/subscription/payment-options?interval=annual')) return { ok: true, json: async () => annualOptions } as Response
       if (url.includes('/subscription/crypto/invoice/inv_123/payment-methods')) return { ok: true, json: async () => ({ paymentMethods: [{ id: 'btc', label: 'BTC', qrValue: 'bitcoin:test', address: 'bc1test', amountDue: '0.001', cryptoCode: 'BTC' }] }) } as Response
       if (url.includes('/subscription/crypto/invoice/inv_123')) return { ok: true, json: async () => ({ status: 'pending' }) } as Response
+      if (url.includes('/subscription/payment-flows/cancel')) return { ok: true, json: async () => ({ cancelled: true, flowKind: 'btcpay_annual' }) } as Response
       if (url.includes('/subscription/payment-flows')) return { ok: true, json: async () => ({ checkoutUrl: 'https://btcpay.silentsuite.io/i/inv_123', invoiceId: 'inv_123', invoiceLookupToken: 'lookup_123' }) } as Response
       return { ok: false, json: async () => ({}) } as Response
     })
@@ -101,6 +102,13 @@ describe('AddCardBanner', () => {
         body: JSON.stringify({ flowKind: 'btcpay_annual', planId: 'early_annual', returnUrl: '/settings/subscription' }),
       }),
     ))
+
+    await waitFor(() => expect(screen.getAllByText('Back to payment options').length).toBeGreaterThan(0))
+    fireEvent.click(screen.getAllByText('Back to payment options')[0])
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      'https://billing.example.test/subscription/payment-flows/cancel',
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
+    ))
   })
 
   it('cancels a pending card payment flow when backing out of the card form', async () => {
@@ -118,7 +126,8 @@ describe('AddCardBanner', () => {
     fireEvent.click(await screen.findByText('Continue to card payment'))
 
     expect(await screen.findByText('Powered by Stripe')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('← Back to options'))
+    expect(screen.getAllByText('← Back to payment options').length).toBeGreaterThan(0)
+    fireEvent.click(screen.getAllByText('← Back to payment options')[0])
 
     await waitFor(() => expect(fetch).toHaveBeenCalledWith(
       'https://billing.example.test/subscription/payment-flows/cancel',

--- a/apps/web/app/components/bitcoin-payment-panel.tsx
+++ b/apps/web/app/components/bitcoin-payment-panel.tsx
@@ -26,7 +26,7 @@ type BitcoinPaymentPanelProps = {
   title?: string
   description?: string
   settledMessage?: string
-  onBack: () => void
+  onBack: () => void | Promise<void>
   onInvoiceInactive?: () => void
   onPaymentComplete: () => void | Promise<void>
   externalCheckoutLabel?: string
@@ -127,13 +127,26 @@ export default function BitcoinPaymentPanel({
     }
   }
 
-  function handleBack() {
+  async function handleBack() {
     if (status === 'expired' || status === 'settled' || status === 'error') onInvoiceInactive?.()
-    onBack()
+    await onBack()
   }
+
+  const backButton = (
+    <button
+      type="button"
+      onClick={() => { void handleBack() }}
+      className="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--muted))] transition-colors hover:text-[rgb(var(--foreground))]"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      Back to payment options
+    </button>
+  )
 
   return (
     <div className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
+      <div>{backButton}</div>
+
       <div className="space-y-2 text-center">
         <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">{title}</h2>
         <p className="text-sm text-[rgb(var(--muted))]">{description}</p>
@@ -200,10 +213,7 @@ export default function BitcoinPaymentPanel({
         </div>
       )}
 
-      <button onClick={handleBack} className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
-        <ArrowLeft className="h-4 w-4" />
-        Back to payment methods
-      </button>
+      <div>{backButton}</div>
     </div>
   )
 }

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -292,7 +292,7 @@ export default function PaymentChoicePanel({
         title="Pay annual with Bitcoin"
         description="Scan the QR code or copy the payment details. Your 14 bonus days and paid access apply after BTCPay settlement confirms."
         settledMessage="Payment settled. Refreshing your subscription..."
-        onBack={() => setBitcoinSession(null)}
+        onBack={cancelCurrentFlow}
         onPaymentComplete={async () => {
           await onSuccess()
           await successPoll?.()
@@ -304,6 +304,15 @@ export default function PaymentChoicePanel({
   if (clientSecret) {
     return (
       <div className="space-y-4">
+        <button
+          type="button"
+          onClick={() => { void cancelCurrentFlow() }}
+          disabled={loading !== null}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--muted))] transition-colors hover:text-[rgb(var(--foreground))] disabled:opacity-50"
+        >
+          ← Back to payment options
+        </button>
+
         <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
           <div className="flex items-center justify-between gap-4">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add visible Back to payment options actions at the top and bottom of Bitcoin payment UI
- make Bitcoin back cancel the active BTCPay flow before returning to choices
- add a visible top Back to payment options action above the Stripe card form
- cover Bitcoin and card back/cancel behavior in focused tests

## Tests
- pnpm run type-check
- pnpm exec vitest run app/components/__tests__/AddCardBanner.test.tsx