### PR TITLE
web: add privacy-safe sync timing instrumentation

### DIFF
--- a/apps/web/app/(app)/calendar/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/calendar/__tests__/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, within } from '@testing-library/react'
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import CalendarPage from '../page'
@@ -16,6 +16,10 @@ import type { CalendarList } from '@/app/stores/use-calendar-list-store'
 // catalog so the tests do not couple to English copy.
 
 const manageCalendars = messages.Collections.manageCalendars
+
+const timingMock = vi.hoisted(() => ({
+  logCalendarPaintTiming: vi.fn(),
+}))
 
 const storeMock = vi.hoisted(() => ({
   calendarState: {
@@ -57,6 +61,8 @@ vi.mock('@/app/stores/use-auth-store', () => ({
 vi.mock('@/app/stores/use-preferences-store', () => ({
   usePreferencesStore: (selector: (state: { dateFormat: 'system'; firstDayOfWeek: 'monday' }) => unknown) => selector({ dateFormat: 'system', firstDayOfWeek: 'monday' }),
 }))
+
+vi.mock('@/app/lib/sync-timing', () => timingMock)
 
 vi.mock('@/app/components/PullToRefresh', () => ({
   PullToRefresh: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -110,6 +116,9 @@ function resetCalendarMocks() {
   storeMock.calendarState.setCurrentView.mockReset()
   storeMock.calendarState.setSearchQuery.mockReset()
   storeMock.authState.canWrite.mockReturnValue(true)
+  timingMock.logCalendarPaintTiming.mockReset()
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0))
+  vi.stubGlobal('cancelAnimationFrame', (handle: number) => window.clearTimeout(handle))
 }
 
 describe('CalendarPage calendar visibility', () => {
@@ -152,6 +161,81 @@ describe('CalendarPage calendar visibility', () => {
     const sevenDayGrid = within(screen.getByTestId('mobile-seven-day-grid'))
     expect(sevenDayGrid.getByText('Visible event')).toBeInTheDocument()
     expect(sevenDayGrid.queryByText('Hidden event')).not.toBeInTheDocument()
+  })
+})
+
+describe('CalendarPage first content paint timing', () => {
+  beforeEach(() => {
+    resetCalendarMocks()
+    storeMock.calendarState.events = []
+    storeMock.calendarListState.calendars = []
+  })
+
+  it('does not log while the calendar is still loading', () => {
+    storeMock.calendarState.isLoading = true
+
+    renderWithIntl(<CalendarPage />)
+
+    expect(timingMock.logCalendarPaintTiming).not.toHaveBeenCalled()
+  })
+
+  it('logs first non-loading content once with visible aggregate counts only', async () => {
+    storeMock.calendarState.isLoading = false
+    storeMock.calendarState.events = [
+      { id: 'visible-event', calendarId: 'visible-cal', title: 'Visible event' },
+      { id: 'hidden-event', calendarId: 'hidden-cal', title: 'Hidden event' },
+    ]
+    storeMock.calendarListState.calendars = [
+      { id: 'visible-cal', name: 'Visible', color: '#10b981', visible: true },
+      { id: 'hidden-cal', name: 'Hidden', color: '#ef4444', visible: false },
+    ]
+
+    const { rerender } = renderWithIntl(<CalendarPage />)
+
+    await waitFor(() => expect(timingMock.logCalendarPaintTiming).toHaveBeenCalledTimes(1))
+    expect(timingMock.logCalendarPaintTiming).toHaveBeenCalledWith({
+      view: 'week',
+      totalEventCount: 2,
+      visibleEventCount: 1,
+      visibleCalendarCount: 1,
+      hasEvents: true,
+    })
+
+    rerender(<CalendarPage />)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(timingMock.logCalendarPaintTiming).toHaveBeenCalledTimes(1)
+  })
+
+  it('logs valid empty calendar content with hasEvents false', async () => {
+    storeMock.calendarState.isLoading = false
+
+    renderWithIntl(<CalendarPage />)
+
+    await waitFor(() => expect(timingMock.logCalendarPaintTiming).toHaveBeenCalledWith({
+      view: 'week',
+      totalEventCount: 0,
+      visibleEventCount: 0,
+      visibleCalendarCount: 0,
+      hasEvents: false,
+    }))
+  })
+
+  it('cancels the pending paint callback on unmount', async () => {
+    storeMock.calendarState.isLoading = false
+    let queued: FrameRequestCallback | null = null
+    const cancel = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      queued = callback
+      return 42
+    })
+    vi.stubGlobal('cancelAnimationFrame', cancel)
+
+    const { unmount } = renderWithIntl(<CalendarPage />)
+    unmount()
+    queued?.(Date.now())
+
+    expect(cancel).toHaveBeenCalledWith(42)
+    expect(timingMock.logCalendarPaintTiming).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { ChevronLeft, ChevronRight, Plus, Folder, Search as SearchIcon } from 'lucide-react'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
@@ -16,6 +16,7 @@ import { AgendaView } from './components/AgendaView'
 import { EventDialog } from './components/EventDialog'
 import { FloatingAddButton } from './components/FloatingAddButton'
 import { resolveUserTimezone } from '@/app/lib/tz'
+import { logCalendarPaintTiming } from '@/app/lib/sync-timing'
 
 /** Snap a Date to the nearest 30-minute boundary */
 function snapTo30Min(date: Date): Date {
@@ -160,6 +161,7 @@ export default function CalendarPage() {
   const [eventInstanceDate, setEventInstanceDate] = useState<Date | undefined>(undefined)
   const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
   const [mobileCalendarMode, setMobileCalendarMode] = useState<MobileCalendarMode>('agenda')
+  const firstContentPaintLoggedRef = useRef(false)
 
   const dateLabel = useMemo(
     () => formatDateRange(currentDate, currentView, dateFormat, firstDayOfWeek),
@@ -195,6 +197,32 @@ export default function CalendarPage() {
     () => events.filter((event) => visibleCalendarIds.has(event.calendarId ?? 'default')),
     [events, visibleCalendarIds],
   )
+
+  useEffect(() => {
+    if (isLoading || firstContentPaintLoggedRef.current) return
+    const requestFrame = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0)
+    const cancelFrame = typeof cancelAnimationFrame === 'function'
+      ? cancelAnimationFrame
+      : (handle: number) => window.clearTimeout(handle)
+    let cancelled = false
+    const frame = requestFrame(() => {
+      if (cancelled || firstContentPaintLoggedRef.current) return
+      firstContentPaintLoggedRef.current = true
+      logCalendarPaintTiming({
+        view: currentView,
+        totalEventCount: events.length,
+        visibleEventCount: visibleEvents.length,
+        visibleCalendarCount: calendars.filter((calendar) => calendar.visible).length,
+        hasEvents: visibleEvents.length > 0,
+      })
+    })
+    return () => {
+      cancelled = true
+      cancelFrame(frame)
+    }
+  }, [calendars, currentView, events.length, isLoading, visibleEvents.length])
 
   // Search
   const searchQuery = useCalendarStore((s) => s.searchQuery)

--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import 'fake-indexeddb/auto'
 import {
   getItemsByType,
@@ -16,6 +16,7 @@ import {
   putMeta,
   clearAll,
   ensureFingerprint,
+  getCacheCapabilityStatus,
   isCacheEnabled,
   CACHE_SCHEMA_VERSION,
   _resetForTests,
@@ -46,6 +47,23 @@ function makeItem(uid: string, type: 'tasks' | 'contacts' | 'calendar' = 'tasks'
 
 describe('data-cache', () => {
   describe('encryption guard', () => {
+    it('reports cache capability without touching IndexedDB', () => {
+      const previous = process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED
+      process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'
+      _setEncryptedCacheAvailableForTests(true)
+      const openSpy = vi.spyOn(indexedDB, 'open')
+
+      expect(getCacheCapabilityStatus()).toEqual({
+        featureFlagEnabled: true,
+        encryptedEnvelopeAvailable: true,
+        enabled: true,
+      })
+      expect(openSpy).not.toHaveBeenCalled()
+
+      process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = previous
+      openSpy.mockRestore()
+    })
+
     it('does not enable cache when the env flag is true but encryption is unavailable', () => {
       const previous = process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED
       process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'

--- a/apps/web/app/lib/__tests__/sync-timing.test.ts
+++ b/apps/web/app/lib/__tests__/sync-timing.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  elapsedMs,
+  getSyncTimingStartedAt,
+  isSyncTimingEnabled,
+  logCalendarPaintTiming,
+  logSyncTiming,
+  markSyncTimingStart,
+  safeTimingErrorCategory,
+  sanitizeSyncTimingPayload,
+} from '../sync-timing'
+
+describe('sync timing helpers', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    delete (globalThis as unknown as Record<string, unknown>).__silentsuiteSyncTimingStartedAt
+    window.localStorage.clear()
+    window.history.replaceState(null, '', '/')
+    process.env.NODE_ENV = originalNodeEnv
+  })
+
+  it('rounds elapsed milliseconds without going negative', () => {
+    expect(elapsedMs(10, 42.4)).toBe(32)
+    expect(elapsedMs(42, 10)).toBe(0)
+    expect(elapsedMs(Number.NaN, 10)).toBe(0)
+  })
+
+  it('stores and reads a module-level sync start marker', () => {
+    markSyncTimingStart(123)
+    expect(getSyncTimingStartedAt()).toBe(123)
+    expect(window.sessionStorage.getItem('__silentsuiteSyncTimingStartedAt')).toBeNull()
+    expect(window.localStorage.getItem('__silentsuiteSyncTimingStartedAt')).toBeNull()
+  })
+
+  it('does not enable preview or production timing without explicit opt-in', () => {
+    process.env.NODE_ENV = 'production'
+    window.history.replaceState(null, '', '/calendar')
+    expect(isSyncTimingEnabled()).toBe(false)
+
+    window.history.replaceState(null, '', '/calendar')
+    expect(isSyncTimingEnabled()).toBe(false)
+  })
+
+  it('enables timing in production only for exact query or localStorage opt-in', () => {
+    process.env.NODE_ENV = 'production'
+
+    window.history.replaceState(null, '', '/calendar?syncTiming=true')
+    expect(isSyncTimingEnabled()).toBe(false)
+
+    window.history.replaceState(null, '', '/calendar?syncTiming=0')
+    expect(isSyncTimingEnabled()).toBe(false)
+
+    window.history.replaceState(null, '', '/calendar?syncTiming=1')
+    expect(isSyncTimingEnabled()).toBe(true)
+
+    window.history.replaceState(null, '', '/calendar')
+    window.localStorage.setItem('silentsuite:syncTiming', 'yes')
+    expect(isSyncTimingEnabled()).toBe(false)
+
+    window.localStorage.setItem('silentsuite:syncTiming', 'true')
+    expect(isSyncTimingEnabled()).toBe(true)
+  })
+
+  it('sanitizes payloads and drops unknown or unsafe values', () => {
+    const sanitized = sanitizeSyncTimingPayload({
+      phase: 'calendar-load',
+      source: 'server',
+      itemCount: 12.3,
+      cacheEnabled: true,
+      unknownSecret: 'token=secret',
+      itemUid: 'item-secret',
+      collectionUid: 'collection-secret',
+      url: 'https://server.example/private?token=secret',
+      view: 'week',
+      status: 'ok',
+      errorCategory: 'user@example.com token=secret',
+      rawError: new Error('secret'),
+      negative: -1,
+    })
+
+    expect(sanitized).toEqual({
+      phase: 'calendar-load',
+      source: 'server',
+      itemCount: 12,
+      cacheEnabled: true,
+      view: 'week',
+      status: 'ok',
+      errorCategory: 'unknown',
+    })
+    expect(JSON.stringify(sanitized)).not.toContain('secret')
+    expect(JSON.stringify(sanitized)).not.toContain('item-secret')
+    expect(JSON.stringify(sanitized)).not.toContain('collection-secret')
+  })
+
+  it('never trusts unsafe error names', () => {
+    expect(safeTimingErrorCategory('cache')).toBe('cache')
+    expect(safeTimingErrorCategory('user@example.com token=secret')).toBe('unknown')
+    expect(safeTimingErrorCategory(new Error('message'))).toBe('unknown')
+  })
+
+  it('emits only a sanitized JSON copy, not the caller payload object', () => {
+    process.env.NODE_ENV = 'production'
+    window.localStorage.setItem('silentsuite:syncTiming', 'true')
+    const payload = { itemCount: 1, itemUid: 'item-secret' }
+
+    logSyncTiming('calendar-load', 100, payload)
+
+    expect(console.info).toHaveBeenCalledTimes(1)
+    const [label, json] = vi.mocked(console.info).mock.calls[0]!
+    expect(label).toBe('[silentsuite-sync-timing]')
+    expect(typeof json).toBe('string')
+    expect(json).toContain('calendar-load')
+    expect(json).not.toContain('item-secret')
+  })
+
+  it('logs first calendar content paint relative to the sync marker', () => {
+    process.env.NODE_ENV = 'production'
+    window.history.replaceState(null, '', '/calendar?syncTiming=1')
+    markSyncTimingStart(100)
+
+    logCalendarPaintTiming({ view: 'week', visibleEventCount: 2, totalEventCount: 3, hasEvents: true })
+
+    expect(console.info).toHaveBeenCalledTimes(1)
+    const json = vi.mocked(console.info).mock.calls[0]![1] as string
+    expect(json).toContain('first-calendar-content-paint')
+    expect(json).toContain('visibleEventCount')
+    expect(json).not.toContain('calendarId')
+  })
+
+  it('does not throw when localStorage or console are unavailable', () => {
+    process.env.NODE_ENV = 'production'
+    vi.spyOn(window.localStorage.__proto__, 'getItem').mockImplementation(() => {
+      throw new Error('storage blocked')
+    })
+    vi.mocked(console.info).mockImplementation(() => {
+      throw new Error('console blocked')
+    })
+
+    expect(() => logSyncTiming('cache-capability', 1, { enabled: true })).not.toThrow()
+  })
+})

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -389,13 +389,33 @@ export async function ensureFingerprint(accountFingerprint: string): Promise<boo
 
 // ── Feature flag helper ──
 
+export interface CacheCapabilityStatus {
+  featureFlagEnabled: boolean
+  encryptedEnvelopeAvailable: boolean
+  enabled: boolean
+}
+
+/**
+ * Privacy-safe cache capability status for timing diagnostics. Synchronous and
+ * side-effect-free: no IndexedDB open, schema migration, cache reads, or writes.
+ */
+export function getCacheCapabilityStatus(): CacheCapabilityStatus {
+  const featureFlagEnabled = process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED === 'true'
+  const encryptedEnvelopeAvailable = hasEncryptedCacheEnvelope()
+  return {
+    featureFlagEnabled,
+    encryptedEnvelopeAvailable,
+    enabled: featureFlagEnabled && encryptedEnvelopeAvailable,
+  }
+}
+
 /**
  * Returns true only when the local cache feature is enabled and encrypted
  * cache storage is available. Off by default, and fail-closed if the flag is
  * enabled before encryption exists.
  */
 export function isCacheEnabled(): boolean {
-  return process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED === 'true' && hasEncryptedCacheEnvelope()
+  return getCacheCapabilityStatus().enabled
 }
 
 // ── Test helpers ──

--- a/apps/web/app/lib/sync-timing.ts
+++ b/apps/web/app/lib/sync-timing.ts
@@ -1,0 +1,206 @@
+const GLOBAL_SYNC_TIMING_STARTED_AT = '__silentsuiteSyncTimingStartedAt'
+const LOCAL_STORAGE_SYNC_TIMING = 'silentsuite:syncTiming'
+const CONSOLE_LABEL = '[silentsuite-sync-timing]'
+
+export type SyncTimingPhase =
+  | 'cache-capability'
+  | 'cache-hydrate'
+  | 'cache-hydrate-failed'
+  | 'cache-mirror'
+  | 'cache-mirror-failed'
+  | 'etebase-initialize'
+  | 'load-items'
+  | 'tasks-load'
+  | 'contacts-load'
+  | 'calendar-load'
+  | 'wire-change-handler'
+  | 'wire-status-handler'
+  | 'initial-sync-complete'
+  | 'initial-sync-failed'
+  | 'first-calendar-content-paint'
+
+export type SyncTimingErrorCategory =
+  | 'unknown'
+  | 'network'
+  | 'storage'
+  | 'deserialize'
+  | 'cache'
+  | 'etebase'
+  | 'syncEngine'
+  | 'Error'
+
+export interface SyncTimingFields {
+  [key: string]: unknown
+}
+
+type SafeTimingValue = string | number | boolean | null
+
+type SafeTimingPayload = Record<string, SafeTimingValue>
+
+const VALID_PHASES = new Set<SyncTimingPhase>([
+  'cache-capability',
+  'cache-hydrate',
+  'cache-hydrate-failed',
+  'cache-mirror',
+  'cache-mirror-failed',
+  'etebase-initialize',
+  'load-items',
+  'tasks-load',
+  'contacts-load',
+  'calendar-load',
+  'wire-change-handler',
+  'wire-status-handler',
+  'initial-sync-complete',
+  'initial-sync-failed',
+  'first-calendar-content-paint',
+])
+
+const VALID_STRING_FIELDS: Record<string, Set<string>> = {
+  phase: VALID_PHASES,
+  source: new Set(['cache', 'server', 'provider', 'calendar-page']),
+  status: new Set(['ok', 'failed', 'skipped']),
+  group: new Set(['startup', 'cache', 'server', 'handlers', 'calendar']),
+  type: new Set(['tasks', 'contacts', 'calendar']),
+  view: new Set(['day', 'week', 'month', 'threeDay', 'sevenDay', 'agenda']),
+  errorCategory: new Set(['unknown', 'network', 'storage', 'deserialize', 'cache', 'etebase', 'syncEngine', 'Error']),
+}
+
+const VALID_FIELD_NAMES = new Set([
+  'phase',
+  'elapsedMs',
+  'elapsedSinceSyncStartMs',
+  'source',
+  'status',
+  'group',
+  'type',
+  'view',
+  'errorCategory',
+  'featureFlagEnabled',
+  'encryptedEnvelopeAvailable',
+  'enabled',
+  'cacheEnabled',
+  'hadErrors',
+  'hasEvents',
+  'itemCount',
+  'taskItemCount',
+  'contactItemCount',
+  'calendarItemCount',
+  'taskCount',
+  'contactCount',
+  'eventCount',
+  'visibleEventCount',
+  'totalEventCount',
+  'visibleCalendarCount',
+])
+
+function safeWindow(): Window | null {
+  if (typeof window === 'undefined') return null
+  return window
+}
+
+function readTimingOptIn(): boolean {
+  const win = safeWindow()
+  if (!win) return false
+  try {
+    if (new URLSearchParams(win.location.search).get('syncTiming') === '1') return true
+  } catch {
+    // Best-effort debug gate only.
+  }
+  try {
+    return win.localStorage?.getItem(LOCAL_STORAGE_SYNC_TIMING) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function nowMs(): number {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now()
+  }
+  return Date.now()
+}
+
+export function elapsedMs(startedAt: number, endedAt = nowMs()): number {
+  if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) return 0
+  return Math.max(0, Math.round(endedAt - startedAt))
+}
+
+export function markSyncTimingStart(startedAt = nowMs()): number {
+  ;(globalThis as unknown as Record<string, number>)[GLOBAL_SYNC_TIMING_STARTED_AT] = startedAt
+  return startedAt
+}
+
+export function getSyncTimingStartedAt(): number | null {
+  const value = (globalThis as unknown as Record<string, unknown>)[GLOBAL_SYNC_TIMING_STARTED_AT]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+export function isSyncTimingEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'production') return true
+  return readTimingOptIn()
+}
+
+export function safeTimingErrorCategory(value: unknown): SyncTimingErrorCategory {
+  if (typeof value !== 'string') return 'unknown'
+  if (VALID_STRING_FIELDS.errorCategory.has(value)) return value as SyncTimingErrorCategory
+  return /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/.test(value) ? 'Error' : 'unknown'
+}
+
+export function sanitizeSyncTimingPayload(payload: SyncTimingFields): SafeTimingPayload {
+  const safe: SafeTimingPayload = {}
+  for (const [key, value] of Object.entries(payload)) {
+    if (!VALID_FIELD_NAMES.has(key)) continue
+    if (typeof value === 'boolean' || value === null) {
+      safe[key] = value
+      continue
+    }
+    if (typeof value === 'number') {
+      if (Number.isFinite(value) && value >= 0) safe[key] = Math.round(value)
+      continue
+    }
+    if (typeof value === 'string') {
+      const validValues = VALID_STRING_FIELDS[key]
+      if (key === 'errorCategory') {
+        safe[key] = safeTimingErrorCategory(value)
+      } else if (validValues?.has(value)) {
+        safe[key] = value
+      }
+    }
+  }
+  return safe
+}
+
+function emitTiming(payload: SafeTimingPayload): void {
+  if (!isSyncTimingEnabled()) return
+  try {
+    console.info(CONSOLE_LABEL, JSON.stringify(Object.freeze({ ...payload })))
+  } catch {
+    // Timing diagnostics must never affect app behavior.
+  }
+}
+
+export function logSyncTiming(phase: SyncTimingPhase, startedAt: number, fields: SyncTimingFields = {}): void {
+  try {
+    emitTiming(sanitizeSyncTimingPayload({
+      phase,
+      elapsedMs: elapsedMs(startedAt),
+      ...fields,
+    }))
+  } catch {
+    // Timing diagnostics must never affect app behavior.
+  }
+}
+
+export function logCalendarPaintTiming(fields: SyncTimingFields = {}): void {
+  try {
+    const syncStartedAt = getSyncTimingStartedAt()
+    emitTiming(sanitizeSyncTimingPayload({
+      phase: 'first-calendar-content-paint',
+      elapsedSinceSyncStartMs: syncStartedAt === null ? null : elapsedMs(syncStartedAt),
+      source: 'calendar-page',
+      ...fields,
+    }))
+  } catch {
+    // Timing diagnostics must never affect app behavior.
+  }
+}

--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -1,0 +1,214 @@
+import { render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SyncProvider } from '../sync-provider'
+
+const order: string[] = []
+
+const syncStoreMock = vi.hoisted(() => ({
+  initializeSync: vi.fn(() => {
+    order.push('initializeSync')
+    return vi.fn()
+  }),
+  setSyncStatus: vi.fn((status: string) => order.push(`setSyncStatus:${status}`)),
+  setLastSynced: vi.fn(() => order.push('setLastSynced')),
+  setError: vi.fn((error: string | null) => order.push(`setError:${error ?? 'null'}`)),
+}))
+
+const etebaseMock = vi.hoisted(() => {
+  const state = {
+    initialize: vi.fn(async () => order.push('etebaseInitialize')),
+    fetchAllItems: vi.fn(async (type: 'tasks' | 'contacts' | 'calendar') => {
+      order.push(`fetchAllItems:${type}`)
+      return []
+    }),
+    onSyncChange: vi.fn(() => {
+      order.push('wireChangeHandler')
+      return vi.fn()
+    }),
+    onStatusChange: vi.fn(() => {
+      order.push('wireStatusHandler')
+      return vi.fn()
+    }),
+    isInitialized: false,
+    refreshCollection: vi.fn(),
+  }
+  return { state }
+})
+
+const taskStoreMock = vi.hoisted(() => ({ syncFromRemote: vi.fn(() => order.push('syncTasks')) }))
+const contactStoreMock = vi.hoisted(() => ({ syncFromRemote: vi.fn(() => order.push('syncContacts')) }))
+const calendarStoreMock = vi.hoisted(() => ({ syncFromRemote: vi.fn(() => order.push('syncCalendar')) }))
+
+const cacheMock = vi.hoisted(() => ({
+  getItemsByType: vi.fn(async (type: string) => {
+    order.push(`cacheGet:${type}`)
+    return []
+  }),
+  replaceItemsForType: vi.fn(async (type: string) => order.push(`cacheReplace:${type}`)),
+  isCacheEnabled: vi.fn(() => false),
+  getCacheCapabilityStatus: vi.fn(() => ({
+    featureFlagEnabled: false,
+    encryptedEnvelopeAvailable: false,
+    enabled: false,
+  })),
+}))
+
+const timingMock = vi.hoisted(() => ({
+  logSyncTiming: vi.fn(() => {}),
+  markSyncTimingStart: vi.fn(() => 100),
+  nowMs: vi.fn(() => 100),
+  safeTimingErrorCategory: vi.fn(() => 'unknown'),
+}))
+
+const sentryMock = vi.hoisted(() => ({ captureException: vi.fn() }))
+
+vi.mock('@sentry/nextjs', () => sentryMock)
+
+vi.mock('@/app/lib/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/app/lib/privacy-safe-errors', () => ({
+  createSafeOperationalError: vi.fn((_component: string, operation: string) => new Error(operation)),
+  getSafeErrorDetails: vi.fn(() => ({ name: 'Error' })),
+}))
+
+vi.mock('@/app/lib/data-cache', () => cacheMock)
+vi.mock('@/app/lib/sync-timing', () => timingMock)
+
+vi.mock('@/app/stores/use-sync-store', () => ({
+  useSyncStore: (selector: (state: typeof syncStoreMock) => unknown) => selector(syncStoreMock),
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: Object.assign(
+    (selector: (state: typeof etebaseMock.state) => unknown) => selector(etebaseMock.state),
+    { getState: () => etebaseMock.state },
+  ),
+}))
+
+vi.mock('@/app/stores/use-task-store', () => ({
+  useTaskStore: { getState: () => taskStoreMock },
+}))
+
+vi.mock('@/app/stores/use-contact-store', () => ({
+  useContactStore: { getState: () => contactStoreMock },
+}))
+
+vi.mock('@/app/stores/use-calendar-store', () => ({
+  useCalendarStore: { getState: () => calendarStoreMock },
+}))
+
+vi.mock('@silentsuite/core', () => ({
+  deserializeTask: vi.fn(() => ({ title: 'task' })),
+  deserializeContact: vi.fn(() => ({ name: 'contact' })),
+  deserializeCalendarEvent: vi.fn(() => ({ title: 'event' })),
+}))
+
+function renderProvider() {
+  return render(<SyncProvider><div>child</div></SyncProvider>)
+}
+
+describe('SyncProvider timing instrumentation', () => {
+  beforeEach(() => {
+    order.length = 0
+    vi.clearAllMocks()
+    syncStoreMock.initializeSync.mockImplementation(() => {
+      order.push('initializeSync')
+      return vi.fn()
+    })
+    syncStoreMock.setSyncStatus.mockImplementation((status: string) => order.push(`setSyncStatus:${status}`))
+    syncStoreMock.setLastSynced.mockImplementation(() => order.push('setLastSynced'))
+    syncStoreMock.setError.mockImplementation((error: string | null) => order.push(`setError:${error ?? 'null'}`))
+    etebaseMock.state.initialize.mockImplementation(async () => order.push('etebaseInitialize'))
+    etebaseMock.state.fetchAllItems.mockImplementation(async (type: 'tasks' | 'contacts' | 'calendar') => {
+      order.push(`fetchAllItems:${type}`)
+      return []
+    })
+    etebaseMock.state.onSyncChange.mockImplementation(() => {
+      order.push('wireChangeHandler')
+      return vi.fn()
+    })
+    etebaseMock.state.onStatusChange.mockImplementation(() => {
+      order.push('wireStatusHandler')
+      return vi.fn()
+    })
+    cacheMock.isCacheEnabled.mockReturnValue(false)
+    cacheMock.getItemsByType.mockImplementation(async (type: string) => {
+      order.push(`cacheGet:${type}`)
+      return []
+    })
+    timingMock.logSyncTiming.mockImplementation(() => {})
+    timingMock.markSyncTimingStart.mockReturnValue(100)
+    timingMock.nowMs.mockReturnValue(100)
+  })
+
+  it('preserves the existing startup order while recording timings', async () => {
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+
+    expect(order).toEqual([
+      'initializeSync',
+      'setSyncStatus:syncing',
+      'etebaseInitialize',
+      'fetchAllItems:tasks',
+      'fetchAllItems:contacts',
+      'fetchAllItems:calendar',
+      'wireChangeHandler',
+      'wireStatusHandler',
+      'setSyncStatus:synced',
+      'setLastSynced',
+    ])
+    expect(timingMock.logSyncTiming).toHaveBeenCalledWith('cache-capability', 100, expect.any(Object))
+    expect(timingMock.logSyncTiming).toHaveBeenCalledWith('initial-sync-complete', 100, {})
+  })
+
+  it('hydrates cache only when cache is enabled and still continues startup', async () => {
+    cacheMock.isCacheEnabled.mockReturnValue(true)
+
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    expect(order.slice(0, 6)).toEqual([
+      'initializeSync',
+      'setSyncStatus:syncing',
+      'cacheGet:tasks',
+      'cacheGet:contacts',
+      'cacheGet:calendar',
+      'etebaseInitialize',
+    ])
+  })
+
+  it('does not let timing helper failures change sync status flow', async () => {
+    timingMock.logSyncTiming.mockImplementation(() => {
+      throw new Error('timing broke')
+    })
+
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    expect(syncStoreMock.setSyncStatus).toHaveBeenCalledWith('synced')
+    expect(syncStoreMock.setError).not.toHaveBeenCalledWith('Sync initialization failed')
+  })
+
+  it('keeps domain load errors non-fatal and completes initialization', async () => {
+    etebaseMock.state.fetchAllItems.mockImplementation(async (type: 'tasks' | 'contacts' | 'calendar') => {
+      order.push(`fetchAllItems:${type}`)
+      if (type === 'contacts') throw new Error('contact load failed')
+      return []
+    })
+
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    expect(syncStoreMock.setSyncStatus).toHaveBeenCalledWith('synced')
+    expect(sentryMock.captureException).toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -12,12 +12,21 @@ import {
   getItemsByType as cacheGetItemsByType,
   replaceItemsForType as cacheReplaceItemsForType,
   isCacheEnabled as isLocalCacheEnabled,
+  getCacheCapabilityStatus,
   type CachedItem,
 } from '@/app/lib/data-cache'
 import {
   createSafeOperationalError,
   getSafeErrorDetails,
 } from '@/app/lib/privacy-safe-errors'
+import {
+  logSyncTiming,
+  markSyncTimingStart,
+  nowMs,
+  safeTimingErrorCategory,
+  type SyncTimingPhase,
+  type SyncTimingFields,
+} from '@/app/lib/sync-timing'
 
 function reportSyncError(operation: string, err: unknown) {
   Sentry.captureException(createSafeOperationalError('sync-provider', operation), {
@@ -25,6 +34,14 @@ function reportSyncError(operation: string, err: unknown) {
     extra: getSafeErrorDetails(err),
   })
   logger.error(`[sync-provider] ${operation} failed`, getSafeErrorDetails(err))
+}
+
+function safeLogSyncTiming(phase: SyncTimingPhase, startedAt: number, fields: SyncTimingFields = {}) {
+  try {
+    logSyncTiming(phase, startedAt, fields)
+  } catch {
+    // Instrumentation must never affect sync behavior.
+  }
 }
 
 /**
@@ -64,31 +81,44 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     let unsubStatus: (() => void) | null = null
 
     async function init() {
+      const initStartedAt = markSyncTimingStart()
       try {
         setSyncStatus('syncing')
+        safeLogSyncTiming('cache-capability', initStartedAt, { ...getCacheCapabilityStatus() })
 
         // Cache-first hydration: when the feature flag is on, paint the UI
         // from IndexedDB before the network sync starts. This is best-effort
         // — failures are logged and the normal init path proceeds.
         if (isLocalCacheEnabled()) {
-          await hydrateFromCache()
+          const cacheStartedAt = nowMs()
+          await hydrateFromCache(cacheStartedAt)
         }
 
         // Restore session, create/fetch collections, load items, start SyncEngine
+        const etebaseStartedAt = nowMs()
         await etebaseInitialize()
+        safeLogSyncTiming('etebase-initialize', etebaseStartedAt)
 
         // Now load items from each collection into the data stores
+        const loadStartedAt = nowMs()
         await loadItemsIntoStores()
+        safeLogSyncTiming('load-items', loadStartedAt)
 
         // Wire SyncEngine change events
+        const changeHandlerStartedAt = nowMs()
         unsubChange = wireChangeHandler()
+        safeLogSyncTiming('wire-change-handler', changeHandlerStartedAt, { status: unsubChange ? 'ok' : 'skipped' })
 
         // Wire SyncEngine status
+        const statusHandlerStartedAt = nowMs()
         unsubStatus = wireStatusHandler()
+        safeLogSyncTiming('wire-status-handler', statusHandlerStartedAt, { status: unsubStatus ? 'ok' : 'skipped' })
 
         setSyncStatus('synced')
         setLastSynced(new Date())
+        safeLogSyncTiming('initial-sync-complete', initStartedAt)
       } catch (err) {
+        safeLogSyncTiming('initial-sync-failed', initStartedAt, { errorCategory: safeTimingErrorCategory('unknown') })
         reportSyncError('init', err)
         setSyncStatus('error')
         setError('Sync initialization failed')
@@ -105,7 +135,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
      * Cheap (~10-50ms for a typical vault) and fully off the network path.
      * Failures here are non-fatal; we just skip the optimistic paint.
      */
-    async function hydrateFromCache() {
+    async function hydrateFromCache(startedAt = nowMs()) {
       try {
         const [taskItems, contactItems, eventItems, core] = await Promise.all([
           cacheGetItemsByType('tasks'),
@@ -152,8 +182,15 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             logger.warn('[sync-provider] Failed to hydrate calendar events from cache', getSafeErrorDetails(err))
           }
         }
+        safeLogSyncTiming('cache-hydrate', startedAt, {
+          status: 'ok',
+          taskItemCount: taskItems.length,
+          contactItemCount: contactItems.length,
+          calendarItemCount: eventItems.length,
+        })
       } catch (err) {
         logger.warn('[sync-provider] Cache hydration failed', getSafeErrorDetails(err))
+        safeLogSyncTiming('cache-hydrate-failed', startedAt, { status: 'failed', errorCategory: 'cache' })
       }
     }
 
@@ -166,6 +203,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         items: { uid: string; content: string; collectionUid: string }[],
       ) {
         if (!cacheEnabled || items.length === 0) return
+        const startedAt = nowMs()
         const records: CachedItem[] = items.map((it) => ({
           itemUid: it.uid,
           collectionType: type,
@@ -175,14 +213,18 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         }))
         try {
           await cacheReplaceItemsForType(type, records)
+          safeLogSyncTiming('cache-mirror', startedAt, { type, itemCount: items.length })
         } catch (err) {
           logger.warn(`[sync-provider] Failed to mirror ${type} to cache`, getSafeErrorDetails(err))
+          safeLogSyncTiming('cache-mirror-failed', startedAt, { type, itemCount: items.length, errorCategory: 'cache' })
         }
       }
 
       // Load tasks
+      const taskStartedAt = nowMs()
       try {
         const taskItems = await etebase.fetchAllItems('tasks')
+        let taskCount = 0
         if (taskItems.length > 0) {
           const { deserializeTask } = await import('@silentsuite/core')
           const tasks = taskItems.map((item) => {
@@ -191,45 +233,73 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             // can address the item without changing the stable iCalendar UID.
             return { ...task, id: item.uid, listId: item.collectionUid }
           })
+          taskCount = tasks.length
           useTaskStore.getState().syncFromRemote(tasks)
           logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
           await mirrorToCache('tasks', taskItems)
         }
+        safeLogSyncTiming('tasks-load', taskStartedAt, {
+          source: 'server',
+          cacheEnabled,
+          itemCount: taskItems.length,
+          taskCount,
+        })
       } catch (err) {
+        safeLogSyncTiming('tasks-load', taskStartedAt, { source: 'server', status: 'failed', errorCategory: 'deserialize' })
         reportSyncError('load tasks', err)
       }
 
       // Load contacts
+      const contactStartedAt = nowMs()
       try {
         const contactItems = await etebase.fetchAllItems('contacts')
+        let contactCount = 0
         if (contactItems.length > 0) {
           const { deserializeContact } = await import('@silentsuite/core')
           const contacts = contactItems.map((item) => {
             const contact = deserializeContact(item.content)
             return { ...contact, id: item.uid, listId: item.collectionUid }
           })
+          contactCount = contacts.length
           useContactStore.getState().syncFromRemote(contacts)
           logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
           await mirrorToCache('contacts', contactItems)
         }
+        safeLogSyncTiming('contacts-load', contactStartedAt, {
+          source: 'server',
+          cacheEnabled,
+          itemCount: contactItems.length,
+          contactCount,
+        })
       } catch (err) {
+        safeLogSyncTiming('contacts-load', contactStartedAt, { source: 'server', status: 'failed', errorCategory: 'deserialize' })
         reportSyncError('load contacts', err)
       }
 
       // Load calendar events
+      const calendarStartedAt = nowMs()
       try {
         const eventItems = await etebase.fetchAllItems('calendar')
+        let eventCount = 0
         if (eventItems.length > 0) {
           const { deserializeCalendarEvent } = await import('@silentsuite/core')
           const events = eventItems.map((item) => {
             const event = deserializeCalendarEvent(item.content)
             return { ...event, id: item.uid, calendarId: item.collectionUid }
           })
+          eventCount = events.length
           useCalendarStore.getState().syncFromRemote(events)
           logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
           await mirrorToCache('calendar', eventItems)
         }
+        safeLogSyncTiming('calendar-load', calendarStartedAt, {
+          source: 'server',
+          cacheEnabled,
+          itemCount: eventItems.length,
+          eventCount,
+        })
       } catch (err) {
+        safeLogSyncTiming('calendar-load', calendarStartedAt, { source: 'server', status: 'failed', errorCategory: 'deserialize' })
         reportSyncError('load calendar events', err)
       }
 

--- a/docs/contributing/authenticated-restore-smoke.md
+++ b/docs/contributing/authenticated-restore-smoke.md
@@ -40,6 +40,14 @@ Production smoke is mutation-free only when the account is already initialized. 
    https://previewapp.silentsuite.io/calendar?syncDebug=1
    ```
 
+   If the change also needs privacy-safe startup timing evidence, explicitly opt in for that run:
+
+   ```text
+   https://previewapp.silentsuite.io/calendar?syncDebug=1&syncTiming=1
+   ```
+
+   Timing output is console-only and explicit-opt-in only outside local development. Do not enable it for general preview browsing.
+
 3. Sign in only if no valid session exists.
 4. Hard reload once after login so the saved encrypted-session restore path runs.
 5. Wait until the app reaches a steady state and the sync indicator is not actively syncing.
@@ -87,6 +95,14 @@ Production smoke has the same steps as preview, but with stricter gates:
 7. Share only the redacted report.
 
 `?syncDebug=1` is an intentional user/operator opt-in for this slice. It may expose redacted self-account metadata such as phase timings, counts, hostnames, and safe error categories. It must never expose secrets, raw identifiers, plaintext PIM, raw errors, or unknown stored fields.
+
+## Optional sync timing capture
+
+For changes that instrument startup timing, add `syncTiming=1` to the smoke URL for that single run or set `localStorage.setItem('silentsuite:syncTiming', 'true')` before reload. Timing is not auto-enabled on preview or production.
+
+Capture only console lines beginning with `[silentsuite-sync-timing]`. Before sharing timing evidence, confirm it contains only phase names, durations, counts, booleans, status/source labels, and safe error categories. Do not share credentials, cookies, tokens, session blobs, item IDs, collection IDs, stokens, raw browser storage, raw errors, plaintext PIM, or full URLs with paths/query strings.
+
+Timing evidence is optional context. It does not replace the restore smoke helper report.
 
 ## Expected redacted diagnostics
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -68,6 +68,8 @@ Validate the report helper with:
 node scripts/restore-smoke-report.mjs --self-test
 ```
 
+For timing instrumentation changes, collect optional console timing only with explicit opt-in (`?syncTiming=1` or `localStorage.setItem('silentsuite:syncTiming', 'true')` before reload). Preview and production must not emit timing automatically. Share only `[silentsuite-sync-timing]` lines after confirming they contain no credentials, cookies, session blobs, item IDs, collection IDs, stokens, raw errors, plaintext PIM, or full private URLs.
+
 ## Before Submitting a PR
 
 Make sure all checks pass:


### PR DESCRIPTION
## Summary
- Add privacy-safe, allowlisted sync timing instrumentation for startup/cache/domain-load phases.
- Add explicit opt-in timing output via `?syncTiming=1` or `localStorage.setItem('silentsuite:syncTiming', 'true')`; preview/production do not emit timing automatically.
- Add page-level first calendar content paint timing and docs for optional timing capture during restore smoke.

## Privacy and behavior guardrails
- Console output only, no timing payloads written to browser storage.
- Sanitizer drops unknown fields, raw errors, URLs, item IDs, collection IDs, stokens, tokens, session blobs, and plaintext PIM.
- `SyncProvider` timing logging is best-effort and wrapped so logging failures do not affect sync flow.
- Cache capability helper is synchronous and side-effect-free.

## Verification
- `pnpm run test` passed
  - web: 43 files, 436 tests
  - core: 13 files, 294 tests
- `pnpm run lint` passed
- `pnpm run build` passed
- `git diff --check` passed

## Follow-up after merge
- Wait for preview deploy.
- Run authenticated restore smoke against preview with `?syncDebug=1&syncTiming=1` using an approved internal already-initialized account.
- Share only the redacted restore report and `[silentsuite-sync-timing]` lines after privacy review.
