### PR TITLE
docs(web): add authenticated restore smoke probe

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -10,6 +10,7 @@ Thank you for your interest in contributing to SilentSuite. This guide will help
 | [Architecture Overview](./architecture-overview.md) | How the codebase is organized |
 | [Code Conventions](./code-conventions.md) | Style guide and patterns we follow |
 | [Testing](./testing.md) | How to run and write tests |
+| [Authenticated Restore Smoke](./authenticated-restore-smoke.md) | Verify encrypted-session restore with redacted diagnostics |
 | [Pull Request Guide](./pull-request-guide.md) | How to submit changes |
 | [Translation Guide](../../TRANSLATING.md) | Help translate the web app safely and consistently |
 

--- a/docs/contributing/authenticated-restore-smoke.md
+++ b/docs/contributing/authenticated-restore-smoke.md
@@ -1,0 +1,76 @@
+# Authenticated restore smoke probe
+
+Use this recipe after preview or production deploys that could affect web login, encrypted-session restore, Etebase item listing, or SyncEngine startup. It proves the authenticated restore path, not just CI or unauthenticated deploy health.
+
+## What this verifies
+
+The smoke is passing only when the redacted diagnostics show all of these phases as `ok` and `failedPhase` is `null`:
+
+- `sessionRead`
+- `restoreSession`
+- `ensureCollections`
+- `hydrateLists`
+- `listItems:calendar`
+- `listItems:tasks`
+- `listItems:contacts`
+- `syncEngineTrackCollections`
+- `syncEngineStart`
+
+The diagnostics intentionally contain only phase/status/count metadata, safe error names, hostnames, booleans, and durations. They must not contain cookies, headers, session blobs, collection ids, item ids, event/task/contact contents, labels, request bodies, or response bodies.
+
+## Manual browser recipe
+
+1. Open the environment with restore diagnostics enabled:
+
+   ```text
+   https://app.silentsuite.io/calendar?syncDebug=1
+   ```
+
+   For a preview environment, use that preview host with the same `?syncDebug=1` query.
+
+2. Sign in with an approved internal or seeded smoke account. Do not use a live customer account unless the customer explicitly supplied the diagnostic payload.
+
+3. Wait until the sync indicator settles.
+
+4. If the app shows `Sync error`, click **Copy diagnostics** in the sync indicator. If the button is unavailable, use the console command below.
+
+5. If the app appears healthy, still copy the diagnostics from the console so the success has phase evidence:
+
+   ```js
+   copy(sessionStorage.getItem('silentsuite.restore-diagnostics.v1'))
+   ```
+
+   If `copy()` is unavailable in the browser console, run `sessionStorage.getItem('silentsuite.restore-diagnostics.v1')` and copy only that returned JSON string.
+
+6. Save the copied JSON to a local temporary file outside the repo, for example:
+
+   ```bash
+   tmp=$(mktemp /tmp/silentsuite-restore-smoke-XXXXXX.json)
+   $EDITOR "$tmp"
+   ```
+
+7. Generate the privacy-safe pass/fail report:
+
+   ```bash
+   node scripts/restore-smoke-report.mjs "$tmp"
+   rm -f "$tmp"
+   ```
+
+8. Paste only the report into the PR, issue, or release checklist. Do not paste the raw browser diagnostics unless a maintainer explicitly asks for it in a private channel.
+
+## Pass criteria
+
+A passing report starts with `Authenticated restore smoke: PASS` and includes `failedPhase: null`; every required phase is present with `ok` status.
+
+A failing report starts with `Authenticated restore smoke: FAIL` and includes safe findings such as a missing phase, a failed phase, or a visible collection type with no collections.
+
+## Scope boundaries
+
+This smoke distinguishes deployment health from real authenticated restore health. It does not prove every event/task/contact is correct, and it does not inspect plaintext PIM. If it fails, use the failed phase to choose the next narrow investigation:
+
+- `sessionRead` or `restoreSession`: saved session or Etebase restore path
+- `ensureCollections`: collection listing/creation path
+- `listItems:*`: item route, auth, msgpack, or server protocol path
+- `syncEngineTrackCollections` or `syncEngineStart`: SyncEngine wiring/startup path
+
+Do not clear browser storage before collecting diagnostics unless the user chooses data recovery over root-cause evidence.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -56,6 +56,16 @@ These tests exercise real FastAPI router mounting, path-parameter binding, depen
 
 CI runs this focused gate before the full server test suite. Keep CI step names precise: `py_compile` proves modules compile; it is not a functional smoke test.
 
+## Authenticated restore smoke
+
+After changes that affect web login, encrypted-session restore, Etebase item listing, or SyncEngine startup, run the [authenticated restore smoke probe](./authenticated-restore-smoke.md). It uses the app's redacted `silentsuite.restore-diagnostics.v1` payload and `scripts/restore-smoke-report.mjs` to distinguish CI/deploy health from real authenticated restore health without exposing plaintext PIM or credentials.
+
+Validate the report helper with:
+
+```bash
+node scripts/restore-smoke-report.mjs --self-test
+```
+
 ## Before Submitting a PR
 
 Make sure all checks pass:

--- a/scripts/restore-smoke-report.mjs
+++ b/scripts/restore-smoke-report.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+
+const REQUIRED_PHASES = [
+  'sessionRead',
+  'restoreSession',
+  'ensureCollections',
+  'hydrateLists',
+  'listItems:calendar',
+  'listItems:tasks',
+  'listItems:contacts',
+  'syncEngineTrackCollections',
+  'syncEngineStart',
+]
+
+const VISIBLE_COLLECTION_TYPES = new Set(['calendar', 'tasks', 'contacts'])
+
+function usage() {
+  return [
+    'Usage:',
+    '  node scripts/restore-smoke-report.mjs <diagnostics-json-file|->',
+    '  node scripts/restore-smoke-report.mjs --self-test',
+    '',
+    'Input must be the redacted JSON from sessionStorage key silentsuite.restore-diagnostics.v1.',
+    'The report intentionally prints only phase/status/count metadata, never session blobs, item ids, or content.',
+  ].join('\n')
+}
+
+function readInput(path) {
+  if (!path || path === '--help' || path === '-h') {
+    console.log(usage())
+    process.exit(path ? 0 : 2)
+  }
+  if (path === '-') return fs.readFileSync(0, 'utf8')
+  return fs.readFileSync(path, 'utf8')
+}
+
+function parseSnapshot(raw) {
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new Error(`Input is not valid JSON: ${err.message}`)
+  }
+  if (parsed?.version !== 1) throw new Error('Unsupported or missing diagnostics version')
+  if (!Array.isArray(parsed.entries)) throw new Error('Diagnostics entries must be an array')
+  return parsed
+}
+
+function phaseEntries(snapshot, phase) {
+  return snapshot.entries.filter((entry) => entry.phase === phase)
+}
+
+function phaseOk(snapshot, phase) {
+  return phaseEntries(snapshot, phase).some((entry) => entry.status === 'ok')
+}
+
+function sumForPhase(snapshot, phase, field) {
+  return phaseEntries(snapshot, phase).reduce((sum, entry) => sum + (Number.isFinite(entry[field]) ? entry[field] : 0), 0)
+}
+
+function assessSnapshot(snapshot) {
+  const findings = []
+  const missing = []
+  const failed = []
+  const nonOk = []
+
+  for (const phase of REQUIRED_PHASES) {
+    const entries = phaseEntries(snapshot, phase)
+    if (entries.length === 0) {
+      missing.push(phase)
+      continue
+    }
+    if (entries.some((entry) => entry.status === 'failed')) failed.push(phase)
+    if (entries.some((entry) => entry.status !== 'ok')) nonOk.push(phase)
+  }
+
+  if (snapshot.failedPhase !== null) findings.push(`failedPhase is ${String(snapshot.failedPhase)}`)
+  if (missing.length > 0) findings.push(`missing phases: ${missing.join(', ')}`)
+  if (failed.length > 0) findings.push(`failed phases: ${failed.join(', ')}`)
+  if (nonOk.length > 0) findings.push(`non-ok phases: ${[...new Set(nonOk)].join(', ')}`)
+
+  for (const type of VISIBLE_COLLECTION_TYPES) {
+    const phase = `listItems:${type}`
+    const collectionCount = sumForPhase(snapshot, phase, 'collectionCount')
+    if (phaseOk(snapshot, phase) && collectionCount < 1) {
+      findings.push(`${phase} reported no collections`)
+    }
+  }
+
+  const pass = findings.length === 0
+  return { pass, findings }
+}
+
+function safeHost(host) {
+  return typeof host === 'string' && host.length > 0 ? host : 'unknown'
+}
+
+function report(snapshot) {
+  const { pass, findings } = assessSnapshot(snapshot)
+  const lines = []
+  lines.push(`Authenticated restore smoke: ${pass ? 'PASS' : 'FAIL'}`)
+  lines.push(`source: ${snapshot.source ?? 'unknown'}`)
+  lines.push(`etebaseHost: ${safeHost(snapshot.etebaseHost)}`)
+  lines.push(`billingHost: ${safeHost(snapshot.billingHost)}`)
+  lines.push(`failedPhase: ${snapshot.failedPhase === null ? 'null' : String(snapshot.failedPhase)}`)
+  lines.push('phases:')
+  for (const phase of REQUIRED_PHASES) {
+    const entries = phaseEntries(snapshot, phase)
+    if (entries.length === 0) {
+      lines.push(`  - ${phase}: missing`)
+      continue
+    }
+    const status = entries.map((entry) => entry.status).join('/')
+    const countBits = []
+    const collectionCount = sumForPhase(snapshot, phase, 'collectionCount')
+    const itemCount = sumForPhase(snapshot, phase, 'itemCount')
+    const pageCount = sumForPhase(snapshot, phase, 'pageCount')
+    if (collectionCount) countBits.push(`collections=${collectionCount}`)
+    if (itemCount) countBits.push(`items=${itemCount}`)
+    if (pageCount) countBits.push(`pages=${pageCount}`)
+    lines.push(`  - ${phase}: ${status}${countBits.length ? ` (${countBits.join(', ')})` : ''}`)
+  }
+  if (findings.length > 0) {
+    lines.push('findings:')
+    for (const finding of findings) lines.push(`  - ${finding}`)
+  }
+  return lines.join('\n')
+}
+
+function makePassingFixture() {
+  return {
+    version: 1,
+    source: 'restore',
+    generatedAtMs: 1,
+    etebaseHost: 'server.silentsuite.io',
+    billingHost: 'api.silentsuite.io',
+    failedPhase: null,
+    entries: [
+      { phase: 'sessionRead', status: 'ok', session: { present: true, parseableJson: true, shape: 'json' } },
+      { phase: 'restoreSession', status: 'ok', durationMs: 12 },
+      { phase: 'ensureCollections', status: 'ok', collectionCount: 3 },
+      { phase: 'hydrateLists', status: 'ok' },
+      { phase: 'listItems:calendar', status: 'ok', collectionType: 'calendar', collectionCount: 1, itemCount: 2, pageCount: 1 },
+      { phase: 'listItems:tasks', status: 'ok', collectionType: 'tasks', collectionCount: 1, itemCount: 0, pageCount: 1 },
+      { phase: 'listItems:contacts', status: 'ok', collectionType: 'contacts', collectionCount: 1, itemCount: 0, pageCount: 1 },
+      { phase: 'syncEngineTrackCollections', status: 'ok' },
+      { phase: 'syncEngineStart', status: 'ok' },
+    ],
+  }
+}
+
+function runSelfTest() {
+  const passReport = report(makePassingFixture())
+  if (!passReport.startsWith('Authenticated restore smoke: PASS')) {
+    throw new Error('expected passing fixture to pass')
+  }
+
+  const bogusFixture = makePassingFixture()
+  bogusFixture.entries = bogusFixture.entries.map((entry) => (
+    entry.phase === 'hydrateLists'
+      ? { ...entry, status: 'bogus', collectionUid: 'collection-secret', itemUid: 'item-secret', content: 'plaintext-pim-secret' }
+      : entry
+  ))
+  const bogusReport = report(bogusFixture)
+  if (!bogusReport.startsWith('Authenticated restore smoke: FAIL')) {
+    throw new Error('expected non-ok status fixture to fail')
+  }
+  for (const forbidden of ['collection-secret', 'item-secret', 'plaintext-pim-secret']) {
+    if (bogusReport.includes(forbidden)) {
+      throw new Error(`self-test report leaked forbidden field: ${forbidden}`)
+    }
+  }
+
+  const failFixture = makePassingFixture()
+  failFixture.failedPhase = 'listItems:calendar'
+  failFixture.entries = failFixture.entries.map((entry) => (
+    entry.phase === 'listItems:calendar' ? { phase: 'listItems:calendar', status: 'failed', errorName: 'Error' } : entry
+  ))
+  const failReport = report(failFixture)
+  if (!failReport.startsWith('Authenticated restore smoke: FAIL')) {
+    throw new Error('expected failing fixture to fail')
+  }
+  if (failReport.includes('session-secret') || failReport.includes('item-uid')) {
+    throw new Error('self-test report leaked forbidden fixture data')
+  }
+  console.log('restore-smoke-report self-test: PASS')
+}
+
+function main() {
+  const arg = process.argv[2]
+  if (arg === '--self-test') {
+    runSelfTest()
+    return
+  }
+  const snapshot = parseSnapshot(readInput(arg))
+  const text = report(snapshot)
+  console.log(text)
+  process.exitCode = text.startsWith('Authenticated restore smoke: PASS') ? 0 : 1
+}
+
+try {
+  main()
+} catch (err) {
+  console.error(`restore-smoke-report: ${err.message}`)
+  process.exit(2)
+}


### PR DESCRIPTION
## Summary

- documents an authenticated restore smoke recipe for preview/production checks
- adds `scripts/restore-smoke-report.mjs` to turn the redacted `silentsuite.restore-diagnostics.v1` payload into a safe PASS/FAIL report
- links the restore smoke from contributor testing docs

## Verification

```bash
pnpm install --frozen-lockfile
node scripts/restore-smoke-report.mjs --self-test
pnpm --filter @silentsuite/web test -- app/lib/__tests__/sync-restore-diagnostics.test.ts app/components/__tests__/SyncIndicator.test.tsx
pnpm --filter @silentsuite/web type-check
git diff --check
```

Observed:

- restore smoke report self-test passed
- web tests passed: 40 files, 413 tests
- web type-check passed
- diff check passed

Closes #467
