### PR TITLE
Scale calendar week grid to visible hours

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -18,6 +18,7 @@ import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
 import { startOfWeek, endOfWeek } from '@/app/lib/date'
 import { expandEventsForRange, toScheduleXEvents, type DisplayEvent } from '../lib/calendar-grid-events'
 import {
+  getScheduleXWeekGridHeight,
   toScheduleXDayBoundariesExternal,
   toScheduleXDayBoundariesInternal,
 } from '../lib/calendar-day-boundaries'
@@ -400,6 +401,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
   // Capture initial first-day-of-week for Schedule-X config (changes pushed via signal below)
   const initialFirstDayRef = useRef(effectiveSxFirstDayOfWeek)
   const initialDayBoundariesRef = useRef(toScheduleXDayBoundariesExternal(dayStartHour, dayEndHour))
+  const initialWeekGridHeightRef = useRef(getScheduleXWeekGridHeight(dayStartHour, dayEndHour))
 
   // Memoize the event click handler
   const handleEventClick = useCallback(
@@ -439,7 +441,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
     dayBoundaries: initialDayBoundariesRef.current,
     timezone: initialTimezoneRef.current,
     weekOptions: {
-      gridHeight: 800,
+      gridHeight: initialWeekGridHeightRef.current,
       eventWidth: 95,
       // Concurrent (overlapping) events — e.g. from different collections — must
       // render in side-by-side columns instead of stacking on top of each other.
@@ -489,20 +491,26 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
     }
   }, [calendar, effectiveSxFirstDayOfWeek])
 
-  // Push the effective week column count through Schedule-X. The mobile 3-day
-  // views reuse the week renderer with nDays=3 or nDays=7; normal week/month keep 7 days.
+  // Push effective week options through Schedule-X. The grid height is tied to
+  // the visible day-boundary span so user-shortened days do not leave a blank
+  // parent band below the final hour row on tall screens.
   useEffect(() => {
     if (!calendar) return
     try {
       const app = (calendar as any).$app
       const weekOptionsSignal = app?.config?.weekOptions
-      if (weekOptionsSignal?.value && weekOptionsSignal.value.nDays !== effectiveWeekDays) {
-        weekOptionsSignal.value = { ...weekOptionsSignal.value, nDays: effectiveWeekDays }
+      const gridHeight = getScheduleXWeekGridHeight(dayStartHour, dayEndHour)
+      if (
+        weekOptionsSignal?.value &&
+        (weekOptionsSignal.value.nDays !== effectiveWeekDays ||
+          weekOptionsSignal.value.gridHeight !== gridHeight)
+      ) {
+        weekOptionsSignal.value = { ...weekOptionsSignal.value, nDays: effectiveWeekDays, gridHeight }
       }
     } catch {
       // Schedule-X internals may not be ready
     }
-  }, [calendar, effectiveWeekDays])
+  }, [calendar, effectiveWeekDays, dayStartHour, dayEndHour])
 
   // Push day-boundary preference changes into Schedule-X and our drag/select math.
   useEffect(() => {

--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   formatDayBoundary,
+  getScheduleXWeekGridHeight,
   hourToScheduleXTimePoint,
   toScheduleXDayBoundariesExternal,
   toScheduleXDayBoundariesInternal,
@@ -19,5 +20,11 @@ describe('calendar day boundaries', () => {
     expect(hourToScheduleXTimePoint(6)).toBe(600)
     expect(hourToScheduleXTimePoint(24)).toBe(2400)
     expect(toScheduleXDayBoundariesInternal(7, 23)).toEqual({ start: 700, end: 2300 })
+  })
+
+  it('scales week grid height with visible day span', () => {
+    expect(getScheduleXWeekGridHeight(7, 23)).toBe(1792)
+    expect(getScheduleXWeekGridHeight(8, 22)).toBe(1568)
+    expect(getScheduleXWeekGridHeight(9, 10)).toBe(800)
   })
 })

--- a/apps/web/app/(app)/calendar/lib/calendar-day-boundaries.ts
+++ b/apps/web/app/(app)/calendar/lib/calendar-day-boundaries.ts
@@ -8,6 +8,9 @@ export interface ScheduleXDayBoundariesInternal {
   end: number
 }
 
+const MIN_WEEK_GRID_HEIGHT = 800
+const WEEK_GRID_HOUR_HEIGHT = 112
+
 export function formatDayBoundary(hour: number): string {
   return `${String(hour).padStart(2, '0')}:00`
 }
@@ -34,4 +37,9 @@ export function toScheduleXDayBoundariesInternal(
     start: hourToScheduleXTimePoint(startHour),
     end: hourToScheduleXTimePoint(endHour),
   }
+}
+
+export function getScheduleXWeekGridHeight(startHour: number, endHour: number): number {
+  const visibleHours = Math.max(1, endHour - startHour)
+  return Math.max(MIN_WEEK_GRID_HEIGHT, visibleHours * WEEK_GRID_HOUR_HEIGHT)
 }


### PR DESCRIPTION
## Summary
- Scale Schedule-X week grid height from the configured visible day-boundary span instead of keeping it fixed at 800px.
- Preserve Schedule-X internal CSS height rules and only update weekOptions through config signals.
- Add regression coverage for the grid-height calculation.

## Why
The white band persists because a short visible day span, for example 8 AM-10 PM, still used an 800px fixed grid. Tall preview viewports expose the parent calendar background after the final hour row.

## Verification
- pnpm --filter @silentsuite/web test --run app/'(app)'/calendar/lib/__tests__/calendar-day-boundaries.test.ts app/'(app)'/calendar/lib/__tests__/calendar-grid-events.test.ts app/'(app)'/calendar/lib/__tests__/calendar-week-layout-css.test.ts app/stores/__tests__/use-preferences-store.test.ts
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web lint
- git diff --check