### PR TITLE
web: preserve data on partial sync loads

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -7,6 +7,7 @@ import { Header } from '@/app/components/header'
 import { BottomNav } from '@/app/components/bottom-nav'
 import { ReadOnlyBanner, DegradedModeBanner } from '@/app/components/read-only-overlay'
 import { RestoreBlockedBanner } from '@/app/components/restore-blocked-banner'
+import { PartialLoadBanner } from '@/app/components/partial-load-banner'
 import { PendingSyncBanner } from '@/app/components/PendingSyncBanner'
 import { OfflineToast } from '@/app/components/OfflineToast'
 import { ToastContainer } from '@/app/components/Toast'
@@ -38,6 +39,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               <Header />
               <EmailVerificationBanner />
               <RestoreBlockedBanner />
+              <PartialLoadBanner />
               {!isSelfHosted && degraded && <DegradedModeBanner />}
               {!isSelfHosted && readOnly && <ReadOnlyBanner />}
               <PendingSyncBanner />

--- a/apps/web/app/components/SyncIndicator.tsx
+++ b/apps/web/app/components/SyncIndicator.tsx
@@ -25,11 +25,12 @@ const ariaLabels: Record<SyncStatus, string> = {
   error: 'Sync status: error',
 }
 
-function getTooltipText(status: SyncStatus, lastSyncedAt: Date | null, error: string | null, pendingCount: number): string {
+function getTooltipText(status: SyncStatus, lastSyncedAt: Date | null, error: string | null, pendingCount: number, partialLoad = false): string {
   const queueSuffix = pendingCount > 0 ? ` (${pendingCount} queued)` : ''
+  const partialSuffix = partialLoad && status === 'synced' ? ' · some data did not load' : ''
   switch (status) {
     case 'synced':
-      return (lastSyncedAt ? `Synced ${formatTimeAgo(lastSyncedAt)}` : 'Synced') + queueSuffix
+      return (lastSyncedAt ? `Synced ${formatTimeAgo(lastSyncedAt)}` : 'Synced') + queueSuffix + partialSuffix
     case 'syncing':
       return 'Syncing...' + queueSuffix
     case 'offline':
@@ -45,6 +46,7 @@ export function SyncIndicator() {
   const error = useSyncStore((s) => s.error)
   const simulateSyncCycle = useSyncStore((s) => s.simulateSyncCycle)
   const pendingQueueCount = useSyncStore((s) => s.pendingQueueCount)
+  const partialLoad = useSyncStore((s) => s.partialLoad)
   const [showTooltip, setShowTooltip] = useState(false)
   const [tooltipText, setTooltipText] = useState('')
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -69,15 +71,15 @@ export function SyncIndicator() {
   // Update tooltip text on an interval while visible so relative times stay fresh
   useEffect(() => {
     if (showTooltip) {
-      setTooltipText(getTooltipText(syncStatus, lastSyncedAt, error, pendingQueueCount))
+      setTooltipText(getTooltipText(syncStatus, lastSyncedAt, error, pendingQueueCount, partialLoad))
       intervalRef.current = setInterval(() => {
-        setTooltipText(getTooltipText(syncStatus, lastSyncedAt, error, pendingQueueCount))
+        setTooltipText(getTooltipText(syncStatus, lastSyncedAt, error, pendingQueueCount, partialLoad))
       }, 1000)
     }
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current)
     }
-  }, [showTooltip, syncStatus, lastSyncedAt, error, pendingQueueCount])
+  }, [showTooltip, syncStatus, lastSyncedAt, error, pendingQueueCount, partialLoad])
 
   return (
     <div
@@ -88,9 +90,9 @@ export function SyncIndicator() {
       {/* Status dot with smooth transition */}
       <div className="relative">
         <div
-          className={`h-2 w-2 rounded-full transition-all duration-300 ${dotStyles[syncStatus]}`}
+          className={`h-2 w-2 rounded-full transition-all duration-300 ${partialLoad && syncStatus === 'synced' ? 'bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.45)]' : dotStyles[syncStatus]}`}
           role="status"
-          aria-label={ariaLabels[syncStatus]}
+          aria-label={partialLoad && syncStatus === 'synced' ? 'Sync status: synced with warning' : ariaLabels[syncStatus]}
         />
         {pendingQueueCount > 0 && (
           <span className="absolute -top-1.5 -right-1.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-amber-500 text-[8px] font-bold leading-none text-white">

--- a/apps/web/app/components/__tests__/SyncIndicator.test.tsx
+++ b/apps/web/app/components/__tests__/SyncIndicator.test.tsx
@@ -9,6 +9,7 @@ const mockSyncState = {
   lastSyncedAt: null as Date | null,
   error: null as string | null,
   pendingQueueCount: 0,
+  partialLoad: false,
   simulateSyncCycle: vi.fn(),
 }
 
@@ -26,6 +27,7 @@ describe('SyncIndicator', () => {
     mockSyncState.lastSyncedAt = null
     mockSyncState.error = null
     mockSyncState.pendingQueueCount = 0
+    mockSyncState.partialLoad = false
     mockSyncState.simulateSyncCycle.mockClear()
     sessionStorage.clear()
   })
@@ -43,6 +45,15 @@ describe('SyncIndicator', () => {
     render(<SyncIndicator />)
     const dot = screen.getByRole('status')
     expect(dot).toHaveAttribute('aria-label', 'Sync status: syncing')
+    expect(dot.className).toContain('bg-amber-400')
+  })
+
+  it('renders a synced warning affordance when partial load is active', () => {
+    mockSyncState.syncStatus = 'synced'
+    mockSyncState.partialLoad = true
+    render(<SyncIndicator />)
+    const dot = screen.getByRole('status')
+    expect(dot).toHaveAttribute('aria-label', 'Sync status: synced with warning')
     expect(dot.className).toContain('bg-amber-400')
   })
 

--- a/apps/web/app/components/__tests__/partial-load-banner.test.tsx
+++ b/apps/web/app/components/__tests__/partial-load-banner.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { PartialLoadBanner } from '../partial-load-banner'
+
+const authState = {
+  isAuthenticated: false,
+}
+
+const etebaseState = {
+  restoreBlocked: false,
+}
+
+const syncState = {
+  partialLoad: false,
+  syncStatus: 'synced' as const,
+  simulateSyncCycle: vi.fn(),
+}
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: (selector: (s: typeof authState) => unknown) => selector(authState),
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: (selector: (s: typeof etebaseState) => unknown) => selector(etebaseState),
+}))
+
+vi.mock('@/app/stores/use-sync-store', () => ({
+  useSyncStore: (selector: (s: typeof syncState) => unknown) => selector(syncState),
+}))
+
+describe('PartialLoadBanner', () => {
+  beforeEach(() => {
+    authState.isAuthenticated = false
+    etebaseState.restoreBlocked = false
+    syncState.partialLoad = false
+    syncState.syncStatus = 'synced'
+    syncState.simulateSyncCycle.mockClear()
+  })
+
+  it('renders when authenticated with a partial load', () => {
+    authState.isAuthenticated = true
+    syncState.partialLoad = true
+
+    render(<PartialLoadBanner />)
+
+    expect(screen.getByText(/Some of your data could not be loaded/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry sync/i })).toBeEnabled()
+  })
+
+  it('hides when restore-blocked is active, unauthenticated, or healthy', () => {
+    authState.isAuthenticated = true
+    syncState.partialLoad = true
+    etebaseState.restoreBlocked = true
+    const { container, rerender } = render(<PartialLoadBanner />)
+    expect(container).toBeEmptyDOMElement()
+
+    etebaseState.restoreBlocked = false
+    authState.isAuthenticated = false
+    rerender(<PartialLoadBanner />)
+    expect(container).toBeEmptyDOMElement()
+
+    authState.isAuthenticated = true
+    syncState.partialLoad = false
+    rerender(<PartialLoadBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('uses static privacy-safe copy and retries sync', () => {
+    authState.isAuthenticated = true
+    syncState.partialLoad = true
+
+    const { container } = render(<PartialLoadBanner />)
+    const text = container.textContent ?? ''
+    expect(text).not.toMatch(/restoreSession|sessionRead|listItems|syncEngine|item-|col-|uid|token/i)
+    expect(text).not.toMatch(/error|failed/i)
+
+    fireEvent.click(screen.getByRole('button', { name: /retry sync/i }))
+    expect(syncState.simulateSyncCycle).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables retry while syncing or offline', () => {
+    authState.isAuthenticated = true
+    syncState.partialLoad = true
+    syncState.syncStatus = 'syncing'
+
+    const { rerender } = render(<PartialLoadBanner />)
+    expect(screen.getByRole('button', { name: /retry sync/i })).toBeDisabled()
+
+    syncState.syncStatus = 'offline'
+    rerender(<PartialLoadBanner />)
+    expect(screen.getByRole('button', { name: /retry sync/i })).toBeDisabled()
+  })
+})

--- a/apps/web/app/components/partial-load-banner.tsx
+++ b/apps/web/app/components/partial-load-banner.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { TriangleAlert } from 'lucide-react'
+import { useAuthStore } from '@/app/stores/use-auth-store'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+import { useSyncStore } from '@/app/stores/use-sync-store'
+
+export function PartialLoadBanner() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const restoreBlocked = useEtebaseStore((s) => s.restoreBlocked)
+  const partialLoad = useSyncStore((s) => s.partialLoad)
+  const syncStatus = useSyncStore((s) => s.syncStatus)
+  const simulateSyncCycle = useSyncStore((s) => s.simulateSyncCycle)
+
+  if (!partialLoad || restoreBlocked || !isAuthenticated) return null
+
+  const disabled = syncStatus === 'syncing' || syncStatus === 'offline'
+
+  return (
+    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm md:mx-4">
+      <TriangleAlert className="h-4 w-4 flex-none text-amber-300" aria-hidden="true" />
+      <p className="min-w-0 flex-1 text-amber-100">
+        Some of your data could not be loaded and is not shown right now. Your information is safe. Retry to load it again.
+      </p>
+      <button
+        type="button"
+        onClick={() => simulateSyncCycle()}
+        disabled={disabled}
+        className="rounded-md border border-amber-300/40 px-2.5 py-1 text-xs font-medium text-amber-100 transition-colors hover:border-amber-200 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Retry sync
+      </button>
+    </div>
+  )
+}

--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -13,17 +13,20 @@ const syncStoreMock = vi.hoisted(() => ({
   setSyncStatus: vi.fn((status: string) => order.push(`setSyncStatus:${status}`)),
   setLastSynced: vi.fn(() => order.push('setLastSynced')),
   setError: vi.fn((error: string | null) => order.push(`setError:${error ?? 'null'}`)),
+  setPartialLoad: vi.fn((partial: boolean, count = 0) => order.push(`setPartialLoad:${partial}:${count}`)),
 }))
 
 const etebaseMock = vi.hoisted(() => {
+  let syncChangeHandler: ((event: { collectionType: string; collectionUid: string; itemUids: string[]; changeType: string }) => Promise<void>) | null = null
   const state = {
     initialize: vi.fn(async () => order.push('etebaseInitialize')),
     fetchAllItems: vi.fn(async (type: 'tasks' | 'contacts' | 'calendar') => {
       order.push(`fetchAllItems:${type}`)
       return []
     }),
-    onSyncChange: vi.fn(() => {
+    onSyncChange: vi.fn((handler?: typeof syncChangeHandler) => {
       order.push('wireChangeHandler')
+      syncChangeHandler = handler ?? null
       return vi.fn()
     }),
     onStatusChange: vi.fn(() => {
@@ -32,8 +35,15 @@ const etebaseMock = vi.hoisted(() => {
     }),
     isInitialized: false,
     refreshCollection: vi.fn(),
+    domainLoadState: { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' },
   }
-  return { state }
+  return {
+    state,
+    getSyncChangeHandler: () => syncChangeHandler,
+    setSyncChangeHandler: (handler: typeof syncChangeHandler) => {
+      syncChangeHandler = handler
+    },
+  }
 })
 
 const taskStoreMock = vi.hoisted(() => ({ syncFromRemote: vi.fn(() => order.push('syncTasks')) }))
@@ -83,7 +93,10 @@ vi.mock('@/app/lib/data-cache', () => cacheMock)
 vi.mock('@/app/lib/sync-timing', () => timingMock)
 
 vi.mock('@/app/stores/use-sync-store', () => ({
-  useSyncStore: (selector: (state: typeof syncStoreMock) => unknown) => selector(syncStoreMock),
+  useSyncStore: Object.assign(
+    (selector: (state: typeof syncStoreMock) => unknown) => selector(syncStoreMock),
+    { getState: () => syncStoreMock },
+  ),
 }))
 
 vi.mock('@/app/stores/use-etebase-store', () => ({
@@ -126,13 +139,17 @@ describe('SyncProvider timing instrumentation', () => {
     syncStoreMock.setSyncStatus.mockImplementation((status: string) => order.push(`setSyncStatus:${status}`))
     syncStoreMock.setLastSynced.mockImplementation(() => order.push('setLastSynced'))
     syncStoreMock.setError.mockImplementation((error: string | null) => order.push(`setError:${error ?? 'null'}`))
+    syncStoreMock.setPartialLoad.mockImplementation((partial: boolean, count = 0) => order.push(`setPartialLoad:${partial}:${count}`))
+    etebaseMock.state.domainLoadState = { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' }
     etebaseMock.state.initialize.mockImplementation(async () => order.push('etebaseInitialize'))
     etebaseMock.state.fetchAllItems.mockImplementation(async (type: 'tasks' | 'contacts' | 'calendar') => {
       order.push(`fetchAllItems:${type}`)
       return []
     })
-    etebaseMock.state.onSyncChange.mockImplementation(() => {
+    etebaseMock.state.refreshCollection.mockImplementation(async () => [])
+    etebaseMock.state.onSyncChange.mockImplementation((handler?: Parameters<typeof etebaseMock.state.onSyncChange>[0]) => {
       order.push('wireChangeHandler')
+      etebaseMock.setSyncChangeHandler(handler ?? null)
       return vi.fn()
     })
     etebaseMock.state.onStatusChange.mockImplementation(() => {
@@ -159,8 +176,12 @@ describe('SyncProvider timing instrumentation', () => {
       'setSyncStatus:syncing',
       'etebaseInitialize',
       'fetchAllItems:tasks',
+      'syncTasks',
       'fetchAllItems:contacts',
+      'syncContacts',
       'fetchAllItems:calendar',
+      'syncCalendar',
+      'setPartialLoad:false:0',
       'wireChangeHandler',
       'wireStatusHandler',
       'setSyncStatus:synced',
@@ -210,5 +231,33 @@ describe('SyncProvider timing instrumentation', () => {
     await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
     expect(syncStoreMock.setSyncStatus).toHaveBeenCalledWith('synced')
     expect(sentryMock.captureException).toHaveBeenCalled()
+  })
+
+  it('does not full-replace a failed domain after a scoped change refresh succeeds', async () => {
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    vi.clearAllMocks()
+    order.length = 0
+    etebaseMock.state.domainLoadState = { tasks: 'loaded', contacts: 'loaded', calendar: 'failed', preferences: 'unknown' }
+    etebaseMock.state.refreshCollection.mockImplementation(async () => {
+      order.push('refreshCalendarScoped')
+      return []
+    })
+
+    const handler = etebaseMock.getSyncChangeHandler()
+    expect(handler).toBeTruthy()
+    await handler!({
+      collectionType: 'etebase.vevent',
+      collectionUid: 'calendar-one',
+      itemUids: ['redacted-item'],
+      changeType: 'change',
+    })
+
+    expect(etebaseMock.state.refreshCollection).toHaveBeenCalledWith('calendar', 'calendar-one')
+    expect(calendarStoreMock.syncFromRemote).not.toHaveBeenCalled()
+    expect(syncStoreMock.setPartialLoad).toHaveBeenCalledWith(true, 1)
+    expect(order).toContain('refreshCalendarScoped')
+    expect(order).not.toContain('syncCalendar')
   })
 })

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -44,6 +44,16 @@ function safeLogSyncTiming(phase: SyncTimingPhase, startedAt: number, fields: Sy
   }
 }
 
+function countVisiblePartialDomains() {
+  const state = useEtebaseStore.getState().domainLoadState
+  return (['tasks', 'contacts', 'calendar'] as const).filter((type) => state[type] === 'failed').length
+}
+
+function updatePartialLoadFlag() {
+  const failedCount = countVisiblePartialDomains()
+  useSyncStore.getState().setPartialLoad(failedCount > 0, failedCount)
+}
+
 /**
  * SyncProvider orchestrates:
  * 1. Online/offline listeners (existing behavior)
@@ -102,6 +112,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         // Now load items from each collection into the data stores
         const loadStartedAt = nowMs()
         await loadItemsIntoStores()
+        updatePartialLoadFlag()
         safeLogSyncTiming('load-items', loadStartedAt)
 
         // Wire SyncEngine change events
@@ -225,7 +236,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       try {
         const taskItems = await etebase.fetchAllItems('tasks')
         let taskCount = 0
-        if (taskItems.length > 0) {
+        if (useEtebaseStore.getState().domainLoadState.tasks === 'loaded') {
           const { deserializeTask } = await import('@silentsuite/core')
           const tasks = taskItems.map((item) => {
             const task = deserializeTask(item.content)
@@ -254,7 +265,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       try {
         const contactItems = await etebase.fetchAllItems('contacts')
         let contactCount = 0
-        if (contactItems.length > 0) {
+        if (useEtebaseStore.getState().domainLoadState.contacts === 'loaded') {
           const { deserializeContact } = await import('@silentsuite/core')
           const contacts = contactItems.map((item) => {
             const contact = deserializeContact(item.content)
@@ -281,7 +292,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       try {
         const eventItems = await etebase.fetchAllItems('calendar')
         let eventCount = 0
-        if (eventItems.length > 0) {
+        if (useEtebaseStore.getState().domainLoadState.calendar === 'loaded') {
           const { deserializeCalendarEvent } = await import('@silentsuite/core')
           const events = eventItems.map((item) => {
             const event = deserializeCalendarEvent(item.content)
@@ -319,36 +330,45 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         if (collectionType === 'etebase.vtodo') {
           try {
             await refresher('tasks', event.collectionUid)
-            const taskItems = await useEtebaseStore.getState().fetchAllItems('tasks')
-            const tasks = taskItems.map((item) => {
-              const task = core.deserializeTask(item.content)
-              return { ...task, id: item.uid, listId: item.collectionUid }
-            })
-            useTaskStore.getState().syncFromRemote(tasks)
+            updatePartialLoadFlag()
+            if (useEtebaseStore.getState().domainLoadState.tasks === 'loaded') {
+              const taskItems = await useEtebaseStore.getState().fetchAllItems('tasks')
+              const tasks = taskItems.map((item) => {
+                const task = core.deserializeTask(item.content)
+                return { ...task, id: item.uid, listId: item.collectionUid }
+              })
+              useTaskStore.getState().syncFromRemote(tasks)
+            }
           } catch (err) {
             reportSyncError('sync tasks', err)
           }
         } else if (collectionType === 'etebase.vcard') {
           try {
             await refresher('contacts', event.collectionUid)
-            const contactItems = await useEtebaseStore.getState().fetchAllItems('contacts')
-            const contacts = contactItems.map((item) => {
-              const contact = core.deserializeContact(item.content)
-              return { ...contact, id: item.uid, listId: item.collectionUid }
-            })
-            useContactStore.getState().syncFromRemote(contacts)
+            updatePartialLoadFlag()
+            if (useEtebaseStore.getState().domainLoadState.contacts === 'loaded') {
+              const contactItems = await useEtebaseStore.getState().fetchAllItems('contacts')
+              const contacts = contactItems.map((item) => {
+                const contact = core.deserializeContact(item.content)
+                return { ...contact, id: item.uid, listId: item.collectionUid }
+              })
+              useContactStore.getState().syncFromRemote(contacts)
+            }
           } catch (err) {
             reportSyncError('sync contacts', err)
           }
         } else if (collectionType === 'etebase.vevent') {
           try {
             await refresher('calendar', event.collectionUid)
-            const eventItems = await useEtebaseStore.getState().fetchAllItems('calendar')
-            const events = eventItems.map((item) => {
-              const event = core.deserializeCalendarEvent(item.content)
-              return { ...event, id: item.uid, calendarId: item.collectionUid }
-            })
-            useCalendarStore.getState().syncFromRemote(events)
+            updatePartialLoadFlag()
+            if (useEtebaseStore.getState().domainLoadState.calendar === 'loaded') {
+              const eventItems = await useEtebaseStore.getState().fetchAllItems('calendar')
+              const events = eventItems.map((item) => {
+                const event = core.deserializeCalendarEvent(item.content)
+                return { ...event, id: item.uid, calendarId: item.collectionUid }
+              })
+              useCalendarStore.getState().syncFromRemote(events)
+            }
           } catch (err) {
             reportSyncError('sync calendar events', err)
           }

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -79,6 +79,14 @@ function mockItem(uid: string, content: string, isDeleted = false) {
   }
 }
 
+function loadedDomainLoadState() {
+  return { calendar: 'loaded' as const, tasks: 'loaded' as const, contacts: 'loaded' as const, preferences: 'unknown' as const }
+}
+
+function unknownDomainLoadState() {
+  return { calendar: 'unknown' as const, tasks: 'unknown' as const, contacts: 'unknown' as const, preferences: 'unknown' as const }
+}
+
 function mockCollection(uid: string, meta: Record<string, string> = {}) {
   return {
     uid,
@@ -100,6 +108,7 @@ function setupStoreWithMocks(itemManager: MockItemManager, syncEngine: MockSyncE
     itemTypeMap: new Map(),
     itemCollectionMap: new Map(),
     isInitialized: true,
+    domainLoadState: loadedDomainLoadState(),
     syncEngine: syncEngine as any,
   })
 }
@@ -118,6 +127,7 @@ function setupStoreWithCollections(itemManagerByUid: Record<string, MockItemMana
     itemTypeMap: new Map(),
     itemCollectionMap: new Map(),
     isInitialized: true,
+    domainLoadState: loadedDomainLoadState(),
     syncEngine: syncEngine as any,
   })
 }
@@ -235,7 +245,14 @@ describe('useEtebaseStore.initialize restoreBlocked flag', () => {
     coreMock.restoreSession.mockResolvedValueOnce({ id: 'account' })
     coreMock.getAccountFingerprint.mockReturnValueOnce('fingerprint')
     coreMock.listCollections.mockImplementation(async () => [mockCollection('col-1')])
-    coreMock.listItems.mockRejectedValueOnce(new Error('server 500 on listItems'))
+    coreMock.listItems
+      .mockRejectedValueOnce(new Error('server 500 on listItems'))
+      .mockResolvedValue({ items: [], stoken: null, done: true })
+    coreMock.SyncEngine.mockImplementation(function (this: any) {
+      this.trackCollection = vi.fn()
+      this.onStokenAdvance = vi.fn()
+      this.start = vi.fn(async () => {})
+    })
     offlineQueueMock.isOfflineError.mockReturnValue(false)
 
     await useEtebaseStore.getState().initialize()
@@ -245,6 +262,8 @@ describe('useEtebaseStore.initialize restoreBlocked flag', () => {
     // Slice 3 concern, NOT an unlock case.
     expect(state.restoreBlocked).toBe(false)
     expect(state.isInitialized).toBe(true)
+    expect(state.domainLoadState).toMatchObject({ calendar: 'failed', tasks: 'loaded', contacts: 'loaded' })
+    expect(state.syncEngine).toBeTruthy()
   })
 
   it('leaves restoreBlocked false on a fully successful restore', async () => {
@@ -265,6 +284,7 @@ describe('useEtebaseStore.initialize restoreBlocked flag', () => {
     const state = useEtebaseStore.getState()
     expect(state.restoreBlocked).toBe(false)
     expect(state.isInitialized).toBe(true)
+    expect(state.domainLoadState).toMatchObject({ calendar: 'loaded', tasks: 'loaded', contacts: 'loaded' })
     expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
   })
 
@@ -277,6 +297,7 @@ describe('useEtebaseStore.initialize restoreBlocked flag', () => {
     useEtebaseStore.getState().destroy()
 
     expect(useEtebaseStore.getState().restoreBlocked).toBe(false)
+    expect(useEtebaseStore.getState().domainLoadState).toEqual(unknownDomainLoadState())
   })
 })
 
@@ -493,6 +514,7 @@ describe('useEtebaseStore.moveItem', () => {
       itemTypeMap: new Map([['item-old', 'calendar']]),
       itemCollectionMap: new Map([['item-old', 'col-1']]),
       isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
       syncEngine: null,
     })
 
@@ -527,6 +549,7 @@ describe('useEtebaseStore.moveItem', () => {
       itemTypeMap: new Map([['item-old', 'calendar']]),
       itemCollectionMap: new Map([['item-old', 'col-1']]),
       isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
       syncEngine: null,
     })
 
@@ -562,6 +585,34 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
     })
   })
 
+  it('refuses to clear a collection before that domain is fully loaded', async () => {
+    const itemManager = { batch: vi.fn(async () => {}) }
+    const account = {
+      getCollectionManager: () => ({
+        getItemManager: () => itemManager,
+      }),
+    }
+
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map([['item-1', { uid: 'item-1', delete: vi.fn() }]]),
+      itemTypeMap: new Map([['item-1', 'calendar']]),
+      itemCollectionMap: new Map([['item-1', 'col-1']]),
+      isInitialized: true,
+      domainLoadState: { ...loadedDomainLoadState(), calendar: 'failed' },
+      syncEngine: null,
+    })
+
+    const deleted = await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
+
+    expect(deleted).toBe(0)
+    expect(itemManager.batch).not.toHaveBeenCalled()
+    expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith(
+      "This data hasn't finished loading yet. Retry sync, then try again.",
+    )
+  })
+
   it('deletes only items in the requested collection and clears local maps', async () => {
     const deleteItemOne = { uid: 'item-1', delete: vi.fn() }
     const deleteItemTwo = { uid: 'item-2', delete: vi.fn() }
@@ -592,6 +643,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
         ['item-3', 'col-2'],
       ]),
       isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
       syncEngine: null,
     })
 
@@ -636,6 +688,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
       itemTypeMap: new Map(),
       itemCollectionMap: new Map(),
       isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
       syncEngine: null,
     })
     useCalendarStore.setState({
@@ -674,6 +727,7 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
       itemTypeMap: new Map(items.map((item) => [item.uid, 'calendar' as const])),
       itemCollectionMap: new Map(items.map((item) => [item.uid, 'col-1'])),
       isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
       syncEngine: null,
     })
     useCalendarStore.setState({
@@ -745,6 +799,7 @@ describe('useEtebaseStore.refreshCollection', () => {
         ['keep-col-2', 'col-2'],
       ]),
       isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
       syncEngine: null,
     })
 
@@ -757,6 +812,7 @@ describe('useEtebaseStore.refreshCollection', () => {
     expect(state.itemCollectionMap.get('new-col-1')).toBe('col-1')
     expect(state.itemCache.get('keep-col-2')).toBe(survivorItem)
     expect(state.itemCollectionMap.get('keep-col-2')).toBe('col-2')
+    expect(state.domainLoadState.calendar).toBe('loaded')
     expect(itemManagers['col-2'].list).not.toHaveBeenCalled()
   })
 
@@ -778,6 +834,7 @@ describe('useEtebaseStore.refreshCollection', () => {
       itemTypeMap: new Map([['existing', 'calendar']]),
       itemCollectionMap: new Map([['existing', 'col-1']]),
       isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
       syncEngine: null,
     })
 
@@ -787,7 +844,45 @@ describe('useEtebaseStore.refreshCollection', () => {
     expect(result).toEqual([{ uid: 'existing', content: 'existing calendar', collectionUid: 'col-1' }])
     expect(state.itemCache.get('existing')).toBe(existingItem)
     expect(state.itemCollectionMap.get('existing')).toBe('col-1')
+    expect(state.domainLoadState.calendar).toBe('failed')
     errorSpy.mockRestore()
+  })
+
+  it('does not mark a failed domain loaded after only one collection refresh succeeds', async () => {
+    const existingItem = mockItem('existing-col-2', 'existing calendar')
+    const freshItem = mockItem('fresh-col-1', 'fresh calendar')
+    const collections = [{ uid: 'col-1' }, { uid: 'col-2' }]
+    const itemManagers = {
+      'col-1': { list: vi.fn(async () => ({ data: [freshItem], stoken: null, done: true })) },
+      'col-2': { list: vi.fn(async () => ({ data: [existingItem], stoken: null, done: true })) },
+    }
+    const account = {
+      getCollectionManager: () => ({
+        fetch: vi.fn(async (uid: string) => ({ uid })),
+        getItemManager: (collection: { uid: keyof typeof itemManagers }) => itemManagers[collection.uid],
+      }),
+    }
+
+    useEtebaseStore.setState({
+      account: account as any,
+      collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map([['existing-col-2', existingItem]]),
+      itemTypeMap: new Map([['existing-col-2', 'calendar']]),
+      itemCollectionMap: new Map([['existing-col-2', 'col-2']]),
+      isInitialized: true,
+      domainLoadState: { ...loadedDomainLoadState(), calendar: 'failed' },
+      syncEngine: null,
+    })
+
+    const scoped = await useEtebaseStore.getState().refreshCollection('calendar', 'col-1')
+    expect(scoped).toEqual([{ uid: 'fresh-col-1', content: 'fresh calendar', collectionUid: 'col-1' }])
+    expect(useEtebaseStore.getState().domainLoadState.calendar).toBe('failed')
+    expect(useEtebaseStore.getState().itemCache.get('existing-col-2')).toBe(existingItem)
+    expect(itemManagers['col-2'].list).not.toHaveBeenCalled()
+
+    await useEtebaseStore.getState().refreshCollection('calendar')
+    expect(useEtebaseStore.getState().domainLoadState.calendar).toBe('loaded')
+    expect(itemManagers['col-2'].list).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -6,6 +6,7 @@ const etebaseMock = vi.hoisted(() => ({
   state: {
     account: null as unknown,
     syncEngine: null as { syncNow: ReturnType<typeof vi.fn> } | null,
+    domainLoadState: { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' },
     reconcileCollections: vi.fn().mockResolvedValue(undefined),
     refreshCollection: vi.fn().mockResolvedValue([]),
     moveItem: vi.fn(),
@@ -66,6 +67,7 @@ vi.mock('@/app/stores/use-toast-store', () => ({
 function resetStore() {
   etebaseMock.state.account = null
   etebaseMock.state.syncEngine = null
+  etebaseMock.state.domainLoadState = { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' }
   etebaseMock.state.reconcileCollections.mockReset().mockResolvedValue(undefined)
   etebaseMock.state.refreshCollection.mockReset().mockResolvedValue([])
   etebaseMock.state.moveItem.mockReset()
@@ -78,6 +80,8 @@ function resetStore() {
     error: null,
     pendingQueueCount: 0,
     failedQueueCount: 0,
+    partialLoad: false,
+    partialLoadDomainCount: 0,
   })
 }
 
@@ -162,6 +166,26 @@ describe('useSyncStore', () => {
     const reconcileOrder = etebaseMock.state.reconcileCollections.mock.invocationCallOrder[0]!
     const firstRefreshOrder = etebaseMock.state.refreshCollection.mock.invocationCallOrder[0]!
     expect(reconcileOrder).toBeLessThan(firstRefreshOrder)
+  })
+
+  it('does not replace a domain store when that domain refresh failed', async () => {
+    etebaseMock.state.refreshCollection.mockImplementation(async (type: string) => {
+      if (type === 'calendar') {
+        etebaseMock.state.domainLoadState = { ...etebaseMock.state.domainLoadState, calendar: 'failed' }
+        return []
+      }
+      return []
+    })
+    calendarStoreMock.events = [{ id: 'existing', calendarId: 'cal-1' }]
+
+    useSyncStore.getState().simulateSyncCycle()
+
+    await flushPromises()
+    await flushPromises()
+    expect(calendarStoreMock.syncFromRemote).not.toHaveBeenCalled()
+    expect(calendarStoreMock.events).toEqual([{ id: 'existing', calendarId: 'cal-1' }])
+    expect(useSyncStore.getState().partialLoad).toBe(true)
+    expect(useSyncStore.getState().partialLoadDomainCount).toBe(1)
   })
 
   it('replays queued collection moves and remaps the calendar event id', async () => {

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -76,10 +76,27 @@ const COLLECTION_TYPE_CONTACTS = 'etebase.vcard'
 
 type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
 type VisibleCollectionTypeKey = Exclude<CollectionTypeKey, 'preferences'>
+type DomainLoadStatus = 'unknown' | 'loaded' | 'failed'
+type DomainLoadState = Record<CollectionTypeKey, DomainLoadStatus>
 type CollectionMetaUpdates = { name?: string; description?: string; color?: string }
 type EtebaseCore = typeof import('@silentsuite/core')
 
 type CachedContentItem = { uid: string; content: string; collectionUid: string }
+
+const UNKNOWN_DOMAIN_LOAD_STATE: DomainLoadState = {
+  calendar: 'unknown',
+  tasks: 'unknown',
+  contacts: 'unknown',
+  preferences: 'unknown',
+}
+
+function unknownDomainLoadState(): DomainLoadState {
+  return { ...UNKNOWN_DOMAIN_LOAD_STATE }
+}
+
+function incompleteLoadMessage(): string {
+  return "This data hasn't finished loading yet. Retry sync, then try again."
+}
 
 const COLLECTION_DEFINITIONS: [VisibleCollectionTypeKey, string, string][] = [
   ['calendar', COLLECTION_TYPE_CALENDAR, 'Personal Calendar'],
@@ -319,6 +336,10 @@ function collectionDisplayName(type: CollectionTypeKey): string {
   return 'preferences'
 }
 
+function isDomainLoadedForBulkMutation(domainLoadState: DomainLoadState, type: CollectionTypeKey): boolean {
+  return domainLoadState[type] === 'loaded'
+}
+
 interface EtebaseState {
   // The live Account object (null until session restored)
   account: any | null
@@ -338,6 +359,10 @@ interface EtebaseState {
   // (missing/invalid/corrupt local session) and re-unlocking would help.
   // Not set for offline errors or post-restore listing/sync failures.
   restoreBlocked: boolean
+  // Per-domain post-restore load outcome. 'loaded' means the app has a
+  // complete server view of the domain; 'failed'/'unknown' means bulk
+  // destructive operations must not trust the in-memory view.
+  domainLoadState: DomainLoadState
   // SyncEngine reference
   syncEngine: any | null
 }
@@ -491,6 +516,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   itemCollectionMap: new Map(),
   isInitialized: false,
   restoreBlocked: false,
+  domainLoadState: unknownDomainLoadState(),
   syncEngine: null,
 
   initialize: async () => {
@@ -560,6 +586,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const itemTypeMap = new Map<string, CollectionTypeKey>()
       const itemCollectionMap = new Map<string, string>()
 
+      const domainLoadState = unknownDomainLoadState()
+
       for (const [key] of COLLECTION_DEFINITIONS) {
         const phase = `listItems:${key}` as const
         diagnostics.startPhase(phase)
@@ -567,34 +595,41 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         let itemCount = 0
         let pageCount = 0
 
-        for (const collection of typedCollections) {
-          let stoken: string | null = null
-          let done = false
+        try {
+          for (const collection of typedCollections) {
+            let stoken: string | null = null
+            let done = false
 
-          while (!done) {
-            const response = await core.listItems(account, collection, stoken)
-            pageCount += 1
-            for (const item of response.items) {
-              if (!item.isDeleted) {
-                itemCache.set(item.uid, item)
-                itemTypeMap.set(item.uid, key)
-                itemCollectionMap.set(item.uid, collection.uid)
-                itemCount += 1
+            while (!done) {
+              const response = await core.listItems(account, collection, stoken)
+              pageCount += 1
+              for (const item of response.items) {
+                if (!item.isDeleted) {
+                  itemCache.set(item.uid, item)
+                  itemTypeMap.set(item.uid, key)
+                  itemCollectionMap.set(item.uid, collection.uid)
+                  itemCount += 1
+                }
               }
+              stoken = response.stoken
+              done = response.done
             }
-            stoken = response.stoken
-            done = response.done
           }
+          domainLoadState[key] = 'loaded'
+          diagnostics.completePhase(phase, {
+            collectionType: key,
+            collectionCount: typedCollections.length,
+            itemCount,
+            pageCount,
+          })
+        } catch (err) {
+          domainLoadState[key] = 'failed'
+          diagnostics.failActivePhase(err)
+          logger.warn(`[etebase-store] Failed to load ${key} items`, getSafeErrorDetails(err))
         }
-        diagnostics.completePhase(phase, {
-          collectionType: key,
-          collectionCount: typedCollections.length,
-          itemCount,
-          pageCount,
-        })
       }
 
-      set({ itemCache, itemTypeMap, itemCollectionMap })
+      set({ itemCache, itemTypeMap, itemCollectionMap, domainLoadState })
       logger.debug(`[etebase-store] Loaded ${itemCache.size} items into cache`)
 
       // 4. Start SyncEngine
@@ -678,10 +713,15 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   deleteCollection: async (type: CollectionTypeKey, collectionUid: string) => {
-    const { account, collections, syncEngine } = get()
+    const { account, collections, domainLoadState, syncEngine } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot delete ${type} collection ${collectionUid}: missing account or collection`)
+      return false
+    }
+    if (!isDomainLoadedForBulkMutation(domainLoadState, type)) {
+      showErrorToast(incompleteLoadMessage())
+      logger.warn(`[etebase-store] Refusing to delete ${type} collection before domain load completes`)
       return false
     }
     if (collections[type].length <= 1) {
@@ -1013,10 +1053,15 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   deleteItemsInCollection: async (type: CollectionTypeKey, collectionUid: string) => {
-    const { account, collections, itemCache, itemCollectionMap } = get()
+    const { account, collections, domainLoadState, itemCache, itemCollectionMap } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot clear ${type} collection ${collectionUid}: missing account or collection`)
+      return 0
+    }
+    if (!isDomainLoadedForBulkMutation(domainLoadState, type)) {
+      showErrorToast(incompleteLoadMessage())
+      logger.warn(`[etebase-store] Refusing to clear ${type} collection before domain load completes`)
       return 0
     }
 
@@ -1495,7 +1540,15 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       newCollections[type] = newCollections[type].map((collection) =>
         refreshedByUid.get(collection.uid) ?? collection,
       )
-      set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, itemCollectionMap: newItemCollectionMap, collections: newCollections })
+      const nextDomainStatus = collectionUid ? get().domainLoadState[type] : 'loaded'
+
+      set((state) => ({
+        itemCache: newItemCache,
+        itemTypeMap: newItemTypeMap,
+        itemCollectionMap: newItemCollectionMap,
+        collections: newCollections,
+        domainLoadState: { ...state.domainLoadState, [type]: nextDomainStatus },
+      }))
 
       // Mirror the refresh into the local cache. Use replace-style writes so
       // items deleted upstream are also dropped from disk.
@@ -1516,6 +1569,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       return allResults
     } catch (err) {
       console.error(`[etebase-store] Failed to refresh ${type}`, getSafeErrorDetails(err))
+      set((state) => ({ domainLoadState: { ...state.domainLoadState, [type]: 'failed' } }))
       return get().fetchAllItems(type)
     }
   },
@@ -1534,6 +1588,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       itemCollectionMap: new Map(),
       isInitialized: false,
       restoreBlocked: false,
+      domainLoadState: unknownDomainLoadState(),
       syncEngine: null,
     })
     logger.debug('[etebase-store] Destroyed')

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -14,6 +14,8 @@ interface SyncState {
   error: string | null
   pendingQueueCount: number
   failedQueueCount: number
+  partialLoad: boolean
+  partialLoadDomainCount: number
 }
 
 interface SyncActions {
@@ -21,6 +23,7 @@ interface SyncActions {
   setLastSynced: (date: Date) => void
   setOnline: (online: boolean) => void
   setError: (error: string | null) => void
+  setPartialLoad: (partial: boolean, domainCount?: number) => void
   initializeSync: () => () => void
   /**
    * Trigger a real sync cycle via the SyncEngine.
@@ -38,11 +41,14 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
   error: null,
   pendingQueueCount: 0,
   failedQueueCount: 0,
+  partialLoad: false,
+  partialLoadDomainCount: 0,
 
   setSyncStatus: (status) => set({ syncStatus: status }),
   setLastSynced: (date) => set({ lastSyncedAt: date }),
   setOnline: (online) => set({ isOnline: online }),
   setError: (error) => set({ error }),
+  setPartialLoad: (partial, domainCount = 0) => set({ partialLoad: partial, partialLoadDomainCount: partial ? domainCount : 0 }),
 
   initializeSync: () => {
     const handleOnline = async () => {
@@ -225,23 +231,39 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       const { useContactStore } = await import('@/app/stores/use-contact-store')
       const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
 
+      const refreshedEtebase = useEtebaseStore.getState()
+      const domainLoadState = refreshedEtebase.domainLoadState
+      let partialDomainCount = 0
+
       const tasks = taskItems.map((item) => {
         const task = core.deserializeTask(item.content)
         return { ...task, id: item.uid, listId: item.collectionUid }
       })
-      useTaskStore.getState().syncFromRemote(tasks)
+      if (domainLoadState.tasks === 'loaded') {
+        useTaskStore.getState().syncFromRemote(tasks)
+      } else {
+        partialDomainCount += 1
+      }
 
       const contacts = contactItems.map((item) => {
         const contact = core.deserializeContact(item.content)
         return { ...contact, id: item.uid, listId: item.collectionUid }
       })
-      useContactStore.getState().syncFromRemote(contacts)
+      if (domainLoadState.contacts === 'loaded') {
+        useContactStore.getState().syncFromRemote(contacts)
+      } else {
+        partialDomainCount += 1
+      }
 
       const events = eventItems.map((item) => {
         const event = core.deserializeCalendarEvent(item.content)
         return { ...event, id: item.uid, calendarId: item.collectionUid }
       })
-      useCalendarStore.getState().syncFromRemote(events)
+      if (domainLoadState.calendar === 'loaded') {
+        useCalendarStore.getState().syncFromRemote(events)
+      } else {
+        partialDomainCount += 1
+      }
       // Purge stale queue entries (older than 24h) that may cause phantom indicators
       const stale = await getStaleEntries()
       for (const entry of stale) {
@@ -251,7 +273,15 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       // Refresh counts to ensure UI is accurate after sync
       const pc = await getPendingCount()
       const fc = await getFailedCount()
-      set({ syncStatus: 'synced', lastSyncedAt: new Date(), error: null, pendingQueueCount: pc, failedQueueCount: fc })
+      set({
+        syncStatus: 'synced',
+        lastSyncedAt: new Date(),
+        error: null,
+        pendingQueueCount: pc,
+        failedQueueCount: fc,
+        partialLoad: partialDomainCount > 0,
+        partialLoadDomainCount: partialDomainCount,
+      })
     }).catch((err) => {
       console.error('[sync-store] Manual sync failed', getSafeErrorDetails(err))
       set({ syncStatus: 'error', error: 'Sync failed' })

--- a/docs/contributing/authenticated-restore-smoke.md
+++ b/docs/contributing/authenticated-restore-smoke.md
@@ -123,6 +123,32 @@ The raw diagnostics in `sessionStorage` should be JSON under the key `silentsuit
 
 A `source: "login"` snapshot only proves login/session persistence diagnostics. It is not sufficient for authenticated restore smoke; hard reload and collect a `source: "restore"` snapshot.
 
+## Partial-load warning check
+
+After Slice 4, one failed visible domain load must not make sibling domains look empty or block the app shell. If the app reaches the calendar while one or more domains could not be refreshed, expected behavior is:
+
+- cached or already-loaded sibling domains remain visible;
+- bulk destructive collection clears are blocked until that domain finishes loading;
+- a calm amber warning appears in the app shell with static copy and a **Retry sync** action;
+- the sync indicator uses a warning affordance instead of reporting a fully healthy synced state;
+- no raw errors, phase names, tokens, collection IDs, item IDs, plaintext PIM, or request details are shown.
+
+Use this as a non-destructive smoke after preview deploys that touch domain item loading:
+
+```text
+Partial-load warning check: PASS|FAIL
+environment: preview|local
+app reached shell: yes|no
+healthy sibling data preserved: yes|no
+partial-load banner shown: yes|no
+retry action present: yes|no
+sync indicator warning affordance: yes|no
+privacy-safe copy only: yes|no
+bulk clear blocked before full domain load: yes|no
+findings:
+  - <privacy-safe finding, if any>
+```
+
 ## Failure triage by `failedPhase`
 
 If the smoke fails, do not start with broad rollback. Use the failed phase to choose the next narrow investigation:


### PR DESCRIPTION
## Summary
- track per-domain load state during Etebase initialization and manual refresh
- preserve existing visible data when one domain fails to load instead of replacing it with an empty state
- block bulk collection clears until the target domain is fully loaded
- add an amber partial-load warning banner, sync indicator affordance, tests, and smoke-doc checklist

## Verification
- pnpm --filter @silentsuite/web test -- app/stores/__tests__/use-etebase-store.test.ts app/stores/__tests__/use-sync-store.test.ts app/components/__tests__/SyncIndicator.test.tsx app/components/__tests__/partial-load-banner.test.tsx app/providers/__tests__/sync-provider.timing.test.tsx
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web lint
- pnpm run build
- pnpm run test
- git diff --check

## Notes
- No plaintext PIM, item IDs, collection IDs, raw errors, tokens, or session data are exposed in the new UI copy.
- Review subagent is running as the required PR gate before merge.