### PR TITLE
web: enable encrypted cache-first paint

### DIFF
--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -16,23 +16,25 @@ import {
   putMeta,
   clearAll,
   ensureFingerprint,
+  ensureEncryptedEnvelope,
   getCacheCapabilityStatus,
   isCacheEnabled,
   CACHE_SCHEMA_VERSION,
   _resetForTests,
   _setEncryptedCacheAvailableForTests,
+  _setEnvelopeKeyForTests,
   type CachedItem,
 } from '../data-cache'
 
 beforeEach(async () => {
   await _resetForTests()
-  _setEncryptedCacheAvailableForTests(true)
   await new Promise<void>((resolve) => {
     const req = indexedDB.deleteDatabase('silentsuite-data-cache')
     req.onsuccess = () => resolve()
     req.onerror = () => resolve()
     req.onblocked = () => resolve()
   })
+  await installTestEnvelope()
 })
 
 function makeItem(uid: string, type: 'tasks' | 'contacts' | 'calendar' = 'tasks', content = 'CONTENT', collectionUid = 'col-1'): CachedItem {
@@ -45,12 +47,86 @@ function makeItem(uid: string, type: 'tasks' | 'contacts' | 'calendar' = 'tasks'
   }
 }
 
+async function makeTestKey(): Promise<CryptoKey> {
+  return crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt'])
+}
+
+async function installTestEnvelope(): Promise<void> {
+  _setEnvelopeKeyForTests(await makeTestKey())
+  _setEncryptedCacheAvailableForTests(true)
+}
+
+async function rawItems(): Promise<unknown[]> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open('silentsuite-data-cache')
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+  try {
+    if (!db.objectStoreNames.contains('items')) return []
+    return await new Promise<unknown[]>((resolve, reject) => {
+      const tx = db.transaction('items', 'readonly')
+      const req = tx.objectStore('items').getAll()
+      req.onsuccess = () => resolve(req.result ?? [])
+      req.onerror = () => reject(req.error)
+    })
+  } finally {
+    db.close()
+  }
+}
+
+async function rawCryptoKeys(): Promise<unknown[]> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open('silentsuite-data-cache')
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+  try {
+    if (!db.objectStoreNames.contains('crypto')) return []
+    return await new Promise<unknown[]>((resolve, reject) => {
+      const tx = db.transaction('crypto', 'readonly')
+      const req = tx.objectStore('crypto').getAll()
+      req.onsuccess = () => resolve(req.result ?? [])
+      req.onerror = () => reject(req.error)
+    })
+  } finally {
+    db.close()
+  }
+}
+
+async function corruptRawItem(itemUid: string): Promise<void> {
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open('silentsuite-data-cache')
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction('items', 'readwrite')
+      const store = tx.objectStore('items')
+      const getReq = store.get(itemUid)
+      getReq.onsuccess = () => {
+        const value = getReq.result as { ct?: number[] } | undefined
+        if (value?.ct) {
+          value.ct = [...value.ct]
+          value.ct[0] = (value.ct[0] ?? 0) ^ 255
+          store.put(value)
+        }
+      }
+      getReq.onerror = () => reject(getReq.error)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  } finally {
+    db.close()
+  }
+}
+
 describe('data-cache', () => {
   describe('encryption guard', () => {
     it('reports cache capability without touching IndexedDB', () => {
       const previous = process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED
       process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'
-      _setEncryptedCacheAvailableForTests(true)
       const openSpy = vi.spyOn(indexedDB, 'open')
 
       expect(getCacheCapabilityStatus()).toEqual({
@@ -68,6 +144,7 @@ describe('data-cache', () => {
       const previous = process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED
       process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'
       _setEncryptedCacheAvailableForTests(false)
+      _setEnvelopeKeyForTests(null)
 
       expect(isCacheEnabled()).toBe(false)
 
@@ -76,6 +153,7 @@ describe('data-cache', () => {
 
     it('refuses plaintext item writes without an encrypted cache envelope', async () => {
       _setEncryptedCacheAvailableForTests(false)
+      _setEnvelopeKeyForTests(null)
 
       await putItem(makeItem('plain-1', 'tasks', 'PRIVATE TASK SUMMARY'))
       await putItems([makeItem('plain-2', 'tasks', 'PRIVATE BULK TASK')])
@@ -83,6 +161,39 @@ describe('data-cache', () => {
       await replaceItemsForCollection('col-1', [makeItem('plain-4', 'tasks', 'PRIVATE REPLACE COLLECTION')])
 
       expect(await getItemsByType('tasks')).toEqual([])
+      expect(await rawItems()).toEqual([])
+    })
+
+    it('stores item content encrypted at rest and round-trips through the public API', async () => {
+      const sentinel = 'PRIVATE SENTINEL VEVENT SUMMARY 2026-07-09'
+
+      await putItem(makeItem('encrypted-1', 'calendar', sentinel))
+
+      const raw = await rawItems()
+      expect(raw).toHaveLength(1)
+      const serialized = JSON.stringify(raw[0])
+      expect(serialized).toContain('"iv"')
+      expect(serialized).toContain('"ct"')
+      expect(serialized).not.toContain(sentinel)
+      expect(serialized).not.toContain('content')
+
+      const items = await getItemsByType('calendar')
+      expect(items).toHaveLength(1)
+      expect(items[0]!.content).toBe(sentinel)
+    })
+
+    it('skips a corrupt cached item without poisoning other cached items', async () => {
+      await putItems([
+        makeItem('good', 'tasks', 'PRIVATE GOOD TASK'),
+        makeItem('bad', 'tasks', 'PRIVATE BAD TASK'),
+      ])
+
+      await corruptRawItem('bad')
+
+      const items = await getItemsByType('tasks')
+      expect(items.map((item) => item.itemUid)).toEqual(['good'])
+      expect(items[0]!.content).toBe('PRIVATE GOOD TASK')
+      expect(await rawItems()).toHaveLength(2)
     })
   })
 
@@ -237,6 +348,8 @@ describe('data-cache', () => {
 
     it('ensureFingerprint wipes when accounts differ', async () => {
       await setStoken('tasks', 'col-tasks', 'stk-a')
+      await putItem(makeItem('cached-task', 'tasks', 'PRIVATE TASK'))
+      await ensureEncryptedEnvelope()
       await ensureFingerprint('alice@example.com')
 
       const ok = await ensureFingerprint('bob@example.com')
@@ -244,6 +357,8 @@ describe('data-cache', () => {
 
       // Cache should be wiped for the new account.
       expect(await getStoken('col-tasks')).toBeNull()
+      expect(await getItemsByType('tasks')).toEqual([])
+      expect(await rawCryptoKeys()).toEqual([])
       const meta = await getMeta()
       expect(meta?.accountFingerprint).toBe('bob@example.com')
       expect(meta?.lastInvalidatedAt).not.toBeNull()
@@ -258,10 +373,10 @@ describe('data-cache', () => {
       expect(await getStoken('col-tasks')).toBe('stk-a')
     })
 
-    it('upgrades and clears the rolled-back v3 encrypted cache schema', async () => {
+    it('upgrades and clears the rolled-back v4 encrypted cache schema', async () => {
       await _resetForTests()
-      const v3Db = await new Promise<IDBDatabase>((resolve, reject) => {
-        const req = indexedDB.open('silentsuite-data-cache', 3)
+      const v4Db = await new Promise<IDBDatabase>((resolve, reject) => {
+        const req = indexedDB.open('silentsuite-data-cache', 4)
         req.onupgradeneeded = () => {
           const db = req.result
           const items = db.createObjectStore('items', { keyPath: 'itemUid' })
@@ -269,12 +384,12 @@ describe('data-cache', () => {
           items.createIndex('byCollectionUid', 'collectionUid', { unique: false })
           db.createObjectStore('collections', { keyPath: 'collectionUid' })
           db.createObjectStore('meta')
-          db.createObjectStore('crypto')
         }
         req.onsuccess = () => resolve(req.result)
         req.onerror = () => reject(req.error)
       })
-      v3Db.close()
+      v4Db.close()
+      await installTestEnvelope()
 
       await ensureFingerprint('alice@example.com')
       await _resetForTests()
@@ -285,17 +400,22 @@ describe('data-cache', () => {
         req.onerror = () => reject(req.error)
       })
 
-      expect(upgradedDb.version).toBe(4)
-      expect(upgradedDb.objectStoreNames.contains('crypto')).toBe(false)
+      expect(upgradedDb.version).toBe(5)
+      expect(upgradedDb.objectStoreNames.contains('crypto')).toBe(true)
       expect(upgradedDb.objectStoreNames.contains('items')).toBe(true)
       upgradedDb.close()
+    })
+
+    it('uses cache schema version 5 for encrypted records', () => {
+      expect(CACHE_SCHEMA_VERSION).toBe(5)
     })
   })
 
   describe('clearAll', () => {
-    it('wipes items, collections, and meta', async () => {
+    it('wipes items, collections, meta, and crypto', async () => {
       await putItem(makeItem('x', 'tasks'))
       await setStoken('tasks', 'col-tasks', 'stk')
+      await ensureEncryptedEnvelope()
       await putMeta({
         accountFingerprint: 'a',
         cacheSchemaVersion: CACHE_SCHEMA_VERSION,
@@ -307,6 +427,7 @@ describe('data-cache', () => {
       expect(await getItemsByType('tasks')).toEqual([])
       expect(await getStoken('col-tasks')).toBeNull()
       expect(await getMeta()).toBeNull()
+      expect(await rawCryptoKeys()).toEqual([])
     })
 
     it('is safe to call repeatedly', async () => {

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -1,9 +1,10 @@
 /**
  * Local data cache for instant reload — IndexedDB-backed values.
  *
- * Stores already-decrypted item content (iCal/vCard/vTodo strings) plus
- * per-collection sync cursors (stokens) so that on the next page load the
- * UI can paint from the cache before the network sync completes.
+ * Stores decrypted item content at the public call boundary, but encrypts item
+ * content before it reaches IndexedDB. Collection/type indexes and stokens stay
+ * plaintext client-local metadata so cache reads can be efficient; item PIM
+ * content must never be stored as raw iCal/vCard/vTodo text.
  *
  * SCOPE: This module follows the same raw-IDB pattern as `secure-storage.ts`
  * and `offline-queue.ts` — no `idb` / Dexie dependency.
@@ -29,6 +30,17 @@ export interface CachedItem {
   lastModified: number
 }
 
+interface StoredItem {
+  itemUid: string
+  collectionType: CollectionTypeKey
+  collectionUid: string
+  /** AES-GCM IV bytes */
+  iv: number[]
+  /** AES-GCM ciphertext bytes */
+  ct: number[]
+  lastModified: number
+}
+
 export interface CachedCollection {
   collectionType: CollectionTypeKey
   collectionUid: string
@@ -46,23 +58,35 @@ export interface CacheMeta {
 }
 
 /** Bumped on shape changes to the cached records. */
-export const CACHE_SCHEMA_VERSION = 4
+export const CACHE_SCHEMA_VERSION = 5
 
 const DB_NAME = 'silentsuite-data-cache'
-const DB_VERSION = 4
+const DB_VERSION = 5
 const STORE_ITEMS = 'items'
 const STORE_COLLECTIONS = 'collections'
 const STORE_META = 'meta'
 const STORE_CRYPTO = 'crypto'
 
 const META_KEY = 'singleton'
+const ENVELOPE_KEY = 'envelope-key'
 
 let dbPromise: Promise<IDBDatabase> | null = null
 let encryptedCacheAvailableForTests: boolean | null = null
+let envelopeKey: CryptoKey | null = null
+let envelopeReady = false
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+function hasWebCrypto(): boolean {
+  return Boolean(globalThis.crypto?.subtle && globalThis.crypto?.getRandomValues)
+}
 
 function hasEncryptedCacheEnvelope(): boolean {
-  if (encryptedCacheAvailableForTests !== null) return encryptedCacheAvailableForTests
-  return false
+  if (encryptedCacheAvailableForTests !== null) {
+    return encryptedCacheAvailableForTests && envelopeKey !== null
+  }
+  return hasWebCrypto() && envelopeReady && envelopeKey !== null
 }
 
 function canWriteItemContent(operation: string): boolean {
@@ -81,11 +105,10 @@ function openDB(): Promise<IDBDatabase> {
     const request = indexedDB.open(DB_NAME, DB_VERSION)
     request.onupgradeneeded = (event) => {
       const db = request.result
-      // v4 intentionally rolls back the encrypted local item cache. Browsers
-      // that already opened the v3 database cannot be downgraded to v2; clear
-      // all prior stores, including the v3 crypto key store, then recreate the
-      // minimal fail-closed cache schema used by this build.
-      if (event.oldVersion > 0 && event.oldVersion < 4) {
+      // v5 stores item content as ciphertext and reintroduces the crypto key
+      // store after the v4 rollback. Wipe earlier local-cache schemas rather
+      // than trying to reinterpret plaintext/v3 crypto records.
+      if (event.oldVersion > 0 && event.oldVersion < 5) {
         for (const storeName of [STORE_ITEMS, STORE_COLLECTIONS, STORE_META, STORE_CRYPTO]) {
           if (db.objectStoreNames.contains(storeName)) db.deleteObjectStore(storeName)
         }
@@ -95,14 +118,14 @@ function openDB(): Promise<IDBDatabase> {
         items.createIndex('byCollectionType', 'collectionType', { unique: false })
         items.createIndex('byCollectionUid', 'collectionUid', { unique: false })
       }
-      if (db.objectStoreNames.contains(STORE_COLLECTIONS) && event.oldVersion < 2) {
-        db.deleteObjectStore(STORE_COLLECTIONS)
-      }
       if (!db.objectStoreNames.contains(STORE_COLLECTIONS)) {
         db.createObjectStore(STORE_COLLECTIONS, { keyPath: 'collectionUid' })
       }
       if (!db.objectStoreNames.contains(STORE_META)) {
         db.createObjectStore(STORE_META)
+      }
+      if (!db.objectStoreNames.contains(STORE_CRYPTO)) {
+        db.createObjectStore(STORE_CRYPTO)
       }
     }
     request.onsuccess = () => resolve(request.result)
@@ -131,22 +154,131 @@ function withStore<T>(
   )
 }
 
+async function getStoredEnvelopeKey(): Promise<CryptoKey | null> {
+  try {
+    const key = await withStore<CryptoKey | undefined>(STORE_CRYPTO, 'readonly', (store) => store.get(ENVELOPE_KEY))
+    return key ?? null
+  } catch (err) {
+    logger.warn('[data-cache] encrypted envelope key read failed', err)
+    return null
+  }
+}
+
+async function putStoredEnvelopeKey(key: CryptoKey): Promise<void> {
+  await withStore<IDBValidKey>(STORE_CRYPTO, 'readwrite', (store) => store.put(key, ENVELOPE_KEY))
+}
+
+/**
+ * Ensure the encrypted cache envelope is ready for this browser session.
+ * Returns false instead of throwing so cache enablement always fails closed.
+ */
+export async function ensureEncryptedEnvelope(): Promise<boolean> {
+  if (!hasWebCrypto()) {
+    envelopeKey = null
+    envelopeReady = false
+    return false
+  }
+
+  if (envelopeKey && envelopeReady) return true
+
+  try {
+    const existing = await getStoredEnvelopeKey()
+    if (existing) {
+      envelopeKey = existing
+      envelopeReady = true
+      return true
+    }
+
+    const generated = await globalThis.crypto.subtle.generateKey(
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt'],
+    )
+    await putStoredEnvelopeKey(generated)
+    envelopeKey = generated
+    envelopeReady = true
+    return true
+  } catch (err) {
+    logger.warn('[data-cache] encrypted envelope unavailable', err)
+    envelopeKey = null
+    envelopeReady = false
+    return false
+  }
+}
+
+async function encryptContent(content: string): Promise<{ iv: number[]; ct: number[] }> {
+  if (!envelopeKey) throw new Error('Encrypted cache envelope is unavailable')
+  const iv = new Uint8Array(12)
+  globalThis.crypto.getRandomValues(iv)
+  const encrypted = await globalThis.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    envelopeKey,
+    encoder.encode(content),
+  )
+  return {
+    iv: Array.from(iv),
+    ct: Array.from(new Uint8Array(encrypted)),
+  }
+}
+
+async function decryptStoredItem(item: StoredItem): Promise<CachedItem> {
+  if (!envelopeKey) throw new Error('Encrypted cache envelope is unavailable')
+  if (!Array.isArray(item.iv) || !Array.isArray(item.ct)) {
+    throw new Error('Encrypted cache record is malformed')
+  }
+  const decrypted = await globalThis.crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: Uint8Array.from(item.iv) },
+    envelopeKey,
+    Uint8Array.from(item.ct),
+  )
+  return {
+    itemUid: item.itemUid,
+    collectionType: item.collectionType,
+    collectionUid: item.collectionUid,
+    content: decoder.decode(decrypted),
+    lastModified: item.lastModified,
+  }
+}
+
+async function toStoredItem(item: CachedItem): Promise<StoredItem> {
+  const encrypted = await encryptContent(item.content)
+  return {
+    itemUid: item.itemUid,
+    collectionType: item.collectionType,
+    collectionUid: item.collectionUid,
+    iv: encrypted.iv,
+    ct: encrypted.ct,
+    lastModified: item.lastModified,
+  }
+}
+
 // ── Items ──
 
 /**
  * Read all cached items for a collection type.
- * Returns an empty array if the cache is empty or unavailable.
+ * Returns an empty array if the cache is empty, unavailable, or undecryptable.
  */
 export async function getItemsByType(type: CollectionTypeKey): Promise<CachedItem[]> {
+  if (!hasEncryptedCacheEnvelope()) return []
   try {
     const db = await openDB()
-    return await new Promise<CachedItem[]>((resolve, reject) => {
+    const records = await new Promise<StoredItem[]>((resolve, reject) => {
       const tx = db.transaction(STORE_ITEMS, 'readonly')
       const idx = tx.objectStore(STORE_ITEMS).index('byCollectionType')
       const req = idx.getAll(type)
-      req.onsuccess = () => resolve((req.result as CachedItem[]) ?? [])
+      req.onsuccess = () => resolve((req.result as StoredItem[]) ?? [])
       req.onerror = () => reject(req.error)
     })
+
+    const items: CachedItem[] = []
+    for (const record of records) {
+      try {
+        items.push(await decryptStoredItem(record))
+      } catch (err) {
+        logger.warn('[data-cache] cached item decrypt failed', { name: err instanceof Error ? err.name : 'Error' })
+      }
+    }
+    return items
   } catch (err) {
     logger.warn('[data-cache] getItemsByType failed', err)
     return []
@@ -157,7 +289,8 @@ export async function getItemsByType(type: CollectionTypeKey): Promise<CachedIte
 export async function putItem(item: CachedItem): Promise<void> {
   if (!canWriteItemContent('putItem')) return
   try {
-    await withStore(STORE_ITEMS, 'readwrite', (store) => store.put(item))
+    const stored = await toStoredItem(item)
+    await withStore(STORE_ITEMS, 'readwrite', (store) => store.put(stored))
   } catch (err) {
     logger.warn('[data-cache] putItem failed', err)
   }
@@ -168,11 +301,12 @@ export async function putItems(items: CachedItem[]): Promise<void> {
   if (items.length === 0) return
   if (!canWriteItemContent('putItems')) return
   try {
+    const storedItems = await Promise.all(items.map(toStoredItem))
     const db = await openDB()
     await new Promise<void>((resolve, reject) => {
       const tx = db.transaction(STORE_ITEMS, 'readwrite')
       const store = tx.objectStore(STORE_ITEMS)
-      for (const item of items) store.put(item)
+      for (const item of storedItems) store.put(item)
       tx.oncomplete = () => resolve()
       tx.onerror = () => reject(tx.error)
     })
@@ -199,6 +333,7 @@ export async function replaceItemsForType(
 ): Promise<void> {
   if (!canWriteItemContent('replaceItemsForType')) return
   try {
+    const storedItems = await Promise.all(items.map(toStoredItem))
     const db = await openDB()
     await new Promise<void>((resolve, reject) => {
       const tx = db.transaction(STORE_ITEMS, 'readwrite')
@@ -211,7 +346,7 @@ export async function replaceItemsForType(
           cursor.delete()
           cursor.continue()
         } else {
-          for (const item of items) store.put(item)
+          for (const item of storedItems) store.put(item)
         }
       }
       cursorReq.onerror = () => reject(cursorReq.error)
@@ -233,6 +368,7 @@ export async function replaceItemsForCollection(
 ): Promise<void> {
   if (!canWriteItemContent('replaceItemsForCollection')) return
   try {
+    const storedItems = await Promise.all(items.map(toStoredItem))
     const db = await openDB()
     await new Promise<void>((resolve, reject) => {
       const tx = db.transaction(STORE_ITEMS, 'readwrite')
@@ -245,7 +381,7 @@ export async function replaceItemsForCollection(
           cursor.delete()
           cursor.continue()
         } else {
-          for (const item of items) store.put(item)
+          for (const item of storedItems) store.put(item)
         }
       }
       cursorReq.onerror = () => reject(cursorReq.error)
@@ -329,17 +465,20 @@ export async function putMeta(meta: CacheMeta): Promise<void> {
 // ── Whole-cache operations ──
 
 /**
- * Wipe everything — items, collections, meta. Called on logout, password
- * change, account fingerprint mismatch, or schema bump.
+ * Wipe everything — items, collections, meta, and the crypto envelope. Called
+ * on logout, password change, account fingerprint mismatch, or schema bump.
  */
 export async function clearAll(): Promise<void> {
+  envelopeKey = null
+  envelopeReady = false
   try {
     const db = await openDB()
     await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction([STORE_ITEMS, STORE_COLLECTIONS, STORE_META], 'readwrite')
+      const tx = db.transaction([STORE_ITEMS, STORE_COLLECTIONS, STORE_META, STORE_CRYPTO], 'readwrite')
       tx.objectStore(STORE_ITEMS).clear()
       tx.objectStore(STORE_COLLECTIONS).clear()
       tx.objectStore(STORE_META).clear()
+      tx.objectStore(STORE_CRYPTO).clear()
       tx.oncomplete = () => resolve()
       tx.onerror = () => reject(tx.error)
     })
@@ -432,9 +571,17 @@ export async function _resetForTests(): Promise<void> {
   }
   dbPromise = null
   encryptedCacheAvailableForTests = null
+  envelopeKey = null
+  envelopeReady = false
 }
 
 /** Test-only hook that simulates encrypted cache availability. */
 export function _setEncryptedCacheAvailableForTests(value: boolean | null): void {
   encryptedCacheAvailableForTests = value
+}
+
+/** Test-only hook that injects a real WebCrypto key without relying on IDB CryptoKey cloning. */
+export function _setEnvelopeKeyForTests(key: CryptoKey | null): void {
+  envelopeKey = key
+  envelopeReady = key !== null
 }

--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -24,12 +24,13 @@ type OnDomainLoaded = (event: {
   pageCount: number
   collectionCount: number
 }) => void | Promise<void>
+type OnCacheHydrate = () => void | Promise<void>
 
 const etebaseMock = vi.hoisted(() => {
   let syncChangeHandler: ((event: { collectionType: string; collectionUid: string; itemUids: string[]; changeType: string }) => Promise<void>) | null = null
   // Default initialize replays the real store contract: calendar → tasks →
   // contacts, one terminal callback each, statuses driven by domainLoadState.
-  async function defaultInitialize(options?: { onDomainLoaded?: OnDomainLoaded }) {
+  async function defaultInitialize(options?: { onCacheHydrate?: OnCacheHydrate; onDomainLoaded?: OnDomainLoaded }) {
     order.push('etebaseInitialize')
     for (const type of ['calendar', 'tasks', 'contacts'] as const) {
       const status = state.domainLoadState[type] === 'failed' ? 'failed' : 'loaded'
@@ -277,20 +278,55 @@ describe('SyncProvider timing instrumentation', () => {
     expect(order.filter((entry) => entry === 'syncCalendar')).toHaveLength(1)
   })
 
-  it('hydrates cache only when cache is enabled and still continues startup', async () => {
+  it('hydrates cache through the verified Etebase callback and still continues startup', async () => {
     cacheMock.isCacheEnabled.mockReturnValue(true)
+    etebaseMock.state.initialize.mockImplementation(async (options?: { onCacheHydrate?: OnCacheHydrate; onDomainLoaded?: OnDomainLoaded }) => {
+      order.push('etebaseInitialize')
+      await options?.onCacheHydrate?.()
+      for (const type of ['calendar', 'tasks', 'contacts'] as const) {
+        await options?.onDomainLoaded?.({ type, status: 'loaded', itemCount: 0, pageCount: 1, collectionCount: 1 })
+      }
+    })
 
     renderProvider()
 
     await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
-    expect(order.slice(0, 6)).toEqual([
+    expect(order.slice(0, 7)).toEqual([
       'initializeSync',
       'setSyncStatus:syncing',
+      'etebaseInitialize',
       'cacheGet:tasks',
       'cacheGet:contacts',
       'cacheGet:calendar',
-      'etebaseInitialize',
+      'fetchAllItems:calendar',
     ])
+  })
+
+  it('lets cache hydrate first and then overwrites calendar with server truth', async () => {
+    cacheMock.isCacheEnabled.mockReturnValue(true)
+    cacheMock.getItemsByType.mockImplementation(async (type: string) => {
+      order.push(`cacheGet:${type}`)
+      if (type === 'calendar') return [{ itemUid: 'cached-event', collectionUid: 'cal-1', content: 'VCALENDAR:CACHED' }]
+      return []
+    })
+    etebaseMock.state.initialize.mockImplementation(async (options?: { onCacheHydrate?: OnCacheHydrate; onDomainLoaded?: OnDomainLoaded }) => {
+      order.push('etebaseInitialize')
+      await options?.onCacheHydrate?.()
+      await options?.onDomainLoaded?.({ type: 'calendar', status: 'loaded', itemCount: 1, pageCount: 1, collectionCount: 1 })
+      await options?.onDomainLoaded?.({ type: 'tasks', status: 'loaded', itemCount: 0, pageCount: 1, collectionCount: 1 })
+      await options?.onDomainLoaded?.({ type: 'contacts', status: 'loaded', itemCount: 0, pageCount: 1, collectionCount: 1 })
+    })
+    etebaseMock.state.fetchAllItems.mockImplementation(async (type: DomainKey) => {
+      order.push(`fetchAllItems:${type}`)
+      if (type === 'calendar') return [{ uid: 'server-event', content: 'VEVENT:SERVER', collectionUid: 'cal-1' }]
+      return []
+    })
+
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    expect(order.filter((entry) => entry === 'syncCalendar')).toHaveLength(2)
+    expect(order.indexOf('cacheGet:calendar')).toBeLessThan(order.indexOf('fetchAllItems:calendar'))
   })
 
   it('does not let timing helper failures change sync status flow', async () => {

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -96,14 +96,6 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         setSyncStatus('syncing')
         safeLogSyncTiming('cache-capability', initStartedAt, { ...getCacheCapabilityStatus() })
 
-        // Cache-first hydration: when the feature flag is on, paint the UI
-        // from IndexedDB before the network sync starts. This is best-effort
-        // — failures are logged and the normal init path proceeds.
-        if (isLocalCacheEnabled()) {
-          const cacheStartedAt = nowMs()
-          await hydrateFromCache(cacheStartedAt)
-        }
-
         // Restore session, create/fetch collections, and enumerate items. The
         // onDomainLoaded hook fires once per visible domain as soon as that
         // domain reaches a terminal state, so calendar deserializes and paints
@@ -111,6 +103,10 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         // post-initialize all-domain load, so no domain is replaced twice.
         const etebaseStartedAt = nowMs()
         await etebaseInitialize({
+          onCacheHydrate: async () => {
+            const cacheStartedAt = nowMs()
+            await hydrateFromCache(cacheStartedAt)
+          },
           onDomainLoaded: async (event) => {
             await loadDomainIntoStore(event.type)
             updatePartialLoadFlag()
@@ -142,9 +138,10 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     /**
      * Cache-first paint. Reads decrypted item content out of IndexedDB and
      * pushes it into the domain stores so the UI renders from cache before
-     * the network sync settles. The subsequent etebaseInitialize() +
-     * loadItemsIntoStores() pass overwrites with server data, which is the
-     * source of truth.
+     * the network sync settles. This is invoked only after the restored
+     * account fingerprint and encrypted cache envelope are verified. The
+     * subsequent per-domain server load overwrites with server data, which is
+     * the source of truth.
      *
      * Cheap (~10-50ms for a typical vault) and fully off the network path.
      * Failures here are non-fatal; we just skip the optimistic paint.

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -28,6 +28,19 @@ const toastStoreMock = vi.hoisted(() => ({
   showErrorToast: vi.fn(),
 }))
 
+const dataCacheMock = vi.hoisted(() => ({
+  ensureEncryptedEnvelope: vi.fn(async () => true),
+  ensureFingerprint: vi.fn(async () => true),
+  getCacheCapabilityStatus: vi.fn(() => ({ featureFlagEnabled: false, encryptedEnvelopeAvailable: false, enabled: false })),
+  getStoken: vi.fn(async () => null),
+  setStoken: vi.fn(async () => {}),
+  putItems: vi.fn(async () => {}),
+  putItem: vi.fn(async () => {}),
+  deleteItem: vi.fn(async () => {}),
+  replaceItemsForCollection: vi.fn(async () => {}),
+  isCacheEnabled: vi.fn(() => false),
+}))
+
 // Stub the offline queue so isOfflineError + enqueue don't try to open IndexedDB.
 vi.mock('@/app/lib/offline-queue', () => offlineQueueMock)
 
@@ -42,6 +55,8 @@ vi.mock('@/app/lib/secure-storage', () => ({
 }))
 
 vi.mock('@/app/stores/use-toast-store', () => toastStoreMock)
+
+vi.mock('@/app/lib/data-cache', () => dataCacheMock)
 
 beforeEach(() => {
   offlineQueueMock.enqueue.mockClear()
@@ -58,6 +73,16 @@ beforeEach(() => {
   coreMock.deleteItem.mockReset()
   coreMock.updateCollectionMeta.mockReset()
   toastStoreMock.showErrorToast.mockReset()
+  dataCacheMock.ensureEncryptedEnvelope.mockReset().mockResolvedValue(true)
+  dataCacheMock.ensureFingerprint.mockReset().mockResolvedValue(true)
+  dataCacheMock.getCacheCapabilityStatus.mockReset().mockReturnValue({ featureFlagEnabled: false, encryptedEnvelopeAvailable: false, enabled: false })
+  dataCacheMock.getStoken.mockReset().mockResolvedValue(null)
+  dataCacheMock.setStoken.mockReset().mockResolvedValue(undefined)
+  dataCacheMock.putItems.mockReset().mockResolvedValue(undefined)
+  dataCacheMock.putItem.mockReset().mockResolvedValue(undefined)
+  dataCacheMock.deleteItem.mockReset().mockResolvedValue(undefined)
+  dataCacheMock.replaceItemsForCollection.mockReset().mockResolvedValue(undefined)
+  dataCacheMock.isCacheEnabled.mockReset().mockReturnValue(false)
   sessionStorage.clear()
 })
 
@@ -394,6 +419,42 @@ describe('useEtebaseStore.initialize incremental domain loading', () => {
     expect(state.syncEngine).toBeTruthy()
   })
 
+  it('preserves calendar map mutations made during early paint while slower domains continue loading', async () => {
+    await primeSuccessfulRestore()
+    const originalCalendarItem = mockItem('event-1', 'VEVENT')
+    const userCreatedCalendarItem = mockItem('event-user', 'VEVENT')
+    coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => {
+      if (collection.uid === 'cal-1') return { items: [originalCalendarItem], stoken: null, done: true }
+      if (collection.uid === 'task-1') return { items: [mockItem('task-1', 'VTODO')], stoken: null, done: true }
+      if (collection.uid === 'contact-1') return { items: [mockItem('contact-1', 'VCARD')], stoken: null, done: true }
+      return { items: [], stoken: null, done: true }
+    })
+
+    await useEtebaseStore.getState().initialize({
+      onDomainLoaded: (event) => {
+        if (event.type !== 'calendar') return
+        const itemCache = new Map(useEtebaseStore.getState().itemCache)
+        const itemTypeMap = new Map(useEtebaseStore.getState().itemTypeMap)
+        const itemCollectionMap = new Map(useEtebaseStore.getState().itemCollectionMap)
+        itemCache.delete('event-1')
+        itemTypeMap.delete('event-1')
+        itemCollectionMap.delete('event-1')
+        itemCache.set('event-user', userCreatedCalendarItem)
+        itemTypeMap.set('event-user', 'calendar')
+        itemCollectionMap.set('event-user', 'cal-1')
+        useEtebaseStore.setState({ itemCache, itemTypeMap, itemCollectionMap })
+      },
+    })
+
+    const finalState = useEtebaseStore.getState()
+    expect(finalState.itemCache.has('event-1')).toBe(false)
+    expect(finalState.itemCache.get('event-user')).toBe(userCreatedCalendarItem)
+    expect(finalState.itemTypeMap.get('event-user')).toBe('calendar')
+    expect(finalState.itemCollectionMap.get('event-user')).toBe('cal-1')
+    expect(finalState.itemTypeMap.get('task-1')).toBe('tasks')
+    expect(finalState.itemTypeMap.get('contact-1')).toBe('contacts')
+  })
+
   it('emits only privacy-safe aggregate fields in the domain event payload', async () => {
     await primeSuccessfulRestore()
     coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => {
@@ -423,6 +484,57 @@ describe('useEtebaseStore.initialize incremental domain loading', () => {
     }
     const calendarEvent = captured.find((e) => e.type === 'calendar')
     expect(calendarEvent).toMatchObject({ type: 'calendar', status: 'loaded', itemCount: 1, collectionCount: 1 })
+  })
+
+  it('hydrates local cache only after fingerprint survives and envelope is available', async () => {
+    await primeSuccessfulRestore()
+    dataCacheMock.getCacheCapabilityStatus.mockReturnValue({ featureFlagEnabled: true, encryptedEnvelopeAvailable: false, enabled: false })
+    dataCacheMock.isCacheEnabled.mockReturnValueOnce(false).mockReturnValue(true)
+    dataCacheMock.ensureFingerprint.mockResolvedValueOnce(true)
+    dataCacheMock.ensureEncryptedEnvelope.mockResolvedValueOnce(true)
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+
+    const calls: string[] = []
+    await useEtebaseStore.getState().initialize({
+      onCacheHydrate: () => calls.push('cacheHydrate'),
+      onDomainLoaded: (event) => calls.push(`domain:${event.type}`),
+    })
+
+    expect(dataCacheMock.ensureFingerprint).toHaveBeenCalledWith('fingerprint')
+    expect(dataCacheMock.ensureEncryptedEnvelope).toHaveBeenCalledTimes(1)
+    expect(calls).toEqual(['cacheHydrate', 'domain:calendar', 'domain:tasks', 'domain:contacts'])
+  })
+
+  it('does not hydrate local cache when fingerprint mismatch wipes stale cache', async () => {
+    await primeSuccessfulRestore()
+    dataCacheMock.getCacheCapabilityStatus.mockReturnValue({ featureFlagEnabled: true, encryptedEnvelopeAvailable: false, enabled: false })
+    dataCacheMock.isCacheEnabled.mockReturnValueOnce(false).mockReturnValue(true)
+    dataCacheMock.ensureFingerprint.mockResolvedValueOnce(false)
+    dataCacheMock.ensureEncryptedEnvelope.mockResolvedValueOnce(true)
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+
+    const onCacheHydrate = vi.fn()
+    await useEtebaseStore.getState().initialize({ onCacheHydrate })
+
+    expect(dataCacheMock.ensureFingerprint).toHaveBeenCalledWith('fingerprint')
+    expect(dataCacheMock.ensureEncryptedEnvelope).toHaveBeenCalledTimes(1)
+    expect(onCacheHydrate).not.toHaveBeenCalled()
+    expect(useEtebaseStore.getState().isInitialized).toBe(true)
+  })
+
+  it('continues restore when encrypted cache envelope setup fails', async () => {
+    await primeSuccessfulRestore()
+    dataCacheMock.getCacheCapabilityStatus.mockReturnValue({ featureFlagEnabled: true, encryptedEnvelopeAvailable: false, enabled: false })
+    dataCacheMock.ensureFingerprint.mockResolvedValueOnce(true)
+    dataCacheMock.ensureEncryptedEnvelope.mockRejectedValueOnce(new Error('quota'))
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+
+    const onCacheHydrate = vi.fn()
+    await useEtebaseStore.getState().initialize({ onCacheHydrate })
+
+    expect(onCacheHydrate).not.toHaveBeenCalled()
+    expect(useEtebaseStore.getState().isInitialized).toBe(true)
+    expect(useEtebaseStore.getState().domainLoadState).toMatchObject({ calendar: 'loaded', tasks: 'loaded', contacts: 'loaded' })
   })
 
   it('remains backwards-compatible when called with no options', async () => {

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -17,7 +17,9 @@ import { secureGet } from '@/app/lib/secure-storage'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
 import {
+  ensureEncryptedEnvelope as cacheEnsureEncryptedEnvelope,
   ensureFingerprint as cacheEnsureFingerprint,
+  getCacheCapabilityStatus,
   getStoken as cacheGetStoken,
   setStoken as cacheSetStoken,
   putItems as cachePutItems,
@@ -101,6 +103,13 @@ export interface InitialDomainLoadEvent {
 }
 
 export interface InitializeOptions {
+  /**
+   * Called once after the Etebase session fingerprint has been verified and
+   * the encrypted local-cache envelope is available, before network item
+   * enumeration starts. This keeps cache-first paint account-scoped.
+   */
+  onCacheHydrate?: () => void | Promise<void>
+
   /**
    * Called after each visible domain reaches a terminal ('loaded'/'failed')
    * state and the store's maps + domainLoadState have been published. Lets a
@@ -210,6 +219,51 @@ async function loadInitialDomainItems(
   }
 
   return { itemCount, pageCount }
+}
+
+function buildInitialDomainPublish(
+  state: EtebaseState,
+  key: VisibleCollectionTypeKey,
+  loadedMaps: {
+    itemCache: Map<string, any>
+    itemTypeMap: Map<string, CollectionTypeKey>
+    itemCollectionMap: Map<string, string>
+  },
+  domainLoadState: DomainLoadState,
+  status: InitialDomainLoadStatus,
+): Partial<EtebaseState> {
+  const itemCache = new Map(state.itemCache)
+  const itemTypeMap = new Map(state.itemTypeMap)
+  const itemCollectionMap = new Map(state.itemCollectionMap)
+
+  // Early-paint domains can be interacted with while slower domains are still
+  // enumerating. Publish only the domain that just reached a terminal state;
+  // otherwise a later tasks/contacts publish can overwrite calendar mutations
+  // made against the live store with an older local snapshot.
+  if (status === 'loaded') {
+    for (const [uid, type] of itemTypeMap.entries()) {
+      if (type !== key) continue
+      itemCache.delete(uid)
+      itemTypeMap.delete(uid)
+      itemCollectionMap.delete(uid)
+    }
+    for (const [uid, item] of loadedMaps.itemCache.entries()) {
+      itemCache.set(uid, item)
+    }
+    for (const [uid, type] of loadedMaps.itemTypeMap.entries()) {
+      itemTypeMap.set(uid, type)
+    }
+    for (const [uid, collectionUid] of loadedMaps.itemCollectionMap.entries()) {
+      itemCollectionMap.set(uid, collectionUid)
+    }
+  }
+
+  return {
+    itemCache,
+    itemTypeMap,
+    itemCollectionMap,
+    domainLoadState: { ...state.domainLoadState, ...domainLoadState },
+  }
 }
 
 async function trackCollectionWithSyncEngine(
@@ -632,10 +686,15 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       // Local-cache fingerprint check: if a different account previously
       // hydrated this browser, wipe before reseeding. Belt-and-braces against
       // the Android-style stale-cache contamination bug.
-      const cacheEnabled = isLocalCacheEnabled()
-      if (cacheEnabled) {
+      let cacheEnabled = isLocalCacheEnabled()
+      if (getCacheCapabilityStatus().featureFlagEnabled) {
         try {
-          await cacheEnsureFingerprint(accountFingerprint)
+          const cacheSurvived = await cacheEnsureFingerprint(accountFingerprint)
+          await cacheEnsureEncryptedEnvelope()
+          cacheEnabled = isLocalCacheEnabled()
+          if (cacheSurvived && cacheEnabled) {
+            await options?.onCacheHydrate?.()
+          }
         } catch (err) {
           logger.warn('[etebase-store] Cache fingerprint check failed', err)
         }
@@ -654,13 +713,12 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       diagnostics.completePhase('hydrateLists')
 
       // 3. Load items from each visible collection into the cache, one domain
-      // at a time. After each domain reaches a terminal state we publish the
-      // accumulated maps + domainLoadState and notify the caller, so a fast
+      // at a time. After each domain reaches a terminal state we publish that
+      // domain into the current live maps and notify the caller, so a fast
       // domain (calendar comes first in COLLECTION_DEFINITIONS) can paint
-      // before slower domains finish enumerating.
-      const itemCache = new Map<string, any>()
-      const itemTypeMap = new Map<string, CollectionTypeKey>()
-      const itemCollectionMap = new Map<string, string>()
+      // before slower domains finish enumerating without later stale snapshots
+      // overwriting user mutations made during that exposed window.
+      let totalLoadedItemCount = 0
 
       const domainLoadState = unknownDomainLoadState()
 
@@ -671,15 +729,21 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         let itemCount = 0
         let pageCount = 0
         let status: InitialDomainLoadStatus
+        const loadedMaps = {
+          itemCache: new Map<string, any>(),
+          itemTypeMap: new Map<string, CollectionTypeKey>(),
+          itemCollectionMap: new Map<string, string>(),
+        }
 
         try {
           const counts = await loadInitialDomainItems(core, account, key, typedCollections, {
-            itemCache,
-            itemTypeMap,
-            itemCollectionMap,
+            itemCache: loadedMaps.itemCache,
+            itemTypeMap: loadedMaps.itemTypeMap,
+            itemCollectionMap: loadedMaps.itemCollectionMap,
           })
           itemCount = counts.itemCount
           pageCount = counts.pageCount
+          totalLoadedItemCount += itemCount
           domainLoadState[key] = 'loaded'
           status = 'loaded'
           diagnostics.completePhase(phase, {
@@ -695,14 +759,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           logger.warn(`[etebase-store] Failed to load ${key} items`, getSafeErrorDetails(err))
         }
 
-        // Publish incrementally with fresh Map copies + a fresh domainLoadState
-        // object so Zustand subscribers observe the completed domain right away.
-        set({
-          itemCache: new Map(itemCache),
-          itemTypeMap: new Map(itemTypeMap),
-          itemCollectionMap: new Map(itemCollectionMap),
-          domainLoadState: { ...domainLoadState },
-        })
+        // Publish incrementally using the current live maps. Do not overwrite
+        // previously painted domains with the snapshot from earlier awaits.
+        set((state) => buildInitialDomainPublish(state, key, loadedMaps, domainLoadState, status))
 
         await options?.onDomainLoaded?.({
           type: key,
@@ -713,7 +772,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         })
       }
 
-      logger.debug(`[etebase-store] Loaded ${itemCache.size} items into cache`)
+      logger.debug(`[etebase-store] Loaded ${totalLoadedItemCount} items into cache`)
 
       // 4. Start SyncEngine
       const engine = new core.SyncEngine({


### PR DESCRIPTION
## Summary

- enables encrypted-at-rest local data-cache item content behind the existing `NEXT_PUBLIC_LOCAL_CACHE_ENABLED` gate
- bumps the local data-cache schema/version to 5 and clears items, metadata, stokens, and the crypto envelope on logout/account/schema mismatch
- moves cache hydration behind restored-account fingerprint and envelope verification so cache-first paint is account-scoped
- preserves Slice 4 partial-load semantics and Slice 5 calendar-first server-truth overwrites

## Validation

- `pnpm --filter @silentsuite/web test -- app/lib/__tests__/data-cache.test.ts app/stores/__tests__/use-etebase-store.test.ts app/providers/__tests__/sync-provider.timing.test.tsx`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint`
- `pnpm run build`
- `pnpm run test`
- `git diff --check`

## Notes

- Production remains gated by `NEXT_PUBLIC_LOCAL_CACHE_ENABLED`; unsupported WebCrypto/envelope setup fails closed with no plaintext cache writes.
- No server/API, billing/auth flow, preferences, label suggestions, Android, or bridge changes.
