### PR TITLE
web: redirect unlock submit immediately

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -34,9 +34,6 @@ export default function LoginPage() {
   const [serverUrl, setServerUrl] = useState('')
   const [rememberDevice, setRememberDevice] = useState(false)
   const isUnlock = searchParams.get('reason') === 'unlock'
-  // Tracks a fresh successful unlock submit so the redirect effect fires only
-  // after the user has actually re-entered credentials on the unlock route.
-  const [didUnlockSubmit, setDidUnlockSubmit] = useState(false)
 
   const {
     register,
@@ -52,10 +49,10 @@ export default function LoginPage() {
     // On the unlock route, stay put until the user re-enters credentials --
     // an already-authenticated-but-restore-blocked user must not be bounced
     // straight back into the broken empty state (redirect loop).
-    if (isUnlock && !didUnlockSubmit) return
+    if (isUnlock) return
     const returnTo = safeReturnTo(searchParams.get('returnTo'))
     router.replace(returnTo)
-  }, [isAuthenticated, isUnlock, didUnlockSubmit, router, searchParams])
+  }, [isAuthenticated, isUnlock, router, searchParams])
 
   useEffect(() => {
     return () => clearError()
@@ -72,7 +69,8 @@ export default function LoginPage() {
     await login(data.email, data.password, normalizedUrl, useHostedBilling && rememberDevice)
     // Read the store directly to avoid a stale closure over `error`.
     if (isUnlock && !useAuthStore.getState().error) {
-      setDidUnlockSubmit(true)
+      const returnTo = safeReturnTo(searchParams.get('returnTo'))
+      router.replace(returnTo)
     }
   }
 


### PR DESCRIPTION
## Summary
- make `/login?reason=unlock` redirect immediately after a successful unlock login submit
- keep the route parked for already-authenticated users before credential entry
- avoid double redirects from the effect path

## Why
Preview negative restore-blocked smoke showed the banner and unlock page, but the post-submit navigation could be racey because `isAuthenticated` was already true. This makes successful unlock submit navigate directly to the validated `returnTo` path.

## Verification
- `pnpm --filter @silentsuite/web exec vitest run 'app/(auth)/login/__tests__/login-unlock.test.tsx'`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`