### PR TITLE
ci(server): add FastAPI route contract gate

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -45,7 +45,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
-      - name: Compile check (smoke test)
+      - name: Compile Python modules
         working-directory: server
         run: |
           python -m py_compile manage.py
@@ -57,6 +57,15 @@ jobs:
       - name: Verify Django app loads
         working-directory: server
         run: python -c "import django; django.setup(); print('Django loaded OK')"
+
+      - name: Run FastAPI route contract tests
+        working-directory: server
+        run: |
+          python -m pytest \
+            etebase_server/fastapi/test_collection_route_contracts.py \
+            etebase_server/fastapi/test_item_list_queryset.py \
+            etebase_server/fastapi/test_authentication.py \
+            -v --tb=short
 
       - name: Verify Docker secret exclusions
         run: |

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -32,6 +32,30 @@ pnpm type-check
 - Test behaviour, not implementation details.
 - Keep tests independent -- each test should be able to run in isolation.
 
+## Server framework upgrade gate
+
+PRs that touch any server request-routing or serialization dependency must run the FastAPI route contract gate, not only compile checks. This includes changes to:
+
+- `server/requirements.in/base.txt`
+- `server/requirements.txt`
+- `server/requirements.in/development.txt`
+- `server/requirements-dev.txt`
+- FastAPI, Starlette, Pydantic, `httpx2`/test-client transport dependencies, msgpack, or server request/response middleware
+
+From `server/`, run:
+
+```bash
+python -m pytest \
+  etebase_server/fastapi/test_collection_route_contracts.py \
+  etebase_server/fastapi/test_item_list_queryset.py \
+  etebase_server/fastapi/test_authentication.py \
+  -v --tb=short
+```
+
+These tests exercise real FastAPI router mounting, path-parameter binding, dependency injection, auth headers, and msgpack request/response handling. They are the upgrade gate for the incident class where compile checks and helper tests stayed green while a framework change broke authenticated restore/sync routes.
+
+CI runs this focused gate before the full server test suite. Keep CI step names precise: `py_compile` proves modules compile; it is not a functional smoke test.
+
 ## Before Submitting a PR
 
 Make sure all checks pass:
@@ -42,5 +66,7 @@ pnpm type-check
 pnpm test
 pnpm build
 ```
+
+For server dependency or request-routing changes, also run the FastAPI route contract gate above from `server/`.
 
 CI will run these checks automatically on your pull request.


### PR DESCRIPTION
## Summary

- adds a focused FastAPI route-contract test gate to server CI
- renames the Python compile step so it is not described as a smoke test
- documents the framework/dependency upgrade gate for future FastAPI, Starlette, Pydantic, msgpack, and request-routing changes

## Verification

Ad-hoc focused verification from a temporary `/tmp/hermes-verify-*` script:

```bash
python -m pip install -r requirements.txt
python -m pip install -r requirements-dev.txt
python -m pip check
python -m py_compile manage.py etebase_server/settings.py etebase_server/urls.py etebase_server/utils.py etebase_server/myauth/tests.py
python - <<'PY'
import django
django.setup()
print('Django loaded OK')
PY
python -m pytest \
  etebase_server/fastapi/test_collection_route_contracts.py \
  etebase_server/fastapi/test_item_list_queryset.py \
  etebase_server/fastapi/test_authentication.py \
  -v --tb=short
git diff --check
```

Result: 35 passed, 37 pre-existing Pydantic deprecation warnings.

Closes #466
