### PR TITLE
Respect forget-on-close hosted web sessions

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -24,6 +24,7 @@ export default function LoginPage() {
   const searchParams = useSearchParams()
   const { login, isLoading, error, clearError, isAuthenticated } = useAuthStore()
   const [serverUrl, setServerUrl] = useState('')
+  const [rememberDevice, setRememberDevice] = useState(false)
 
   const {
     register,
@@ -48,13 +49,14 @@ export default function LoginPage() {
   }, [clearError])
 
   const onSubmit = async (data: LoginFormData) => {
-    const normalizedUrl = serverUrl.trim() ? normalizeServerUrl(serverUrl) : undefined
+    const useHostedBilling = !serverUrl.trim()
+    const normalizedUrl = useHostedBilling ? undefined : normalizeServerUrl(serverUrl)
     if (normalizedUrl) {
       localStorage.setItem('silentsuite-server-url', normalizedUrl)
     } else {
       localStorage.removeItem('silentsuite-server-url')
     }
-    await login(data.email, data.password, normalizedUrl)
+    await login(data.email, data.password, normalizedUrl, useHostedBilling && rememberDevice)
   }
 
   return (
@@ -113,6 +115,23 @@ export default function LoginPage() {
             <p id="password-error" role="alert" className="text-xs text-red-400">{errors.password.message}</p>
           )}
         </div>
+
+        {!serverUrl.trim() && (
+          <label className="flex cursor-pointer items-start gap-2.5 rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))]/40 p-3 text-sm text-[rgb(var(--foreground))]/80">
+            <input
+              type="checkbox"
+              checked={rememberDevice}
+              onChange={(e) => setRememberDevice(e.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border-[rgb(var(--border))] bg-[rgb(var(--surface))] text-[rgb(var(--primary))] focus:ring-[rgb(var(--primary))] focus:ring-offset-0"
+            />
+            <span>
+              <span className="block font-medium">Keep me signed in on this device</span>
+              <span className="block text-xs text-[rgb(var(--muted))]">
+                Leave unchecked to let your browser forget this session when all windows are closed.
+              </span>
+            </span>
+          </label>
+        )}
 
         <Button type="submit" disabled={isLoading} className="w-full">
           {isLoading ? 'Logging in...' : 'Log in'}

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -212,6 +212,8 @@ function StepCreateAccount({
   initialData,
   wantsProductUpdates,
   onWantsProductUpdatesChange,
+  rememberDevice,
+  onRememberDeviceChange,
 }: {
   onNext: (data: SignupFormData) => Promise<void>
   serverUrl: string
@@ -219,6 +221,8 @@ function StepCreateAccount({
   initialData?: SignupFormData | null
   wantsProductUpdates: boolean
   onWantsProductUpdatesChange: (value: boolean) => void
+  rememberDevice: boolean
+  onRememberDeviceChange: (value: boolean) => void
 }) {
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -366,6 +370,21 @@ function StepCreateAccount({
             <span className="text-[rgb(var(--muted))]/70">We will never share your email. Unsubscribe anytime.</span>
           </span>
         </label>
+
+        {!serverUrl.trim() && (
+          <label className="flex items-start gap-2.5 cursor-pointer rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))]/40 p-3">
+            <input
+              type="checkbox"
+              checked={rememberDevice}
+              onChange={(e) => onRememberDeviceChange(e.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border-[rgb(var(--border))] bg-[rgb(var(--surface))] text-[rgb(var(--primary))] focus:ring-[rgb(var(--primary))] focus:ring-offset-0"
+            />
+            <span className="text-xs text-[rgb(var(--muted))] leading-relaxed">
+              <span className="block font-medium text-[rgb(var(--foreground))]/80">Keep me signed in on this device</span>
+              Leave unchecked to let your browser forget this session when all windows are closed.
+            </span>
+          </label>
+        )}
 
         {/* Advanced Settings */}
         <details className="group">
@@ -1332,6 +1351,7 @@ export default function SignupPage() {
   const [usingSelfHostedServer, setUsingSelfHostedServer] = useState(false)
   const [planView, setPlanView] = useState<PlanView>('cards')
   const [wantsProductUpdates, setWantsProductUpdates] = useState(false)
+  const [rememberDevice, setRememberDevice] = useState(false)
   const [returnTo, setReturnTo] = useState<string | null>(null)
   const [showReturnFallback, setShowReturnFallback] = useState(false)
   const formDataRef = useRef<SignupFormData | null>(null)
@@ -1367,14 +1387,14 @@ export default function SignupPage() {
       return
     }
 
-    prepareSignupDraft(identifier, wantsProductUpdates)
+    prepareSignupDraft(identifier, wantsProductUpdates, rememberDevice)
     setClientSecret(null)
     setCryptoPaymentSession(null)
     setProvisionError(null)
     setPlanView('cards')
     setUsingSelfHostedServer(false)
     setStep('plan')
-  }, [createEtebaseAccount, prepareSignupDraft, serverUrl, wantsProductUpdates])
+  }, [createEtebaseAccount, prepareSignupDraft, rememberDevice, serverUrl, wantsProductUpdates])
 
   const handleSelfHostChoice = useCallback(async (choice: 'free' | 'support') => {
     if (choice === 'support') {
@@ -1552,6 +1572,8 @@ export default function SignupPage() {
             initialData={formDataRef.current}
             wantsProductUpdates={wantsProductUpdates}
             onWantsProductUpdatesChange={setWantsProductUpdates}
+            rememberDevice={rememberDevice}
+            onRememberDeviceChange={setRememberDevice}
           />
         )}
         {step === 'selfhost' && (

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useAuthStore } from '../use-auth-store'
+import { secureClear } from '@/app/lib/secure-storage'
 
 // Mock fetch globally
 vi.stubGlobal('fetch', vi.fn())
@@ -66,6 +67,9 @@ describe('useAuthStore', () => {
     vi.mocked(fetch).mockReset()
     dataCacheClearAll.mockClear()
     offlineQueueClearAll.mockClear()
+    vi.mocked(secureClear).mockClear()
+    vi.mocked(secureClear).mockImplementation(async () => { secureStore = {} })
+    vi.stubGlobal('BroadcastChannel', undefined)
     secureStore = {}
     localStorage.clear()
     sessionStorage.clear()
@@ -114,6 +118,7 @@ describe('useAuthStore', () => {
           trialPath: '30day',
           promoCode: 'beta196',
           wantsProductUpdates: true,
+          rememberDevice: false,
         }),
       }),
     )
@@ -139,6 +144,7 @@ describe('useAuthStore', () => {
       etebaseSessionToken: 'etebase-token',
       planId: 'early_monthly',
       trialPath: '30day',
+      rememberDevice: false,
     })
   })
 
@@ -173,6 +179,7 @@ describe('useAuthStore', () => {
           trialPath: '30day',
           promoCode: 'BETA196',
           wantsProductUpdates: false,
+          rememberDevice: false,
         }),
       }),
     )
@@ -195,6 +202,7 @@ describe('useAuthStore', () => {
     expect(useAuthStore.getState().pendingSignup).toEqual({
       email: 'new@example.com',
       wantsProductUpdates: true,
+      rememberDevice: false,
     })
   })
 
@@ -323,6 +331,17 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
     })
 
+
+    it('login clears unvalidated local auth material when token exchange is rate limited', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 429 } as Response)
+
+      await useAuthStore.getState().login('a@b.com', 'pw')
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(false)
+      expect(secureStore['etebase_session']).toBeUndefined()
+      expect(localStorage.getItem('silentsuite-hosted-validation-initialized')).toBeNull()
+    })
+
     it('refreshSession hydrates onboardedAt', async () => {
       vi.mocked(fetch).mockResolvedValueOnce({
         ok: true,
@@ -331,6 +350,7 @@ describe('useAuthStore', () => {
           email: 'x@y.com',
           planId: 'free',
           isAdmin: false,
+          rememberDevice: true,
           onboardedAt: '2024-12-01T00:00:00.000Z',
         }),
       } as Response)
@@ -348,6 +368,7 @@ describe('useAuthStore', () => {
           email: 'x@y.com',
           planId: 'free',
           isAdmin: false,
+          rememberDevice: true,
           onboardedAt: null,
         }),
       } as Response)
@@ -355,6 +376,135 @@ describe('useAuthStore', () => {
       await useAuthStore.getState().restoreSession()
 
       expect(useAuthStore.getState().user!.onboardedAt).toBeNull()
+    })
+
+    it('restoreSession rejects restored session-cookie refresh when the session marker is missing', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'u1', email: 'x@y.com', planId: 'free', isAdmin: false, rememberDevice: false }),
+        } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 204 } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(false)
+      expect(state.user).toBeNull()
+      expect(secureStore['etebase_session']).toBeUndefined()
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('/auth/session'),
+        expect.objectContaining({ method: 'DELETE', credentials: 'include' }),
+      )
+    })
+
+
+    it('restoreSession accepts a session-cookie refresh when the session marker matches', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      sessionStorage.setItem('silentsuite-hosted-validation-session', JSON.stringify({ userId: 'u1', rememberDevice: false, validatedAt: Date.now() }))
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'u1', email: 'x@y.com', planId: 'free', isAdmin: false, rememberDevice: false }),
+      } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      expect(useAuthStore.getState().user).toMatchObject({ id: 'u1', rememberDevice: false })
+      expect(fetch).toHaveBeenCalledTimes(1)
+    })
+
+
+    it('restoreSession clears local auth material on unexpected invalid refresh responses', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      sessionStorage.setItem('silentsuite-hosted-validation-session', JSON.stringify({ userId: 'u1', rememberDevice: false, validatedAt: Date.now() }))
+      localStorage.setItem('silentsuite-hosted-validation-initialized', 'true')
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 400 } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(false)
+      expect(state.user).toBeNull()
+      expect(secureStore['etebase_session']).toBeUndefined()
+      expect(sessionStorage.getItem('silentsuite-hosted-validation-session')).toBeNull()
+      expect(localStorage.getItem('silentsuite-hosted-validation-initialized')).toBeNull()
+    })
+
+
+    it('restoreSession skips online refresh when local auth is tombstoned', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      localStorage.setItem('silentsuite-hosted-auth-invalidated', String(Date.now()))
+
+      await useAuthStore.getState().restoreSession()
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(false)
+      expect(fetch).not.toHaveBeenCalled()
+    })
+
+    it('restoreSession clears unmarked local auth material when restore is rate limited', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 429 } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(false)
+      expect(useAuthStore.getState().subscriptionStatus).toBeNull()
+      expect(secureStore['etebase_session']).toBeUndefined()
+    })
+
+    it('clearLocalAuthMaterial clears hosted markers even if secure storage clear fails', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      localStorage.setItem('silentsuite-hosted-validation-initialized', 'true')
+      vi.mocked(secureClear).mockRejectedValueOnce(new Error('idb clear failed'))
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'u1', email: 'x@y.com', planId: 'free', isAdmin: false, rememberDevice: false }),
+        } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 204 } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      expect(sessionStorage.getItem('silentsuite-hosted-validation-session')).toBeNull()
+      expect(localStorage.getItem('silentsuite-hosted-validation-initialized')).toBeNull()
+      expect(localStorage.getItem('silentsuite-hosted-validation-active-tabs')).toBeNull()
+      expect(localStorage.getItem('silentsuite-hosted-auth-invalidated')).toBeTruthy()
+      expect(vi.mocked(secureClear)).toHaveBeenCalled()
+
+      resetStore()
+      vi.mocked(fetch).mockReset()
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      await useAuthStore.getState().restoreSession()
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(false)
+      expect(useAuthStore.getState().subscriptionStatus).not.toBe('billing_unavailable')
+    })
+
+
+    it('restoreSession accepts a session-cookie refresh in a new tab when another active tab is present', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      sessionStorage.setItem('silentsuite-hosted-tab-id', 'tab-current')
+      localStorage.setItem('silentsuite-hosted-validation-active-tabs', JSON.stringify({
+        'tab-existing': { userId: 'u1', validatedAt: Date.now() },
+      }))
+      vi.mocked(fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'u1', email: 'x@y.com', planId: 'free', isAdmin: false, rememberDevice: false }),
+      } as Response)
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(true)
+      expect(state.user).toMatchObject({ id: 'u1', rememberDevice: false })
+      expect(secureStore['etebase_session']).toBe('fake-session-data')
+      expect(fetch).toHaveBeenCalledTimes(1)
     })
 
     it('completeSignup sets onboardedAt to null for fresh accounts', () => {
@@ -639,8 +789,9 @@ describe('useAuthStore', () => {
       expect(useAuthStore.getState().isDegraded()).toBe(false)
     })
 
-    it('restoreSession enters degraded mode on network error with etebase session', async () => {
+    it('restoreSession enters degraded mode on network error with etebase session and validation marker', async () => {
       secureStore['etebase_session'] = 'fake-session-data'
+      sessionStorage.setItem('silentsuite-hosted-validation-session', JSON.stringify({ userId: 'user-1', rememberDevice: false, validatedAt: Date.now() }))
       vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
 
       await useAuthStore.getState().restoreSession()
@@ -650,8 +801,54 @@ describe('useAuthStore', () => {
       expect(state.subscriptionStatus).toBe('billing_unavailable')
       // Degraded users keep a non-null legacy onboardedAt timestamp for
       // backward compatibility with existing account metadata expectations.
-      expect(state.user).toMatchObject({ id: 'degraded', email: '', planId: 'unknown', isAdmin: false })
+      expect(state.user).toMatchObject({ id: 'user-1', email: '', planId: 'unknown', isAdmin: false })
       expect(state.user!.onboardedAt).toEqual(expect.any(String))
+    })
+
+
+    it('restoreSession does not trust unmarked legacy local sessions on first offline load', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(false)
+      expect(state.user).toBeNull()
+      expect(state.subscriptionStatus).toBeNull()
+      expect(secureStore['etebase_session']).toBeUndefined()
+    })
+
+    it('restoreSession preserves local data in an offline new tab while another session tab is active', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      sessionStorage.setItem('silentsuite-hosted-tab-id', 'tab-current')
+      localStorage.setItem('silentsuite-hosted-validation-initialized', 'true')
+      localStorage.setItem('silentsuite-hosted-validation-active-tabs', JSON.stringify({
+        'tab-existing': { userId: 'u1', validatedAt: Date.now() },
+      }))
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(true)
+      expect(state.subscriptionStatus).toBe('billing_unavailable')
+      expect(state.user).toMatchObject({ id: 'u1', rememberDevice: false })
+      expect(secureStore['etebase_session']).toBe('fake-session-data')
+    })
+
+    it('restoreSession clears stale local auth after validation has initialized and no marker is present', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      localStorage.setItem('silentsuite-hosted-validation-initialized', 'true')
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+      await useAuthStore.getState().restoreSession()
+
+      const state = useAuthStore.getState()
+      expect(state.isAuthenticated).toBe(false)
+      expect(state.user).toBeNull()
+      expect(state.subscriptionStatus).not.toBe('billing_unavailable')
+      expect(secureStore['etebase_session']).toBeUndefined()
     })
 
     it('restoreSession does not enter degraded mode on network error without etebase session', async () => {
@@ -700,7 +897,7 @@ describe('useAuthStore', () => {
       vi.mocked(fetch)
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ id: 'u1', email: 'test@x.com', planId: 'pro', isAdmin: false }),
+          json: async () => ({ id: 'u1', email: 'test@x.com', planId: 'pro', isAdmin: false, rememberDevice: true }),
         } as Response)
         .mockResolvedValueOnce({
           ok: true,
@@ -712,6 +909,55 @@ describe('useAuthStore', () => {
       expect(result).toBe(true)
       expect(useAuthStore.getState().subscriptionStatus).toBe('active')
       expect(useAuthStore.getState().isDegraded()).toBe(false)
+    })
+
+
+    it('retryBillingConnection rejects non-remembered refresh when the session marker is missing', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      useAuthStore.setState({ subscriptionStatus: 'billing_unavailable', isAuthenticated: true })
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ id: 'u1', email: 'test@x.com', planId: 'pro', isAdmin: false, rememberDevice: false }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ status: 'active' }),
+        } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 204 } as Response)
+
+      const result = await useAuthStore.getState().retryBillingConnection()
+
+      expect(result).toBe(false)
+      expect(useAuthStore.getState().isAuthenticated).toBe(false)
+      expect(secureStore['etebase_session']).toBeUndefined()
+      expect(fetch).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('/auth/session'),
+        expect.objectContaining({ method: 'DELETE', credentials: 'include' }),
+      )
+    })
+
+
+    it('retryBillingConnection clears local auth on explicit refresh auth failure', async () => {
+      secureStore['etebase_session'] = 'fake-session-data'
+      useAuthStore.setState({ subscriptionStatus: 'billing_unavailable', isAuthenticated: true })
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({ ok: false, status: 401 } as Response)
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ status: 'active' }) } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 204 } as Response)
+
+      const result = await useAuthStore.getState().retryBillingConnection()
+
+      expect(result).toBe(false)
+      expect(useAuthStore.getState().isAuthenticated).toBe(false)
+      expect(secureStore['etebase_session']).toBeUndefined()
+      expect(localStorage.getItem('silentsuite-hosted-auth-invalidated')).toBeTruthy()
+      expect(fetch).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('/auth/session'),
+        expect.objectContaining({ method: 'DELETE', credentials: 'include' }),
+      )
     })
 
     it('retryBillingConnection returns false on continued network failure', async () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -17,6 +17,7 @@ export interface User {
   email: string
   planId: string
   emailVerified?: boolean
+  rememberDevice?: boolean
   /**
    * Legacy account metadata from the old first-run onboarding flow. The web app
    * no longer shows an onboarding window at startup, but we still hydrate the
@@ -31,6 +32,7 @@ interface PendingSignup {
   paymentSessionToken?: string
   earlyAdopter?: boolean
   wantsProductUpdates?: boolean
+  rememberDevice?: boolean
   /** Provisioned user data — stored here until the entire signup flow completes. */
   provisionedUser?: {
     id: string
@@ -66,13 +68,13 @@ interface AuthState {
   isDegraded: () => boolean
   isReadOnly: () => boolean
   canWrite: () => boolean
-  prepareSignupDraft: (email: string, wantsProductUpdates?: boolean) => void
+  prepareSignupDraft: (email: string, wantsProductUpdates?: boolean, rememberDevice?: boolean) => void
   createEtebaseAccount: (email: string, password: string, serverUrl?: string) => Promise<void>
   signup: (planId: string, trialPath: string, promoCode?: string) => Promise<SignupResult>
   finalizePaidSignup: () => Promise<SignupResult>
   /** Call after the entire signup flow (including payment + vault) to finalize authentication. */
   completeSignup: () => void
-  login: (email: string, password: string, serverUrl?: string) => Promise<void>
+  login: (email: string, password: string, serverUrl?: string, rememberDevice?: boolean) => Promise<void>
   logout: () => Promise<void>
   refreshSession: () => Promise<boolean>
   restoreSession: () => Promise<void>
@@ -103,19 +105,292 @@ interface AuthState {
 }
 
 
+const HOSTED_VALIDATION_SESSION_KEY = 'silentsuite-hosted-validation-session'
+const HOSTED_VALIDATION_REMEMBERED_KEY = 'silentsuite-hosted-validation-remembered'
+const HOSTED_REMEMBERED_MARKER_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const HOSTED_ACTIVE_TABS_KEY = 'silentsuite-hosted-validation-active-tabs'
+const HOSTED_TAB_ID_KEY = 'silentsuite-hosted-tab-id'
+const HOSTED_VALIDATION_INITIALIZED_KEY = 'silentsuite-hosted-validation-initialized'
+const HOSTED_AUTH_INVALIDATED_KEY = 'silentsuite-hosted-auth-invalidated'
+const HOSTED_ACTIVE_TAB_TTL_MS = 15_000
+const HOSTED_ACTIVE_TAB_HEARTBEAT_MS = 5_000
+const HOSTED_ACTIVE_TAB_BROADCAST = 'silentsuite-hosted-session-tabs'
+const HOSTED_ACTIVE_TAB_PING_TIMEOUT_MS = 1000
+
+let hostedActiveTabHeartbeat: number | null = null
+let hostedActiveTabUnloadHooked = false
+
+interface HostedValidationMarker {
+  userId: string
+  rememberDevice: boolean
+  validatedAt: number
+}
+
+interface HostedActiveTabMarker {
+  userId: string
+  validatedAt: number
+}
+
+function getHostedTabId(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    let tabId = sessionStorage.getItem(HOSTED_TAB_ID_KEY)
+    if (!tabId) {
+      tabId = `tab-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      sessionStorage.setItem(HOSTED_TAB_ID_KEY, tabId)
+    }
+    return tabId
+  } catch {
+    return null
+  }
+}
+
+function readHostedActiveTabs(): Record<string, HostedActiveTabMarker> {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(HOSTED_ACTIVE_TABS_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as Record<string, HostedActiveTabMarker>
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeHostedActiveTabs(tabs: Record<string, HostedActiveTabMarker>) {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(HOSTED_ACTIVE_TABS_KEY, JSON.stringify(tabs))
+  } catch (err) {
+    logger.warn('[auth-store] Failed to write hosted active-tab marker:', err)
+  }
+}
+
+function pruneHostedActiveTabs(now = Date.now()): Record<string, HostedActiveTabMarker> {
+  const tabs = readHostedActiveTabs()
+  let changed = false
+  for (const [tabId, marker] of Object.entries(tabs)) {
+    if (!marker?.userId || now - marker.validatedAt > HOSTED_ACTIVE_TAB_TTL_MS) {
+      delete tabs[tabId]
+      changed = true
+    }
+  }
+  if (changed) writeHostedActiveTabs(tabs)
+  return tabs
+}
+
+function markHostedActiveTab(userId: string) {
+  const tabId = getHostedTabId()
+  if (!tabId || !userId) return
+  const tabs = pruneHostedActiveTabs()
+  tabs[tabId] = { userId, validatedAt: Date.now() }
+  writeHostedActiveTabs(tabs)
+}
+
+function readOtherActiveHostedSessionTab(userId?: string): HostedActiveTabMarker | null {
+  const tabId = getHostedTabId()
+  if (!tabId) return null
+  const tabs = pruneHostedActiveTabs()
+  const match = Object.entries(tabs).find(([id, marker]) => {
+    return id !== tabId && (!userId || marker.userId === userId)
+  })
+  return match?.[1] ?? null
+}
+
+function hasOtherActiveHostedSessionTab(userId: string): boolean {
+  return !!readOtherActiveHostedSessionTab(userId)
+}
+
+async function hasLiveOtherHostedSessionTab(userId: string): Promise<boolean> {
+  if (typeof window === 'undefined') return false
+  if (typeof window.BroadcastChannel !== 'function') return hasOtherActiveHostedSessionTab(userId)
+
+  try {
+    return await new Promise<boolean>((resolve) => {
+      const channel = new window.BroadcastChannel(HOSTED_ACTIVE_TAB_BROADCAST)
+      const timer = window.setTimeout(() => {
+        channel.close()
+        resolve(hasOtherActiveHostedSessionTab(userId))
+      }, HOSTED_ACTIVE_TAB_PING_TIMEOUT_MS)
+      channel.addEventListener('message', (event) => {
+        if (event.data?.type !== 'pong' || event.data?.userId !== userId) return
+        window.clearTimeout(timer)
+        channel.close()
+        resolve(true)
+      })
+      channel.postMessage({ type: 'ping', userId, tabId: getHostedTabId() })
+    })
+  } catch {
+    return hasOtherActiveHostedSessionTab(userId)
+  }
+}
+
+function stopHostedActiveTabHeartbeat() {
+  if (hostedActiveTabHeartbeat) {
+    clearInterval(hostedActiveTabHeartbeat)
+    hostedActiveTabHeartbeat = null
+  }
+}
+
+function startHostedActiveTabHeartbeat(userId: string) {
+  if (typeof window === 'undefined' || !userId) return
+  markHostedActiveTab(userId)
+  stopHostedActiveTabHeartbeat()
+  hostedActiveTabHeartbeat = window.setInterval(() => markHostedActiveTab(userId), HOSTED_ACTIVE_TAB_HEARTBEAT_MS)
+  if (!hostedActiveTabUnloadHooked) {
+    hostedActiveTabUnloadHooked = true
+    window.addEventListener('pagehide', clearCurrentHostedActiveTab)
+    window.addEventListener('beforeunload', clearCurrentHostedActiveTab)
+    if (typeof window.BroadcastChannel === 'function') {
+      try {
+        const channel = new window.BroadcastChannel(HOSTED_ACTIVE_TAB_BROADCAST)
+        channel.addEventListener('message', (event) => {
+          const current = readHostedValidationMarker()
+          if (!current || current.rememberDevice !== false) return
+          if (event.data?.type !== 'ping' || event.data?.userId !== current.userId) return
+          channel.postMessage({ type: 'pong', userId: current.userId, tabId: getHostedTabId() })
+        })
+      } catch {
+        // Fall back to the local active-tab TTL marker when BroadcastChannel is unavailable.
+      }
+    }
+  }
+}
+
+function clearCurrentHostedActiveTab() {
+  const tabId = getHostedTabId()
+  if (!tabId) return
+  const tabs = readHostedActiveTabs()
+  if (tabs[tabId]) {
+    delete tabs[tabId]
+    writeHostedActiveTabs(tabs)
+  }
+}
+
+function clearHostedValidationMarkers() {
+  if (typeof window === 'undefined') return
+  try {
+    sessionStorage.removeItem(HOSTED_VALIDATION_SESSION_KEY)
+    localStorage.removeItem(HOSTED_VALIDATION_REMEMBERED_KEY)
+    localStorage.removeItem(HOSTED_ACTIVE_TABS_KEY)
+    localStorage.removeItem(HOSTED_VALIDATION_INITIALIZED_KEY)
+    stopHostedActiveTabHeartbeat()
+  } catch (err) {
+    logger.warn('[auth-store] Failed to clear hosted validation markers:', err)
+  }
+}
+
+function markHostedValidation(userId: string, rememberDevice: boolean) {
+  if (typeof window === 'undefined' || !userId) return
+  const marker: HostedValidationMarker = { userId, rememberDevice, validatedAt: Date.now() }
+  try {
+    if (rememberDevice) {
+      localStorage.removeItem(HOSTED_AUTH_INVALIDATED_KEY)
+      localStorage.setItem(HOSTED_VALIDATION_REMEMBERED_KEY, JSON.stringify(marker))
+      sessionStorage.removeItem(HOSTED_VALIDATION_SESSION_KEY)
+      clearCurrentHostedActiveTab()
+      stopHostedActiveTabHeartbeat()
+    } else {
+      localStorage.removeItem(HOSTED_AUTH_INVALIDATED_KEY)
+      sessionStorage.setItem(HOSTED_VALIDATION_SESSION_KEY, JSON.stringify(marker))
+      localStorage.removeItem(HOSTED_VALIDATION_REMEMBERED_KEY)
+      startHostedActiveTabHeartbeat(userId)
+    }
+    localStorage.setItem(HOSTED_VALIDATION_INITIALIZED_KEY, 'true')
+  } catch (err) {
+    logger.warn('[auth-store] Failed to write hosted validation marker:', err)
+  }
+}
+
+function readHostedValidationMarker(): HostedValidationMarker | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const sessionRaw = sessionStorage.getItem(HOSTED_VALIDATION_SESSION_KEY)
+    if (sessionRaw) {
+      const marker = JSON.parse(sessionRaw) as HostedValidationMarker
+      if (marker.userId && marker.rememberDevice === false) return marker
+    }
+    const rememberedRaw = localStorage.getItem(HOSTED_VALIDATION_REMEMBERED_KEY)
+    if (!rememberedRaw) return null
+    const marker = JSON.parse(rememberedRaw) as HostedValidationMarker
+    if (!marker.userId || marker.rememberDevice !== true) return null
+    if (Date.now() - marker.validatedAt > HOSTED_REMEMBERED_MARKER_TTL_MS) {
+      localStorage.removeItem(HOSTED_VALIDATION_REMEMBERED_KEY)
+      return null
+    }
+    return marker
+  } catch (err) {
+    logger.warn('[auth-store] Failed to read hosted validation marker:', err)
+    clearHostedValidationMarkers()
+    return null
+  }
+}
+
+async function clearLocalAuthMaterial(reason: 'logout' | 'invalid-hosted-auth') {
+  try {
+    const { useEtebaseStore } = await import('@/app/stores/use-etebase-store')
+    useEtebaseStore.getState().destroy()
+  } catch (err) {
+    logger.warn(`[auth-store] Failed to destroy Etebase store during ${reason}:`, err)
+  }
+
+  try {
+    await clearLocalDataCache()
+  } catch (err) {
+    logger.warn(`[auth-store] Failed to clear local data cache during ${reason}:`, err)
+  }
+
+  try {
+    await clearOfflineQueue()
+  } catch (err) {
+    logger.warn(`[auth-store] Failed to clear offline queue during ${reason}:`, err)
+  }
+
+  if (typeof window !== 'undefined') {
+    sessionStorage.removeItem('silentsuite-signup-in-progress')
+    sessionStorage.removeItem('silentsuite-signup-redirect-state')
+  }
+
+  try {
+    await secureClear()
+  } catch (err) {
+    logger.warn(`[auth-store] Failed to clear secure storage during ${reason}:`, err)
+  }
+  localStorage.removeItem('silentsuite-server-url')
+  localStorage.removeItem('silentsuite-tasks')
+  localStorage.removeItem('silentsuite-contacts')
+  localStorage.removeItem('silentsuite-calendar')
+  localStorage.removeItem('etebase_session')
+  clearHostedValidationMarkers()
+  localStorage.setItem(HOSTED_AUTH_INVALIDATED_KEY, String(Date.now()))
+
+  try {
+    const { usePreferencesStore } = await import('@/app/stores/use-preferences-store')
+    usePreferencesStore.getState().resetSyncedPreferences()
+  } catch (err) {
+    logger.warn(`[auth-store] Failed to reset synced preferences during ${reason}:`, err)
+  }
+}
 
 /** Sync the is_admin cookie so Next.js middleware can guard /admin routes server-side. */
-function syncAdminCookie(isAdmin: boolean) {
+function syncAdminCookie(isAdmin: boolean, rememberDevice = false) {
   if (typeof document === 'undefined') return
   const secure = window.location.protocol === 'https:' ? '; Secure' : ''
-  // Self-hosted users are always admin — use a longer cookie lifetime (7 days).
-  // SaaS users get 15 min and rely on session refresh to renew.
   const isSH = typeof localStorage !== 'undefined' && !!localStorage.getItem('silentsuite-server-url')
-  const maxAge = (isSelfHosted || isSH) ? COOKIE_MAX_AGE_SELF_HOSTED : COOKIE_MAX_AGE_HOSTED
+  const maxAge = (isSelfHosted || isSH) ? COOKIE_MAX_AGE_SELF_HOSTED : (rememberDevice ? COOKIE_MAX_AGE_HOSTED : null)
   if (isAdmin) {
-    document.cookie = `is_admin=true; path=/; max-age=${maxAge}; SameSite=Strict${secure}`
+    const maxAgePart = maxAge == null ? '' : `; max-age=${maxAge}`
+    document.cookie = `is_admin=true; path=/${maxAgePart}; SameSite=Strict${secure}`
   } else {
     document.cookie = `is_admin=; path=/; max-age=0; SameSite=Strict${secure}`
+  }
+}
+
+async function deleteHostedServerSession(context: string) {
+  try {
+    await fetch(`${BILLING_API_URL}/auth/session`, { method: 'DELETE', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+  } catch (err) {
+    logger.warn(`[auth-store] Failed to delete server session during ${context}:`, err)
   }
 }
 
@@ -139,7 +414,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
   canWrite: () => !get().isReadOnly(),
 
-  prepareSignupDraft: (email: string, wantsProductUpdates?: boolean) => {
+  prepareSignupDraft: (email: string, wantsProductUpdates?: boolean, rememberDevice?: boolean) => {
     const pending = get().pendingSignup
     const reusablePending = pending?.email.toLowerCase() === email.toLowerCase() ? pending : null
     if (typeof window !== 'undefined') {
@@ -150,6 +425,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         ...(reusablePending ?? {}),
         email,
         wantsProductUpdates,
+        rememberDevice: rememberDevice === true,
       },
       error: null,
     })
@@ -171,6 +447,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         authResult = await etebaseLogIn(email, password, serverUrl)
       }
       const { authToken, savedSession } = authResult
+      if (!isSelfHosted && !isCustomServer(serverUrl)) clearHostedValidationMarkers()
       await secureSet('etebase_session', savedSession)
 
       let earlyAdopter = false
@@ -265,6 +542,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
             trialPath,
             ...(promoCode?.trim() ? { promoCode: promoCode.trim() } : {}),
             wantsProductUpdates: pending.wantsProductUpdates,
+            rememberDevice: pending.rememberDevice === true,
           }),
           credentials: 'include',
         })
@@ -311,6 +589,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           trialPath,
           ...(promoCode?.trim() ? { promoCode: promoCode.trim() } : {}),
           wantsProductUpdates: pending.wantsProductUpdates,
+          rememberDevice: pending.rememberDevice === true,
         }),
         credentials: 'include',
       })
@@ -320,7 +599,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       }
       const data = await res.json()
       const isAdmin = data.isAdmin === true
-      syncAdminCookie(isAdmin)
+      syncAdminCookie(isAdmin, data.rememberDevice === true)
       // Store provisioned data in pendingSignup — do NOT set isAuthenticated yet.
       // The user is still in the signup flow (payment + vault steps remain).
       set({
@@ -328,6 +607,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           ...pending,
           provisionedUser: { id: data.id, planId, isAdmin },
             provisionedSubscriptionStatus: data.provisioningStatus ?? 'trialing',
+          rememberDevice: data.rememberDevice === true,
         },
         isLoading: false,
       })
@@ -372,6 +652,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           ...pending,
           provisionedUser: { id: data.id, planId: data.planId ?? 'early_annual', isAdmin },
           provisionedSubscriptionStatus: data.provisioningStatus ?? 'active',
+          rememberDevice: data.rememberDevice === true,
         },
         isLoading: false,
       })
@@ -400,7 +681,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       sessionStorage.removeItem('silentsuite-signup-in-progress')
     }
     // Sync admin cookie so middleware allows /admin access
-    syncAdminCookie(pending.provisionedUser.isAdmin)
+    syncAdminCookie(pending.provisionedUser.isAdmin, pending.rememberDevice === true)
+    if (!isSelfHosted) markHostedValidation(pending.provisionedUser.id, pending.rememberDevice === true)
     set({
       user: {
         id: pending.provisionedUser.id,
@@ -418,7 +700,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     })
   },
 
-  login: async (email: string, password: string, serverUrl?: string) => {
+  login: async (email: string, password: string, serverUrl?: string, rememberDevice?: boolean) => {
     set({ isLoading: true, error: null })
     try {
       const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
@@ -430,6 +712,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // failed login attempts do not destroy the current account's offline work
       // and queued work from one account cannot replay into another account.
       await clearOfflineQueue()
+      if (!isSelfHosted && !isCustomServer(serverUrl)) clearHostedValidationMarkers()
       await secureSet('etebase_session', savedSession)
       try {
         const persistedSession = await secureGet('etebase_session')
@@ -461,25 +744,30 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const res = await fetch(`${BILLING_API_URL}/auth/token-exchange`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-        body: JSON.stringify({ etebaseSessionToken: authToken }),
+        body: JSON.stringify({ etebaseSessionToken: authToken, rememberDevice: rememberDevice === true }),
         credentials: 'include',
       })
 
       if (res.status === 429) {
+        await clearLocalAuthMaterial('invalid-hosted-auth')
         set({ isLoading: false, error: 'Too many attempts. Please try again later.' }); return
       }
       if (res.status === 404 || res.status === 409) {
+        await clearLocalAuthMaterial('invalid-hosted-auth')
         set({ isLoading: false, error: 'Account not fully set up. Please complete signup first.' }); return
       }
       if (!res.ok) {
+        await clearLocalAuthMaterial('invalid-hosted-auth')
         set({ isLoading: false, error: 'Login failed. Please check your credentials.' }); return
       }
 
       const data = await res.json()
+      const confirmedRememberDevice = data.rememberDevice === true
       const isAdmin = data.isAdmin === true
-      syncAdminCookie(isAdmin)
+      syncAdminCookie(isAdmin, confirmedRememberDevice)
+      markHostedValidation(data.id, confirmedRememberDevice)
       set({
-        user: { id: data.id, email: data.email ?? email, planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null },
+        user: { id: data.id, email: data.email ?? email, planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, rememberDevice: data.rememberDevice === true, onboardedAt: data.onboardedAt ?? null },
         isAuthenticated: true,
         isLoading: false,
       })
@@ -503,63 +791,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   logout: async () => {
     if (!isSelfHosted) {
-      try {
-        await fetch(`${BILLING_API_URL}/auth/session`, { method: 'DELETE', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-      } catch (err) {
-        logger.warn('[auth-store] Failed to delete server session during logout:', err)
-      }
+      await deleteHostedServerSession('invalid-hosted-auth')
     }
 
-    // Destroy Etebase store (stops SyncEngine, clears SDK objects)
-    try {
-      const { useEtebaseStore } = await import('@/app/stores/use-etebase-store')
-      useEtebaseStore.getState().destroy()
-    } catch (err) {
-      logger.warn('[auth-store] Failed to destroy Etebase store during logout:', err)
-    }
-
-    // Clear the local data cache (decrypted iCal/vCard/vTodo on disk).
-    // Runs unconditionally — even if the feature flag was just turned off,
-    // any cache left from a previous session must not survive logout.
-    // Order matters: clear before invalidating session state, so a
-    // background read can't repopulate from a still-live store.
-    try {
-      await clearLocalDataCache()
-    } catch (err) {
-      logger.warn('[auth-store] Failed to clear local data cache during logout:', err)
-    }
-
-    // Clear the offline mutation queue as well. Queue entries are scoped to
-    // the current Etebase account/collections and must not survive logout or
-    // replay after a later account switch.
-    try {
-      await clearOfflineQueue()
-    } catch (err) {
-      logger.warn('[auth-store] Failed to clear offline queue during logout:', err)
-    }
-
-    // Clear signup-in-progress flag
-    if (typeof window !== 'undefined') {
-      sessionStorage.removeItem('silentsuite-signup-in-progress')
-    }
-
-    // Clear persisted data stores so next login starts fresh
-    await secureClear()
-    localStorage.removeItem('silentsuite-server-url')
-    // Legacy localStorage keys (no longer written, but clear in case of stale data)
-    localStorage.removeItem('silentsuite-tasks')
-    localStorage.removeItem('silentsuite-contacts')
-    localStorage.removeItem('silentsuite-calendar')
-    localStorage.removeItem('etebase_session')
-
-    // Keep device-local notificationSound, but reset account-scoped preference
-    // metadata when another user signs in here.
-    try {
-      const { usePreferencesStore } = await import('@/app/stores/use-preferences-store')
-      usePreferencesStore.getState().resetSyncedPreferences()
-    } catch (err) {
-      logger.warn('[auth-store] Failed to reset synced preferences during logout:', err)
-    }
+    await clearLocalAuthMaterial('logout')
 
     syncAdminCookie(false)
     set({ user: null, isAuthenticated: false, error: null, subscriptionStatus: null })
@@ -579,6 +814,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       return false
     }
 
+    if (typeof window !== 'undefined' && localStorage.getItem(HOSTED_AUTH_INVALIDATED_KEY)) {
+      syncAdminCookie(false)
+      set({ user: null, isAuthenticated: false, subscriptionStatus: null })
+      return false
+    }
+
     try {
       const res = await fetch(`${BILLING_API_URL}/auth/refresh`, { method: 'POST', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
       // Only treat the session as invalid on explicit auth failures. A 5xx
@@ -586,8 +827,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // user when the verify-banner re-checks on tab focus (see
       // EmailVerificationBanner).
       if (res.status === 401 || res.status === 403) {
+        await deleteHostedServerSession('refresh auth failure')
+        await clearLocalAuthMaterial('invalid-hosted-auth')
         syncAdminCookie(false)
-        set({ user: null, isAuthenticated: false })
+        set({ user: null, isAuthenticated: false, subscriptionStatus: null })
         return false
       }
       if (!res.ok) {
@@ -595,9 +838,21 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         return false
       }
       const data = await res.json()
+      const rememberDevice = data.rememberDevice === true
+      if (!rememberDevice) {
+        const marker = readHostedValidationMarker()
+        if ((!marker || marker.rememberDevice !== false || marker.userId !== data.id) && !(await hasLiveOtherHostedSessionTab(data.id))) {
+          await deleteHostedServerSession('invalid-hosted-auth')
+          await clearLocalAuthMaterial('invalid-hosted-auth')
+          syncAdminCookie(false)
+          set({ user: null, isAuthenticated: false, subscriptionStatus: null })
+          return false
+        }
+      }
       const isAdmin = data.isAdmin === true
-      syncAdminCookie(isAdmin)
-      set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true })
+      syncAdminCookie(isAdmin, rememberDevice)
+      markHostedValidation(data.id, rememberDevice)
+      set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, rememberDevice, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true })
       return true
     } catch (err) {
       logger.warn('[auth-store] Session refresh failed (network), leaving session intact:', err)
@@ -630,16 +885,50 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       return
     }
 
+    if (typeof window !== 'undefined' && localStorage.getItem(HOSTED_AUTH_INVALIDATED_KEY)) {
+      syncAdminCookie(false)
+      set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
+      return
+    }
+
     set({ isLoading: true })
     try {
       const res = await fetch(`${BILLING_API_URL}/auth/refresh`, { method: 'POST', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } })
       if (res.ok) {
         const data = await res.json()
+        const rememberDevice = data.rememberDevice === true
+        if (!rememberDevice) {
+          const marker = readHostedValidationMarker()
+          if ((!marker || marker.rememberDevice !== false || marker.userId !== data.id) && !(await hasLiveOtherHostedSessionTab(data.id))) {
+            await deleteHostedServerSession('invalid-hosted-auth')
+            await clearLocalAuthMaterial('invalid-hosted-auth')
+            syncAdminCookie(false)
+            set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
+            return
+          }
+        }
         const isAdmin = data.isAdmin === true
-        syncAdminCookie(isAdmin)
-        set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true, isLoading: false })
+        syncAdminCookie(isAdmin, rememberDevice)
+        markHostedValidation(data.id, rememberDevice)
+        set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, rememberDevice, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true, isLoading: false })
+      } else if (res.status === 401 || res.status === 403) {
+        await deleteHostedServerSession('restore auth failure')
+        await clearLocalAuthMaterial('invalid-hosted-auth')
+        syncAdminCookie(false)
+        set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
+      } else if (res.status === 429) {
+        const hasEtebaseSession = !!(await secureGet('etebase_session'))
+        const marker = readHostedValidationMarker()
+        const activeTabMarker = hasEtebaseSession ? readOtherActiveHostedSessionTab() : null
+        if (hasEtebaseSession && !marker && !activeTabMarker) await clearLocalAuthMaterial('invalid-hosted-auth')
+        syncAdminCookie(false)
+        set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
+      } else if (res.status >= 400 && res.status < 500) {
+        await deleteHostedServerSession('restore auth failure')
+        await clearLocalAuthMaterial('invalid-hosted-auth')
+        syncAdminCookie(false)
+        set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
       } else {
-        // HTTP error (401/403 etc.) — billing responded, auth is invalid
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, isLoading: false })
       }
@@ -648,18 +937,28 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       logger.warn('[auth-store] Session restore failed (network):', err)
       // If a valid Etebase session exists, enter degraded mode instead of kicking the user out.
       const hasEtebaseSession = !!(await secureGet('etebase_session'))
-      if (hasEtebaseSession) {
+      const marker = readHostedValidationMarker()
+      const activeTabMarker = hasEtebaseSession ? readOtherActiveHostedSessionTab() : null
+      if (hasEtebaseSession && marker) {
         // Preserve the legacy onboardedAt metadata shape while billing is down;
         // startup UI no longer depends on this field.
         set({
-          user: { id: 'degraded', email: '', planId: 'unknown', isAdmin: false, onboardedAt: new Date().toISOString() },
+          user: { id: marker.userId, email: '', planId: 'unknown', isAdmin: false, rememberDevice: marker.rememberDevice, onboardedAt: new Date().toISOString() },
+          isAuthenticated: true,
+          isLoading: false,
+          subscriptionStatus: 'billing_unavailable',
+        })
+      } else if (hasEtebaseSession && activeTabMarker) {
+        set({
+          user: { id: activeTabMarker.userId, email: '', planId: 'unknown', isAdmin: false, rememberDevice: false, onboardedAt: new Date().toISOString() },
           isAuthenticated: true,
           isLoading: false,
           subscriptionStatus: 'billing_unavailable',
         })
       } else {
+        if (hasEtebaseSession) await clearLocalAuthMaterial('invalid-hosted-auth')
         syncAdminCookie(false)
-        set({ user: null, isAuthenticated: false, isLoading: false })
+        set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
       }
     }
   },
@@ -685,19 +984,40 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     const storedServerUrl = typeof window !== 'undefined' ? localStorage.getItem('silentsuite-server-url') : null
     if (isSelfHosted || isCustomServer(storedServerUrl ?? undefined)) return true
 
+    if (typeof window !== 'undefined' && localStorage.getItem(HOSTED_AUTH_INVALIDATED_KEY)) return false
+
     try {
       // Fetch both endpoints — only apply state if BOTH succeed
       const [refreshRes, subRes] = await Promise.all([
         fetch(`${BILLING_API_URL}/auth/refresh`, { method: 'POST', credentials: 'include', headers: { 'X-Requested-With': 'XMLHttpRequest' } }),
         fetch(`${BILLING_API_URL}/subscription`, { credentials: 'include' }),
       ])
+      if (refreshRes.status === 401 || refreshRes.status === 403 || (refreshRes.status >= 400 && refreshRes.status < 500 && refreshRes.status !== 429)) {
+        await deleteHostedServerSession('retry auth failure')
+        await clearLocalAuthMaterial('invalid-hosted-auth')
+        syncAdminCookie(false)
+        set({ user: null, isAuthenticated: false, subscriptionStatus: null })
+        return false
+      }
       if (!refreshRes.ok || !subRes.ok) return false
       const refreshData = await refreshRes.json()
       const subData = await subRes.json()
+      const rememberDevice = refreshData.rememberDevice === true
+      if (!rememberDevice) {
+        const marker = readHostedValidationMarker()
+        if ((!marker || marker.rememberDevice !== false || marker.userId !== refreshData.id) && !(await hasLiveOtherHostedSessionTab(refreshData.id))) {
+          await deleteHostedServerSession('invalid-hosted-auth')
+          await clearLocalAuthMaterial('invalid-hosted-auth')
+          syncAdminCookie(false)
+          set({ user: null, isAuthenticated: false, subscriptionStatus: null })
+          return false
+        }
+      }
       const isAdmin = refreshData.isAdmin === true
-      syncAdminCookie(isAdmin)
+      syncAdminCookie(isAdmin, rememberDevice)
+      markHostedValidation(refreshData.id, rememberDevice)
       set({
-        user: { id: refreshData.id, email: refreshData.email ?? '', planId: refreshData.planId ?? 'free', isAdmin, emailVerified: refreshData.emailVerified ?? false, onboardedAt: refreshData.onboardedAt ?? null },
+        user: { id: refreshData.id, email: refreshData.email ?? '', planId: refreshData.planId ?? 'free', isAdmin, emailVerified: refreshData.emailVerified ?? false, rememberDevice, onboardedAt: refreshData.onboardedAt ?? null },
         isAuthenticated: true,
         subscriptionStatus: subData.status,
       })


### PR DESCRIPTION
## Summary
- Add explicit hosted "Keep me signed in on this device" login/signup flow.
- Default hosted sessions to browser-session persistence and require validation markers or live-tab proof before accepting refreshed hosted sessions.
- Clear/tombstone stale local auth material on invalid hosted auth, including restore/refresh/retry paths.
- Harden multi-tab and offline/billing-down behavior with active-tab coordination and degraded-mode safeguards.

## Verification
- `pnpm run test app/stores/__tests__/use-auth-store.test.ts` — 64 passed
- `pnpm run type-check` — passed
- `git diff --check` — passed

## Review gate
- GPT-5.5 final adversarial review: GREEN, Proceed to PR: yes
- GLM 5.2/NanoGPT final adversarial review: GREEN, Proceed to PR: YES

## Notes
- Internal billing API companion PR is required for the server-side `rememberDevice` contract and cookie persistence support.
- Residual accepted risk from GPT-5.5: active-tab TTL fallback can preserve a non-remembered session for up to 15s after abnormal tab termination if session cookies also survive; judged non-blocking.