### PR TITLE
Adapt calendar week density to viewport

### DIFF
--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -18,7 +18,7 @@ import { resolveUserTimezone, instantFromWallClock } from '@/app/lib/tz'
 import { startOfWeek, endOfWeek } from '@/app/lib/date'
 import { expandEventsForRange, toScheduleXEvents, type DisplayEvent } from '../lib/calendar-grid-events'
 import {
-  getScheduleXWeekGridHeight,
+  getScheduleXWeekLayout,
   toScheduleXDayBoundariesExternal,
   toScheduleXDayBoundariesInternal,
 } from '../lib/calendar-day-boundaries'
@@ -224,6 +224,13 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
   const effectiveWeekDays = effectiveView === 'threeDay' ? 3 : 7
 
   const rootRef = useRef<HTMLDivElement>(null)
+  const [calendarPaneHeight, setCalendarPaneHeight] = useState(0)
+  const weekLayout = useMemo(
+    () => getScheduleXWeekLayout(dayStartHour, dayEndHour, calendarPaneHeight),
+    [dayStartHour, dayEndHour, calendarPaneHeight],
+  )
+  const displayDayStartHour = weekLayout.startHour
+  const displayDayEndHour = weekLayout.endHour
   const lastClickPos = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
 
   // Ref to prevent feedback loops between store↔Schedule-X sync
@@ -400,8 +407,8 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
   const initialTimezoneRef = useRef(userTz)
   // Capture initial first-day-of-week for Schedule-X config (changes pushed via signal below)
   const initialFirstDayRef = useRef(effectiveSxFirstDayOfWeek)
-  const initialDayBoundariesRef = useRef(toScheduleXDayBoundariesExternal(dayStartHour, dayEndHour))
-  const initialWeekGridHeightRef = useRef(getScheduleXWeekGridHeight(dayStartHour, dayEndHour))
+  const initialDayBoundariesRef = useRef(toScheduleXDayBoundariesExternal(displayDayStartHour, displayDayEndHour))
+  const initialWeekGridHeightRef = useRef(weekLayout.gridHeight)
 
   // Memoize the event click handler
   const handleEventClick = useCallback(
@@ -491,15 +498,39 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
     }
   }, [calendar, effectiveSxFirstDayOfWeek])
 
-  // Push effective week options through Schedule-X. The grid height is tied to
-  // the visible day-boundary span so user-shortened days do not leave a blank
-  // parent band below the final hour row on tall screens.
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+
+    const measure = () => {
+      const viewContainer = root.querySelector('.sx__view-container') as HTMLElement | null
+      const nextHeight = Math.round((viewContainer ?? root).clientHeight)
+      if (nextHeight > 0) {
+        setCalendarPaneHeight((current) => (Math.abs(current - nextHeight) > 8 ? nextHeight : current))
+      }
+    }
+
+    measure()
+    const raf = requestAnimationFrame(measure)
+    const observer = new ResizeObserver(measure)
+    observer.observe(root)
+    const viewContainer = root.querySelector('.sx__view-container') as HTMLElement | null
+    if (viewContainer) observer.observe(viewContainer)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      observer.disconnect()
+    }
+  }, [calendar])
+
+  // Push effective week options through Schedule-X. The grid height adapts to
+  // the rendered pane instead of forcing oversized rows or exposing a blank band.
   useEffect(() => {
     if (!calendar) return
     try {
       const app = (calendar as any).$app
       const weekOptionsSignal = app?.config?.weekOptions
-      const gridHeight = getScheduleXWeekGridHeight(dayStartHour, dayEndHour)
+      const gridHeight = weekLayout.gridHeight
       if (
         weekOptionsSignal?.value &&
         (weekOptionsSignal.value.nDays !== effectiveWeekDays ||
@@ -510,22 +541,22 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
     } catch {
       // Schedule-X internals may not be ready
     }
-  }, [calendar, effectiveWeekDays, dayStartHour, dayEndHour])
+  }, [calendar, effectiveWeekDays, weekLayout.gridHeight])
 
-  // Push day-boundary preference changes into Schedule-X and our drag/select math.
+  // Push adaptive day boundaries into Schedule-X and our drag/select math.
   useEffect(() => {
     if (!calendar) return
     try {
       const app = (calendar as any).$app
       const boundariesSignal = app?.config?.dayBoundaries
-      const next = toScheduleXDayBoundariesInternal(dayStartHour, dayEndHour)
+      const next = toScheduleXDayBoundariesInternal(displayDayStartHour, displayDayEndHour)
       if (boundariesSignal) {
         boundariesSignal.value = next
       }
     } catch {
       // Schedule-X internals may not be ready
     }
-  }, [calendar, dayStartHour, dayEndHour])
+  }, [calendar, displayDayStartHour, displayDayEndHour])
 
   // Sync view AND date changes from store → Schedule-X via internal API.
   // CalendarApp has NO public navigation methods. We access the private $app
@@ -706,11 +737,11 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
     (clientY: number, gridEl: HTMLElement): number => {
       const rect = gridEl.getBoundingClientRect()
       const relativeY = clientY - rect.top + gridEl.scrollTop
-      const totalHours = dayEndHour - dayStartHour
+      const totalHours = displayDayEndHour - displayDayStartHour
       const pixelsPerHour = gridEl.scrollHeight / totalHours
-      return dayStartHour + relativeY / pixelsPerHour
+      return displayDayStartHour + relativeY / pixelsPerHour
     },
-    [dayStartHour, dayEndHour],
+    [displayDayStartHour, displayDayEndHour],
   )
 
   /** Find which day column the X coordinate is within */
@@ -765,18 +796,18 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
       const snappedHour = Math.round(hour * 2) / 2
 
       const durationHours = dragMoveStartRef.current.duration / (60 * 60 * 1000)
-      const maxStartHour = dayEndHour - durationHours
-      const clampedHour = Math.max(dayStartHour, Math.min(snappedHour, maxStartHour))
+      const maxStartHour = displayDayEndHour - durationHours
+      const clampedHour = Math.max(displayDayStartHour, Math.min(snappedHour, maxStartHour))
       const clampedStart = buildDateFromHour(dayInfo.date, clampedHour)
       const clampedEnd = new Date(clampedStart.getTime() + dragMoveStartRef.current.duration)
 
-      const totalHours = dayEndHour - dayStartHour
+      const totalHours = displayDayEndHour - displayDayStartHour
       const pixelsPerHour = gridEl.scrollHeight / totalHours
       const gridRect = gridEl.getBoundingClientRect()
       const wrapperRect = wrapper.getBoundingClientRect()
 
       const topY =
-        (clampedHour - dayStartHour) * pixelsPerHour -
+        (clampedHour - displayDayStartHour) * pixelsPerHour -
         gridEl.scrollTop +
         gridRect.top -
         wrapperRect.top
@@ -807,7 +838,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
         newEnd: clampedEnd,
       })
     },
-    [getDayColumnInfo, getTimeFromY, buildDateFromHour, use12h, userTz],
+    [getDayColumnInfo, getTimeFromY, buildDateFromHour, use12h, userTz, displayDayStartHour, displayDayEndHour],
   )
 
   /** Shared helper: complete drag-move drop */
@@ -839,8 +870,8 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
       const hour = getTimeFromY(clientY, gridEl)
       const snappedHour = Math.round(hour * 2) / 2
       const durationHours = moveStart.duration / (60 * 60 * 1000)
-      const maxStartHour = dayEndHour - durationHours
-      const clampedHour = Math.max(dayStartHour, Math.min(snappedHour, maxStartHour))
+      const maxStartHour = displayDayEndHour - durationHours
+      const clampedHour = Math.max(displayDayStartHour, Math.min(snappedHour, maxStartHour))
       const newStart = buildDateFromHour(dayInfo.date, clampedHour)
       const newEnd = new Date(newStart.getTime() + moveStart.duration)
 
@@ -866,7 +897,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
         isDragMovingRef.current = false
       }, 100)
     },
-    [getDayColumnInfo, getTimeFromY, buildDateFromHour, setSelectedEvent, updateEvent],
+    [getDayColumnInfo, getTimeFromY, buildDateFromHour, setSelectedEvent, updateEvent, displayDayStartHour, displayDayEndHour],
   )
 
   // Track mouse position for event click anchoring + drag-to-select start
@@ -1004,12 +1035,12 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
         const origStartHour =
           origStart.getHours() + origStart.getMinutes() / 60
         const minEndHour = origStartHour + 0.5 // 30 min minimum
-        const clampedEndHour = Math.max(minEndHour, Math.min(snappedHour, dayEndHour))
+        const clampedEndHour = Math.max(minEndHour, Math.min(snappedHour, displayDayEndHour))
 
         const newEnd = buildDateFromHour(origStart, clampedEndHour)
 
         // Compute ghost overlay
-        const totalHours = dayEndHour - dayStartHour
+        const totalHours = displayDayEndHour - displayDayStartHour
         const pixelsPerHour = gridEl.scrollHeight / totalHours
         const gridRect = gridEl.getBoundingClientRect()
         const wrapperRect = wrapper.getBoundingClientRect()
@@ -1039,7 +1070,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
         if (!dayInfo) return
 
         const topY =
-          (origStartHour - dayStartHour) * pixelsPerHour -
+          (origStartHour - displayDayStartHour) * pixelsPerHour -
           gridEl.scrollTop +
           gridRect.top -
           wrapperRect.top
@@ -1170,13 +1201,13 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
       const snappedEnd = snapHour(Math.max(startHour, endHour))
 
       // Convert snapped hours back to pixel positions
-      const totalHours = dayEndHour - dayStartHour
+      const totalHours = displayDayEndHour - displayDayStartHour
       const pixelsPerHour = gridEl.scrollHeight / totalHours
       const gridRect = gridEl.getBoundingClientRect()
       const wrapperRect = wrapper.getBoundingClientRect()
 
-      const snappedTopY = (snappedStart - dayStartHour) * pixelsPerHour - gridEl.scrollTop + gridRect.top - wrapperRect.top
-      const snappedBottomY = (snappedEnd - dayStartHour) * pixelsPerHour - gridEl.scrollTop + gridRect.top - wrapperRect.top
+      const snappedTopY = (snappedStart - displayDayStartHour) * pixelsPerHour - gridEl.scrollTop + gridRect.top - wrapperRect.top
+      const snappedBottomY = (snappedEnd - displayDayStartHour) * pixelsPerHour - gridEl.scrollTop + gridRect.top - wrapperRect.top
 
       const colRect = dragStartRef.current.dayColRect
       if (!colRect) return
@@ -1196,7 +1227,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
         endTime,
       })
     },
-    [getTimeFromY, buildDateFromHour, getDayColumnInfo, updateDragMovePosition, viewRange, use12h, userTz],
+    [getTimeFromY, buildDateFromHour, getDayColumnInfo, updateDragMovePosition, viewRange, use12h, userTz, displayDayStartHour, displayDayEndHour],
   )
 
   const handleMouseUp = useCallback(
@@ -1229,7 +1260,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
         const origStart = resizeStart.originalStart
         const origStartHour = origStart.getHours() + origStart.getMinutes() / 60
         const minEndHour = origStartHour + 0.5
-        const clampedEndHour = Math.max(minEndHour, Math.min(snappedHour, dayEndHour))
+        const clampedEndHour = Math.max(minEndHour, Math.min(snappedHour, displayDayEndHour))
         const newEnd = buildDateFromHour(origStart, clampedEndHour)
 
         if (newEnd.getTime() !== resizeStart.originalEnd.getTime()) {
@@ -1303,7 +1334,7 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
         isDraggingRef.current = false
       }, 100)
     },
-    [onSlotClick, getTimeFromY, buildDateFromHour, setSelectedEvent, updateEvent, completeDragMove],
+    [onSlotClick, getTimeFromY, buildDateFromHour, setSelectedEvent, updateEvent, completeDragMove, displayDayEndHour],
   )
 
   // ESC key handler for cancelling drag-to-move and drag-to-resize

--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-day-boundaries.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   formatDayBoundary,
-  getScheduleXWeekGridHeight,
+  getScheduleXWeekLayout,
   hourToScheduleXTimePoint,
   toScheduleXDayBoundariesExternal,
   toScheduleXDayBoundariesInternal,
@@ -22,9 +22,10 @@ describe('calendar day boundaries', () => {
     expect(toScheduleXDayBoundariesInternal(7, 23)).toEqual({ start: 700, end: 2300 })
   })
 
-  it('scales week grid height with visible day span', () => {
-    expect(getScheduleXWeekGridHeight(7, 23)).toBe(1792)
-    expect(getScheduleXWeekGridHeight(8, 22)).toBe(1568)
-    expect(getScheduleXWeekGridHeight(9, 10)).toBe(800)
+  it('keeps hour rows within a readable adaptive density range', () => {
+    expect(getScheduleXWeekLayout(8, 22, 900)).toEqual({ startHour: 8, endHour: 22, gridHeight: 900 })
+    expect(getScheduleXWeekLayout(8, 22, 1600)).toEqual({ startHour: 1, endHour: 24, gridHeight: 1600 })
+    expect(getScheduleXWeekLayout(9, 10, 900)).toEqual({ startHour: 3, endHour: 16, gridHeight: 900 })
+    expect(getScheduleXWeekLayout(8, 22, 500)).toEqual({ startHour: 8, endHour: 22, gridHeight: 672 })
   })
 })

--- a/apps/web/app/(app)/calendar/lib/calendar-day-boundaries.ts
+++ b/apps/web/app/(app)/calendar/lib/calendar-day-boundaries.ts
@@ -8,8 +8,40 @@ export interface ScheduleXDayBoundariesInternal {
   end: number
 }
 
-const MIN_WEEK_GRID_HEIGHT = 800
-const WEEK_GRID_HOUR_HEIGHT = 112
+export interface ScheduleXWeekLayout {
+  startHour: number
+  endHour: number
+  gridHeight: number
+}
+
+const DEFAULT_WEEK_HOUR_HEIGHT = 64
+const MIN_WEEK_HOUR_HEIGHT = 48
+const MAX_WEEK_HOUR_HEIGHT = 72
+const MIN_WEEK_VISIBLE_HOURS = 12
+const HOURS_PER_DAY = 24
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function expandDayWindow(startHour: number, endHour: number, targetHours: number): { startHour: number; endHour: number } {
+  const visibleHours = Math.max(1, endHour - startHour)
+  const extraHours = Math.max(0, targetHours - visibleHours)
+  let start = startHour - Math.floor(extraHours / 2)
+  let end = endHour + Math.ceil(extraHours / 2)
+
+  if (start < 0) {
+    end = Math.min(HOURS_PER_DAY, end - start)
+    start = 0
+  }
+
+  if (end > HOURS_PER_DAY) {
+    start = Math.max(0, start - (end - HOURS_PER_DAY))
+    end = HOURS_PER_DAY
+  }
+
+  return { startHour: start, endHour: end }
+}
 
 export function formatDayBoundary(hour: number): string {
   return `${String(hour).padStart(2, '0')}:00`
@@ -39,7 +71,32 @@ export function toScheduleXDayBoundariesInternal(
   }
 }
 
-export function getScheduleXWeekGridHeight(startHour: number, endHour: number): number {
-  const visibleHours = Math.max(1, endHour - startHour)
-  return Math.max(MIN_WEEK_GRID_HEIGHT, visibleHours * WEEK_GRID_HOUR_HEIGHT)
+export function getScheduleXWeekLayout(
+  startHour: number,
+  endHour: number,
+  availableHeight = 0,
+): ScheduleXWeekLayout {
+  const preferredStart = clamp(Math.floor(startHour), 0, HOURS_PER_DAY - 1)
+  const preferredEnd = clamp(Math.ceil(endHour), preferredStart + 1, HOURS_PER_DAY)
+  const preferredHours = preferredEnd - preferredStart
+  const hoursNeededForHeight = availableHeight > 0 ? Math.ceil(availableHeight / MAX_WEEK_HOUR_HEIGHT) : 0
+  const targetHours = Math.min(
+    HOURS_PER_DAY,
+    Math.max(preferredHours, MIN_WEEK_VISIBLE_HOURS, hoursNeededForHeight),
+  )
+  const { startHour: expandedStart, endHour: expandedEnd } = expandDayWindow(preferredStart, preferredEnd, targetHours)
+  const visibleHours = expandedEnd - expandedStart
+
+  const idealHourHeight = availableHeight > 0 ? availableHeight / visibleHours : DEFAULT_WEEK_HOUR_HEIGHT
+  const hourHeight = clamp(idealHourHeight, MIN_WEEK_HOUR_HEIGHT, MAX_WEEK_HOUR_HEIGHT)
+
+  return {
+    startHour: expandedStart,
+    endHour: expandedEnd,
+    gridHeight: Math.round(hourHeight * visibleHours),
+  }
+}
+
+export function getScheduleXWeekGridHeight(startHour: number, endHour: number, availableHeight = 0): number {
+  return getScheduleXWeekLayout(startHour, endHour, availableHeight).gridHeight
 }


### PR DESCRIPTION
## Summary
- Replace the fixed 112px/hour week-grid scale with an adaptive viewport-aware layout.
- Keep hour rows in a readable 48-72px range and expand the displayed day window when the pane is very tall or the configured range is very small.
- Measure the rendered Schedule-X view container and update weekOptions/dayBoundaries through Schedule-X config signals.
- Keep drag/select/resize math aligned to the displayed adaptive window.

## Why
The prior fix removed the white band but made rows huge because it scaled every visible hour to 112px. Very small user-selected day ranges also still behaved badly. Common calendars avoid this by adapting density and/or expanding the visible range instead of endlessly stretching one or two hours.

## Verification
- pnpm --filter @silentsuite/web test --run app/'(app)'/calendar/lib/__tests__/calendar-day-boundaries.test.ts app/'(app)'/calendar/lib/__tests__/calendar-grid-events.test.ts app/'(app)'/calendar/lib/__tests__/calendar-week-layout-css.test.ts app/stores/__tests__/use-preferences-store.test.ts
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web lint
- pnpm --filter @silentsuite/web build
- git diff --check