### PR TITLE
web: paint calendar before slower domains on restore

### DIFF
--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -16,10 +16,28 @@ const syncStoreMock = vi.hoisted(() => ({
   setPartialLoad: vi.fn((partial: boolean, count = 0) => order.push(`setPartialLoad:${partial}:${count}`)),
 }))
 
+type DomainKey = 'calendar' | 'tasks' | 'contacts'
+type OnDomainLoaded = (event: {
+  type: DomainKey
+  status: 'loaded' | 'failed'
+  itemCount: number
+  pageCount: number
+  collectionCount: number
+}) => void | Promise<void>
+
 const etebaseMock = vi.hoisted(() => {
   let syncChangeHandler: ((event: { collectionType: string; collectionUid: string; itemUids: string[]; changeType: string }) => Promise<void>) | null = null
+  // Default initialize replays the real store contract: calendar → tasks →
+  // contacts, one terminal callback each, statuses driven by domainLoadState.
+  async function defaultInitialize(options?: { onDomainLoaded?: OnDomainLoaded }) {
+    order.push('etebaseInitialize')
+    for (const type of ['calendar', 'tasks', 'contacts'] as const) {
+      const status = state.domainLoadState[type] === 'failed' ? 'failed' : 'loaded'
+      await options?.onDomainLoaded?.({ type, status, itemCount: 0, pageCount: 1, collectionCount: 1 })
+    }
+  }
   const state = {
-    initialize: vi.fn(async () => order.push('etebaseInitialize')),
+    initialize: vi.fn(defaultInitialize),
     fetchAllItems: vi.fn(async (type: 'tasks' | 'contacts' | 'calendar') => {
       order.push(`fetchAllItems:${type}`)
       return []
@@ -39,6 +57,7 @@ const etebaseMock = vi.hoisted(() => {
   }
   return {
     state,
+    defaultInitialize,
     getSyncChangeHandler: () => syncChangeHandler,
     setSyncChangeHandler: (handler: typeof syncChangeHandler) => {
       syncChangeHandler = handler
@@ -141,7 +160,7 @@ describe('SyncProvider timing instrumentation', () => {
     syncStoreMock.setError.mockImplementation((error: string | null) => order.push(`setError:${error ?? 'null'}`))
     syncStoreMock.setPartialLoad.mockImplementation((partial: boolean, count = 0) => order.push(`setPartialLoad:${partial}:${count}`))
     etebaseMock.state.domainLoadState = { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' }
-    etebaseMock.state.initialize.mockImplementation(async () => order.push('etebaseInitialize'))
+    etebaseMock.state.initialize.mockImplementation(etebaseMock.defaultInitialize)
     etebaseMock.state.fetchAllItems.mockImplementation(async (type: 'tasks' | 'contacts' | 'calendar') => {
       order.push(`fetchAllItems:${type}`)
       return []
@@ -166,7 +185,7 @@ describe('SyncProvider timing instrumentation', () => {
     timingMock.nowMs.mockReturnValue(100)
   })
 
-  it('preserves the existing startup order while recording timings', async () => {
+  it('loads each domain into its store as the domain callback fires (calendar first)', async () => {
     renderProvider()
 
     await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
@@ -175,12 +194,14 @@ describe('SyncProvider timing instrumentation', () => {
       'initializeSync',
       'setSyncStatus:syncing',
       'etebaseInitialize',
-      'fetchAllItems:tasks',
-      'syncTasks',
-      'fetchAllItems:contacts',
-      'syncContacts',
       'fetchAllItems:calendar',
       'syncCalendar',
+      'setPartialLoad:false:0',
+      'fetchAllItems:tasks',
+      'syncTasks',
+      'setPartialLoad:false:0',
+      'fetchAllItems:contacts',
+      'syncContacts',
       'setPartialLoad:false:0',
       'wireChangeHandler',
       'wireStatusHandler',
@@ -189,6 +210,71 @@ describe('SyncProvider timing instrumentation', () => {
     ])
     expect(timingMock.logSyncTiming).toHaveBeenCalledWith('cache-capability', 100, expect.any(Object))
     expect(timingMock.logSyncTiming).toHaveBeenCalledWith('initial-sync-complete', 100, {})
+  })
+
+  it('paints calendar as soon as its domain callback fires, before delayed tasks/contacts', async () => {
+    let releaseLater: () => void = () => {}
+    const laterGate = new Promise<void>((resolve) => {
+      releaseLater = resolve
+    })
+    etebaseMock.state.initialize.mockImplementation(async (options?: { onDomainLoaded?: OnDomainLoaded }) => {
+      order.push('etebaseInitialize')
+      await options?.onDomainLoaded?.({ type: 'calendar', status: 'loaded', itemCount: 1, pageCount: 1, collectionCount: 1 })
+      order.push('calendarCallbackDone')
+      await laterGate
+      await options?.onDomainLoaded?.({ type: 'tasks', status: 'loaded', itemCount: 0, pageCount: 1, collectionCount: 1 })
+      await options?.onDomainLoaded?.({ type: 'contacts', status: 'loaded', itemCount: 0, pageCount: 1, collectionCount: 1 })
+    })
+    etebaseMock.state.fetchAllItems.mockImplementation(async (type: DomainKey) => {
+      order.push(`fetchAllItems:${type}`)
+      if (type === 'calendar') return [{ uid: 'evt-1', content: 'VEVENT', collectionUid: 'cal-1' }]
+      return []
+    })
+
+    renderProvider()
+
+    // Calendar paints while tasks/contacts are still gated behind laterGate.
+    await waitFor(() => expect(calendarStoreMock.syncFromRemote).toHaveBeenCalledTimes(1))
+    expect(taskStoreMock.syncFromRemote).not.toHaveBeenCalled()
+    expect(contactStoreMock.syncFromRemote).not.toHaveBeenCalled()
+    expect(order).toContain('syncCalendar')
+    expect(order).not.toContain('syncTasks')
+
+    releaseLater()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    expect(taskStoreMock.syncFromRemote).toHaveBeenCalledTimes(1)
+    expect(contactStoreMock.syncFromRemote).toHaveBeenCalledTimes(1)
+    // Calendar was replaced exactly once, never re-run by a later catch-up pass.
+    expect(calendarStoreMock.syncFromRemote).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps calendar and flags partial load when tasks fail after calendar succeeds', async () => {
+    etebaseMock.state.domainLoadState = { tasks: 'failed', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' }
+    etebaseMock.state.fetchAllItems.mockImplementation(async (type: DomainKey) => {
+      order.push(`fetchAllItems:${type}`)
+      if (type === 'calendar') return [{ uid: 'evt-1', content: 'VEVENT', collectionUid: 'cal-1' }]
+      return []
+    })
+
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    expect(calendarStoreMock.syncFromRemote).toHaveBeenCalledTimes(1)
+    expect(taskStoreMock.syncFromRemote).not.toHaveBeenCalled()
+    expect(contactStoreMock.syncFromRemote).toHaveBeenCalledTimes(1)
+    expect(syncStoreMock.setPartialLoad).toHaveBeenCalledWith(true, 1)
+    expect(order).not.toContain('syncTasks')
+  })
+
+  it('replaces the calendar store only once during initial load', async () => {
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    expect(calendarStoreMock.syncFromRemote).toHaveBeenCalledTimes(1)
+    expect(taskStoreMock.syncFromRemote).toHaveBeenCalledTimes(1)
+    expect(contactStoreMock.syncFromRemote).toHaveBeenCalledTimes(1)
+    expect(order.filter((entry) => entry === 'syncCalendar')).toHaveLength(1)
   })
 
   it('hydrates cache only when cache is enabled and still continues startup', async () => {

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -104,16 +104,19 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           await hydrateFromCache(cacheStartedAt)
         }
 
-        // Restore session, create/fetch collections, load items, start SyncEngine
+        // Restore session, create/fetch collections, and enumerate items. The
+        // onDomainLoaded hook fires once per visible domain as soon as that
+        // domain reaches a terminal state, so calendar deserializes and paints
+        // before slower tasks/contacts finish. This replaces the old
+        // post-initialize all-domain load, so no domain is replaced twice.
         const etebaseStartedAt = nowMs()
-        await etebaseInitialize()
+        await etebaseInitialize({
+          onDomainLoaded: async (event) => {
+            await loadDomainIntoStore(event.type)
+            updatePartialLoadFlag()
+          },
+        })
         safeLogSyncTiming('etebase-initialize', etebaseStartedAt)
-
-        // Now load items from each collection into the data stores
-        const loadStartedAt = nowMs()
-        await loadItemsIntoStores()
-        updatePartialLoadFlag()
-        safeLogSyncTiming('load-items', loadStartedAt)
 
         // Wire SyncEngine change events
         const changeHandlerStartedAt = nowMs()
@@ -205,115 +208,88 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       }
     }
 
-    async function loadItemsIntoStores() {
-      const etebase = useEtebaseStore.getState()
+    async function mirrorToCache(
+      type: 'tasks' | 'contacts' | 'calendar',
+      items: { uid: string; content: string; collectionUid: string }[],
+    ) {
+      if (!isLocalCacheEnabled() || items.length === 0) return
+      const startedAt = nowMs()
+      const records: CachedItem[] = items.map((it) => ({
+        itemUid: it.uid,
+        collectionType: type,
+        collectionUid: it.collectionUid,
+        content: it.content,
+        lastModified: Date.now(),
+      }))
+      try {
+        await cacheReplaceItemsForType(type, records)
+        safeLogSyncTiming('cache-mirror', startedAt, { type, itemCount: items.length })
+      } catch (err) {
+        logger.warn(`[sync-provider] Failed to mirror ${type} to cache`, getSafeErrorDetails(err))
+        safeLogSyncTiming('cache-mirror-failed', startedAt, { type, itemCount: items.length, errorCategory: 'cache' })
+      }
+    }
+
+    // Explicit per-type phase names keep sync timing off arbitrary strings.
+    const TIMING_PHASE_BY_TYPE = {
+      tasks: 'tasks-load',
+      contacts: 'contacts-load',
+      calendar: 'calendar-load',
+    } as const
+
+    /**
+     * Deserialize one visible domain's server items into its Zustand store.
+     * Only replaces the store when that domain is 'loaded' -- a failed/unknown
+     * domain (Slice 4) keeps its existing store contents untouched.
+     */
+    async function loadDomainIntoStore(type: 'calendar' | 'tasks' | 'contacts') {
+      const startedAt = nowMs()
       const cacheEnabled = isLocalCacheEnabled()
-
-      async function mirrorToCache(
-        type: 'tasks' | 'contacts' | 'calendar',
-        items: { uid: string; content: string; collectionUid: string }[],
-      ) {
-        if (!cacheEnabled || items.length === 0) return
-        const startedAt = nowMs()
-        const records: CachedItem[] = items.map((it) => ({
-          itemUid: it.uid,
-          collectionType: type,
-          collectionUid: it.collectionUid,
-          content: it.content,
-          lastModified: Date.now(),
-        }))
-        try {
-          await cacheReplaceItemsForType(type, records)
-          safeLogSyncTiming('cache-mirror', startedAt, { type, itemCount: items.length })
-        } catch (err) {
-          logger.warn(`[sync-provider] Failed to mirror ${type} to cache`, getSafeErrorDetails(err))
-          safeLogSyncTiming('cache-mirror-failed', startedAt, { type, itemCount: items.length, errorCategory: 'cache' })
-        }
-      }
-
-      // Load tasks
-      const taskStartedAt = nowMs()
       try {
-        const taskItems = await etebase.fetchAllItems('tasks')
-        let taskCount = 0
-        if (useEtebaseStore.getState().domainLoadState.tasks === 'loaded') {
-          const { deserializeTask } = await import('@silentsuite/core')
-          const tasks = taskItems.map((item) => {
-            const task = deserializeTask(item.content)
-            // Use the Etebase item UID only as the local id so updates/deletes
-            // can address the item without changing the stable iCalendar UID.
-            return { ...task, id: item.uid, listId: item.collectionUid }
-          })
-          taskCount = tasks.length
-          useTaskStore.getState().syncFromRemote(tasks)
-          logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
-          await mirrorToCache('tasks', taskItems)
+        const items = await useEtebaseStore.getState().fetchAllItems(type)
+        let domainItemCount = 0
+        if (useEtebaseStore.getState().domainLoadState[type] === 'loaded') {
+          const core = await import('@silentsuite/core')
+          if (type === 'tasks') {
+            const tasks = items.map((item) => {
+              // Use the Etebase item UID only as the local id so updates/deletes
+              // can address the item without changing the stable iCalendar UID.
+              const task = core.deserializeTask(item.content)
+              return { ...task, id: item.uid, listId: item.collectionUid }
+            })
+            domainItemCount = tasks.length
+            useTaskStore.getState().syncFromRemote(tasks)
+            logger.log(`[sync-provider] Loaded ${tasks.length} tasks from server`)
+          } else if (type === 'contacts') {
+            const contacts = items.map((item) => {
+              const contact = core.deserializeContact(item.content)
+              return { ...contact, id: item.uid, listId: item.collectionUid }
+            })
+            domainItemCount = contacts.length
+            useContactStore.getState().syncFromRemote(contacts)
+            logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
+          } else {
+            const events = items.map((item) => {
+              const event = core.deserializeCalendarEvent(item.content)
+              return { ...event, id: item.uid, calendarId: item.collectionUid }
+            })
+            domainItemCount = events.length
+            useCalendarStore.getState().syncFromRemote(events)
+            logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
+          }
+          await mirrorToCache(type, items)
         }
-        safeLogSyncTiming('tasks-load', taskStartedAt, {
+        const countField = type === 'tasks' ? 'taskCount' : type === 'contacts' ? 'contactCount' : 'eventCount'
+        safeLogSyncTiming(TIMING_PHASE_BY_TYPE[type], startedAt, {
           source: 'server',
           cacheEnabled,
-          itemCount: taskItems.length,
-          taskCount,
+          itemCount: items.length,
+          [countField]: domainItemCount,
         })
       } catch (err) {
-        safeLogSyncTiming('tasks-load', taskStartedAt, { source: 'server', status: 'failed', errorCategory: 'deserialize' })
-        reportSyncError('load tasks', err)
+        safeLogSyncTiming(TIMING_PHASE_BY_TYPE[type], startedAt, { source: 'server', status: 'failed', errorCategory: 'deserialize' })
+        reportSyncError(`load ${type}`, err)
       }
-
-      // Load contacts
-      const contactStartedAt = nowMs()
-      try {
-        const contactItems = await etebase.fetchAllItems('contacts')
-        let contactCount = 0
-        if (useEtebaseStore.getState().domainLoadState.contacts === 'loaded') {
-          const { deserializeContact } = await import('@silentsuite/core')
-          const contacts = contactItems.map((item) => {
-            const contact = deserializeContact(item.content)
-            return { ...contact, id: item.uid, listId: item.collectionUid }
-          })
-          contactCount = contacts.length
-          useContactStore.getState().syncFromRemote(contacts)
-          logger.log(`[sync-provider] Loaded ${contacts.length} contacts from server`)
-          await mirrorToCache('contacts', contactItems)
-        }
-        safeLogSyncTiming('contacts-load', contactStartedAt, {
-          source: 'server',
-          cacheEnabled,
-          itemCount: contactItems.length,
-          contactCount,
-        })
-      } catch (err) {
-        safeLogSyncTiming('contacts-load', contactStartedAt, { source: 'server', status: 'failed', errorCategory: 'deserialize' })
-        reportSyncError('load contacts', err)
-      }
-
-      // Load calendar events
-      const calendarStartedAt = nowMs()
-      try {
-        const eventItems = await etebase.fetchAllItems('calendar')
-        let eventCount = 0
-        if (useEtebaseStore.getState().domainLoadState.calendar === 'loaded') {
-          const { deserializeCalendarEvent } = await import('@silentsuite/core')
-          const events = eventItems.map((item) => {
-            const event = deserializeCalendarEvent(item.content)
-            return { ...event, id: item.uid, calendarId: item.collectionUid }
-          })
-          eventCount = events.length
-          useCalendarStore.getState().syncFromRemote(events)
-          logger.log(`[sync-provider] Loaded ${events.length} calendar events from server`)
-          await mirrorToCache('calendar', eventItems)
-        }
-        safeLogSyncTiming('calendar-load', calendarStartedAt, {
-          source: 'server',
-          cacheEnabled,
-          itemCount: eventItems.length,
-          eventCount,
-        })
-      } catch (err) {
-        safeLogSyncTiming('calendar-load', calendarStartedAt, { source: 'server', status: 'failed', errorCategory: 'deserialize' })
-        reportSyncError('load calendar events', err)
-      }
-
     }
 
     function wireChangeHandler(): (() => void) | null {

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -301,6 +301,142 @@ describe('useEtebaseStore.initialize restoreBlocked flag', () => {
   })
 })
 
+describe('useEtebaseStore.initialize incremental domain loading', () => {
+  beforeEach(() => {
+    useEtebaseStore.setState({
+      account: null,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: false,
+      restoreBlocked: false,
+      domainLoadState: unknownDomainLoadState(),
+      syncEngine: null,
+    })
+  })
+
+  function mockSuccessfulSyncEngine() {
+    coreMock.SyncEngine.mockImplementation(function (this: any) {
+      this.trackCollection = vi.fn()
+      this.onStokenAdvance = vi.fn()
+      this.start = vi.fn(async () => {})
+    })
+  }
+
+  async function primeSuccessfulRestore() {
+    const { secureGet } = await import('@/app/lib/secure-storage')
+    vi.mocked(secureGet).mockResolvedValueOnce('raw-session')
+    coreMock.restoreSession.mockResolvedValueOnce({ id: 'account' })
+    coreMock.getAccountFingerprint.mockReturnValueOnce('fingerprint')
+    coreMock.listCollections.mockImplementation(async (_account: unknown, colType: string) => {
+      if (colType === 'etebase.vevent') return [mockCollection('cal-1')]
+      if (colType === 'etebase.vtodo') return [mockCollection('task-1')]
+      if (colType === 'etebase.vcard') return [mockCollection('contact-1')]
+      return []
+    })
+    mockSuccessfulSyncEngine()
+  }
+
+  it('invokes onDomainLoaded in calendar → tasks → contacts order with completed state visible', async () => {
+    await primeSuccessfulRestore()
+    coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => {
+      if (collection.uid === 'cal-1') return { items: [mockItem('event-1', 'VEVENT')], stoken: null, done: true }
+      if (collection.uid === 'task-1') return { items: [mockItem('task-item-1', 'VTODO')], stoken: null, done: true }
+      return { items: [mockItem('contact-item-1', 'VCARD')], stoken: null, done: true }
+    })
+
+    const events: { type: string; status: string }[] = []
+    let calendarItemsAtCalendarCallback = -1
+    let calendarStatusAtCalendarCallback = 'unseen'
+    await useEtebaseStore.getState().initialize({
+      onDomainLoaded: (event) => {
+        events.push({ type: event.type, status: event.status })
+        if (event.type === 'calendar') {
+          const state = useEtebaseStore.getState()
+          calendarItemsAtCalendarCallback = state.itemCache.size
+          calendarStatusAtCalendarCallback = state.domainLoadState.calendar
+        }
+      },
+    })
+
+    expect(events.map((e) => `${e.type}:${e.status}`)).toEqual([
+      'calendar:loaded',
+      'tasks:loaded',
+      'contacts:loaded',
+    ])
+    // Calendar was published as loaded, with its item already in the cache,
+    // before tasks/contacts were enumerated.
+    expect(calendarStatusAtCalendarCallback).toBe('loaded')
+    expect(calendarItemsAtCalendarCallback).toBe(1)
+    expect(useEtebaseStore.getState().isInitialized).toBe(true)
+  })
+
+  it('marks a failed domain without aborting later domains and still starts sync', async () => {
+    await primeSuccessfulRestore()
+    coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => {
+      if (collection.uid === 'task-1') throw new Error('server 500 on tasks')
+      return { items: [], stoken: null, done: true }
+    })
+
+    const events: string[] = []
+    await useEtebaseStore.getState().initialize({
+      onDomainLoaded: (event) => {
+        events.push(`${event.type}:${event.status}`)
+      },
+    })
+
+    expect(events).toEqual(['calendar:loaded', 'tasks:failed', 'contacts:loaded'])
+    const state = useEtebaseStore.getState()
+    expect(state.domainLoadState).toMatchObject({ calendar: 'loaded', tasks: 'failed', contacts: 'loaded' })
+    expect(state.restoreBlocked).toBe(false)
+    expect(state.isInitialized).toBe(true)
+    expect(state.syncEngine).toBeTruthy()
+  })
+
+  it('emits only privacy-safe aggregate fields in the domain event payload', async () => {
+    await primeSuccessfulRestore()
+    coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => {
+      if (collection.uid === 'cal-1') return { items: [mockItem('event-1', 'VEVENT')], stoken: null, done: true }
+      return { items: [], stoken: null, done: true }
+    })
+
+    const captured: Record<string, unknown>[] = []
+    await useEtebaseStore.getState().initialize({
+      onDomainLoaded: (event) => {
+        captured.push({ ...event })
+      },
+    })
+
+    expect(captured).toHaveLength(3)
+    for (const event of captured) {
+      expect(Object.keys(event).sort()).toEqual([
+        'collectionCount',
+        'itemCount',
+        'pageCount',
+        'status',
+        'type',
+      ])
+      expect(typeof event.itemCount).toBe('number')
+      expect(typeof event.pageCount).toBe('number')
+      expect(typeof event.collectionCount).toBe('number')
+    }
+    const calendarEvent = captured.find((e) => e.type === 'calendar')
+    expect(calendarEvent).toMatchObject({ type: 'calendar', status: 'loaded', itemCount: 1, collectionCount: 1 })
+  })
+
+  it('remains backwards-compatible when called with no options', async () => {
+    await primeSuccessfulRestore()
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+
+    await useEtebaseStore.getState().initialize()
+
+    const state = useEtebaseStore.getState()
+    expect(state.isInitialized).toBe(true)
+    expect(state.domainLoadState).toMatchObject({ calendar: 'loaded', tasks: 'loaded', contacts: 'loaded' })
+  })
+})
+
 describe('useEtebaseStore.createItemsBatch', () => {
   beforeEach(() => {
     offlineQueueMock.enqueue.mockClear()

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -83,6 +83,32 @@ type EtebaseCore = typeof import('@silentsuite/core')
 
 type CachedContentItem = { uid: string; content: string; collectionUid: string }
 
+/** One visible domain reaching a terminal state during initial restore. */
+export type InitialVisibleDomainKey = VisibleCollectionTypeKey
+export type InitialDomainLoadStatus = 'loaded' | 'failed'
+
+/**
+ * Privacy-safe notification emitted after a single visible domain finishes its
+ * initial server enumeration. Carries only aggregate counts and coarse status
+ * -- never item UIDs, collection UIDs, or decrypted content.
+ */
+export interface InitialDomainLoadEvent {
+  type: InitialVisibleDomainKey
+  status: InitialDomainLoadStatus
+  itemCount: number
+  pageCount: number
+  collectionCount: number
+}
+
+export interface InitializeOptions {
+  /**
+   * Called after each visible domain reaches a terminal ('loaded'/'failed')
+   * state and the store's maps + domainLoadState have been published. Lets a
+   * fast domain (calendar) paint before slower domains finish enumerating.
+   */
+  onDomainLoaded?: (event: InitialDomainLoadEvent) => void | Promise<void>
+}
+
 const UNKNOWN_DOMAIN_LOAD_STATE: DomainLoadState = {
   calendar: 'unknown',
   tasks: 'unknown',
@@ -142,6 +168,48 @@ async function ensureCollectionsForAccount(
   }
 
   return collections
+}
+
+/**
+ * List every item for a single visible domain into the shared cache maps.
+ * Paginates each concrete collection to completion and skips tombstones.
+ * Returns privacy-safe aggregate counts only (no UIDs, no content).
+ */
+async function loadInitialDomainItems(
+  core: EtebaseCore,
+  account: any,
+  key: VisibleCollectionTypeKey,
+  typedCollections: any[],
+  maps: {
+    itemCache: Map<string, any>
+    itemTypeMap: Map<string, CollectionTypeKey>
+    itemCollectionMap: Map<string, string>
+  },
+): Promise<{ itemCount: number; pageCount: number }> {
+  let itemCount = 0
+  let pageCount = 0
+
+  for (const collection of typedCollections) {
+    let stoken: string | null = null
+    let done = false
+
+    while (!done) {
+      const response = await core.listItems(account, collection, stoken)
+      pageCount += 1
+      for (const item of response.items) {
+        if (!item.isDeleted) {
+          maps.itemCache.set(item.uid, item)
+          maps.itemTypeMap.set(item.uid, key)
+          maps.itemCollectionMap.set(item.uid, collection.uid)
+          itemCount += 1
+        }
+      }
+      stoken = response.stoken
+      done = response.done
+    }
+  }
+
+  return { itemCount, pageCount }
 }
 
 async function trackCollectionWithSyncEngine(
@@ -371,8 +439,12 @@ interface EtebaseActions {
   /**
    * Restore Etebase session from localStorage, initialize collections,
    * load all items into data stores, and start the SyncEngine.
+   *
+   * Visible domains are enumerated one at a time; options.onDomainLoaded is
+   * invoked after each reaches a terminal state so callers can paint a fast
+   * domain (calendar) before slower domains finish.
    */
-  initialize: () => Promise<void>
+  initialize: (options?: InitializeOptions) => Promise<void>
 
   /**
    * Create an item in the given collection type.
@@ -519,7 +591,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   domainLoadState: unknownDomainLoadState(),
   syncEngine: null,
 
-  initialize: async () => {
+  initialize: async (options?: InitializeOptions) => {
     const serverUrl = getServerUrl()
     const diagnostics = new RestoreDiagnosticsRecorder({
       source: 'restore',
@@ -581,7 +653,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       await hydrateListStores(collections)
       diagnostics.completePhase('hydrateLists')
 
-      // 3. Load all items from each collection into the cache
+      // 3. Load items from each visible collection into the cache, one domain
+      // at a time. After each domain reaches a terminal state we publish the
+      // accumulated maps + domainLoadState and notify the caller, so a fast
+      // domain (calendar comes first in COLLECTION_DEFINITIONS) can paint
+      // before slower domains finish enumerating.
       const itemCache = new Map<string, any>()
       const itemTypeMap = new Map<string, CollectionTypeKey>()
       const itemCollectionMap = new Map<string, string>()
@@ -594,28 +670,18 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const typedCollections = collections[key]
         let itemCount = 0
         let pageCount = 0
+        let status: InitialDomainLoadStatus
 
         try {
-          for (const collection of typedCollections) {
-            let stoken: string | null = null
-            let done = false
-
-            while (!done) {
-              const response = await core.listItems(account, collection, stoken)
-              pageCount += 1
-              for (const item of response.items) {
-                if (!item.isDeleted) {
-                  itemCache.set(item.uid, item)
-                  itemTypeMap.set(item.uid, key)
-                  itemCollectionMap.set(item.uid, collection.uid)
-                  itemCount += 1
-                }
-              }
-              stoken = response.stoken
-              done = response.done
-            }
-          }
+          const counts = await loadInitialDomainItems(core, account, key, typedCollections, {
+            itemCache,
+            itemTypeMap,
+            itemCollectionMap,
+          })
+          itemCount = counts.itemCount
+          pageCount = counts.pageCount
           domainLoadState[key] = 'loaded'
+          status = 'loaded'
           diagnostics.completePhase(phase, {
             collectionType: key,
             collectionCount: typedCollections.length,
@@ -624,12 +690,29 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           })
         } catch (err) {
           domainLoadState[key] = 'failed'
+          status = 'failed'
           diagnostics.failActivePhase(err)
           logger.warn(`[etebase-store] Failed to load ${key} items`, getSafeErrorDetails(err))
         }
+
+        // Publish incrementally with fresh Map copies + a fresh domainLoadState
+        // object so Zustand subscribers observe the completed domain right away.
+        set({
+          itemCache: new Map(itemCache),
+          itemTypeMap: new Map(itemTypeMap),
+          itemCollectionMap: new Map(itemCollectionMap),
+          domainLoadState: { ...domainLoadState },
+        })
+
+        await options?.onDomainLoaded?.({
+          type: key,
+          status,
+          itemCount,
+          pageCount,
+          collectionCount: typedCollections.length,
+        })
       }
 
-      set({ itemCache, itemTypeMap, itemCollectionMap, domainLoadState })
       logger.debug(`[etebase-store] Loaded ${itemCache.size} items into cache`)
 
       // 4. Start SyncEngine


### PR DESCRIPTION
## Summary

- publish initial visible-domain load state after each restored domain instead of waiting for every domain to finish
- load the calendar store from server-backed data as soon as the calendar domain reaches `loaded`
- keep SyncEngine wiring after initial visible-domain enumeration and preserve Slice 4 partial-load/scoped-refresh guards

## Verification

- `pnpm --filter @silentsuite/web test -- app/stores/__tests__/use-etebase-store.test.ts app/providers/__tests__/sync-provider.timing.test.tsx app/stores/__tests__/use-sync-store.test.ts app/lib/__tests__/sync-timing.test.ts`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint`
- `pnpm run build`
- `pnpm run test`
- `git diff --check`

## Notes

- Scope is limited to web restore orchestration and focused tests.
- No server, Android, bridge, data-cache schema, preferences, label-index, billing, or auth changes.
- Cache-first schema work remains deferred to a later slice.
