### PR TITLE
fix(web): cancel abandoned card payment flows

### DIFF
--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -134,4 +134,27 @@ describe('AddCardBanner', () => {
       expect.objectContaining({ method: 'POST', credentials: 'include' }),
     ))
   })
+
+  it('best-effort cancels an active payment flow when the page is hidden during unload', async () => {
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/subscription/payment-flows/current')) return { ok: true, json: async () => ({ flow: null }) } as Response
+      if (url.includes('/subscription/payment-options?interval=monthly')) return { ok: true, json: async () => monthlyOptions } as Response
+      if (url.includes('/subscription/payment-flows/cancel')) return { ok: true, json: async () => ({ cancelled: true, flowKind: 'stripe_pay_now' }) } as Response
+      if (url.includes('/subscription/payment-flows') && init?.method === 'POST') return { ok: true, json: async () => ({ clientSecret: 'pi_secret', flowKind: 'stripe_pay_now', planId: 'early_monthly', billingInterval: 'monthly', amount: '3.60', currency: 'EUR' }) } as Response
+      return { ok: false, json: async () => ({}) } as Response
+    })
+
+    render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
+    fireEvent.click(screen.getByText('Choose payment'))
+    fireEvent.click(await screen.findByText('Continue to card payment'))
+    expect(await screen.findByText('Powered by Stripe')).toBeInTheDocument()
+
+    window.dispatchEvent(new Event('pagehide'))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      'https://billing.example.test/subscription/payment-flows/cancel',
+      expect.objectContaining({ method: 'POST', credentials: 'include', keepalive: true }),
+    ))
+  })
 })

--- a/apps/web/app/components/bitcoin-payment-panel.tsx
+++ b/apps/web/app/components/bitcoin-payment-panel.tsx
@@ -163,7 +163,7 @@ export default function BitcoinPaymentPanel({
       ) : status === 'error' ? (
         <div className="space-y-3 rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">
           <p>{error ?? 'Could not load Bitcoin payment details.'}</p>
-          <a href={session.checkoutUrl} className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border border-red-500/30 bg-transparent px-4 py-2 text-sm font-medium text-red-700 shadow-sm transition-colors hover:bg-red-500/10 dark:text-red-200">
+          <a href={session.checkoutUrl} target="_blank" rel="noreferrer" className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border border-red-500/30 bg-transparent px-4 py-2 text-sm font-medium text-red-700 shadow-sm transition-colors hover:bg-red-500/10 dark:text-red-200">
             {externalCheckoutLabel}<ExternalLink className="h-3.5 w-3.5" />
           </a>
         </div>
@@ -202,7 +202,7 @@ export default function BitcoinPaymentPanel({
             </button>
           </div>
 
-          <a href={session.checkoutUrl} className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100">
+          <a href={session.checkoutUrl} target="_blank" rel="noreferrer" className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100">
             {externalCheckoutLabel}<ExternalLink className="h-3.5 w-3.5" />
           </a>
         </div>

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { Crown, Lock, Zap } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
@@ -143,6 +143,7 @@ export default function PaymentChoicePanel({
   const [error, setError] = useState<string | null>(null)
   const [options, setOptions] = useState<PaymentOption[]>([])
   const [optionsLoaded, setOptionsLoaded] = useState(false)
+  const shouldCancelOnPageExitRef = useRef(false)
 
   async function loadOptionsForInterval(nextInterval: BillingInterval, isCancelled: () => boolean = () => false) {
     setOptionsLoaded(false)
@@ -177,7 +178,9 @@ export default function PaymentChoicePanel({
       const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows/current`, { credentials: 'include' })
       if (!res.ok) return
       const data = await res.json()
-      setCurrentFlow(data.flow ?? null)
+      const flow = data.flow ?? null
+      shouldCancelOnPageExitRef.current = Boolean(flow?.cancellable && flow.flowKind === 'stripe_pay_now')
+      setCurrentFlow(flow)
     } catch {
       // Payment options still render if the recovery endpoint is temporarily unavailable.
     }
@@ -208,6 +211,7 @@ export default function PaymentChoicePanel({
       setClientSecret(null)
       setStripePaymentSummary(null)
       setBitcoinSession(null)
+      shouldCancelOnPageExitRef.current = false
       await loadOptionsForInterval(interval)
       await loadCurrentFlow()
     } catch (err) {
@@ -216,6 +220,24 @@ export default function PaymentChoicePanel({
       setLoading(null)
     }
   }
+
+  useEffect(() => {
+    shouldCancelOnPageExitRef.current = Boolean(clientSecret || (currentFlow?.cancellable && currentFlow.flowKind === 'stripe_pay_now'))
+  }, [clientSecret, currentFlow])
+
+  useEffect(() => {
+    function cancelOnPageExit() {
+      if (!shouldCancelOnPageExitRef.current) return
+      void fetch(`${BILLING_API_URL}/subscription/payment-flows/cancel`, {
+        method: 'POST',
+        credentials: 'include',
+        keepalive: true,
+      }).catch(() => undefined)
+    }
+
+    window.addEventListener('pagehide', cancelOnPageExit)
+    return () => window.removeEventListener('pagehide', cancelOnPageExit)
+  }, [])
 
   const startStripe = async () => {
     setLoading('stripe')
@@ -236,6 +258,7 @@ export default function PaymentChoicePanel({
         throw new Error(data?.detail ?? 'Failed to set up payment')
       }
       const data = await res.json()
+      shouldCancelOnPageExitRef.current = true
       setClientSecret(data.clientSecret)
       setStripePaymentSummary({
         planId: typeof data.planId === 'string' ? data.planId : planId,
@@ -294,6 +317,7 @@ export default function PaymentChoicePanel({
         settledMessage="Payment settled. Refreshing your subscription..."
         onBack={cancelCurrentFlow}
         onPaymentComplete={async () => {
+          shouldCancelOnPageExitRef.current = false
           await onSuccess()
           await successPoll?.()
         }}
@@ -335,6 +359,7 @@ export default function PaymentChoicePanel({
         <StripePaymentForm
           clientSecret={clientSecret}
           onSuccess={async () => {
+            shouldCancelOnPageExitRef.current = false
             await onSuccess()
             await successPoll?.()
           }}


### PR DESCRIPTION
## Summary
- best-effort cancel in-progress card payment flows on `pagehide` so browser back/reload/window close does not leave a stuck Stripe flow
- keep explicit Back actions cancelling the pending flow before returning to options
- open BTCPay checkout links in a new tab so the SilentSuite page does not accidentally invalidate an invoice during legitimate payment handoff

## Validation
- `pnpm --filter @silentsuite/web exec vitest run app/components/__tests__/AddCardBanner.test.tsx`
- `pnpm --filter @silentsuite/web lint`
- `git diff --check`

Note: Bitcoin/BTCPay abandonment is primarily handled by the paired billing API stale-flow expiry; unload cancellation is intentionally limited to card flows to avoid invalidating an invoice the user opened in BTCPay.