### PR TITLE
web: add restore-blocked unlock path

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -6,6 +6,7 @@ import { Sidebar } from '@/app/components/sidebar'
 import { Header } from '@/app/components/header'
 import { BottomNav } from '@/app/components/bottom-nav'
 import { ReadOnlyBanner, DegradedModeBanner } from '@/app/components/read-only-overlay'
+import { RestoreBlockedBanner } from '@/app/components/restore-blocked-banner'
 import { PendingSyncBanner } from '@/app/components/PendingSyncBanner'
 import { OfflineToast } from '@/app/components/OfflineToast'
 import { ToastContainer } from '@/app/components/Toast'
@@ -36,6 +37,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
             <div className="flex flex-1 flex-col min-w-0">
               <Header />
               <EmailVerificationBanner />
+              <RestoreBlockedBanner />
               {!isSelfHosted && degraded && <DegradedModeBanner />}
               {!isSelfHosted && readOnly && <ReadOnlyBanner />}
               <PendingSyncBanner />

--- a/apps/web/app/(auth)/login/__tests__/login-unlock.test.tsx
+++ b/apps/web/app/(auth)/login/__tests__/login-unlock.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import LoginPage from '../page'
+
+const replace = vi.fn()
+let searchParams = new URLSearchParams()
+
+const authState = {
+  login: vi.fn(async () => {}),
+  isLoading: false,
+  error: null as string | null,
+  clearError: vi.fn(),
+  isAuthenticated: false,
+}
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => searchParams,
+}))
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: Object.assign((selector?: (s: typeof authState) => unknown) =>
+    selector ? selector(authState) : authState, { getState: () => authState }),
+}))
+
+// Avoid pulling the full etebase store (WASM / IndexedDB) into the test.
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  normalizeServerUrl: (url: string) => url,
+}))
+
+beforeEach(() => {
+  replace.mockClear()
+  authState.login.mockClear().mockResolvedValue(undefined)
+  authState.clearError.mockClear()
+  authState.isAuthenticated = false
+  authState.error = null
+  searchParams = new URLSearchParams()
+  localStorage.clear()
+})
+
+describe('LoginPage unlock route', () => {
+  it('does NOT bounce an already-authenticated user on the unlock route, and shows unlock copy', () => {
+    authState.isAuthenticated = true
+    searchParams = new URLSearchParams('reason=unlock&returnTo=/calendar')
+
+    render(<LoginPage />)
+
+    expect(replace).not.toHaveBeenCalled()
+    expect(screen.getByText(/Sign in again to unlock it on this browser/i)).toBeInTheDocument()
+  })
+
+  it('redirects to returnTo after a fresh successful unlock submit', async () => {
+    authState.isAuthenticated = true
+    searchParams = new URLSearchParams('reason=unlock&returnTo=/calendar')
+
+    render(<LoginPage />)
+
+    fireEvent.change(screen.getByLabelText(/Email address/i), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText(/^Password$/i), {
+      target: { value: 'correct-horse' },
+    })
+    fireEvent.submit(screen.getByRole('button', { name: /log in/i }))
+
+    await waitFor(() => expect(authState.login).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/calendar'))
+    expect(replace).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to calendar for malicious or self-looping returnTo values', async () => {
+    authState.isAuthenticated = true
+
+    for (const rawReturnTo of ['//evil.example', 'https://evil.example', '/login?reason=unlock&returnTo=/calendar']) {
+      replace.mockClear()
+      searchParams = new URLSearchParams()
+      searchParams.set('reason', 'unlock')
+      searchParams.set('returnTo', rawReturnTo)
+
+      const { unmount } = render(<LoginPage />)
+      fireEvent.change(screen.getByLabelText(/Email address/i), {
+        target: { value: 'user@example.com' },
+      })
+      fireEvent.change(screen.getByLabelText(/^Password$/i), {
+        target: { value: 'correct-horse' },
+      })
+      fireEvent.submit(screen.getByRole('button', { name: /log in/i }))
+
+      await waitFor(() => expect(replace).toHaveBeenCalledWith('/calendar'))
+      unmount()
+    }
+  })
+
+  it('preserves the normal authenticated bounce when reason is absent', () => {
+    authState.isAuthenticated = true
+    searchParams = new URLSearchParams('returnTo=/tasks')
+
+    render(<LoginPage />)
+
+    expect(replace).toHaveBeenCalledWith('/tasks')
+  })
+})

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -19,12 +19,24 @@ const loginSchema = z.object({
 
 type LoginFormData = z.infer<typeof loginSchema>
 
+function safeReturnTo(raw: string | null): string {
+  if (!raw || !raw.startsWith('/') || raw.includes('://') || raw.includes('//')) return '/calendar'
+
+  // Never bounce back into login after a successful unlock. That can strand a
+  // direct-link user on the unlock route even after valid credentials.
+  return raw === '/login' || raw.startsWith('/login?') || raw.startsWith('/login/') ? '/calendar' : raw
+}
+
 export default function LoginPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const { login, isLoading, error, clearError, isAuthenticated } = useAuthStore()
   const [serverUrl, setServerUrl] = useState('')
   const [rememberDevice, setRememberDevice] = useState(false)
+  const isUnlock = searchParams.get('reason') === 'unlock'
+  // Tracks a fresh successful unlock submit so the redirect effect fires only
+  // after the user has actually re-entered credentials on the unlock route.
+  const [didUnlockSubmit, setDidUnlockSubmit] = useState(false)
 
   const {
     register,
@@ -36,13 +48,14 @@ export default function LoginPage() {
   })
 
   useEffect(() => {
-    if (isAuthenticated) {
-      const raw = searchParams.get('returnTo') ?? '/calendar'
-      // Validate returnTo to prevent open redirect: must be a relative path
-      const returnTo = raw.startsWith('/') && !raw.includes('://') && !raw.includes('//') ? raw : '/calendar'
-      router.replace(returnTo)
-    }
-  }, [isAuthenticated, router, searchParams])
+    if (!isAuthenticated) return
+    // On the unlock route, stay put until the user re-enters credentials --
+    // an already-authenticated-but-restore-blocked user must not be bounced
+    // straight back into the broken empty state (redirect loop).
+    if (isUnlock && !didUnlockSubmit) return
+    const returnTo = safeReturnTo(searchParams.get('returnTo'))
+    router.replace(returnTo)
+  }, [isAuthenticated, isUnlock, didUnlockSubmit, router, searchParams])
 
   useEffect(() => {
     return () => clearError()
@@ -57,14 +70,22 @@ export default function LoginPage() {
       localStorage.removeItem('silentsuite-server-url')
     }
     await login(data.email, data.password, normalizedUrl, useHostedBilling && rememberDevice)
+    // Read the store directly to avoid a stale closure over `error`.
+    if (isUnlock && !useAuthStore.getState().error) {
+      setDidUnlockSubmit(true)
+    }
   }
 
   return (
     <div className="max-w-md mx-auto space-y-6">
       <div className="space-y-2 text-center">
-        <h2 className="text-xl font-semibold text-[rgb(var(--foreground))]">Welcome back</h2>
+        <h2 className="text-xl font-semibold text-[rgb(var(--foreground))]">
+          {isUnlock ? 'Unlock this browser' : 'Welcome back'}
+        </h2>
         <p className="text-sm text-[rgb(var(--muted))]">
-          Log in to your encrypted workspace
+          {isUnlock
+            ? 'Your encrypted data is safe. Sign in again to unlock it on this browser.'
+            : 'Log in to your encrypted workspace'}
         </p>
       </div>
 

--- a/apps/web/app/components/__tests__/restore-blocked-banner.test.tsx
+++ b/apps/web/app/components/__tests__/restore-blocked-banner.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RestoreBlockedBanner } from '../restore-blocked-banner'
+
+const etebaseState = {
+  restoreBlocked: false,
+}
+
+const authState = {
+  isAuthenticated: false,
+}
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: (selector: (s: typeof etebaseState) => unknown) => selector(etebaseState),
+}))
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: (selector: (s: typeof authState) => unknown) => selector(authState),
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/calendar',
+}))
+
+describe('RestoreBlockedBanner', () => {
+  beforeEach(() => {
+    etebaseState.restoreBlocked = false
+    authState.isAuthenticated = false
+  })
+
+  it('renders nothing when restore is not blocked', () => {
+    etebaseState.restoreBlocked = false
+    authState.isAuthenticated = true
+    const { container } = render(<RestoreBlockedBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when blocked but not authenticated', () => {
+    etebaseState.restoreBlocked = true
+    authState.isAuthenticated = false
+    const { container } = render(<RestoreBlockedBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders reassurance copy and an unlock link when blocked and authenticated', () => {
+    etebaseState.restoreBlocked = true
+    authState.isAuthenticated = true
+    render(<RestoreBlockedBanner />)
+
+    expect(
+      screen.getByText(/Your data is encrypted and safe on the server/i),
+    ).toBeInTheDocument()
+
+    const link = screen.getByRole('link', { name: /unlock now/i })
+    expect(link).toHaveAttribute('href', '/login?reason=unlock&returnTo=%2Fcalendar')
+  })
+
+  it('renders reassuring copy that contains no error/failure/phase wording', () => {
+    etebaseState.restoreBlocked = true
+    authState.isAuthenticated = true
+    const { container } = render(<RestoreBlockedBanner />)
+
+    const text = container.textContent ?? ''
+    expect(text).not.toMatch(/error/i)
+    expect(text).not.toMatch(/failed/i)
+    expect(text).not.toMatch(/restoreSession|sessionRead|listItems|syncEngine/i)
+  })
+})

--- a/apps/web/app/components/restore-blocked-banner.tsx
+++ b/apps/web/app/components/restore-blocked-banner.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { KeyRound } from 'lucide-react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useAuthStore } from '@/app/stores/use-auth-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+
+/**
+ * Non-blocking banner shown when the encrypted session could not be restored
+ * on this browser (missing/invalid/corrupt local session). Reassuring, not an
+ * error: the data is safe on the server; this browser just needs to unlock it
+ * again. The CTA links to the loop-free unlock route. It never clears storage
+ * and never calls logout().
+ */
+export function RestoreBlockedBanner() {
+  const restoreBlocked = useEtebaseStore((s) => s.restoreBlocked)
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const pathname = usePathname()
+
+  if (!restoreBlocked || !isAuthenticated) return null
+
+  // Same-origin relative path only; fall back to /calendar.
+  const returnTo = pathname && pathname.startsWith('/') && !pathname.includes('//') ? pathname : '/calendar'
+  const href = `/login?reason=unlock&returnTo=${encodeURIComponent(returnTo)}`
+
+  return (
+    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200 md:mx-4">
+      <KeyRound className="h-4 w-4 shrink-0 text-emerald-400" />
+      <span className="flex-1">
+        Your data is encrypted and safe on the server. This browser needs to unlock it again.
+      </span>
+      <Link
+        href={href}
+        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+      >
+        Unlock now
+      </Link>
+    </div>
+  )
+}

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -167,6 +167,119 @@ describe('useEtebaseStore.initialize restore diagnostics', () => {
   })
 })
 
+describe('useEtebaseStore.initialize restoreBlocked flag', () => {
+  beforeEach(() => {
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      restoreBlocked: false,
+      syncEngine: null,
+    })
+  })
+
+  async function getSecureStorage() {
+    return import('@/app/lib/secure-storage')
+  }
+
+  it('defaults restoreBlocked to false', () => {
+    expect(useEtebaseStore.getState().restoreBlocked).toBe(false)
+  })
+
+  it('sets restoreBlocked when there is no saved session, without toast or removal', async () => {
+    const { secureGet, secureRemove } = await getSecureStorage()
+    vi.mocked(secureGet).mockResolvedValueOnce(null)
+
+    await useEtebaseStore.getState().initialize()
+
+    expect(useEtebaseStore.getState().restoreBlocked).toBe(true)
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+    expect(vi.mocked(secureRemove)).not.toHaveBeenCalled()
+  })
+
+  it('sets restoreBlocked on a non-offline restoreSession failure and preserves the session', async () => {
+    const { secureGet, secureRemove } = await getSecureStorage()
+    vi.mocked(secureGet).mockResolvedValueOnce('raw-session')
+    coreMock.restoreSession.mockRejectedValueOnce(new Error('bad session blob'))
+    offlineQueueMock.isOfflineError.mockReturnValue(false)
+
+    await useEtebaseStore.getState().initialize()
+
+    const state = useEtebaseStore.getState()
+    expect(state.restoreBlocked).toBe(true)
+    expect(state.isInitialized).toBe(true)
+    expect(vi.mocked(secureRemove)).not.toHaveBeenCalled()
+    expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith(
+      'Failed to restore session. Please try signing in again.',
+    )
+  })
+
+  it('does NOT set restoreBlocked on an offline restore error, and shows no toast', async () => {
+    const { secureGet } = await getSecureStorage()
+    vi.mocked(secureGet).mockResolvedValueOnce('raw-session')
+    coreMock.restoreSession.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    offlineQueueMock.isOfflineError.mockReturnValue(true)
+
+    await useEtebaseStore.getState().initialize()
+
+    expect(useEtebaseStore.getState().restoreBlocked).toBe(false)
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+  })
+
+  it('does NOT set restoreBlocked when a post-restore listItems phase fails (Slice 3 boundary)', async () => {
+    const { secureGet } = await getSecureStorage()
+    vi.mocked(secureGet).mockResolvedValueOnce('raw-session')
+    coreMock.restoreSession.mockResolvedValueOnce({ id: 'account' })
+    coreMock.getAccountFingerprint.mockReturnValueOnce('fingerprint')
+    coreMock.listCollections.mockImplementation(async () => [mockCollection('col-1')])
+    coreMock.listItems.mockRejectedValueOnce(new Error('server 500 on listItems'))
+    offlineQueueMock.isOfflineError.mockReturnValue(false)
+
+    await useEtebaseStore.getState().initialize()
+
+    const state = useEtebaseStore.getState()
+    // restoreSession succeeded; the failure is in listItems:calendar, which is a
+    // Slice 3 concern, NOT an unlock case.
+    expect(state.restoreBlocked).toBe(false)
+    expect(state.isInitialized).toBe(true)
+  })
+
+  it('leaves restoreBlocked false on a fully successful restore', async () => {
+    const { secureGet } = await getSecureStorage()
+    vi.mocked(secureGet).mockResolvedValueOnce('raw-session')
+    coreMock.restoreSession.mockResolvedValueOnce({ id: 'account' })
+    coreMock.getAccountFingerprint.mockReturnValueOnce('fingerprint')
+    coreMock.listCollections.mockImplementation(async () => [mockCollection('col-1')])
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+    coreMock.SyncEngine.mockImplementation(function (this: any) {
+      this.trackCollection = vi.fn()
+      this.onStokenAdvance = vi.fn()
+      this.start = vi.fn(async () => {})
+    })
+
+    await useEtebaseStore.getState().initialize()
+
+    const state = useEtebaseStore.getState()
+    expect(state.restoreBlocked).toBe(false)
+    expect(state.isInitialized).toBe(true)
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+  })
+
+  it('resets restoreBlocked to false on destroy()', async () => {
+    const { secureGet } = await getSecureStorage()
+    vi.mocked(secureGet).mockResolvedValueOnce(null)
+    await useEtebaseStore.getState().initialize()
+    expect(useEtebaseStore.getState().restoreBlocked).toBe(true)
+
+    useEtebaseStore.getState().destroy()
+
+    expect(useEtebaseStore.getState().restoreBlocked).toBe(false)
+  })
+})
+
 describe('useEtebaseStore.createItemsBatch', () => {
   beforeEach(() => {
     offlineQueueMock.enqueue.mockClear()

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -334,6 +334,10 @@ interface EtebaseState {
   itemCollectionMap: Map<string, string>
   // Whether initial data load from server is complete
   isInitialized: boolean
+  // True when the encrypted session could not be restored on this browser
+  // (missing/invalid/corrupt local session) and re-unlocking would help.
+  // Not set for offline errors or post-restore listing/sync failures.
+  restoreBlocked: boolean
   // SyncEngine reference
   syncEngine: any | null
 }
@@ -486,6 +490,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   itemTypeMap: new Map(),
   itemCollectionMap: new Map(),
   isInitialized: false,
+  restoreBlocked: false,
   syncEngine: null,
 
   initialize: async () => {
@@ -495,6 +500,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       etebaseServerUrl: serverUrl,
       billingApiUrl: BILLING_API_URL,
     })
+    // Clear any stale blocked state from a prior attempt before re-trying.
+    set({ restoreBlocked: false })
 
     try {
       diagnostics.startPhase('sessionRead')
@@ -505,7 +512,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (!savedSession) {
         diagnostics.skipPhase('restoreSession')
         diagnostics.persist()
-        logger.debug('[etebase-store] No saved session, skipping initialization')
+        // Authenticated (initialize only runs under ProtectedRoute) but no local
+        // vault to unlock -- re-entering credentials re-persists the session.
+        set({ restoreBlocked: true })
+        logger.debug('[etebase-store] No saved session, restore blocked')
         return
       }
 
@@ -628,7 +638,13 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       console.error('[etebase-store] Initialization failed', getSafeErrorDetails(err))
       // Don't clear the session -- the user might be offline
       // They can retry on next page load
-      set({ isInitialized: true })
+      // Only a session-restore failure (missing/invalid/corrupt local session)
+      // is recoverable by re-unlocking. Offline errors and post-restore
+      // listing/sync failures are NOT unlock cases (Slice 3 territory).
+      const failedPhase = diagnostics.snapshot().failedPhase
+      const isSessionRestoreFailure =
+        !isOfflineError(err) && (failedPhase === 'sessionRead' || failedPhase === 'restoreSession')
+      set({ isInitialized: true, restoreBlocked: isSessionRestoreFailure })
       if (!isOfflineError(err)) {
         showErrorToast('Failed to restore session. Please try signing in again.')
       }
@@ -1517,6 +1533,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
       isInitialized: false,
+      restoreBlocked: false,
       syncEngine: null,
     })
     logger.debug('[etebase-store] Destroyed')

--- a/docs/contributing/authenticated-restore-smoke.md
+++ b/docs/contributing/authenticated-restore-smoke.md
@@ -170,6 +170,50 @@ findings:
 
 Before sharing, confirm the evidence contains no credentials, emails, session blobs, collection IDs, item IDs, plaintext PIM, raw URLs with query strings, cookies, headers, response bodies, or raw error messages.
 
+## Negative check: restore-blocked / unlock path
+
+The positive smoke proves a healthy restore. This negative check proves the app is honest when the encrypted session cannot be restored on a browser: it shows a calm, non-blocking restore-blocked banner and offers a loop-free unlock route, without clearing any local data.
+
+It requires no secrets and no stored credentials. It uses a controlled local mutation to force the blocked state, then re-unlocks with the same approved account you already use for the positive smoke.
+
+### Safety
+
+- Do not paste session blobs, storage values, tokens, cookies, IDs, or plaintext PIM anywhere. Observe shapes and booleans only.
+- This check is intentionally recoverable: re-entering credentials restores the vault. It never asks you to permanently delete data.
+
+### Recipe
+
+1. Start from a healthy state: sign in on preview with an approved test account and confirm the positive smoke passes (`failedPhase: null`, and **no** restore-blocked banner is visible).
+2. Force a blocked local session using DevTools, choosing one:
+   - Remove or scramble the local `etebase_session` entry in the browser's encrypted secure storage (Application → IndexedDB / storage), then reload; or
+   - Open the app in a fresh browser profile that still has a valid billing cookie/session but no local `etebase_session`, then load `/calendar`.
+   Both simulate "authenticated at billing, but this browser cannot unlock the local vault."
+3. Reload and observe the app shell. Expected:
+   - The **restore-blocked banner** appears with reassurance copy along the lines of "Your data is encrypted and safe on the server. This browser needs to unlock it again."
+   - The banner shows **no** raw error text, phase names, counts, IDs, or PIM — only static reassurance copy plus an "Unlock now" action.
+   - The sync indicator no longer implies a healthy empty account.
+4. Click **Unlock now**. Expected:
+   - You land on `/login?reason=unlock&returnTo=…` and are **not** immediately bounced back to `/calendar` (no redirect loop).
+   - The login page shows a short unlock explanation instead of the normal "Welcome back" copy.
+5. Re-enter the approved account credentials and submit. Expected:
+   - Login succeeds, the browser navigates to the `returnTo` path, the next restore initializes cleanly, and the restore-blocked banner disappears.
+6. Confirm non-destructiveness. Before unlocking, verify that no local data was auto-cleared by the blocked state itself (the only clearing is the pre-existing offline-queue clear that happens when you explicitly re-enter credentials via `login()`). The app must never auto-clear localStorage, sessionStorage, or IndexedDB, and must never auto-logout, in the blocked state.
+
+### Expected result shape
+
+```text
+Restore-blocked negative check: PASS|FAIL
+environment: preview|local
+trigger: missing-session|corrupt-session|fresh-profile
+banner shown while blocked: yes|no
+banner copy privacy-safe (no error/phase/ID/PIM): yes|no
+/login?reason=unlock bounced back: yes|no   (PASS requires "no")
+re-unlock restored vault + cleared banner: yes|no
+local data auto-cleared before unlock: yes|no   (PASS requires "no")
+findings:
+  - <privacy-safe finding, if any>
+```
+
 ## Automation follow-up design
 
 A future automation slice may add a local-only or secure-runner probe that reads credentials from environment variables outside the repo, for example:


### PR DESCRIPTION
## Summary
- add a narrowly scoped `restoreBlocked` state for missing/invalid local encrypted session restore
- show a calm app-shell banner that sends users to `/login?reason=unlock`
- let authenticated users stay on the unlock login route until they re-enter credentials
- document the negative restore-blocked smoke check

## Safety / privacy
- no automatic logout or local storage/session/IndexedDB clearing in the blocked state
- no raw errors, IDs, collection IDs, session blobs, tokens, cookies, or PIM rendered in the banner
- non-session post-restore failures stay out of the unlock path

## Verification
- `pnpm --filter @silentsuite/web exec vitest run app/stores/__tests__/use-etebase-store.test.ts app/components/__tests__/restore-blocked-banner.test.tsx 'app/(auth)/login/__tests__/login-unlock.test.tsx'`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

## Notes
- re-unlocking uses the existing login flow, including its existing offline queue clear on explicit login submit
- preview restore-blocked negative smoke remains to run after deploy