### PR TITLE
web: restore encrypted session without billing reexchange

### DIFF
--- a/apps/web/app/(auth)/login/__tests__/login-unlock.test.tsx
+++ b/apps/web/app/(auth)/login/__tests__/login-unlock.test.tsx
@@ -7,6 +7,7 @@ let searchParams = new URLSearchParams()
 
 const authState = {
   login: vi.fn(async () => {}),
+  unlockEtebaseSession: vi.fn(async () => {}),
   isLoading: false,
   error: null as string | null,
   clearError: vi.fn(),
@@ -31,6 +32,7 @@ vi.mock('@/app/stores/use-etebase-store', () => ({
 beforeEach(() => {
   replace.mockClear()
   authState.login.mockClear().mockResolvedValue(undefined)
+  authState.unlockEtebaseSession.mockClear().mockResolvedValue(undefined)
   authState.clearError.mockClear()
   authState.isAuthenticated = false
   authState.error = null
@@ -63,9 +65,31 @@ describe('LoginPage unlock route', () => {
     })
     fireEvent.submit(screen.getByRole('button', { name: /log in/i }))
 
-    await waitFor(() => expect(authState.login).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(authState.unlockEtebaseSession).toHaveBeenCalledTimes(1))
+    expect(authState.login).not.toHaveBeenCalled()
     await waitFor(() => expect(replace).toHaveBeenCalledWith('/calendar'))
     expect(replace).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not redirect after a failed unlock submit', async () => {
+    authState.isAuthenticated = true
+    authState.unlockEtebaseSession.mockImplementationOnce(async () => {
+      authState.error = 'Invalid email or password. Please try again.'
+    })
+    searchParams = new URLSearchParams('reason=unlock&returnTo=/calendar')
+
+    render(<LoginPage />)
+
+    fireEvent.change(screen.getByLabelText(/Email address/i), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText(/^Password$/i), {
+      target: { value: 'wrong-password' },
+    })
+    fireEvent.submit(screen.getByRole('button', { name: /log in/i }))
+
+    await waitFor(() => expect(authState.unlockEtebaseSession).toHaveBeenCalledTimes(1))
+    expect(replace).not.toHaveBeenCalled()
   })
 
   it('falls back to calendar for malicious or self-looping returnTo values', async () => {
@@ -89,6 +113,24 @@ describe('LoginPage unlock route', () => {
       await waitFor(() => expect(replace).toHaveBeenCalledWith('/calendar'))
       unmount()
     }
+  })
+
+  it('uses full login when unlock route is visited without an authenticated hosted session', async () => {
+    authState.isAuthenticated = false
+    searchParams = new URLSearchParams('reason=unlock&returnTo=/calendar')
+
+    render(<LoginPage />)
+
+    fireEvent.change(screen.getByLabelText(/Email address/i), {
+      target: { value: 'user@example.com' },
+    })
+    fireEvent.change(screen.getByLabelText(/^Password$/i), {
+      target: { value: 'correct-horse' },
+    })
+    fireEvent.submit(screen.getByRole('button', { name: /log in/i }))
+
+    await waitFor(() => expect(authState.login).toHaveBeenCalledTimes(1))
+    expect(authState.unlockEtebaseSession).not.toHaveBeenCalled()
   })
 
   it('preserves the normal authenticated bounce when reason is absent', () => {

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -30,7 +30,7 @@ function safeReturnTo(raw: string | null): string {
 export default function LoginPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { login, isLoading, error, clearError, isAuthenticated } = useAuthStore()
+  const { login, unlockEtebaseSession, isLoading, error, clearError, isAuthenticated } = useAuthStore()
   const [serverUrl, setServerUrl] = useState('')
   const [rememberDevice, setRememberDevice] = useState(false)
   const isUnlock = searchParams.get('reason') === 'unlock'
@@ -66,7 +66,11 @@ export default function LoginPage() {
     } else {
       localStorage.removeItem('silentsuite-server-url')
     }
-    await login(data.email, data.password, normalizedUrl, useHostedBilling && rememberDevice)
+    if (isUnlock && isAuthenticated) {
+      await unlockEtebaseSession(data.email, data.password, normalizedUrl)
+    } else {
+      await login(data.email, data.password, normalizedUrl, useHostedBilling && rememberDevice)
+    }
     // Read the store directly to avoid a stale closure over `error`.
     if (isUnlock && !useAuthStore.getState().error) {
       const returnTo = safeReturnTo(searchParams.get('returnTo'))

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -92,6 +92,33 @@ describe('useAuthStore', () => {
     expect(state.isLoading).toBe(false)
   })
 
+  it('unlockEtebaseSession restores only the local session for the signed-in account', async () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'test@example.com', planId: 'pro', isAdmin: false, onboardedAt: null },
+      isAuthenticated: true,
+    })
+
+    await useAuthStore.getState().unlockEtebaseSession('TEST@example.com', 'password123')
+
+    expect(secureStore.etebase_session).toBe('mock-saved-session')
+    expect(fetch).not.toHaveBeenCalled()
+    expect(offlineQueueClearAll).not.toHaveBeenCalled()
+    expect(useAuthStore.getState().error).toBeNull()
+  })
+
+  it('unlockEtebaseSession refuses to mix a different Etebase account with the hosted session', async () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'test@example.com', planId: 'pro', isAdmin: false, onboardedAt: null },
+      isAuthenticated: true,
+    })
+
+    await useAuthStore.getState().unlockEtebaseSession('other@example.com', 'password123')
+
+    expect(secureStore.etebase_session).toBeUndefined()
+    expect(fetch).not.toHaveBeenCalled()
+    expect(useAuthStore.getState().error).toMatch(/already signed in/i)
+  })
+
   it('signup sends a trimmed promo code when provided', async () => {
     useAuthStore.setState({
       pendingSignup: {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -75,6 +75,7 @@ interface AuthState {
   /** Call after the entire signup flow (including payment + vault) to finalize authentication. */
   completeSignup: () => void
   login: (email: string, password: string, serverUrl?: string, rememberDevice?: boolean) => Promise<void>
+  unlockEtebaseSession: (email: string, password: string, serverUrl?: string) => Promise<void>
   logout: () => Promise<void>
   refreshSession: () => Promise<boolean>
   restoreSession: () => Promise<void>
@@ -771,6 +772,41 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         isAuthenticated: true,
         isLoading: false,
       })
+    } catch (err) {
+      let message = 'Login failed'
+      if (err instanceof Error) {
+        const raw = err.message.toLowerCase()
+        if (raw.includes('unauthorized') || raw.includes('401')) {
+          message = 'Invalid email or password. Please try again.'
+        } else if (raw.includes('not found') || raw.includes('404')) {
+          message = 'No account found with this email. Please sign up first.'
+        } else if (raw.includes('fetch') || raw.includes('network')) {
+          message = 'Unable to reach the server. Please check your connection and try again.'
+        } else {
+          message = err.message
+        }
+      }
+      set({ isLoading: false, error: message })
+    }
+  },
+
+  unlockEtebaseSession: async (email: string, password: string, serverUrl?: string) => {
+    set({ isLoading: true, error: null })
+    const currentEmail = get().user?.email
+    if (currentEmail && currentEmail.toLowerCase() !== email.toLowerCase()) {
+      set({
+        isLoading: false,
+        error: 'Please unlock this browser with the email address already signed in on this device.',
+      })
+      return
+    }
+    try {
+      const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
+      const { savedSession } = await etebaseLogIn(email, password, serverUrl)
+      // This is same-account recovery, not an account switch. Preserve queued
+      // offline work while restoring the missing encrypted session blob.
+      await secureSet('etebase_session', savedSession)
+      set({ isLoading: false })
     } catch (err) {
       let message = 'Login failed'
       if (err instanceof Error) {


### PR DESCRIPTION
## Summary
- add a local-only Etebase unlock path for already-authenticated restore-blocked users
- keep normal login/signup billing token exchange unchanged
- guard against cross-account unlocks and preserve queued offline work for same-account recovery

## Root cause
Preview negative restore-blocked smoke showed Etebase login succeeded, then hosted billing token exchange returned 429. Re-unlock should restore the missing encrypted local session for the already-authenticated hosted user, not mint a new hosted billing session.

## Verification
- pnpm --filter @silentsuite/web exec vitest run 'app/(auth)/login/__tests__/login-unlock.test.tsx' app/stores/__tests__/use-auth-store.test.ts
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web lint
- pnpm run test
- pnpm run lint
- pnpm run build

## Review
- Claude Code Opus 4.8 supplementary review: no blockers; nits addressed before PR
