### PR TITLE
web: clarify sign-in throttling errors

### DIFF
--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -365,6 +365,9 @@ describe('useAuthStore', () => {
       await useAuthStore.getState().login('a@b.com', 'pw')
 
       expect(useAuthStore.getState().isAuthenticated).toBe(false)
+      expect(useAuthStore.getState().error).toBe(
+        'Too many sign-in attempts. Please wait a few minutes before trying again. Your encrypted data is safe.',
+      )
       expect(secureStore['etebase_session']).toBeUndefined()
       expect(localStorage.getItem('silentsuite-hosted-validation-initialized')).toBeNull()
     })
@@ -739,6 +742,44 @@ describe('useAuthStore', () => {
     expect(offlineQueueClearAll).not.toHaveBeenCalled()
     expect(secureStore.etebase_session).toBeUndefined()
     expect(useAuthStore.getState().error).toBe('Invalid email or password. Please try again.')
+  })
+
+  it('login gives calm retry guidance when Etebase throttles sign-in', async () => {
+    const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
+    vi.mocked(etebaseLogIn).mockRejectedValueOnce(new Error('Too many attempts'))
+
+    await useAuthStore.getState().login('test@example.com', 'password123')
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(useAuthStore.getState().error).toBe(
+      'Too many sign-in attempts. Please wait a few minutes before trying again. Your encrypted data is safe.',
+    )
+  })
+
+  it('login does not surface unmapped raw Etebase errors', async () => {
+    const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
+    vi.mocked(etebaseLogIn).mockRejectedValueOnce(new Error('internal provider detail: req-123'))
+
+    await useAuthStore.getState().login('test@example.com', 'password123')
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(useAuthStore.getState().error).toBe('Login failed. Please try again.')
+  })
+
+  it('unlock gives calm retry guidance when Etebase sign-in is temporarily unavailable', async () => {
+    const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
+    vi.mocked(etebaseLogIn).mockRejectedValueOnce(new Error('network timeout'))
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'test@example.com', planId: 'pro', isAdmin: false, onboardedAt: null },
+      isAuthenticated: true,
+    })
+
+    await useAuthStore.getState().unlockEtebaseSession('test@example.com', 'password123')
+
+    expect(secureStore.etebase_session).toBeUndefined()
+    expect(useAuthStore.getState().error).toBe(
+      'Sign-in is temporarily unavailable. Please wait a minute and try again. Your encrypted data is safe.',
+    )
   })
 
   it('logout still completes when the data-cache wipe throws', async () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -118,6 +118,11 @@ const HOSTED_ACTIVE_TAB_HEARTBEAT_MS = 5_000
 const HOSTED_ACTIVE_TAB_BROADCAST = 'silentsuite-hosted-session-tabs'
 const HOSTED_ACTIVE_TAB_PING_TIMEOUT_MS = 1000
 
+const AUTH_RATE_LIMIT_MESSAGE =
+  'Too many sign-in attempts. Please wait a few minutes before trying again. Your encrypted data is safe.'
+const AUTH_TEMPORARY_UNAVAILABLE_MESSAGE =
+  'Sign-in is temporarily unavailable. Please wait a minute and try again. Your encrypted data is safe.'
+
 let hostedActiveTabHeartbeat: number | null = null
 let hostedActiveTabUnloadHooked = false
 
@@ -279,6 +284,20 @@ function clearHostedValidationMarkers() {
   } catch (err) {
     logger.warn('[auth-store] Failed to clear hosted validation markers:', err)
   }
+}
+
+function authErrorMessage(err: unknown): string {
+  if (!(err instanceof Error)) return 'Login failed'
+  const raw = err.message.toLowerCase()
+  if (raw.includes('unauthorized') || raw.includes('401')) return 'Invalid email or password. Please try again.'
+  if (raw.includes('not found') || raw.includes('404')) return 'No account found with this email. Please sign up first.'
+  if (raw.includes('429') || raw.includes('too many') || raw.includes('rate limit') || raw.includes('throttl')) {
+    return AUTH_RATE_LIMIT_MESSAGE
+  }
+  if (raw.includes('fetch') || raw.includes('network') || raw.includes('timeout') || raw.includes('timed out')) {
+    return AUTH_TEMPORARY_UNAVAILABLE_MESSAGE
+  }
+  return 'Login failed. Please try again.'
 }
 
 function markHostedValidation(userId: string, rememberDevice: boolean) {
@@ -751,7 +770,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
       if (res.status === 429) {
         await clearLocalAuthMaterial('invalid-hosted-auth')
-        set({ isLoading: false, error: 'Too many attempts. Please try again later.' }); return
+        set({ isLoading: false, error: AUTH_RATE_LIMIT_MESSAGE }); return
       }
       if (res.status === 404 || res.status === 409) {
         await clearLocalAuthMaterial('invalid-hosted-auth')
@@ -773,19 +792,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         isLoading: false,
       })
     } catch (err) {
-      let message = 'Login failed'
-      if (err instanceof Error) {
-        const raw = err.message.toLowerCase()
-        if (raw.includes('unauthorized') || raw.includes('401')) {
-          message = 'Invalid email or password. Please try again.'
-        } else if (raw.includes('not found') || raw.includes('404')) {
-          message = 'No account found with this email. Please sign up first.'
-        } else if (raw.includes('fetch') || raw.includes('network')) {
-          message = 'Unable to reach the server. Please check your connection and try again.'
-        } else {
-          message = err.message
-        }
-      }
+      const message = authErrorMessage(err)
       set({ isLoading: false, error: message })
     }
   },
@@ -808,19 +815,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       await secureSet('etebase_session', savedSession)
       set({ isLoading: false })
     } catch (err) {
-      let message = 'Login failed'
-      if (err instanceof Error) {
-        const raw = err.message.toLowerCase()
-        if (raw.includes('unauthorized') || raw.includes('401')) {
-          message = 'Invalid email or password. Please try again.'
-        } else if (raw.includes('not found') || raw.includes('404')) {
-          message = 'No account found with this email. Please sign up first.'
-        } else if (raw.includes('fetch') || raw.includes('network')) {
-          message = 'Unable to reach the server. Please check your connection and try again.'
-        } else {
-          message = err.message
-        }
-      }
+      const message = authErrorMessage(err)
       set({ isLoading: false, error: message })
     }
   },


### PR DESCRIPTION
## Summary
- add calm, actionable copy for sign-in rate limits and temporary auth reachability failures
- share login/unlock auth error mapping so restore-blocked re-unlock shows the same safe guidance
- add auth-store tests for token-exchange 429, Etebase throttle, and unlock temporary-unavailable cases

## Verification
- pnpm --filter @silentsuite/web test -- app/stores/__tests__/use-auth-store.test.ts 'app/(auth)/login/__tests__/login-unlock.test.tsx'
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web lint
- pnpm run build
- git diff --check
- pnpm run test
