### PR TITLE
Fix calendar week bottom blank band

### DIFF
--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-week-layout-css.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-week-layout-css.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const globalsCss = readFileSync(join(process.cwd(), 'app/globals.css'), 'utf8')
+
+describe('Schedule-X week layout CSS', () => {
+  it('themes Schedule-X background surfaces so exposed scroll space is not white in dark mode', () => {
+    expect(globalsCss).toContain('--sx-color-background: rgb(var(--background));')
+    expect(globalsCss).toContain('--sx-color-on-background: rgb(var(--foreground));')
+    expect(globalsCss).toMatch(/\.sx-silentsuite-calendar \.sx__calendar[\s\S]*background: rgb\(var\(--background\)\)/)
+    expect(globalsCss).toMatch(/\.sx-silentsuite-calendar \.sx__view-container[\s\S]*background: rgb\(var\(--background\)\)/)
+  })
+
+  it('lets the fixed Schedule-X week grid cover taller calendar panes', () => {
+    expect(globalsCss).toMatch(/\.sx-silentsuite-calendar \.sx__week-wrapper[\s\S]*min-height: 100%/)
+    expect(globalsCss).toMatch(/\.sx-silentsuite-calendar \.sx__week-grid[\s\S]*height: max\(var\(--sx-week-grid-height\), 100%\)/)
+  })
+})

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -30,6 +30,8 @@
   --sx-color-on-primary: #fff;
   --sx-color-primary-container: rgb(var(--primary) / 0.15);
   --sx-color-on-primary-container: rgb(var(--primary));
+  --sx-color-background: rgb(var(--background));
+  --sx-color-on-background: rgb(var(--foreground));
   --sx-color-surface: rgb(var(--background));
   --sx-color-on-surface: rgb(var(--foreground));
   --sx-color-surface-container-low: rgb(var(--surface));
@@ -75,6 +77,11 @@
   border: none;
   border-radius: 0;
   box-shadow: none;
+  background: rgb(var(--background));
+}
+
+.sx-silentsuite-calendar .sx__calendar,
+.sx-silentsuite-calendar .sx__view-container {
   background: rgb(var(--background));
 }
 
@@ -168,10 +175,12 @@
    --------------------------------------------------------------------------- */
 .sx-silentsuite-calendar .sx__week-grid {
   background: rgb(var(--background));
+  height: max(var(--sx-week-grid-height), 100%);
 }
 
 .sx-silentsuite-calendar .sx__week-wrapper {
   background: rgb(var(--background));
+  min-height: 100%;
 }
 
 .sx-silentsuite-calendar .sx__time-grid-day {


### PR DESCRIPTION
## Summary
- Theme Schedule-X background variables used by the calendar/view container
- Ensure the week grid covers taller calendar panes instead of exposing a blank bottom band
- Add a focused CSS regression test for the week-view layout contract

## Tests
- pnpm --filter @silentsuite/web test --run app/'\(app\)'/calendar/lib/__tests__/calendar-day-boundaries.test.ts app/'\(app\)'/calendar/lib/__tests__/calendar-grid-events.test.ts app/'\(app\)'/calendar/lib/__tests__/calendar-week-layout-css.test.ts app/stores/__tests__/use-preferences-store.test.ts
- pnpm --filter @silentsuite/web type-check
- git diff --check