### PR TITLE
fix: redirect bridge login to dashboard

### DIFF
--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -274,7 +274,7 @@ Use the CalDAV/CardDAV URL shown on the success page or dashboard, for example:
 http://127.0.0.1:37358/your@email.com/
 ```
 
-Do not copy the browser address-bar URL from the temporary sign-in page into Thunderbird, Outlook, or another DAV client.
+Do not copy the browser address-bar URL from the temporary sign-in page into Thunderbird, Outlook, or another DAV client. After sign-in, the success page waits for the real dashboard and automatically switches the tab to `http://127.0.0.1:37358/` once it is reachable.
 
 ### Thunderbird says no calendars, tasks, or contacts were found
 

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -427,6 +427,7 @@ SUCCESS_PAGE_HTML = """<!DOCTYPE html>
         }
         .docs-link a { color: #4ade80; text-decoration: none; }
         .docs-link a:hover { text-decoration: underline; }
+        .redirect-note { color: #4ade80; font-size: 13px; margin-top: 12px; }
     </style>
 </head>
 <body>
@@ -447,8 +448,9 @@ SUCCESS_PAGE_HTML = """<!DOCTYPE html>
             <p class="url-note" style="color:#f59e0b;">This URL is for calendar/contact apps, not a web browser. Copy it into your app &mdash; opening it in a browser can expose your password in the address bar.</p>
             DASHBOARD_BOOKMARK
             <div class="next-step">
-                You're signed in. If you installed through PowerShell, wait for the installer to say the bridge dashboard is reachable before adding the URL to your app.
+                You're signed in. If you installed through PowerShell, this tab will switch to the bridge dashboard as soon as the installer starts it. Wait for the installer to say the bridge dashboard is reachable before adding the URL to your app.
             </div>
+            <p class="redirect-note" id="redirectNote">Waiting for the bridge dashboard...</p>
         </div>
 
         <div class="card">
@@ -613,6 +615,32 @@ SUCCESS_PAGE_HTML = """<!DOCTYPE html>
             document.body.removeChild(ta);
             setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
         }
+        (function redirectWhenDashboardIsReady() {
+            var dashboardUrl = 'DASHBOARD_URL';
+            var note = document.getElementById('redirectNote');
+            if (!dashboardUrl) {
+                if (note) { note.textContent = 'Dashboard is disabled for this bridge bind.'; }
+                return;
+            }
+
+            var attempts = 0;
+            var maxAttempts = 45;
+            function tryDashboard() {
+                attempts += 1;
+                fetch(dashboardUrl, { mode: 'no-cors', cache: 'no-store' }).then(function() {
+                    window.location.href = dashboardUrl;
+                }).catch(function() {
+                    if (attempts >= maxAttempts) {
+                        if (note) {
+                            note.textContent = 'Dashboard did not open automatically. Keep this tab as a reference and open ' + dashboardUrl + ' after the installer reports success.';
+                        }
+                        return;
+                    }
+                    window.setTimeout(tryDashboard, 1000);
+                });
+            }
+            window.setTimeout(tryDashboard, 1000);
+        })();
     </script>
 </body>
 </html>"""
@@ -652,11 +680,13 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
                     "to find these details later</div>"
                 )
             else:
+                dashboard_url = ""
                 dashboard_bookmark = '<div class="bookmark-box">Dashboard is disabled for remote bridge binds.</div>'
 
             page = SUCCESS_PAGE_HTML
             page = page.replace("USER_EMAIL", html_mod.escape(email))
             page = page.replace("BRIDGE_URL", html_mod.escape(bridge_url))
+            page = page.replace("DASHBOARD_URL", html_mod.escape(dashboard_url))
             page = page.replace("DASHBOARD_BOOKMARK", dashboard_bookmark)
 
             self.send_response(200)

--- a/tests/test_windows_installer_static.py
+++ b/tests/test_windows_installer_static.py
@@ -77,7 +77,11 @@ def test_browser_login_success_page_distinguishes_temporary_auth_port_from_dav_p
 
     assert "temporary sign-in page" in auth_browser
     assert "not the address-bar URL" in auth_browser
-    assert "wait for the installer to say the bridge dashboard is reachable" in auth_browser
+    assert "this tab will switch to the bridge dashboard" in auth_browser
+    assert "redirectWhenDashboardIsReady" in auth_browser
+    assert "fetch(dashboardUrl, { mode: 'no-cors', cache: 'no-store' })" in auth_browser
+    assert "window.location.href = dashboardUrl" in auth_browser
+    assert "DASHBOARD_URL" in auth_browser
 
 
 def test_bridge_docs_link_direct_windows_asset_and_visible_error_recovery():
@@ -88,6 +92,7 @@ def test_bridge_docs_link_direct_windows_asset_and_visible_error_recovery():
     assert "already-open PowerShell" in docs or "already-open Windows Terminal" in docs
     assert "-OutFile" in docs and "-File" in docs
     assert "temporary local sign-in page on a random port" in docs
+    assert "automatically switches the tab" in docs
     assert "Thunderbird says no calendars, tasks, or contacts were found" in docs
     assert "%LOCALAPPDATA%\\SilentSuite\\bridge.log" in docs
 


### PR DESCRIPTION
## Summary

- make the temporary bridge login success page poll the real dashboard URL and redirect the tab once it is reachable
- keep the success page usable as a fallback if the dashboard never becomes reachable
- document the automatic switch from the temporary auth port to `127.0.0.1:37358`
- extend static regression coverage for the redirect behavior

## Verification

- `python -m pytest tests/test_windows_installer_static.py -q`
- `python3 -m py_compile bridge/src/silentsuite_bridge/auth_browser.py tests/test_windows_installer_static.py`
- `git diff --check`
