### PR TITLE
Restore calendar grid rendering on preview

### DIFF
--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-week-layout-css.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-week-layout-css.test.ts
@@ -12,8 +12,8 @@ describe('Schedule-X week layout CSS', () => {
     expect(globalsCss).toMatch(/\.sx-silentsuite-calendar \.sx__view-container[\s\S]*background: rgb\(var\(--background\)\)/)
   })
 
-  it('lets the fixed Schedule-X week grid cover taller calendar panes', () => {
-    expect(globalsCss).toMatch(/\.sx-silentsuite-calendar \.sx__week-wrapper[\s\S]*min-height: 100%/)
-    expect(globalsCss).toMatch(/\.sx-silentsuite-calendar \.sx__week-grid[\s\S]*height: max\(var\(--sx-week-grid-height\), 100%\)/)
+  it('does not override Schedule-X week grid height calculations', () => {
+    expect(globalsCss).not.toContain('height: max(var(--sx-week-grid-height), 100%)')
+    expect(globalsCss).not.toMatch(/\.sx-silentsuite-calendar \.sx__week-wrapper[\s\S]*min-height: 100%/)
   })
 })

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -175,12 +175,10 @@
    --------------------------------------------------------------------------- */
 .sx-silentsuite-calendar .sx__week-grid {
   background: rgb(var(--background));
-  height: max(var(--sx-week-grid-height), 100%);
 }
 
 .sx-silentsuite-calendar .sx__week-wrapper {
   background: rgb(var(--background));
-  min-height: 100%;
 }
 
 .sx-silentsuite-calendar .sx__time-grid-day {


### PR DESCRIPTION
## Summary
- Remove the Schedule-X week-grid height override that could blank the deployed calendar
- Keep the background theming fix so exposed Schedule-X surfaces match light/dark theme instead of showing white
- Update the regression test to guard against overriding Schedule-X internal grid-height calculations

## Tests
- pnpm --filter @silentsuite/web test --run app/'\(app\)'/calendar/lib/__tests__/calendar-week-layout-css.test.ts app/'\(app\)'/calendar/lib/__tests__/calendar-day-boundaries.test.ts app/'\(app\)'/calendar/lib/__tests__/calendar-grid-events.test.ts app/stores/__tests__/use-preferences-store.test.ts
- pnpm --filter @silentsuite/web type-check
- git diff --check