### PR TITLE
fix: clarify Windows bridge ports and startup health

### DIFF
--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -259,9 +259,30 @@ silentsuite-bridge --login
 
 ### Can't connect from your app
 
-1. Verify the bridge is running: open `http://localhost:37358/` in your browser
+1. Verify the bridge is running: open `http://127.0.0.1:37358/` in your browser
 2. Check the tray icon color (green = OK, red = error)
 3. Check the dashboard sync log for errors
+4. If you installed on Windows, also check `%LOCALAPPDATA%\SilentSuite\install.log` and `%LOCALAPPDATA%\SilentSuite\bridge.log`
+
+### The sign-in page and dashboard show different ports
+
+This is expected during browser sign-in. `silentsuite-bridge --login` opens a temporary local sign-in page on a random port such as `65486`. The actual CalDAV/CardDAV bridge always uses `http://127.0.0.1:37358/` unless you changed `SILENTSUITE_LISTEN_PORT`.
+
+Use the CalDAV/CardDAV URL shown on the success page or dashboard, for example:
+
+```text
+http://127.0.0.1:37358/your@email.com/
+```
+
+Do not copy the browser address-bar URL from the temporary sign-in page into Thunderbird, Outlook, or another DAV client.
+
+### Thunderbird says no calendars, tasks, or contacts were found
+
+1. Open `http://127.0.0.1:37358/` and confirm the dashboard loads. If it does not load, the bridge daemon is not running yet.
+2. Confirm the dashboard shows your configured account and a recent successful sync. If the sync log shows an error, fix that first.
+3. In Thunderbird, use the full account URL from the dashboard: `http://127.0.0.1:37358/your@email.com/`.
+4. Use your SilentSuite account email as the username and your SilentSuite account password as the password.
+5. If discovery still returns nothing, copy the dashboard sync log plus `%LOCALAPPDATA%\SilentSuite\bridge.log` into a support report. Do not include passwords or session tokens.
 
 ### System tray not visible (GNOME)
 

--- a/bridge/install.ps1
+++ b/bridge/install.ps1
@@ -25,6 +25,8 @@ $BinaryName = "silentsuite-bridge"
 $InstallDir = if ($env:SILENTSUITE_INSTALL_DIR) { $env:SILENTSUITE_INSTALL_DIR } else { "$env:LOCALAPPDATA\SilentSuite" }
 $ExePath = "$InstallDir\$BinaryName.exe"
 $InstallLog = Join-Path $InstallDir "install.log"
+$BridgeLog = Join-Path $InstallDir "bridge.log"
+$BridgeDashboardUrl = "http://127.0.0.1:37358/"
 
 # --- Helpers ---
 function Write-InstallLog($msg) {
@@ -71,6 +73,22 @@ function Get-GitHubErrorHint($errorRecord) {
         return "GitHub did not return release metadata. Check https://github.com/$Repo/releases/latest for current downloads."
     }
     return "Check https://github.com/$Repo/releases/latest for manual downloads."
+}
+
+function Test-BridgeDashboardReady([int]$TimeoutSeconds = 20) {
+    $Deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $Deadline) {
+        try {
+            $Response = Invoke-WebRequest -Uri $BridgeDashboardUrl -UseBasicParsing -TimeoutSec 2
+            if ($Response.StatusCode -ge 200 -and $Response.StatusCode -lt 500) {
+                return $true
+            }
+        } catch {
+            # The bridge may still be starting or syncing. Keep polling until the deadline.
+        }
+        Start-Sleep -Milliseconds 500
+    }
+    return $false
 }
 
 function Invoke-SilentSuiteBridgeInstall {
@@ -200,12 +218,23 @@ function Invoke-SilentSuiteBridgeInstall {
     # --- Login ---
     Write-Step "Launching login..."
     Write-Host "  Opening your browser to sign in."
-    Write-Host "  After login, the bridge runs in the background.`n"
+    Write-Host "  The browser sign-in tab may use a temporary random port. Use the app URL it shows, not the address bar.`n"
     try {
         & $ExePath --login
-        Start-Process -FilePath $ExePath -ArgumentList "--no-tray" -WindowStyle Hidden
-        Start-Sleep -Seconds 2
-        Write-Ok "Bridge is running! Dashboard: http://localhost:37358/"
+        $env:SILENTSUITE_LOG_FILE = $BridgeLog
+        $BridgeProcess = Start-Process -FilePath $ExePath -ArgumentList "--no-tray" -WindowStyle Hidden -PassThru
+        Write-InstallLog "Started bridge process id $($BridgeProcess.Id)"
+
+        if (Test-BridgeDashboardReady -TimeoutSeconds 20) {
+            Write-Ok "Bridge is running! Dashboard: $BridgeDashboardUrl"
+        } else {
+            $BridgeProcess.Refresh()
+            if ($BridgeProcess.HasExited) {
+                Write-Warn "Bridge exited after login (exit code $($BridgeProcess.ExitCode)). Check $BridgeLog, then run: $BinaryName"
+            } else {
+                Write-Warn "Bridge started but the dashboard did not respond yet. Open $BridgeDashboardUrl or check $BridgeLog before adding it to Thunderbird."
+            }
+        }
     } catch {
         Write-Warn "Login did not complete. Run later: $BinaryName --login"
     }
@@ -214,9 +243,10 @@ function Invoke-SilentSuiteBridgeInstall {
     Write-Step "Setup complete!"
     Write-Host ""
     Write-Host "  Bridge installed." -ForegroundColor Green
-    Write-Host "  Dashboard: " -NoNewline; Write-Host "http://localhost:37358/" -ForegroundColor Cyan
+    Write-Host "  Dashboard: " -NoNewline; Write-Host "$BridgeDashboardUrl" -ForegroundColor Cyan
     Write-Host "  Log in:    " -NoNewline; Write-Host "$BinaryName --login" -ForegroundColor Cyan
-    Write-Host "  Log file:  " -NoNewline; Write-Host "$InstallLog" -ForegroundColor Cyan
+    Write-Host "  Install log: " -NoNewline; Write-Host "$InstallLog" -ForegroundColor Cyan
+    Write-Host "  Bridge log:  " -NoNewline; Write-Host "$BridgeLog" -ForegroundColor Cyan
     Write-Host "  Full docs: " -NoNewline; Write-Host "https://docs.silentsuite.io/bridge" -ForegroundColor Cyan
     Write-Host ""
 }

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -443,10 +443,11 @@ SUCCESS_PAGE_HTML = """<!DOCTYPE html>
                 <button class="copy-btn" onclick="copyUrl(event, 'bridgeUrl')">Copy</button>
             </div>
             <p class="url-note">CalDAV and CardDAV share the same base URL &mdash; this is normal. Your app will discover calendars and contacts automatically.</p>
+            <p class="url-note" style="color:#f59e0b;">If your browser address bar shows another localhost port, that is only the temporary sign-in page. Use the copied app URL above, not the address-bar URL.</p>
             <p class="url-note" style="color:#f59e0b;">This URL is for calendar/contact apps, not a web browser. Copy it into your app &mdash; opening it in a browser can expose your password in the address bar.</p>
             DASHBOARD_BOOKMARK
             <div class="next-step">
-                You're signed in. You can close this tab &mdash; the bridge is already running in the background and will keep syncing on its own.
+                You're signed in. If you installed through PowerShell, wait for the installer to say the bridge dashboard is reachable before adding the URL to your app.
             </div>
         </div>
 

--- a/tests/test_windows_installer_static.py
+++ b/tests/test_windows_installer_static.py
@@ -4,6 +4,7 @@ import re
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "bridge" / "install.ps1"
 DOCS = ROOT / "apps" / "docs" / "user-guide" / "apps" / "dav-bridge.md"
+AUTH_BROWSER = ROOT / "bridge" / "src" / "silentsuite_bridge" / "auth_browser.py"
 WINDOWS_WORKFLOW = ROOT / ".github" / "workflows" / "test-bridge-windows.yml"
 
 
@@ -59,6 +60,26 @@ def test_windows_installer_fails_closed_on_checksum_mismatch():
     assert "Write-Ok \"Checksum verified\"" in else_body
 
 
+def test_windows_installer_polls_dashboard_after_starting_hidden_bridge():
+    script = read(INSTALLER)
+
+    assert "$BridgeDashboardUrl = \"http://127.0.0.1:37358/\"" in script
+    assert "function Test-BridgeDashboardReady" in script
+    assert "Invoke-WebRequest -Uri $BridgeDashboardUrl" in script
+    assert "Start-Process -FilePath $ExePath" in script and "-PassThru" in script
+    assert "SILENTSUITE_LOG_FILE" in script and "$BridgeLog" in script
+    assert "dashboard did not respond yet" in script
+    assert "Bridge exited after login" in script
+
+
+def test_browser_login_success_page_distinguishes_temporary_auth_port_from_dav_port():
+    auth_browser = read(AUTH_BROWSER)
+
+    assert "temporary sign-in page" in auth_browser
+    assert "not the address-bar URL" in auth_browser
+    assert "wait for the installer to say the bridge dashboard is reachable" in auth_browser
+
+
 def test_bridge_docs_link_direct_windows_asset_and_visible_error_recovery():
     docs = read(DOCS)
 
@@ -66,6 +87,9 @@ def test_bridge_docs_link_direct_windows_asset_and_visible_error_recovery():
     assert "silentsuite-bridge-windows-x86_64.exe.sha256" in docs
     assert "already-open PowerShell" in docs or "already-open Windows Terminal" in docs
     assert "-OutFile" in docs and "-File" in docs
+    assert "temporary local sign-in page on a random port" in docs
+    assert "Thunderbird says no calendars, tasks, or contacts were found" in docs
+    assert "%LOCALAPPDATA%\\SilentSuite\\bridge.log" in docs
 
 
 def test_windows_github_actions_workflow_covers_installer_and_binary_smoke_tests():


### PR DESCRIPTION
## Summary

- clarify that the browser sign-in tab uses a temporary random localhost port and the DAV bridge uses `127.0.0.1:37358`
- make the Windows installer poll the bridge dashboard after launching the hidden daemon instead of immediately claiming success
- write a bridge runtime log path and add troubleshooting steps for Thunderbird discovery failures

## Verification

- `python -m pytest tests/test_windows_installer_static.py -q`
- `python3 -m py_compile bridge/src/silentsuite_bridge/auth_browser.py tests/test_windows_installer_static.py`
- `git diff --check`
- `pwsh` parser smoke skipped locally because PowerShell is not installed on this Linux host
