### PR TITLE
Bridge: add macOS Apple Accounts HTTPS setup

### DIFF
--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -94,6 +94,24 @@ You can always find these URLs by:
 - Opening the dashboard at `http://localhost:37358/`
 - Using the system tray menu account entries (Copy CalDAV URL / Copy CardDAV URL)
 
+### macOS Apple Internet Accounts HTTPS setup
+
+Most DAV clients can use the default local HTTP bridge URL. macOS Apple Internet Accounts is stricter: use **Advanced** setup with **Use SSL** checked and a trusted localhost certificate.
+
+On the Mac that runs the bridge:
+
+```bash
+silentsuite-bridge --setup-macos-apple-accounts
+```
+
+Then trust the generated localhost certificate in **Keychain Access** with **Trust > Secure Sockets Layer (SSL)** set to **Always Trust**, restart the bridge, and use the `https://` DAV URLs shown in the dashboard.
+
+::: warning HTTPS is all-or-nothing for one bridge profile
+Enabling bridge SSL changes the single local DAV listener from HTTP to HTTPS. Existing Thunderbird, DAVx5, Evolution, KDE, or other clients configured with `http://localhost:37358/` must be updated to the dashboard's `https://` URL and may need to trust the same localhost certificate. Running simultaneous HTTP and HTTPS listeners is not part of this bridge mode.
+:::
+
+For detailed Apple setup fields and troubleshooting, see [macOS Calendar & Contacts](./macos.md).
+
 ## Multi-Account Use
 
 The bridge can keep multiple accounts active in one local bridge profile. Each account has its own credentials, local cache namespace, sync thread, and DAV path.

--- a/apps/docs/user-guide/apps/macos.md
+++ b/apps/docs/user-guide/apps/macos.md
@@ -2,55 +2,97 @@
 
 Sync SilentSuite with the native macOS Calendar and Contacts apps through the [SilentSuite Bridge](./dav-bridge.md).
 
+macOS Apple Internet Accounts is stricter than many DAV clients: use **Advanced** setup with **SSL enabled** and a trusted localhost certificate.
+
 ## Prerequisites
 
-1. The [SilentSuite Bridge](./dav-bridge.md) running on your Mac.
-2. Your **account credentials** from the bridge's web UI at `http://localhost:37358/`.
+1. Install and start the [SilentSuite Bridge](./dav-bridge.md) on your Mac.
+2. Sign in to the bridge dashboard first so your account appears at `http://localhost:37358/`.
+3. Run the macOS Apple Accounts setup command:
+
+   ```bash
+   silentsuite-bridge --setup-macos-apple-accounts
+   ```
+
+4. In **Keychain Access**, add/open the generated localhost certificate and set **Trust > Secure Sockets Layer (SSL)** to **Always Trust**.
+5. Restart the bridge and open the dashboard at `https://localhost:37358/` or `https://127.0.0.1:37358/`.
+
+::: warning HTTPS affects the whole local bridge
+After SSL setup, this bridge profile serves its single DAV listener over HTTPS. Existing clients configured with `http://localhost:37358/` must be updated to the `https://` URL shown in the dashboard and may need to trust the same localhost certificate.
+:::
 
 ## Add Calendar Account
 
 1. Open **System Settings** (or System Preferences on older macOS).
 2. Go to **Internet Accounts** > **Add Account** > **Other**.
 3. Click **CalDAV Account**.
-4. Select **Manual** for the account type.
+4. Select **Advanced** for the account type.
 5. Enter:
-   - **Username**: your account email
-   - **Password**: your **account password**
-   - **Server Address**: `http://localhost:37358/`
+   - **User Name**: your SilentSuite account email
+   - **Password**: your account password
+   - **Server Address**: `localhost` or `127.0.0.1`
+   - **Server Path**: `/your@email.com/` using the exact account email shown in the bridge dashboard
+   - **Port**: `37358`
+   - **Use SSL**: checked
 6. Click **Sign In**.
 
-Your SilentSuite calendars will appear in the Calendar app.
+Your SilentSuite calendars should appear in Calendar after the bridge completes sync.
 
 ## Add Contacts Account
 
 1. Open **System Settings** > **Internet Accounts** > **Add Account** > **Other**.
 2. Click **CardDAV Account**.
-3. Select **Manual**.
+3. Select **Advanced**.
 4. Enter:
-   - **Username**: your account email
-   - **Password**: your **account password**
-   - **Server Address**: `http://localhost:37358/`
+   - **User Name**: your SilentSuite account email
+   - **Password**: your account password
+   - **Server Address**: `localhost` or `127.0.0.1`
+   - **Server Path**: `/your@email.com/` using the exact account email shown in the bridge dashboard
+   - **Port**: `37358`
+   - **Use SSL**: checked
 5. Click **Sign In**.
 
-Your SilentSuite contacts will appear in the Contacts app.
+Your SilentSuite contacts should appear in Contacts after the bridge completes sync.
+
+## If CalDAV Fails
+
+Some macOS versions accept the trusted localhost certificate more reliably after adding CardDAV first.
+
+1. Add the **CardDAV** account using Advanced setup and SSL.
+2. Confirm Contacts can connect.
+3. Add the **CalDAV** account again using the same server address, port, SSL setting, username, password, and account path.
 
 ## Running the Bridge at Login
 
 To keep the SilentSuite Bridge running automatically, see the [DAV bridge guide](./dav-bridge.md) for macOS launchd configuration.
 
-## Known Issues
-
-macOS Mojave and later have known bugs with local CalDAV/CardDAV accounts. If you encounter issues:
-
-- Try using `127.0.0.1` instead of `localhost` in the server address.
-- If macOS rejects the connection, try adding the account via the Calendar or Contacts app directly instead of System Settings.
-
 ## Troubleshooting
-
-### Calendar shows but events are missing
-
-macOS may limit sync to recent events. Open **Calendar > Preferences > Accounts**, select your DAV account, and check the sync range.
 
 ### Connection refused
 
-Make sure the SilentSuite Bridge is running. Open `http://localhost:37358/` in Safari to verify.
+Make sure the SilentSuite Bridge is running. Open the dashboard URL shown by the bridge:
+
+- Before SSL setup: `http://localhost:37358/`
+- After SSL setup: `https://localhost:37358/`
+
+### Certificate warning or account rejected
+
+1. Reopen **Keychain Access**.
+2. Find the generated localhost certificate from `silentsuite-bridge --setup-macos-apple-accounts`.
+3. Set **Trust > Secure Sockets Layer (SSL)** to **Always Trust**.
+4. Restart the bridge and retry Apple Internet Accounts.
+
+### Calendar shows but events are missing
+
+macOS may limit sync to recent events. Open **Calendar > Settings > Accounts**, select your DAV account, and check the sync range.
+
+### Apple Internet Accounts still fails with `/principals/`
+
+If HTTPS + Advanced setup still fails, collect a redacted bridge log for support. Include paths such as:
+
+- `/principals/`
+- `/.well-known/caldav`
+- `/.well-known/carddav`
+- `/your@email.com/`
+
+Do **not** include passwords, session tokens, or full private logs. This evidence determines whether SilentSuite needs a follow-up DAV principal-discovery compatibility shim.

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -26,6 +26,26 @@ The dashboard exposes the same account-management flow without terminal commands
 - **Log out** removes local bridge credentials/session material for one account and keeps that account's local cache.
 - **Remove account** removes local bridge credentials/session material and deletes that account's local cache rows.
 
+## macOS Apple Internet Accounts
+
+Apple Internet Accounts may require the local bridge to use HTTPS with a trusted localhost certificate. To generate or reuse a localhost certificate and print the Keychain setup steps, run this on the Mac that hosts the bridge:
+
+```bash
+silentsuite-bridge --setup-macos-apple-accounts
+```
+
+On macOS, this persists bridge SSL settings, opens the certificate for Keychain, and prints the Advanced account setup fields. Trust the certificate in Keychain with **Secure Sockets Layer (SSL)** set to **Always Trust**, restart the bridge, then use the dashboard's `https://localhost:37358/your@example.com/` DAV URL.
+
+Enabling bridge SSL changes the whole single listener to HTTPS. Existing HTTP clients using the same bridge profile must switch to `https://` and trust the localhost certificate. The bridge does not expose simultaneous HTTP and HTTPS listeners in this mode.
+
+Advanced/headless configuration keys:
+
+- `sslEnabled` / `SILENTSUITE_BRIDGE_SSL`
+- `sslCertFile` / `SILENTSUITE_BRIDGE_SSL_CERT`
+- `sslKeyFile` / `SILENTSUITE_BRIDGE_SSL_KEY`
+
+If Apple Internet Accounts still fails after HTTPS setup, collect redacted bridge logs for `/principals/`, `/.well-known/caldav`, and `/.well-known/carddav`. Do not include passwords or session tokens; this evidence determines whether a later DAV discovery compatibility shim is needed.
+
 The local bridge cache contains decrypted calendar/contact/task data. Use `--remove-account` when retiring a shared or untrusted machine.
 
 ## License

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -9,10 +9,12 @@ Usage:
 """
 
 import logging
+import os
+import subprocess
 import sys
+import tempfile
 
-from . import __version__
-from . import config
+from . import __version__, config
 
 logger = logging.getLogger("silentsuite-bridge")
 
@@ -48,17 +50,23 @@ def build_radicale_configuration():
     Uses SilentSuite's custom storage and auth backends,
     configured to listen on localhost only.
     """
-    from radicale.config import Configuration, DEFAULT_CONFIG_SCHEMA
+    from radicale.config import DEFAULT_CONFIG_SCHEMA, Configuration
 
     config.validate_network_config()
+    _verify_radicale_ssl_schema(DEFAULT_CONFIG_SCHEMA)
 
     configuration = Configuration(DEFAULT_CONFIG_SCHEMA)
     web_type = "silentsuite_bridge.web" if config.is_dashboard_enabled() else "none"
+    server_cfg = {
+        "hosts": config.SERVER_HOSTS,
+    }
+    if config.SSL_ENABLED:
+        server_cfg["ssl"] = True
+        server_cfg["certificate"] = config.SSL_CERT_FILE
+        server_cfg["key"] = config.SSL_KEY_FILE
     configuration.update(
         {
-            "server": {
-                "hosts": config.SERVER_HOSTS,
-            },
+            "server": server_cfg,
             "auth": {
                 "type": "silentsuite_bridge.radicale.auth",
             },
@@ -82,8 +90,31 @@ def build_radicale_configuration():
     return configuration
 
 
+def _verify_radicale_ssl_schema(schema) -> None:
+    """Verify Radicale exposes the SSL keys this bridge config relies on."""
+    server_schema = schema.get("server", {})
+    missing = [key for key in ("ssl", "certificate", "key") if key not in server_schema]
+    if missing:
+        raise RuntimeError(
+            "Installed Radicale does not expose required SSL server config key(s): "
+            + ", ".join(missing)
+        )
+
+
+def validate_radicale_ssl_schema() -> None:
+    """Validate the installed Radicale SSL schema inside main()'s clean guard."""
+    from radicale.config import DEFAULT_CONFIG_SCHEMA
+
+    _verify_radicale_ssl_schema(DEFAULT_CONFIG_SCHEMA)
+
+
+def effective_dav_scheme() -> str:
+    """Test-visible helper reporting the DAV scheme fed into Radicale."""
+    return "https" if config.SSL_ENABLED else "http"
+
+
 def _dashboard_url():
-    return f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/"
+    return f"{config.local_base_url()}/"
 
 
 def _open_dashboard_later(url, delay=1.0):
@@ -129,7 +160,7 @@ def check_credentials(open_browser=True):
 def start_tray():
     """Start the system tray icon if available."""
     try:
-        from .tray import BridgeTray, TRAY_AVAILABLE
+        from .tray import TRAY_AVAILABLE, BridgeTray
 
         if not TRAY_AVAILABLE:
             logger.info("System tray not available (pystray/Pillow not installed)")
@@ -214,6 +245,256 @@ def _initial_status_check():
         update_status("disconnected")
 
 
+_OPENSSL_CONFIG_TEMPLATE = """\
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+req_extensions = v3_req
+x509_extensions = v3_req
+
+[dn]
+CN = localhost
+
+[v3_req]
+subjectAltName = @alt_names
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+IP.2 = ::1
+"""
+
+_OPENSSL_CONFIG_TEMPLATE_NO_IPV6 = """\
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+req_extensions = v3_req
+x509_extensions = v3_req
+
+[dn]
+CN = localhost
+
+[v3_req]
+subjectAltName = @alt_names
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+"""
+
+_CERT_VALIDITY_DAYS = 398
+
+
+def _generate_localhost_certificate(cert_path: str, key_path: str) -> None:
+    """Generate a self-signed localhost certificate + key via system openssl.
+
+    Raises RuntimeError with actionable text on failure. Does not print
+    command output that could include secrets.
+    """
+    parent = os.path.dirname(cert_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    key_parent = os.path.dirname(key_path)
+    if key_parent:
+        os.makedirs(key_parent, exist_ok=True)
+
+    # Try IPv6 SAN first; fall back to DNS+IPv4 if the OpenSSL build rejects ::1.
+    for template in (_OPENSSL_CONFIG_TEMPLATE, _OPENSSL_CONFIG_TEMPLATE_NO_IPV6):
+        with tempfile.NamedTemporaryFile("w", suffix=".cnf", delete=False) as cfg:
+            cfg.write(template)
+            cfg_path = cfg.name
+        try:
+            result = subprocess.run(
+                [
+                    "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+                    "-days", str(_CERT_VALIDITY_DAYS),
+                    "-keyout", key_path,
+                    "-out", cert_path,
+                    "-config", cfg_path,
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            try:
+                os.unlink(cfg_path)
+            except OSError:
+                pass
+        if result.returncode == 0:
+            if template is _OPENSSL_CONFIG_TEMPLATE_NO_IPV6:
+                logger.info(
+                    "Generated localhost certificate with DNS+IPv4 SANs only; "
+                    "use 'localhost' or '127.0.0.1' for Apple Internet Accounts."
+                )
+            _harden_key_permissions(key_path)
+            return
+
+    raise RuntimeError(
+        "Failed to generate a localhost certificate with openssl. "
+        "Ensure the 'openssl' command is available and the bridge data directory "
+        "is writable. See `silentsuite-bridge --setup-macos-apple-accounts` docs."
+    )
+
+
+def _harden_key_permissions(key_path: str) -> None:
+    """Best-effort chmod the private key to 0600."""
+    try:
+        os.chmod(key_path, 0o600)
+    except OSError:
+        logger.debug("Could not chmod key file %s to 0600", key_path)
+
+
+def _cert_and_key_readable(cert_path: str, key_path: str) -> bool:
+    """True only when both files exist, are readable, and appear to match."""
+    for path in (cert_path, key_path):
+        try:
+            with open(path, "rb"):
+                pass
+        except OSError:
+            return False
+    return os.path.isfile(cert_path) and os.path.isfile(key_path) and _cert_and_key_match(cert_path, key_path)
+
+
+def _cert_and_key_match(cert_path: str, key_path: str) -> bool:
+    """Best-effort public-key match check for an existing localhost cert/key pair.
+
+    If openssl is unavailable, reuse readable existing files so a previously
+    configured bridge is not bricked by the setup helper. If openssl is present
+    and either file is invalid or mismatched, return False so both files are
+    regenerated together.
+    """
+    try:
+        cert = subprocess.run(
+            ["openssl", "x509", "-in", cert_path, "-noout", "-pubkey"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        key = subprocess.run(
+            ["openssl", "pkey", "-in", key_path, "-pubout"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+    if cert.returncode != 0 or key.returncode != 0:
+        return False
+    return bool(cert.stdout.strip()) and cert.stdout == key.stdout
+
+
+def _ensure_macos_localhost_certificate(cert_path: str, key_path: str) -> str:
+    """Reuse existing cert/key if both are readable, else regenerate both.
+
+    Returns 'reused' or 'generated'. Regenerating both together avoids pairing
+    a stale cert with a fresh key (or vice versa).
+    """
+    if _cert_and_key_readable(cert_path, key_path):
+        return "reused"
+    _generate_localhost_certificate(cert_path, key_path)
+    return "generated"
+
+
+def _open_certificate_for_trust(cert_path: str) -> bool:
+    """On macOS, open the certificate so the user can add it to Keychain."""
+    if sys.platform != "darwin":
+        return False
+    try:
+        subprocess.run(["open", cert_path], check=False)
+        return True
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _persist_ssl_settings(cert_path: str, key_path: str) -> None:
+    """Persist SSL enablement + paths so launchd autostart survives."""
+    settings = config.get_settings()
+    settings["sslEnabled"] = True
+    settings["sslCertFile"] = os.path.abspath(cert_path)
+    settings["sslKeyFile"] = os.path.abspath(key_path)
+    config.save_settings(settings)
+    config.SSL_ENABLED = True
+    config.SSL_CERT_FILE = settings["sslCertFile"]
+    config.SSL_KEY_FILE = settings["sslKeyFile"]
+
+
+def setup_macos_apple_accounts() -> int:
+    """Generate/reuse a localhost cert and print Apple Internet Accounts setup steps.
+
+    On macOS: persists sslEnabled=true and opens the cert for Keychain trust.
+    On non-Darwin: generates/reuses cert material and prints instructions, but
+    does NOT silently persist sslEnabled=true (avoids flipping a Linux bridge
+    profile to HTTPS-only without explicit user action).
+    """
+    cert_path = config.SSL_CERT_FILE
+    key_path = config.SSL_KEY_FILE
+    config.ensure_data_dir()
+
+    try:
+        status = _ensure_macos_localhost_certificate(cert_path, key_path)
+    except RuntimeError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    if sys.platform == "darwin":
+        _persist_ssl_settings(cert_path, key_path)
+        print(f"Certificate: {cert_path}")
+        print(f"Key: {key_path} (permissions hardened to 0600 best-effort)")
+        if status == "generated":
+            print("Generated a new localhost certificate (398-day validity).")
+        else:
+            print("Reused existing localhost certificate and key.")
+        _open_certificate_for_trust(cert_path)
+        print()
+        print("Next steps:")
+        print("  1. In Keychain Access, add the certificate to your login keychain.")
+        print("     Set Trust > Secure Sockets Layer (SSL) to Always Trust.")
+        print("  2. Restart the bridge: silentsuite-bridge")
+        print(f"  3. Open the dashboard: {config.dav_scheme()}://localhost:{config.LISTEN_PORT}/")
+        print("  4. System Settings > Internet Accounts > Add Account > Other >")
+        print("     CalDAV/CardDAV Account > Advanced:")
+        print(f"       - Server Address: localhost (or 127.0.0.1), Port: {config.LISTEN_PORT}")
+        print("       - Use SSL: checked")
+        print("       - User Name: your account email")
+        print("       - Password: your account password")
+        print("       - Server Path: /your@email.com/ (or the dashboard DAV URL)")
+        print("  5. If CalDAV fails, add CardDAV first to trigger certificate trust,")
+        print("     then retry CalDAV.")
+        return 0
+
+    # Non-Darwin: do not silently persist sslEnabled=true.
+    print(f"Certificate: {cert_path}")
+    print(f"Key: {key_path} (permissions hardened to 0600 best-effort)")
+    if status == "generated":
+        print("Generated a new localhost certificate (398-day validity).")
+    else:
+        print("Reused existing localhost certificate and key.")
+    print()
+    print("Note: enabling SSL is all-or-nothing for the single bridge listener.")
+    print("Existing HTTP clients on this bridge profile must switch to https://")
+    print("and trust the local certificate. To enable SSL on this platform, set")
+    print("sslEnabled=true in settings.json (or SILENTSUITE_BRIDGE_SSL=1) explicitly.")
+    print()
+    print("macOS setup steps (run on the Mac that hosts the bridge):")
+    print("  1. Trust this certificate in Keychain with SSL set to Always Trust.")
+    print("  2. Restart the bridge and open https://localhost:37358/.")
+    print("  3. Use Apple Internet Accounts > Advanced with Use SSL checked.")
+    return 0
+
+
 def run_server():
     """Start the Radicale server with SilentSuite backends."""
     from radicale.server import serve
@@ -226,13 +507,21 @@ def run_server():
         config.SERVER_HOSTS,
     )
     if config.is_remote_bind_configured():
-        logger.warning(
-            "Remote bridge bind enabled by SILENTSUITE_ALLOW_REMOTE=1. "
-            "DAV traffic is plaintext HTTP unless protected by your own proxy/VPN."
-        )
+        if config.SSL_ENABLED:
+            logger.warning(
+                "Remote bridge bind enabled by SILENTSUITE_ALLOW_REMOTE=1 with SSL on. "
+                "The bridge exposes decrypted DAV data over the network; do not expose "
+                "it remotely without an intentional network/security design."
+            )
+        else:
+            logger.warning(
+                "Remote bridge bind enabled by SILENTSUITE_ALLOW_REMOTE=1. "
+                "DAV traffic is plaintext HTTP unless protected by your own proxy/VPN."
+            )
         logger.warning("Bridge dashboard disabled while remote bind is configured.")
     logger.info("Etebase server: %s", config.ETEBASE_SERVER_URL)
     logger.info("Data directory: %s", config.DATA_DIR)
+    logger.info("CalDAV/CardDAV scheme: %s", config.dav_scheme())
     logger.info("CalDAV/CardDAV host(s): %s", config.SERVER_HOSTS)
 
     # Run initial sync so dashboard shows correct status immediately
@@ -281,6 +570,9 @@ def main():
         print("  --install-autostart   Install auto-start for current platform")
         print("  --remove-autostart    Remove auto-start for current platform")
         print("  --no-tray             Start without system tray icon")
+        print("  --setup-macos-apple-accounts")
+        print("                        Generate/reuse a localhost HTTPS certificate")
+        print("                        and print Apple Internet Accounts setup steps")
         print()
         print("Environment variables:")
         print("  SILENTSUITE_SERVER_URL       Etebase server URL")
@@ -292,6 +584,9 @@ def main():
         print("  SILENTSUITE_LOG_LEVEL        Log level (default: INFO)")
         print("  SILENTSUITE_LOG_FILE         Log file path")
         print("  SILENTSUITE_SYNC_INTERVAL    Sync interval in seconds (default: 900)")
+        print("  SILENTSUITE_BRIDGE_SSL       Enable HTTPS for the bridge listener (opt-in)")
+        print("  SILENTSUITE_BRIDGE_SSL_CERT  Path to the SSL certificate file")
+        print("  SILENTSUITE_BRIDGE_SSL_KEY   Path to the SSL private key file")
         sys.exit(0)
 
     # Handle --server before anything that uses config.ETEBASE_SERVER_URL
@@ -304,8 +599,16 @@ def main():
             sys.exit(1)
 
     configure_logging()
+
+    # Handle --setup-macos-apple-accounts before validating existing SSL files:
+    # this command is how users create the missing cert/key in the first place.
+    if "--setup-macos-apple-accounts" in sys.argv:
+        sys.exit(setup_macos_apple_accounts())
+
     try:
         config.validate_network_config()
+        config.validate_ssl_config()
+        validate_radicale_ssl_schema()
     except RuntimeError as exc:
         logger.error("%s", exc)
         sys.exit(1)

--- a/bridge/src/silentsuite_bridge/config.py
+++ b/bridge/src/silentsuite_bridge/config.py
@@ -34,6 +34,35 @@ SERVER_HOSTS = os.environ.get(
 )
 ALLOW_REMOTE = os.environ.get("SILENTSUITE_ALLOW_REMOTE", "").lower() in {"1", "true", "yes", "on"}
 
+# --- SSL ---
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSEY = {"0", "false", "no", "off"}
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    return _bool_value(value, default) if value is not None else default
+
+
+def _bool_value(value, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    normalized = str(value).strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSEY:
+        return False
+    return default
+
+
+SSL_ENABLED = _env_bool("SILENTSUITE_BRIDGE_SSL", False) or _env_bool("SILENTSUITE_SSL", False)
+SSL_CERT_FILE = os.environ.get(
+    "SILENTSUITE_BRIDGE_SSL_CERT", os.environ.get("SILENTSUITE_SSL_CERT", "")
+)
+SSL_KEY_FILE = os.environ.get(
+    "SILENTSUITE_BRIDGE_SSL_KEY", os.environ.get("SILENTSUITE_SSL_KEY", "")
+)
+
 # --- Data directories ---
 APP_NAME = "silentsuite-bridge"
 APP_AUTHOR = "silentsuite"
@@ -42,6 +71,13 @@ DATA_DIR = os.environ.get(
     "SILENTSUITE_DATA_DIR",
     user_data_dir(APP_NAME, APP_AUTHOR),
 )
+
+# Default SSL cert/key live inside the data directory so launchd autostart
+# works without shell environment exports.
+if not SSL_CERT_FILE:
+    SSL_CERT_FILE = os.path.join(DATA_DIR, "localhost-cert.pem")
+if not SSL_KEY_FILE:
+    SSL_KEY_FILE = os.path.join(DATA_DIR, "localhost-key.pem")
 
 # --- Database ---
 DATABASE_FILE = os.environ.get(
@@ -157,23 +193,99 @@ def validate_network_config() -> None:
         )
 
 
+def dav_scheme() -> str:
+    """Return the DAV URL scheme for the current bridge config."""
+    return "https" if SSL_ENABLED else "http"
+
+
+def local_base_url(host: str | None = None) -> str:
+    """Build scheme://host:port for dashboard/DAV URLs.
+
+    Defaults to the configured LISTEN_ADDRESS/LISTEN_PORT. IPv6 literals are
+    bracketed to keep URLs well-formed.
+    """
+    if host is None:
+        host = LISTEN_ADDRESS
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"{dav_scheme()}://{host}:{LISTEN_PORT}"
+
+
+def validate_ssl_config() -> None:
+    """Fail closed with actionable text when SSL is enabled but cert/key are unusable.
+
+    Called from the main() RuntimeError guard so missing material produces a
+    clean exit rather than a Radicale traceback.
+    """
+    if not SSL_ENABLED:
+        return
+    if not os.path.isfile(SSL_CERT_FILE) or not _readable(SSL_CERT_FILE):
+        raise RuntimeError(
+            f"Bridge SSL is enabled but the certificate file is missing or unreadable: "
+            f"{SSL_CERT_FILE}. Run `silentsuite-bridge --setup-macos-apple-accounts` "
+            f"to generate a localhost certificate, or set SILENTSUITE_BRIDGE_SSL_CERT."
+        )
+    if not os.path.isfile(SSL_KEY_FILE) or not _readable(SSL_KEY_FILE):
+        raise RuntimeError(
+            f"Bridge SSL is enabled but the key file is missing or unreadable: "
+            f"{SSL_KEY_FILE}. Run `silentsuite-bridge --setup-macos-apple-accounts` "
+            f"to generate a localhost key, or set SILENTSUITE_BRIDGE_SSL_KEY."
+        )
+
+
+def _readable(path: str) -> bool:
+    try:
+        with open(path, "rb"):
+            return True
+    except OSError:
+        return False
+
+
 def load_settings():
-    """Load settings from settings.json, applying overrides to module globals."""
-    global SYNC_INTERVAL
+    """Load settings from settings.json, applying overrides to module globals.
+
+    Environment variables take precedence over settings file values where both
+    are present, matching the env-override pattern used elsewhere in the bridge.
+    """
+    global SYNC_INTERVAL, SSL_ENABLED, SSL_CERT_FILE, SSL_KEY_FILE
     try:
         with open(SETTINGS_FILE, "r") as f:
             settings = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        settings = {}
+    try:
         if "syncInterval" in settings:
             SYNC_INTERVAL = int(settings["syncInterval"])
-    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+    except ValueError:
         pass
+    # Environment variables override settings even if tests/processes set them
+    # after the module was imported.
+    env_ssl = os.environ.get("SILENTSUITE_BRIDGE_SSL")
+    legacy_env_ssl = os.environ.get("SILENTSUITE_SSL")
+    if env_ssl is not None or legacy_env_ssl is not None:
+        SSL_ENABLED = _bool_value(env_ssl, False) or _bool_value(legacy_env_ssl, False)
+    elif "sslEnabled" in settings:
+        SSL_ENABLED = _bool_value(settings["sslEnabled"], False)
+
+    env_cert = os.environ.get("SILENTSUITE_BRIDGE_SSL_CERT") or os.environ.get("SILENTSUITE_SSL_CERT")
+    env_key = os.environ.get("SILENTSUITE_BRIDGE_SSL_KEY") or os.environ.get("SILENTSUITE_SSL_KEY")
+    if env_cert:
+        SSL_CERT_FILE = env_cert
+    elif "sslCertFile" in settings:
+        SSL_CERT_FILE = str(settings["sslCertFile"])
+    if env_key:
+        SSL_KEY_FILE = env_key
+    elif "sslKeyFile" in settings:
+        SSL_KEY_FILE = str(settings["sslKeyFile"])
 
 
 def save_settings(settings):
-    """Save settings dict to settings.json."""
+    """Save settings dict to settings.json, preserving caller-supplied keys."""
     ensure_data_dir()
+    existing = get_settings()
+    existing.update(settings)
     with open(SETTINGS_FILE, "w") as f:
-        json.dump(settings, f, indent=2)
+        json.dump(existing, f, indent=2)
 
 
 def get_settings():

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -10,8 +10,8 @@ Serves a status dashboard at the bridge root URL showing:
 Integrates with Radicale's web module system.
 """
 
-import html
 import hmac
+import html
 import json
 import logging
 import secrets
@@ -845,7 +845,7 @@ def _render_dashboard():
     creds = Credentials()
     users = creds.list_users()
 
-    base_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}"
+    base_url = config.local_base_url(config.LISTEN_ADDRESS)
 
     with _bridge_status_lock:
         state = _bridge_status["state"]
@@ -936,6 +936,13 @@ def _render_dashboard():
                     '</div>'
                 )
             account_attr = esc(user)
+            ssl_note = (
+                '<div style="font-size:12px;color:#60a5fa;margin-top:6px;">'
+                "For Apple Internet Accounts, use Advanced setup with SSL and trust the localhost certificate."
+                "</div>"
+                if config.SSL_ENABLED
+                else ""
+            )
             account_html += (
                 '<div class="account-card">'
                 f'<h4>{esc(user)}</h4>'
@@ -949,6 +956,7 @@ def _render_dashboard():
                 f'<button class="copy-btn" onclick="copy(event, \'{url_id}\')">Copy</button>'
                 '</div>'
                 '<div style="font-size:12px;color:#f59e0b;margin-top:6px;">For calendar/contact apps only. Copy it into your app &mdash; do not open it in a web browser, which can expose your password in the address bar.</div>'
+                f'{ssl_note}'
                 '<div class="account-actions">'
                 f'<button class="account-action-btn" data-account="{account_attr}" '
                 'onclick="logoutAccount(this)">Log out</button>'
@@ -1077,7 +1085,7 @@ class Web(BaseWeb):
                 return (404, {}, b"Not found")
             if not _has_valid_csrf(environ):
                 return _csrf_error()
-            from ..local_cache import models, db
+            from ..local_cache import db, models
             try:
                 with db.database_proxy:
                     result = {"collections": []}

--- a/bridge/tests/test_config.py
+++ b/bridge/tests/test_config.py
@@ -5,18 +5,24 @@ from unittest.mock import patch
 
 import pytest
 
-
 CONFIG_ENV_KEYS = (
     "SILENTSUITE_LISTEN_ADDRESS",
     "SILENTSUITE_LISTEN_PORT",
     "SILENTSUITE_SERVER_HOSTS",
     "SILENTSUITE_ALLOW_REMOTE",
     "SILENTSUITE_DASHBOARD_DUMP",
+    "SILENTSUITE_BRIDGE_SSL",
+    "SILENTSUITE_BRIDGE_SSL_CERT",
+    "SILENTSUITE_BRIDGE_SSL_KEY",
+    "SILENTSUITE_SSL",
+    "SILENTSUITE_SSL_CERT",
+    "SILENTSUITE_SSL_KEY",
 )
 
 
 def reload_config_with_env(monkeypatch, **values):
     import importlib
+
     from silentsuite_bridge import config
 
     for key in CONFIG_ENV_KEYS:
@@ -28,6 +34,7 @@ def reload_config_with_env(monkeypatch, **values):
 
 def restore_config(monkeypatch):
     import importlib
+
     from silentsuite_bridge import config
 
     for key in CONFIG_ENV_KEYS:
@@ -83,7 +90,6 @@ class TestConfigEnvOverrides:
     def test_server_url_env(self):
         with patch.dict(os.environ, {"SILENTSUITE_SERVER_URL": "https://custom.server"}):
             # Re-import to pick up env
-            import importlib
             from silentsuite_bridge import config
             original = config.ETEBASE_SERVER_URL
             # The env var is read at import time, so we test the mechanism
@@ -232,3 +238,222 @@ class TestConfigHelpers:
         finally:
             config.SETTINGS_FILE = original_settings
             config.DATA_DIR = original_data
+
+
+class TestSslConfig:
+    """Tests for SSL config defaults, env overrides, settings, and validation."""
+
+    def test_ssl_disabled_by_default(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch)
+        try:
+            assert cfg.SSL_ENABLED is False
+            assert cfg.dav_scheme() == "http"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_ssl_env_enables_https(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_BRIDGE_SSL="1")
+        try:
+            assert cfg.SSL_ENABLED is True
+            assert cfg.dav_scheme() == "https"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_ssl_legacy_alias_env_enables_https(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_SSL="true")
+        try:
+            assert cfg.SSL_ENABLED is True
+        finally:
+            restore_config(monkeypatch)
+
+    def test_ssl_cert_and_key_env_overrides(self, monkeypatch, tmp_path):
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_BRIDGE_SSL="1",
+            SILENTSUITE_BRIDGE_SSL_CERT=str(cert),
+            SILENTSUITE_BRIDGE_SSL_KEY=str(key),
+        )
+        try:
+            assert cfg.SSL_CERT_FILE == str(cert)
+            assert cfg.SSL_KEY_FILE == str(key)
+        finally:
+            restore_config(monkeypatch)
+
+    def test_default_cert_and_key_paths_inside_data_dir(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch)
+        try:
+            assert cfg.SSL_CERT_FILE.endswith("localhost-cert.pem")
+            assert cfg.SSL_KEY_FILE.endswith("localhost-key.pem")
+            assert cfg.DATA_DIR in cfg.SSL_CERT_FILE
+        finally:
+            restore_config(monkeypatch)
+
+    def test_dav_scheme_http_when_disabled(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch)
+        try:
+            assert cfg.dav_scheme() == "http"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_local_base_url_http_default(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch)
+        try:
+            assert cfg.local_base_url() == "http://127.0.0.1:37358"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_local_base_url_https_when_ssl_enabled(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch, SILENTSUITE_BRIDGE_SSL="1")
+        try:
+            assert cfg.local_base_url() == "https://127.0.0.1:37358"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_local_base_url_brackets_ipv6(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch)
+        try:
+            assert cfg.local_base_url("::1") == "http://[::1]:37358"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_validate_ssl_config_noop_when_disabled(self, monkeypatch):
+        cfg = reload_config_with_env(monkeypatch)
+        try:
+            cfg.validate_ssl_config()
+        finally:
+            restore_config(monkeypatch)
+
+    def test_validate_ssl_config_missing_cert(self, monkeypatch, tmp_path):
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_BRIDGE_SSL="1",
+            SILENTSUITE_BRIDGE_SSL_CERT=str(tmp_path / "missing-cert.pem"),
+            SILENTSUITE_BRIDGE_SSL_KEY=str(tmp_path / "missing-key.pem"),
+        )
+        try:
+            with pytest.raises(RuntimeError, match="certificate file is missing"):
+                cfg.validate_ssl_config()
+        finally:
+            restore_config(monkeypatch)
+
+    def test_validate_ssl_config_missing_key(self, monkeypatch, tmp_path):
+        cert = tmp_path / "cert.pem"
+        cert.write_text("fake cert")
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_BRIDGE_SSL="1",
+            SILENTSUITE_BRIDGE_SSL_CERT=str(cert),
+            SILENTSUITE_BRIDGE_SSL_KEY=str(tmp_path / "missing-key.pem"),
+        )
+        try:
+            with pytest.raises(RuntimeError, match="key file is missing"):
+                cfg.validate_ssl_config()
+        finally:
+            restore_config(monkeypatch)
+
+    def test_validate_ssl_config_passes_when_files_readable(self, monkeypatch, tmp_path):
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        cert.write_text("fake cert")
+        key.write_text("fake key")
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_BRIDGE_SSL="1",
+            SILENTSUITE_BRIDGE_SSL_CERT=str(cert),
+            SILENTSUITE_BRIDGE_SSL_KEY=str(key),
+        )
+        try:
+            cfg.validate_ssl_config()
+        finally:
+            restore_config(monkeypatch)
+
+
+class TestSslSettingsPersistence:
+    """Tests for SSL settings load/save alongside syncInterval."""
+
+    def test_load_settings_enables_ssl_and_preserves_sync(self, tmp_path, monkeypatch):
+        from silentsuite_bridge import config
+        original_settings = config.SETTINGS_FILE
+        original_data = config.DATA_DIR
+        original_ssl = config.SSL_ENABLED
+        original_cert = config.SSL_CERT_FILE
+        original_key = config.SSL_KEY_FILE
+        original_sync = config.SYNC_INTERVAL
+        config.SETTINGS_FILE = str(tmp_path / "settings.json")
+        config.DATA_DIR = str(tmp_path)
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        config.save_settings({
+            "syncInterval": 120,
+            "sslEnabled": True,
+            "sslCertFile": str(cert),
+            "sslKeyFile": str(key),
+        })
+        try:
+            config.load_settings()
+            assert config.SSL_ENABLED is True
+            assert config.SSL_CERT_FILE == str(cert)
+            assert config.SSL_KEY_FILE == str(key)
+            assert config.SYNC_INTERVAL == 120
+        finally:
+            config.SETTINGS_FILE = original_settings
+            config.DATA_DIR = original_data
+            config.SSL_ENABLED = original_ssl
+            config.SSL_CERT_FILE = original_cert
+            config.SSL_KEY_FILE = original_key
+            config.SYNC_INTERVAL = original_sync
+            restore_config(monkeypatch)
+
+    def test_save_settings_preserves_unrelated_keys(self, tmp_path, monkeypatch):
+        from silentsuite_bridge import config
+        original_settings = config.SETTINGS_FILE
+        original_data = config.DATA_DIR
+        config.SETTINGS_FILE = str(tmp_path / "settings.json")
+        config.DATA_DIR = str(tmp_path)
+        try:
+            config.save_settings({"syncInterval": 60, "customKey": "keep-me"})
+            config.save_settings({"sslEnabled": True})
+            settings = config.get_settings()
+            assert settings["syncInterval"] == 60
+            assert settings["customKey"] == "keep-me"
+            assert settings["sslEnabled"] is True
+        finally:
+            config.SETTINGS_FILE = original_settings
+            config.DATA_DIR = original_data
+            restore_config(monkeypatch)
+
+    def test_env_overrides_settings_for_ssl(self, tmp_path, monkeypatch):
+        from silentsuite_bridge import config
+        original_settings = config.SETTINGS_FILE
+        original_data = config.DATA_DIR
+        config.SETTINGS_FILE = str(tmp_path / "settings.json")
+        config.DATA_DIR = str(tmp_path)
+        config.save_settings({"sslEnabled": False})
+        monkeypatch.setenv("SILENTSUITE_BRIDGE_SSL", "1")
+        try:
+            config.load_settings()
+            assert config.SSL_ENABLED is True
+        finally:
+            config.SETTINGS_FILE = original_settings
+            config.DATA_DIR = original_data
+            restore_config(monkeypatch)
+
+    def test_env_overrides_apply_when_settings_file_is_missing(self, tmp_path, monkeypatch):
+        from silentsuite_bridge import config
+        original_settings = config.SETTINGS_FILE
+        original_data = config.DATA_DIR
+        original_ssl = config.SSL_ENABLED
+        config.SETTINGS_FILE = str(tmp_path / "missing-settings.json")
+        config.DATA_DIR = str(tmp_path)
+        config.SSL_ENABLED = False
+        monkeypatch.setenv("SILENTSUITE_BRIDGE_SSL", "1")
+        try:
+            config.load_settings()
+            assert config.SSL_ENABLED is True
+        finally:
+            config.SETTINGS_FILE = original_settings
+            config.DATA_DIR = original_data
+            config.SSL_ENABLED = original_ssl
+            restore_config(monkeypatch)

--- a/bridge/tests/test_main_accounts.py
+++ b/bridge/tests/test_main_accounts.py
@@ -1,5 +1,10 @@
 """CLI tests for bridge account-management commands."""
 
+import datetime as dt
+import os
+import shutil
+import stat
+import subprocess
 import sys
 
 import pytest
@@ -46,3 +51,241 @@ def test_account_actions_cannot_be_combined(monkeypatch, capsys):
 
     assert code == 1
     assert "account action flags cannot be combined" in capsys.readouterr().out
+
+
+def _openssl_available() -> bool:
+    return shutil.which("openssl") is not None
+
+
+@pytest.mark.skipif(not _openssl_available(), reason="openssl not available")
+def test_generate_localhost_certificate_creates_san_cert(tmp_path):
+    """Real OpenSSL generation: cert exists, has 398-day validity, and SANs."""
+    cert_path = str(tmp_path / "localhost-cert.pem")
+    key_path = str(tmp_path / "localhost-key.pem")
+
+    main_module._generate_localhost_certificate(cert_path, key_path)
+
+    assert os.path.isfile(cert_path)
+    assert os.path.isfile(key_path)
+
+    # Parse the cert for SAN entries and validity.
+    result = subprocess.run(
+        ["openssl", "x509", "-in", cert_path, "-noout", "-text"],
+        capture_output=True, text=True, check=True,
+    )
+    text = result.stdout
+    assert "Subject Alternative Name" in text
+    assert "localhost" in text
+    assert "127.0.0.1" in text
+    # IPv6 ::1 may be present or fall back to DNS+IPv4; accept either.
+    assert "::1" in text or "IPv6" not in text
+
+    # Verify validity period <= 398 days.
+    dates = subprocess.run(
+        ["openssl", "x509", "-in", cert_path, "-noout", "-dates"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    parsed = {}
+    for line in dates.splitlines():
+        key, value = line.split("=", 1)
+        parsed[key] = dt.datetime.strptime(value, "%b %d %H:%M:%S %Y %Z")
+    assert (parsed["notAfter"] - parsed["notBefore"]).days <= 398
+
+
+@pytest.mark.skipif(not _openssl_available(), reason="openssl not available")
+def test_generated_key_has_posix_0600_mode(tmp_path):
+    """POSIX-only: generated private key is hardened to 0600 best-effort."""
+    if os.name == "nt":
+        pytest.skip("POSIX key-mode test only runs on non-Windows")
+    cert_path = str(tmp_path / "localhost-cert.pem")
+    key_path = str(tmp_path / "localhost-key.pem")
+
+    main_module._generate_localhost_certificate(cert_path, key_path)
+
+    mode = stat.S_IMODE(os.stat(key_path).st_mode)
+    assert mode == 0o600
+
+
+def test_setup_macos_apple_accounts_success_non_darwin(tmp_path, monkeypatch, capsys):
+    """On non-Darwin, setup generates cert material but does not persist sslEnabled."""
+    cert_path = str(tmp_path / "cert.pem")
+    key_path = str(tmp_path / "key.pem")
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "SETTINGS_FILE", str(settings_path))
+    monkeypatch.setattr(config, "SSL_CERT_FILE", cert_path)
+    monkeypatch.setattr(config, "SSL_KEY_FILE", key_path)
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(main_module, "_generate_localhost_certificate", lambda c, k: None)
+    monkeypatch.setattr(main_module, "_cert_and_key_readable", lambda c, k: False)
+
+    code = main_module.setup_macos_apple_accounts()
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert cert_path in out
+    assert key_path in out
+    assert "Advanced" in out
+    assert "Use SSL" in out
+    assert "Keychain" in out or "Always Trust" in out
+    assert "restart" in out.lower() or "Restart" in out
+    # Non-Darwin must not silently persist sslEnabled=true.
+    assert config.SSL_ENABLED is False
+    assert not settings_path.exists()
+
+
+def test_setup_macos_apple_accounts_failure_exits_nonzero(monkeypatch, capsys):
+    """When cert generation fails, setup exits nonzero with actionable text."""
+    monkeypatch.setattr(config, "SSL_CERT_FILE", "/tmp/x-cert.pem")
+    monkeypatch.setattr(config, "SSL_KEY_FILE", "/tmp/x-key.pem")
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(
+        main_module,
+        "_generate_localhost_certificate",
+        lambda c, k: (_ for _ in ()).throw(RuntimeError("openssl missing")),
+    )
+    monkeypatch.setattr(main_module, "_cert_and_key_readable", lambda c, k: False)
+
+    code = main_module.setup_macos_apple_accounts()
+
+    out = capsys.readouterr().out
+    assert code == 1
+    assert "openssl missing" in out
+    assert "Traceback" not in out
+
+
+def test_setup_macos_apple_accounts_persists_ssl_settings_on_darwin(tmp_path, monkeypatch):
+    cert_path = str(tmp_path / "cert.pem")
+    key_path = str(tmp_path / "key.pem")
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(config, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(config, "SETTINGS_FILE", str(settings_path))
+    monkeypatch.setattr(config, "SSL_CERT_FILE", cert_path)
+    monkeypatch.setattr(config, "SSL_KEY_FILE", key_path)
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(main_module, "_open_certificate_for_trust", lambda c: True)
+
+    def fake_gen(c, k):
+        with open(c, "w") as f:
+            f.write("new cert")
+        with open(k, "w") as f:
+            f.write("new key")
+
+    monkeypatch.setattr(main_module, "_generate_localhost_certificate", fake_gen)
+
+    code = main_module.setup_macos_apple_accounts()
+
+    settings = config.get_settings()
+    assert code == 0
+    assert config.SSL_ENABLED is True
+    assert settings["sslEnabled"] is True
+    assert settings["sslCertFile"] == cert_path
+    assert settings["sslKeyFile"] == key_path
+
+
+def test_setup_reuses_existing_cert_and_key(tmp_path, monkeypatch, capsys):
+    """When both cert and key are readable, setup reuses them without regenerating."""
+    cert_path = str(tmp_path / "cert.pem")
+    key_path = str(tmp_path / "key.pem")
+    with open(cert_path, "w") as f:
+        f.write("existing cert")
+    with open(key_path, "w") as f:
+        f.write("existing key")
+    monkeypatch.setattr(config, "SSL_CERT_FILE", cert_path)
+    monkeypatch.setattr(config, "SSL_KEY_FILE", key_path)
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(main_module, "_cert_and_key_match", lambda c, k: True)
+
+    def fail_gen(c, k):
+        raise AssertionError("should not regenerate when both files are readable")
+
+    monkeypatch.setattr(main_module, "_generate_localhost_certificate", fail_gen)
+
+    code = main_module.setup_macos_apple_accounts()
+
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Reused" in out
+
+
+def test_setup_regenerates_when_one_file_missing(tmp_path, monkeypatch):
+    """When one of cert/key is missing, setup regenerates both together."""
+    cert_path = str(tmp_path / "cert.pem")
+    key_path = str(tmp_path / "key.pem")
+    with open(cert_path, "w") as f:
+        f.write("stale cert")
+    # key missing
+    monkeypatch.setattr(config, "SSL_CERT_FILE", cert_path)
+    monkeypatch.setattr(config, "SSL_KEY_FILE", key_path)
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    generated = {"called": False}
+
+    def fake_gen(c, k):
+        generated["called"] = True
+        with open(c, "w") as f:
+            f.write("new cert")
+        with open(k, "w") as f:
+            f.write("new key")
+
+    monkeypatch.setattr(main_module, "_generate_localhost_certificate", fake_gen)
+
+    main_module.setup_macos_apple_accounts()
+
+    assert generated["called"] is True
+
+
+def test_setup_regenerates_when_existing_cert_and_key_do_not_match(tmp_path, monkeypatch):
+    cert_path = str(tmp_path / "cert.pem")
+    key_path = str(tmp_path / "key.pem")
+    with open(cert_path, "w") as f:
+        f.write("stale cert")
+    with open(key_path, "w") as f:
+        f.write("stale key")
+    monkeypatch.setattr(config, "SSL_CERT_FILE", cert_path)
+    monkeypatch.setattr(config, "SSL_KEY_FILE", key_path)
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(main_module, "_cert_and_key_match", lambda c, k: False)
+
+    generated = {"called": False}
+
+    def fake_gen(c, k):
+        generated["called"] = True
+        with open(c, "w") as f:
+            f.write("new cert")
+        with open(k, "w") as f:
+            f.write("new key")
+
+    monkeypatch.setattr(main_module, "_generate_localhost_certificate", fake_gen)
+
+    main_module.setup_macos_apple_accounts()
+
+    assert generated["called"] is True
+
+
+def test_setup_command_dispatched_via_run_main(monkeypatch, capsys):
+    """`--setup-macos-apple-accounts` is dispatched by main() and exits 0."""
+    monkeypatch.setattr(config, "SSL_CERT_FILE", "/tmp/x-cert.pem")
+    monkeypatch.setattr(config, "SSL_KEY_FILE", "/tmp/x-key.pem")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:37358")
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(main_module, "_generate_localhost_certificate", lambda c, k: None)
+    monkeypatch.setattr(main_module, "_cert_and_key_readable", lambda c, k: False)
+
+    code = _run_main(["--setup-macos-apple-accounts"], monkeypatch)
+
+    assert code == 0
+    assert "Advanced" in capsys.readouterr().out

--- a/bridge/tests/test_main_startup.py
+++ b/bridge/tests/test_main_startup.py
@@ -1,5 +1,10 @@
 """Tests for bridge startup account decisions."""
 
+import logging
+import sys
+
+import pytest
+
 from silentsuite_bridge import __main__ as bridge_main
 from silentsuite_bridge import config
 
@@ -27,3 +32,146 @@ def test_check_credentials_blocks_no_accounts_when_dashboard_disabled(tmp_path, 
     assert "dashboard is disabled" in output
     assert "--login" in output
     assert "--manual-login" in output
+
+
+def test_check_credentials_prints_https_dashboard_url_when_ssl_enabled(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    monkeypatch.setattr(config, "is_dashboard_enabled", lambda: True)
+
+    assert bridge_main.check_credentials(open_browser=False) is True
+
+    output = capsys.readouterr().out
+    assert "https://127.0.0.1:37358/" in output
+    assert "http://127.0.0.1:37358/" not in output
+
+
+def test_dashboard_url_uses_http_when_ssl_disabled(monkeypatch):
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    assert bridge_main._dashboard_url() == "http://127.0.0.1:37358/"
+
+
+def test_dashboard_url_uses_https_when_ssl_enabled(monkeypatch):
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    assert bridge_main._dashboard_url() == "https://127.0.0.1:37358/"
+
+
+def test_build_radicale_configuration_preserves_http_when_ssl_disabled(monkeypatch):
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:37358")
+    monkeypatch.setattr(config, "is_dashboard_enabled", lambda: True)
+
+    cfg = bridge_main.build_radicale_configuration()
+    assert cfg.get("server", "ssl") is False
+    assert bridge_main.effective_dav_scheme() == "http"
+
+
+def test_build_radicale_configuration_feeds_ssl_when_enabled(monkeypatch, tmp_path):
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text("fake cert")
+    key.write_text("fake key")
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    monkeypatch.setattr(config, "SSL_CERT_FILE", str(cert))
+    monkeypatch.setattr(config, "SSL_KEY_FILE", str(key))
+    monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:37358")
+    monkeypatch.setattr(config, "is_dashboard_enabled", lambda: True)
+
+    cfg = bridge_main.build_radicale_configuration()
+    assert cfg.get("server", "ssl") is True
+    assert cfg.get("server", "certificate") == str(cert)
+    assert cfg.get("server", "key") == str(key)
+    assert bridge_main.effective_dav_scheme() == "https"
+
+
+def test_radicale_ssl_schema_validation_reports_missing_keys():
+    with pytest.raises(RuntimeError, match="certificate, key"):
+        bridge_main._verify_radicale_ssl_schema({"server": {"ssl": {}}})
+
+
+def test_missing_cert_raises_clean_runtime_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    monkeypatch.setattr(config, "SSL_CERT_FILE", str(tmp_path / "missing-cert.pem"))
+    monkeypatch.setattr(config, "SSL_KEY_FILE", str(tmp_path / "missing-key.pem"))
+    with pytest.raises(RuntimeError, match="certificate file is missing"):
+        config.validate_ssl_config()
+
+
+def test_missing_key_raises_clean_runtime_error(monkeypatch, tmp_path):
+    cert = tmp_path / "cert.pem"
+    cert.write_text("fake cert")
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    monkeypatch.setattr(config, "SSL_CERT_FILE", str(cert))
+    monkeypatch.setattr(config, "SSL_KEY_FILE", str(tmp_path / "missing-key.pem"))
+    with pytest.raises(RuntimeError, match="key file is missing"):
+        config.validate_ssl_config()
+
+
+def test_main_missing_ssl_file_exits_cleanly_without_traceback(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(sys, "argv", ["silentsuite-bridge"])
+    monkeypatch.setattr(bridge_main, "configure_logging", lambda: None)
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    monkeypatch.setattr(config, "SSL_CERT_FILE", str(tmp_path / "missing-cert.pem"))
+    monkeypatch.setattr(config, "SSL_KEY_FILE", str(tmp_path / "missing-key.pem"))
+
+    with pytest.raises(SystemExit) as exc:
+        bridge_main.main()
+
+    captured = capsys.readouterr()
+    assert exc.value.code == 1
+    assert "Traceback" not in captured.out
+    assert "Traceback" not in captured.err
+
+
+def _run_server_until_keyboard_interrupt(monkeypatch):
+    from radicale import server as radicale_server
+
+    def stop_server(_configuration):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(bridge_main, "_initial_status_check", lambda: None)
+    monkeypatch.setattr(bridge_main, "_start_sync_threads", lambda: None)
+    monkeypatch.setattr(bridge_main, "start_tray", lambda: None)
+    monkeypatch.setattr(radicale_server, "serve", stop_server)
+    bridge_main.run_server()
+
+
+def test_remote_bind_warning_mentions_plaintext_when_ssl_disabled(monkeypatch, caplog):
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "0.0.0.0")
+    monkeypatch.setattr(config, "SERVER_HOSTS", "0.0.0.0:37358")
+    monkeypatch.setattr(config, "ALLOW_REMOTE", True)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    with caplog.at_level(logging.WARNING, logger="silentsuite-bridge"):
+        _run_server_until_keyboard_interrupt(monkeypatch)
+
+    text = caplog.text
+    assert "DAV traffic is plaintext HTTP unless protected by your own proxy/VPN" in text
+    assert "Bridge dashboard disabled while remote bind is configured" in text
+
+
+def test_remote_bind_warning_avoids_plaintext_claim_when_ssl_enabled(monkeypatch, caplog, tmp_path):
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text("fake cert")
+    key.write_text("fake key")
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "0.0.0.0")
+    monkeypatch.setattr(config, "SERVER_HOSTS", "0.0.0.0:37358")
+    monkeypatch.setattr(config, "ALLOW_REMOTE", True)
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    monkeypatch.setattr(config, "SSL_CERT_FILE", str(cert))
+    monkeypatch.setattr(config, "SSL_KEY_FILE", str(key))
+
+    with caplog.at_level(logging.WARNING, logger="silentsuite-bridge"):
+        _run_server_until_keyboard_interrupt(monkeypatch)
+
+    text = caplog.text
+    assert "exposes decrypted DAV data over the network" in text
+    assert "without an intentional network/security design" in text
+    assert "plaintext HTTP" not in text

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -7,8 +7,8 @@ import pytest
 from radicale.app import Application
 
 import silentsuite_bridge.auth_browser as auth_browser
-from silentsuite_bridge import __main__ as bridge_main
 import silentsuite_bridge.web as web_module
+from silentsuite_bridge import __main__ as bridge_main
 from silentsuite_bridge import accounts, config
 from silentsuite_bridge.accounts import AccountOperationResult
 from silentsuite_bridge.auth_browser import AuthenticatedAccount, AuthenticationError
@@ -22,7 +22,6 @@ from silentsuite_bridge.web import (
     forget_account_status,
     update_status,
 )
-
 
 # Default Host header matching a localhost variant so the SEC-R7.4 Host check
 # accepts the request. Tests that exercise the rejection path set this explicitly.
@@ -166,6 +165,36 @@ def test_update_status_aggregates_background_sync_counts(tmp_path, monkeypatch):
 
     html = _render_dashboard()
     assert "3 calendars, 3 contacts, 1 tasks" in html
+
+
+def test_render_dashboard_uses_https_urls_when_ssl_enabled(tmp_path, monkeypatch):
+    """AC 11: with SSL enabled, account DAV URLs use https://."""
+    _reset_status()
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    monkeypatch.setattr(
+        web_module,
+        "_account_fingerprint",
+        lambda _creds, _username: None,
+    )
+
+    creds = Credentials()
+    creds.set_etebase("alice@example.com", "alice-session", "https://server-a.test")
+    creds.save()
+
+    update_status(
+        "connected",
+        collections={"calendars": 2, "contacts": 1, "tasks": 0},
+        scope="all configured accounts",
+    )
+
+    html = _render_dashboard()
+
+    assert "https://127.0.0.1:37358/alice@example.com/" in html
+    assert "http://127.0.0.1:37358/alice@example.com/" not in html
+    assert "Advanced setup with SSL" in html
 
 
 def test_render_dashboard_handles_no_accounts(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add optional bridge HTTPS mode backed by Radicale SSL config
- add `silentsuite-bridge --setup-macos-apple-accounts` to generate/reuse a localhost certificate and guide Keychain trust + Advanced Apple Internet Accounts setup
- render dashboard/startup DAV URLs with `https://` when SSL is enabled
- update macOS/DAV bridge docs with HTTPS setup, all-or-nothing listener warning, and PR2 evidence checklist for `/principals/` logs

## Validation
- `PYTHONPATH=bridge/src pytest bridge/tests -q` -> 237 passed
- `ruff check --ignore E501 bridge/src/silentsuite_bridge/config.py bridge/src/silentsuite_bridge/__main__.py bridge/src/silentsuite_bridge/web/__init__.py bridge/tests/test_config.py bridge/tests/test_main_startup.py bridge/tests/test_main_accounts.py bridge/tests/test_web_dashboard.py` -> passed
- `git diff --check` -> passed
- `SILENTSUITE_DATA_DIR=$(mktemp -d) PYTHONPATH=bridge/src python -m silentsuite_bridge --setup-macos-apple-accounts` generated cert/key, key mode 600, no non-Darwin settings persistence, SAN includes localhost/127.0.0.1/IPv6 loopback

## Notes
- This is the HTTPS setup unblocker only. It does not implement `/principals/` or well-known DAV discovery shims.
- Full repository bridge ruff still has existing unrelated lint debt outside this diff.
