### PR TITLE
web: expose restore diagnostics for smoke probe

### DIFF
--- a/apps/web/app/components/SyncIndicator.tsx
+++ b/apps/web/app/components/SyncIndicator.tsx
@@ -7,8 +7,8 @@ import { formatTimeAgo } from '@/app/lib/format-time-ago'
 import type { SyncStatus } from '@silentsuite/core'
 import {
   buildRestoreDiagnosticsCopyText,
+  canExposeRestoreDiagnosticsCopy,
   readRestoreDiagnostics,
-  shouldExposeRestoreDiagnostics,
 } from '@/app/lib/sync-restore-diagnostics'
 
 const dotStyles: Record<SyncStatus, string> = {
@@ -52,7 +52,7 @@ export function SyncIndicator() {
   const isSyncing = syncStatus === 'syncing'
   const isOffline = syncStatus === 'offline'
   const isError = syncStatus === 'error'
-  const canCopyDiagnostics = isError && shouldExposeRestoreDiagnostics()
+  const canCopyDiagnostics = canExposeRestoreDiagnosticsCopy()
 
   const handleSync = useCallback(() => {
     if (isSyncing || isOffline) return

--- a/apps/web/app/components/__tests__/SyncIndicator.test.tsx
+++ b/apps/web/app/components/__tests__/SyncIndicator.test.tsx
@@ -87,4 +87,50 @@ describe('SyncIndicator', () => {
     expect(copied).toContain('"failedPhase":"restoreSession"')
     expect(copied).not.toContain('session-secret')
   })
+
+  it('copies successful restore diagnostics in debug-exposed healthy states', async () => {
+    const writeText = vi.fn(async () => {})
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    mockSyncState.syncStatus = 'synced'
+    sessionStorage.setItem('silentsuite.restore-diagnostics.v1', JSON.stringify({
+      version: 1,
+      source: 'restore',
+      generatedAtMs: 1,
+      etebaseHost: 'server.silentsuite.io',
+      billingHost: 'api.silentsuite.io',
+      failedPhase: null,
+      entries: [{ phase: 'syncEngineStart', status: 'ok' }],
+    }))
+
+    render(<SyncIndicator />)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy sync restore diagnostics' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    expect(writeText.mock.calls[0]![0]).toContain('"failedPhase":null')
+  })
+
+  it('hides diagnostics copy in production-like contexts without debug opt-in', () => {
+    vi.stubGlobal('window', {
+      location: { hostname: 'app.silentsuite.io', search: '' },
+      sessionStorage,
+      localStorage,
+    })
+    sessionStorage.setItem('silentsuite.restore-diagnostics.v1', JSON.stringify({
+      version: 1,
+      source: 'restore',
+      generatedAtMs: 1,
+      etebaseHost: 'server.silentsuite.io',
+      billingHost: 'api.silentsuite.io',
+      failedPhase: null,
+      entries: [{ phase: 'syncEngineStart', status: 'ok' }],
+    }))
+
+    render(<SyncIndicator />)
+
+    expect(screen.queryByRole('button', { name: 'Copy sync restore diagnostics' })).toBeNull()
+    vi.unstubAllGlobals()
+  })
 })

--- a/apps/web/app/lib/__tests__/sync-restore-diagnostics.test.ts
+++ b/apps/web/app/lib/__tests__/sync-restore-diagnostics.test.ts
@@ -3,8 +3,10 @@ import {
   RESTORE_DIAGNOSTICS_STORAGE_KEY,
   RestoreDiagnosticsRecorder,
   buildRestoreDiagnosticsCopyText,
+  canExposeRestoreDiagnosticsCopy,
   classifySessionPersistence,
   createLoginSessionPersistenceDiagnostics,
+  hasRestoreDiagnostics,
   readRestoreDiagnostics,
   shouldExposeRestoreDiagnostics,
 } from '../sync-restore-diagnostics'
@@ -77,19 +79,102 @@ describe('sync restore diagnostics', () => {
     vi.stubGlobal('window', {
       location: { hostname: 'app.silentsuite.io', search: '' },
       localStorage,
+      sessionStorage,
     })
     expect(shouldExposeRestoreDiagnostics()).toBe(false)
 
     vi.stubGlobal('window', {
       location: { hostname: 'previewapp.silentsuite.io', search: '' },
       localStorage,
+      sessionStorage,
     })
     expect(shouldExposeRestoreDiagnostics()).toBe(true)
 
     vi.stubGlobal('window', {
       location: { hostname: 'app.silentsuite.io', search: '?syncDebug=1' },
       localStorage,
+      sessionStorage,
     })
     expect(shouldExposeRestoreDiagnostics()).toBe(true)
+  })
+
+  it('separates diagnostics presence from debug exposure policy', () => {
+    vi.stubGlobal('window', {
+      location: { hostname: 'app.silentsuite.io', search: '' },
+      localStorage,
+      sessionStorage,
+    })
+    expect(hasRestoreDiagnostics()).toBe(false)
+    expect(canExposeRestoreDiagnosticsCopy()).toBe(false)
+
+    sessionStorage.setItem(RESTORE_DIAGNOSTICS_STORAGE_KEY, JSON.stringify({
+      version: 1,
+      source: 'restore',
+      generatedAtMs: 1,
+      etebaseHost: 'server.silentsuite.io',
+      billingHost: 'api.silentsuite.io',
+      failedPhase: null,
+      entries: [{ phase: 'syncEngineStart', status: 'ok' }],
+    }))
+
+    expect(hasRestoreDiagnostics()).toBe(true)
+    expect(canExposeRestoreDiagnosticsCopy()).toBe(false)
+
+    vi.stubGlobal('window', {
+      location: { hostname: 'app.silentsuite.io', search: '?syncDebug=1' },
+      localStorage,
+      sessionStorage,
+    })
+    expect(hasRestoreDiagnostics()).toBe(true)
+    expect(canExposeRestoreDiagnosticsCopy()).toBe(true)
+
+    sessionStorage.setItem(RESTORE_DIAGNOSTICS_STORAGE_KEY, '{not-json')
+    expect(hasRestoreDiagnostics()).toBe(false)
+    expect(canExposeRestoreDiagnosticsCopy()).toBe(false)
+  })
+
+  it('drops unknown top-level and entry fields from copied diagnostics', () => {
+    const copyText = buildRestoreDiagnosticsCopyText({
+      version: 1,
+      source: 'restore',
+      generatedAtMs: 3_000,
+      etebaseHost: 'https://server.silentsuite.io/private?token=secret',
+      billingHost: 'api.silentsuite.io',
+      failedPhase: null,
+      entries: [{
+        phase: 'listItems:calendar',
+        status: 'ok',
+        collectionType: 'calendar',
+        collectionCount: 1,
+        itemCount: 2,
+        pageCount: 1,
+        errorName: 'Error: user@example.com raw-session-secret',
+        // Simulate a future/corrupt snapshot that somehow contains unsafe extras.
+        collectionUid: 'collection-secret',
+        itemUid: 'item-secret',
+        content: 'plaintext-pim-secret',
+        rawUrl: 'https://server.silentsuite.io/private?token=secret',
+      } as never],
+      rawEmail: 'user@example.com',
+      sessionBlob: 'raw-session-secret',
+    } as never)
+
+    expect(copyText).toContain('"failedPhase":null')
+    expect(copyText).toContain('"phase":"listItems:calendar"')
+    expect(copyText).toContain('"itemCount":2')
+    for (const forbidden of [
+      'collection-secret',
+      'item-secret',
+      'plaintext-pim-secret',
+      'token=secret',
+      'user@example.com',
+      'raw-session-secret',
+      'collectionUid',
+      'itemUid',
+      'rawUrl',
+      'sessionBlob',
+    ]) {
+      expect(copyText).not.toContain(forbidden)
+    }
   })
 })

--- a/apps/web/app/lib/sync-restore-diagnostics.ts
+++ b/apps/web/app/lib/sync-restore-diagnostics.ts
@@ -216,9 +216,84 @@ export function readRestoreDiagnostics(): RestoreDiagnosticsSnapshot | null {
   }
 }
 
+const VALID_PHASES = new Set<RestoreDiagnosticPhase>([
+  'sessionRead',
+  'sessionPersistence',
+  'restoreSession',
+  'ensureCollections',
+  'hydrateLists',
+  'listItems:calendar',
+  'listItems:tasks',
+  'listItems:contacts',
+  'syncEngineTrackCollections',
+  'syncEngineStart',
+  'unknown',
+])
+
+const VALID_STATUSES = new Set<RestoreDiagnosticStatus>(['ok', 'failed', 'skipped'])
+
+function sanitizeHostValue(host: unknown): string {
+  if (typeof host !== 'string' || host.length === 0) return 'unknown'
+  if (/^[a-z0-9.-]+$/i.test(host)) return host
+  return safeHostname(host, 'unknown')
+}
+
+function sanitizeErrorNameValue(errorName: string): string | undefined {
+  return /^[A-Za-z][A-Za-z0-9_.]*$/.test(errorName) ? errorName : undefined
+}
+
+function sanitizeSessionPersistence(session: SessionPersistenceShape | undefined): SessionPersistenceShape | undefined {
+  if (!session) return undefined
+  if (typeof session.present !== 'boolean') return undefined
+  if (typeof session.parseableJson !== 'boolean') return undefined
+  if (!['missing', 'empty', 'json', 'string'].includes(session.shape)) return undefined
+  return {
+    present: session.present,
+    parseableJson: session.parseableJson,
+    shape: session.shape,
+  }
+}
+
+function sanitizeDiagnosticsEntry(entry: RestoreDiagnosticEntry): RestoreDiagnosticEntry | null {
+  if (!VALID_PHASES.has(entry.phase) || !VALID_STATUSES.has(entry.status)) return null
+  const safe: RestoreDiagnosticEntry = {
+    phase: entry.phase,
+    status: entry.status,
+  }
+  if (typeof entry.durationMs === 'number') safe.durationMs = entry.durationMs
+  const errorName = typeof entry.errorName === 'string' ? sanitizeErrorNameValue(entry.errorName) : undefined
+  if (errorName) safe.errorName = errorName
+  const session = sanitizeSessionPersistence(entry.session)
+  if (session) safe.session = session
+  if (typeof entry.roundtripMatch === 'boolean') safe.roundtripMatch = entry.roundtripMatch
+  if (['calendar', 'tasks', 'contacts'].includes(entry.collectionType ?? '')) {
+    safe.collectionType = entry.collectionType
+  }
+  if (typeof entry.collectionCount === 'number') safe.collectionCount = entry.collectionCount
+  if (typeof entry.itemCount === 'number') safe.itemCount = entry.itemCount
+  if (typeof entry.pageCount === 'number') safe.pageCount = entry.pageCount
+  return safe
+}
+
+function sanitizeDiagnosticsSnapshot(snapshot: RestoreDiagnosticsSnapshot): RestoreDiagnosticsSnapshot {
+  return {
+    version: 1,
+    source: snapshot.source === 'login' ? 'login' : 'restore',
+    generatedAtMs: typeof snapshot.generatedAtMs === 'number' ? snapshot.generatedAtMs : 0,
+    etebaseHost: sanitizeHostValue(snapshot.etebaseHost),
+    billingHost: sanitizeHostValue(snapshot.billingHost),
+    failedPhase: snapshot.failedPhase && VALID_PHASES.has(snapshot.failedPhase) ? snapshot.failedPhase : null,
+    entries: snapshot.entries.map(sanitizeDiagnosticsEntry).filter((entry): entry is RestoreDiagnosticEntry => entry !== null),
+  }
+}
+
 export function buildRestoreDiagnosticsCopyText(snapshot: RestoreDiagnosticsSnapshot | null): string {
   if (!snapshot) return JSON.stringify({ version: 1, error: 'no_restore_diagnostics_recorded' })
-  return JSON.stringify(snapshot)
+  return JSON.stringify(sanitizeDiagnosticsSnapshot(snapshot))
+}
+
+export function hasRestoreDiagnostics(): boolean {
+  return readRestoreDiagnostics() !== null
 }
 
 export function shouldExposeRestoreDiagnostics(): boolean {
@@ -230,4 +305,8 @@ export function shouldExposeRestoreDiagnostics(): boolean {
   const params = new URLSearchParams(window.location.search)
   if (params.get('syncDebug') === '1') return true
   return safeLocalStorage()?.getItem('silentsuite-sync-debug') === '1'
+}
+
+export function canExposeRestoreDiagnosticsCopy(): boolean {
+  return shouldExposeRestoreDiagnostics() && hasRestoreDiagnostics()
 }

--- a/docs/contributing/authenticated-restore-smoke.md
+++ b/docs/contributing/authenticated-restore-smoke.md
@@ -1,76 +1,165 @@
 # Authenticated restore smoke probe
 
-Use this recipe after preview or production deploys that could affect web login, encrypted-session restore, Etebase item listing, or SyncEngine startup. It proves the authenticated restore path, not just CI or unauthenticated deploy health.
+Use this recipe after preview or production deploys that could affect web login, encrypted-session restore, Etebase item listing, or SyncEngine startup. It proves the authenticated restore path, not just CI, image build, or unauthenticated deploy health.
 
-## What this verifies
+## What this proves and does not prove
 
-The smoke is passing only when the redacted diagnostics show all of these phases as `ok` and `failedPhase` is `null`:
+A passing smoke proves that an already-authenticated browser can restore its encrypted Etebase session, list the visible calendar/tasks/contacts collections and items, track collections, and start SyncEngine in the deployed app.
 
-- `sessionRead`
-- `restoreSession`
-- `ensureCollections`
-- `hydrateLists`
-- `listItems:calendar`
-- `listItems:tasks`
-- `listItems:contacts`
-- `syncEngineTrackCollections`
-- `syncEngineStart`
+It does **not** prove every event/task/contact is semantically correct. It does not inspect plaintext PIM. It does not replace focused server route contract tests, unit tests, CI, or later end-to-end automation.
 
-The diagnostics intentionally contain only phase/status/count metadata, safe error names, hostnames, booleans, and durations. They must not contain cookies, headers, session blobs, collection ids, item ids, event/task/contact contents, labels, request bodies, or response bodies.
+## Safety and privacy rules
 
-## Manual browser recipe
+The smoke report and copied diagnostics must contain only phase/status/count metadata, safe error names, hostnames, booleans, and durations.
 
-1. Open the environment with restore diagnostics enabled:
+Never paste any of the following into GitHub, BMAD, chat, release notes, logs, or public artifacts:
+
+- passwords, session blobs, auth tokens, cookies, or headers
+- collection IDs, item IDs, labels, request bodies, or response bodies
+- raw URLs with private paths or query strings
+- plaintext calendar events, tasks, contacts, notes, or other PIM
+- raw error messages or stack traces
+- customer account identifiers unless the customer explicitly supplied the redacted diagnostic payload
+
+Production smoke is mutation-free only when the account is already initialized. Do **not** use first-login, empty, or partially initialized production accounts: the current restore path can create default collections when required collections are missing.
+
+## Prerequisites
+
+- Use an approved internal/test account, or a customer/user-approved account where the user supplied the redacted diagnostics.
+- For production, get explicit owner approval first.
+- For production, confirm the account is already initialized with calendar, tasks, and contacts collections before running the smoke. If it is a new/empty account or required collections are missing, abort production smoke.
+- Use a browser profile approved for the smoke account.
+- Keep raw diagnostics in a temporary local file outside the repo and delete it after generating the report.
+
+## Preview smoke recipe
+
+1. Wait until the target change is merged to `dev` and the preview deploy has completed. PR image builds do not deploy the shared preview.
+2. Open the deployed preview with restore diagnostics enabled:
 
    ```text
-   https://app.silentsuite.io/calendar?syncDebug=1
+   https://previewapp.silentsuite.io/calendar?syncDebug=1
    ```
 
-   For a preview environment, use that preview host with the same `?syncDebug=1` query.
+3. Sign in only if no valid session exists.
+4. Hard reload once after login so the saved encrypted-session restore path runs.
+5. Wait until the app reaches a steady state and the sync indicator is not actively syncing.
+6. Copy restore diagnostics:
+   - Prefer the debug-gated **Copy diagnostics** button in the sync indicator.
+   - If the button is unavailable, use the console fallback:
 
-2. Sign in with an approved internal or seeded smoke account. Do not use a live customer account unless the customer explicitly supplied the diagnostic payload.
+     ```js
+     copy(sessionStorage.getItem('silentsuite.restore-diagnostics.v1'))
+     ```
 
-3. Wait until the sync indicator settles.
+     If `copy()` is unavailable, run `sessionStorage.getItem('silentsuite.restore-diagnostics.v1')` and copy only that returned JSON string.
 
-4. If the app shows `Sync error`, click **Copy diagnostics** in the sync indicator. If the button is unavailable, use the console command below.
-
-5. If the app appears healthy, still copy the diagnostics from the console so the success has phase evidence:
-
-   ```js
-   copy(sessionStorage.getItem('silentsuite.restore-diagnostics.v1'))
-   ```
-
-   If `copy()` is unavailable in the browser console, run `sessionStorage.getItem('silentsuite.restore-diagnostics.v1')` and copy only that returned JSON string.
-
-6. Save the copied JSON to a local temporary file outside the repo, for example:
+7. Save the copied JSON to a temporary file outside the repo:
 
    ```bash
    tmp=$(mktemp /tmp/silentsuite-restore-smoke-XXXXXX.json)
    $EDITOR "$tmp"
    ```
 
-7. Generate the privacy-safe pass/fail report:
+8. Generate the privacy-safe pass/fail report:
 
    ```bash
    node scripts/restore-smoke-report.mjs "$tmp"
    rm -f "$tmp"
    ```
 
-8. Paste only the report into the PR, issue, or release checklist. Do not paste the raw browser diagnostics unless a maintainer explicitly asks for it in a private channel.
+9. Paste only the generated report into the PR, issue, or release checklist. Do not paste raw browser diagnostics unless a maintainer explicitly asks for it in a private channel.
 
-## Pass criteria
+## Production smoke recipe
 
-A passing report starts with `Authenticated restore smoke: PASS` and includes `failedPhase: null`; every required phase is present with `ok` status.
+Production smoke has the same steps as preview, but with stricter gates:
 
-A failing report starts with `Authenticated restore smoke: FAIL` and includes safe findings such as a missing phase, a failed phase, or a visible collection type with no collections.
+1. Get explicit owner approval for the production smoke.
+2. Use only an approved, already-initialized internal/test account or a user-approved account.
+3. Abort if the account is first-login, empty, partially initialized, or missing expected calendar/tasks/contacts collections.
+4. Do not create, update, import, delete, or rename any data during the smoke.
+5. Open production with explicit debug opt-in:
 
-## Scope boundaries
+   ```text
+   https://app.silentsuite.io/calendar?syncDebug=1
+   ```
 
-This smoke distinguishes deployment health from real authenticated restore health. It does not prove every event/task/contact is correct, and it does not inspect plaintext PIM. If it fails, use the failed phase to choose the next narrow investigation:
+6. Copy diagnostics and generate the report as in the preview recipe.
+7. Share only the redacted report.
 
-- `sessionRead` or `restoreSession`: saved session or Etebase restore path
-- `ensureCollections`: collection listing/creation path
-- `listItems:*`: item route, auth, msgpack, or server protocol path
-- `syncEngineTrackCollections` or `syncEngineStart`: SyncEngine wiring/startup path
+`?syncDebug=1` is an intentional user/operator opt-in for this slice. It may expose redacted self-account metadata such as phase timings, counts, hostnames, and safe error categories. It must never expose secrets, raw identifiers, plaintext PIM, raw errors, or unknown stored fields.
+
+## Expected redacted diagnostics
+
+The raw diagnostics in `sessionStorage` should be JSON under the key `silentsuite.restore-diagnostics.v1`. A passing restore smoke requires:
+
+- `source: "restore"`
+- `failedPhase: null`
+- `ok` entries for all required phases:
+  - `sessionRead`
+  - `restoreSession`
+  - `ensureCollections`
+  - `hydrateLists`
+  - `listItems:calendar`
+  - `listItems:tasks`
+  - `listItems:contacts`
+  - `syncEngineTrackCollections`
+  - `syncEngineStart`
+
+A `source: "login"` snapshot only proves login/session persistence diagnostics. It is not sufficient for authenticated restore smoke; hard reload and collect a `source: "restore"` snapshot.
+
+## Failure triage by `failedPhase`
+
+If the smoke fails, do not start with broad rollback. Use the failed phase to choose the next narrow investigation:
+
+| `failedPhase` | First triage direction |
+| --- | --- |
+| `sessionRead` | Browser storage, secure-storage, or saved-session availability. |
+| `sessionPersistence` | Login session write/read roundtrip. |
+| `restoreSession` | Saved Etebase session validity, server URL/account mismatch, or SDK restore path. |
+| `ensureCollections` | Collection list/create path. On production, confirm the account was already initialized and stop if restore would create defaults. |
+| `hydrateLists` | Local list-store hydration. |
+| `listItems:calendar` | Calendar item route/auth/msgpack/decrypt path. If safe local evidence shows HTTP 422, check FastAPI path binding and route contracts before more frontend rollback. |
+| `listItems:tasks` | Tasks item route/auth/msgpack/decrypt path. |
+| `listItems:contacts` | Contacts item route/auth/msgpack/decrypt path. |
+| `syncEngineTrackCollections` | Collection tracking or stoken/cache seeding. |
+| `syncEngineStart` | SyncEngine startup/auth/network path. |
+| `unknown` | Failure before a phase marker or unclassified exception. |
 
 Do not clear browser storage before collecting diagnostics unless the user chooses data recovery over root-cause evidence.
+
+## Evidence template
+
+Paste reports in this shape:
+
+```text
+Authenticated restore smoke: PASS|FAIL
+environment: preview|production|local
+appHost: previewapp.silentsuite.io|app.silentsuite.io
+commitOrDeploy: <short sha / PR / deploy identifier if known>
+timestamp: <UTC timestamp>
+failedPhase: null|<phase>
+phases:
+  - sessionRead: ok|failed|missing
+  - restoreSession: ok|failed|missing
+  - ensureCollections: ok|failed|missing
+  - hydrateLists: ok|failed|missing
+  - listItems:calendar: ok|failed|missing (collections=N, items=N, pages=N)
+  - listItems:tasks: ok|failed|missing (collections=N, items=N, pages=N)
+  - listItems:contacts: ok|failed|missing (collections=N, items=N, pages=N)
+  - syncEngineTrackCollections: ok|failed|missing
+  - syncEngineStart: ok|failed|missing
+findings:
+  - <privacy-safe finding, if any>
+```
+
+Before sharing, confirm the evidence contains no credentials, emails, session blobs, collection IDs, item IDs, plaintext PIM, raw URLs with query strings, cookies, headers, response bodies, or raw error messages.
+
+## Automation follow-up design
+
+A future automation slice may add a local-only or secure-runner probe that reads credentials from environment variables outside the repo, for example:
+
+- `SILENTSUITE_SMOKE_BASE_URL`
+- `SILENTSUITE_SMOKE_EMAIL`
+- `SILENTSUITE_SMOKE_PASSWORD`
+
+That future probe should fail closed when credentials are missing, write no secrets to logs, and print only the same redacted report shape. This runbook-first slice must not add CI secrets, seeded account secrets, or permanent credential storage.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -60,6 +60,8 @@ CI runs this focused gate before the full server test suite. Keep CI step names 
 
 After changes that affect web login, encrypted-session restore, Etebase item listing, or SyncEngine startup, run the [authenticated restore smoke probe](./authenticated-restore-smoke.md). It uses the app's redacted `silentsuite.restore-diagnostics.v1` payload and `scripts/restore-smoke-report.mjs` to distinguish CI/deploy health from real authenticated restore health without exposing plaintext PIM or credentials.
 
+Passing CI, building a PR image, or checking an unauthenticated page only proves deploy health. The authenticated restore smoke must run after the change reaches a deployed preview/dev environment. For production smoke, use only an approved already-initialized account; first-login or empty production accounts are not mutation-free because restore can create default collections.
+
 Validate the report helper with:
 
 ```bash

--- a/scripts/restore-smoke-report.mjs
+++ b/scripts/restore-smoke-report.mjs
@@ -75,6 +75,7 @@ function assessSnapshot(snapshot) {
     if (entries.some((entry) => entry.status !== 'ok')) nonOk.push(phase)
   }
 
+  if (snapshot.source !== 'restore') findings.push(`source is ${String(snapshot.source ?? 'unknown')}, expected restore`)
   if (snapshot.failedPhase !== null) findings.push(`failedPhase is ${String(snapshot.failedPhase)}`)
   if (missing.length > 0) findings.push(`missing phases: ${missing.join(', ')}`)
   if (failed.length > 0) findings.push(`failed phases: ${failed.join(', ')}`)
@@ -183,6 +184,13 @@ function runSelfTest() {
   }
   if (failReport.includes('session-secret') || failReport.includes('item-uid')) {
     throw new Error('self-test report leaked forbidden fixture data')
+  }
+
+  const loginFixture = makePassingFixture()
+  loginFixture.source = 'login'
+  const loginReport = report(loginFixture)
+  if (!loginReport.startsWith('Authenticated restore smoke: FAIL') || !loginReport.includes('source is login, expected restore')) {
+    throw new Error('expected login-source fixture to fail restore smoke')
   }
   console.log('restore-smoke-report self-test: PASS')
 }


### PR DESCRIPTION
## Summary

- show the redacted restore diagnostics copy affordance in debug-exposed healthy states, not only sync-error states
- split diagnostics presence from copy-exposure policy and serialize copied diagnostics through an allowlist
- harden the authenticated restore smoke runbook with production no-mutation gates, source=restore pass criteria, and privacy-safe evidence guidance
- make the smoke report helper fail login-only snapshots so reload/restore evidence is required

References #467.

## Verification

- `node scripts/restore-smoke-report.mjs --self-test`
- `pnpm --filter @silentsuite/web exec vitest run app/lib/__tests__/sync-restore-diagnostics.test.ts app/components/__tests__/SyncIndicator.test.tsx`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint` (passes with existing warnings in calendar/contacts/tasks/notification-provider files)
- `git diff --check`

## Post-merge smoke

After merge to `dev` and preview deploy, run the authenticated restore smoke against `https://previewapp.silentsuite.io/calendar?syncDebug=1` using an approved initialized smoke account. Paste only the redacted report.