### PR TITLE
Simplify remember-device checkbox copy

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -143,12 +143,7 @@ export default function LoginPage() {
               onChange={(e) => setRememberDevice(e.target.checked)}
               className="mt-0.5 h-4 w-4 rounded border-[rgb(var(--border))] bg-[rgb(var(--surface))] text-[rgb(var(--primary))] focus:ring-[rgb(var(--primary))] focus:ring-offset-0"
             />
-            <span>
-              <span className="block font-medium">Keep me signed in on this device</span>
-              <span className="block text-xs text-[rgb(var(--muted))]">
-                Leave unchecked to let your browser forget this session when all windows are closed.
-              </span>
-            </span>
+            <span className="text-sm font-medium text-[rgb(var(--foreground))]/80">Keep me signed in on this device</span>
           </label>
         )}
 

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -379,10 +379,7 @@ function StepCreateAccount({
               onChange={(e) => onRememberDeviceChange(e.target.checked)}
               className="mt-0.5 h-4 w-4 rounded border-[rgb(var(--border))] bg-[rgb(var(--surface))] text-[rgb(var(--primary))] focus:ring-[rgb(var(--primary))] focus:ring-offset-0"
             />
-            <span className="text-xs text-[rgb(var(--muted))] leading-relaxed">
-              <span className="block font-medium text-[rgb(var(--foreground))]/80">Keep me signed in on this device</span>
-              Leave unchecked to let your browser forget this session when all windows are closed.
-            </span>
+            <span className="text-sm font-medium text-[rgb(var(--foreground))]/80">Keep me signed in on this device</span>
           </label>
         )}
 


### PR DESCRIPTION
## Summary
- Remove the helper sentence under the hosted `Keep me signed in on this device` checkbox.
- Keep the checkbox label concise on login and signup.

## Verification
- `pnpm run test app/stores/__tests__/use-auth-store.test.ts` — 64 passed
- `pnpm run type-check`
- `git diff --check`

## Notes
- Copy-only cleanup after manual confirmation that forget-on-close behavior works on the dev preview.
