### PR TITLE
web: add encrypted label suggestions

### DIFF
--- a/apps/web/app/(app)/calendar/components/EventDialog.tsx
+++ b/apps/web/app/(app)/calendar/components/EventDialog.tsx
@@ -854,6 +854,7 @@ export function EventDialog({
                         labels={categories}
                         onChange={setCategories}
                         disabled={!canWrite}
+                        source="calendar"
                         aria-label={t('eventLabels')}
                       />
                     </div>

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -527,6 +527,7 @@ function ContactForm({
             <LabelEditor
               labels={categories}
               onChange={setCategories}
+              source="contacts"
               aria-label={t('contactLabels')}
             />
           </fieldset>

--- a/apps/web/app/(app)/tasks/page.tsx
+++ b/apps/web/app/(app)/tasks/page.tsx
@@ -455,6 +455,7 @@ function TaskDialog({
               <LabelEditor
                 labels={categories}
                 onChange={setCategories}
+                source="tasks"
                 aria-label={t('taskLabels')}
               />
             </div>
@@ -802,6 +803,7 @@ function TaskItem({ task }: { task: Task }) {
               labels={task.categories ?? []}
               onChange={(next) => canWrite && updateTask(task.id, { categories: next })}
               disabled={!canWrite}
+              source="tasks"
               aria-label={t('taskLabels')}
             />
           </div>

--- a/apps/web/app/components/LabelEditor.tsx
+++ b/apps/web/app/components/LabelEditor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useRef, useState, type FormEvent } from 'react'
+import { useCallback, useMemo, useRef, useState, type FormEvent } from 'react'
 import { Palette, Tag, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import {
@@ -8,6 +8,7 @@ import {
   labelTextColor,
   useLabelColorStore,
 } from '@/app/stores/use-label-color-store'
+import { useLabelSuggestionsStore, type LabelIndexSource } from '@/app/stores/use-label-suggestions-store'
 
 // ---------------------------------------------------------------------------
 // Shared label / category chip components (#291)
@@ -119,7 +120,7 @@ function LabelChip({
 }
 
 // ---------------------------------------------------------------------------
-// LabelEditor — add / remove chips
+// LabelEditor — add / remove chips + encrypted client-side suggestions
 // ---------------------------------------------------------------------------
 
 export function LabelEditor({
@@ -127,22 +128,33 @@ export function LabelEditor({
   onChange,
   disabled = false,
   placeholder,
+  source,
   'aria-label': ariaLabel,
 }: {
   labels: string[]
   onChange: (next: string[]) => void
   disabled?: boolean
   placeholder?: string
+  source?: LabelIndexSource
   'aria-label'?: string
 }) {
   const t = useTranslations('Labels')
   const [input, setInput] = useState('')
+  const [isFocused, setIsFocused] = useState(false)
+  const [activeSuggestionIndex, setActiveSuggestionIndex] = useState(0)
+  const getSuggestions = useLabelSuggestionsStore((state) => state.suggestions)
+  const suggestions = useMemo(
+    () => (disabled ? [] : getSuggestions(input, labels, 6)),
+    [disabled, getSuggestions, input, labels],
+  )
+  const showSuggestions = Boolean(!disabled && source && isFocused && suggestions.length > 0)
 
   const commit = useCallback(
     (raw: string) => {
       const next = normalizeLabels([...labels, raw])
       if (next.length !== labels.length) onChange(next)
       setInput('')
+      setActiveSuggestionIndex(0)
     },
     [labels, onChange],
   )
@@ -154,9 +166,26 @@ export function LabelEditor({
     [labels, onChange],
   )
 
+  const chooseSuggestion = useCallback((suggestion: string) => {
+    commit(suggestion)
+    setIsFocused(false)
+  }, [commit])
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === 'Enter' || e.key === ',') {
+      if (e.key === 'ArrowDown' && showSuggestions) {
+        e.preventDefault()
+        setActiveSuggestionIndex((index) => (index + 1) % suggestions.length)
+      } else if (e.key === 'ArrowUp' && showSuggestions) {
+        e.preventDefault()
+        setActiveSuggestionIndex((index) => (index - 1 + suggestions.length) % suggestions.length)
+      } else if (e.key === 'Escape' && showSuggestions) {
+        e.preventDefault()
+        setIsFocused(false)
+      } else if (e.key === 'Enter' && showSuggestions && suggestions[activeSuggestionIndex]) {
+        e.preventDefault()
+        chooseSuggestion(suggestions[activeSuggestionIndex]!)
+      } else if (e.key === 'Enter' || e.key === ',') {
         e.preventDefault()
         if (input.trim()) commit(input)
       } else if (e.key === 'Backspace' && !input && labels.length > 0) {
@@ -164,7 +193,7 @@ export function LabelEditor({
         remove(labels[labels.length - 1]!)
       }
     },
-    [input, labels, commit, remove],
+    [activeSuggestionIndex, chooseSuggestion, input, labels, commit, remove, showSuggestions, suggestions],
   )
 
   return (
@@ -183,13 +212,38 @@ export function LabelEditor({
         <input
           type="text"
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={(e) => {
+            setInput(e.target.value)
+            setActiveSuggestionIndex(0)
+          }}
           onKeyDown={handleKeyDown}
-          onBlur={() => input.trim() && commit(input)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => {
+            setIsFocused(false)
+            if (input.trim()) commit(input)
+          }}
           placeholder={labels.length === 0 ? (placeholder ?? t('addLabelPlaceholder')) : ''}
           aria-label={ariaLabel ?? t('editorAriaLabel')}
+          aria-autocomplete="list"
           className="min-w-[6rem] flex-1 bg-transparent text-sm text-[rgb(var(--foreground))] placeholder:text-[rgb(var(--muted))] focus:outline-none"
         />
+      )}
+      {showSuggestions && (
+        <div className="mt-2 w-full rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-1 shadow-lg" role="listbox" aria-label="Label suggestions">
+          {suggestions.map((suggestion, index) => (
+            <button
+              key={suggestion}
+              type="button"
+              role="option"
+              aria-selected={index === activeSuggestionIndex}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => chooseSuggestion(suggestion)}
+              className={`w-full rounded px-2 py-1 text-left text-sm ${index === activeSuggestionIndex ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300' : 'text-[rgb(var(--foreground))] hover:bg-[rgb(var(--muted))]/10'}`}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/apps/web/app/components/__tests__/LabelEditor.test.tsx
+++ b/apps/web/app/components/__tests__/LabelEditor.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { LabelEditor, LabelChips, normalizeLabels } from '../LabelEditor'
 import { renderWithIntl } from '@/src/__tests__/render-with-intl'
 import { getLabelColor, labelTextColor, useLabelColorStore } from '@/app/stores/use-label-color-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 
 vi.mock('lucide-react', () => ({
   Palette: () => <svg data-testid="palette-icon" />,
@@ -12,6 +13,7 @@ vi.mock('lucide-react', () => ({
 
 beforeEach(() => {
   useLabelColorStore.setState({ colors: {} })
+  useLabelSuggestionsStore.getState().reset()
   localStorage.clear()
 })
 
@@ -136,5 +138,41 @@ describe('LabelEditor', () => {
     expect(screen.queryByLabelText('Labels')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Remove label Work')).not.toBeInTheDocument()
     expect(screen.getByText('Work')).toBeInTheDocument()
+  })
+
+  it('shows encrypted label suggestions on focus and selects one by click', () => {
+    useLabelSuggestionsStore.getState().seedFromVisibleItems({ calendar: [{ categories: ['Work', 'Home'] }] })
+    const onChange = vi.fn()
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} source="calendar" />)
+
+    fireEvent.focus(screen.getByLabelText('Labels'))
+    fireEvent.click(screen.getByRole('option', { name: 'Work' }))
+
+    expect(onChange).toHaveBeenCalledWith(['Work'])
+  })
+
+  it('filters suggestions and excludes labels already present', () => {
+    useLabelSuggestionsStore.getState().seedFromVisibleItems({ tasks: [{ categories: ['Work', 'Weekend', 'Home'] }] })
+    renderWithIntl(<LabelEditor labels={['Work']} onChange={vi.fn()} source="tasks" />)
+    const input = screen.getByLabelText('Labels')
+
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'we' } })
+
+    expect(screen.queryByRole('option', { name: 'Work' })).not.toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Weekend' })).toBeInTheDocument()
+  })
+
+  it('selects suggestions with keyboard navigation', () => {
+    useLabelSuggestionsStore.getState().seedFromVisibleItems({ contacts: [{ categories: ['Alpha', 'Beta'] }] })
+    const onChange = vi.fn()
+    renderWithIntl(<LabelEditor labels={[]} onChange={onChange} source="contacts" />)
+    const input = screen.getByLabelText('Labels')
+
+    fireEvent.focus(input)
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onChange).toHaveBeenCalledWith(['Beta'])
   })
 })

--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -144,6 +144,12 @@ vi.mock('@silentsuite/core', () => ({
   deserializeCalendarEvent: vi.fn(() => ({ title: 'event' })),
 }))
 
+vi.mock('@/app/stores/use-label-suggestions-store', () => ({
+  useLabelSuggestionsStore: {
+    getState: () => ({ initialize: vi.fn(async () => {}), seedFromVisibleItems: vi.fn(), refreshFromRemote: vi.fn(async () => {}) }),
+  },
+}))
+
 function renderProvider() {
   return render(<SyncProvider><div>child</div></SyncProvider>)
 }

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -8,6 +8,7 @@ import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 import {
   getItemsByType as cacheGetItemsByType,
   replaceItemsForType as cacheReplaceItemsForType,
@@ -118,6 +119,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         const changeHandlerStartedAt = nowMs()
         unsubChange = wireChangeHandler()
         safeLogSyncTiming('wire-change-handler', changeHandlerStartedAt, { status: unsubChange ? 'ok' : 'skipped' })
+
+        // Supporting metadata only: no passive writes and no visible restore blocking.
+        void useLabelSuggestionsStore.getState().initialize()
+          .then(() => useLabelSuggestionsStore.getState().seedFromVisibleItems())
+          .catch((err) => logger.warn('[sync-provider] Label suggestions initialization failed', getSafeErrorDetails(err)))
 
         // Wire SyncEngine status
         const statusHandlerStartedAt = nowMs()
@@ -344,6 +350,12 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             }
           } catch (err) {
             reportSyncError('sync calendar events', err)
+          }
+        } else if (collectionType === 'silentsuite.labelindex') {
+          try {
+            await useLabelSuggestionsStore.getState().refreshFromRemote()
+          } catch (err) {
+            logger.warn('[sync-provider] Label suggestions refresh failed', getSafeErrorDetails(err))
           }
         }
 

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -46,6 +46,12 @@ vi.mock('@/app/lib/offline-queue', () => offlineQueueMock)
 
 vi.mock('@silentsuite/core', () => coreMock)
 
+vi.mock('@/app/stores/use-label-suggestions-store', () => ({
+  useLabelSuggestionsStore: {
+    getState: () => ({ recordUsage: vi.fn(async () => {}) }),
+  },
+}))
+
 vi.mock('@/app/lib/secure-storage', () => ({
   secureGet: vi.fn(async () => null),
   secureSet: vi.fn(async () => {}),

--- a/apps/web/app/stores/__tests__/use-label-suggestions-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-label-suggestions-store.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLabelSuggestionsStore } from '../use-label-suggestions-store'
+
+vi.mock('@/app/lib/logger', () => ({
+  logger: { warn: vi.fn(), log: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const etebaseState = vi.hoisted(() => ({
+  account: null as any,
+  syncEngine: { trackCollection: vi.fn() },
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: {
+    getState: () => etebaseState,
+  },
+}))
+
+vi.mock('@/app/stores/use-calendar-store', () => ({
+  useCalendarStore: { getState: () => ({ events: [{ categories: ['Work'] }] }) },
+}))
+vi.mock('@/app/stores/use-task-store', () => ({
+  useTaskStore: { getState: () => ({ tasks: [{ categories: ['Urgent'] }] }) },
+}))
+vi.mock('@/app/stores/use-contact-store', () => ({
+  useContactStore: { getState: () => ({ contacts: [{ categories: ['VIP'] }] }) },
+}))
+
+describe('useLabelSuggestionsStore', () => {
+  beforeEach(() => {
+    etebaseState.account = null
+    etebaseState.syncEngine.trackCollection.mockClear()
+    useLabelSuggestionsStore.getState().reset()
+  })
+
+  it('seeds in-memory suggestions from decrypted visible items without an account write', () => {
+    useLabelSuggestionsStore.getState().seedFromVisibleItems()
+
+    expect(useLabelSuggestionsStore.getState().suggestions('', [], 5)).toEqual(['Urgent', 'VIP', 'Work'])
+    expect(etebaseState.syncEngine.trackCollection).not.toHaveBeenCalled()
+  })
+
+  it('initializes as loaded without creating a remote label-index collection when no account exists', async () => {
+    await useLabelSuggestionsStore.getState().initialize()
+
+    expect(useLabelSuggestionsStore.getState().isLoaded).toBe(true)
+    expect(useLabelSuggestionsStore.getState().remoteCollection).toBeNull()
+  })
+
+  it('records usage locally even when remote persistence is unavailable', async () => {
+    await useLabelSuggestionsStore.getState().recordUsage('calendar', ['Project'])
+
+    expect(useLabelSuggestionsStore.getState().suggestions('', [], 5)).toEqual(['Project'])
+    expect(useLabelSuggestionsStore.getState().lastError).toBeNull()
+  })
+})

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -9,6 +9,7 @@ import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 
 type CalendarView = 'week' | 'month'
 
@@ -115,6 +116,7 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
           return movedItemUid
         }
         await etebase.updateItem('calendar', event.id, content)
+        void useLabelSuggestionsStore.getState().recordUsage('calendar', event.categories ?? [])
         return event.id
       } else {
         const { enqueue } = await import('@/app/lib/offline-queue')
@@ -194,6 +196,7 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
     // Sync to Etebase (pass tempId for offline queue mapping)
     const itemUid = await syncEventToEtebase(event, 'create', tempId)
     if (itemUid) {
+      void useLabelSuggestionsStore.getState().recordUsage('calendar', event.categories ?? [])
       set((state) => ({
         events: state.events.map((e) =>
           e.id === tempId ? { ...e, id: itemUid } : e,

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -8,6 +8,7 @@ import { enqueue } from '@/app/lib/offline-queue'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 
 interface NewContact {
   displayName: string
@@ -92,6 +93,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
             const content = serializeContact(contact)
             const itemUid = await etebase.createItem('contacts', content, tempId, contact.listId)
             if (itemUid) {
+              void useLabelSuggestionsStore.getState().recordUsage('contacts', contact.categories ?? [])
               set((state) => ({
                 contacts: state.contacts.map((c) =>
                   c.id === tempId ? { ...c, id: itemUid } : c,
@@ -128,6 +130,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
               const { serializeContact } = await import('@silentsuite/core')
               const content = serializeContact(updated)
               await etebase.updateItem('contacts', id, content)
+              void useLabelSuggestionsStore.getState().recordUsage('contacts', updated.categories ?? [])
             } catch (err) {
               console.error('[contact-store] Failed to sync contact update to Etebase', getSafeErrorDetails(err))
               showErrorToast('Failed to save contact. Please try again.')

--- a/apps/web/app/stores/use-label-suggestions-store.ts
+++ b/apps/web/app/stores/use-label-suggestions-store.ts
@@ -1,0 +1,210 @@
+'use client'
+
+import { create } from 'zustand'
+import { logger } from '@/app/lib/logger'
+import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+import { useCalendarStore } from '@/app/stores/use-calendar-store'
+import { useTaskStore } from '@/app/stores/use-task-store'
+import { useContactStore } from '@/app/stores/use-contact-store'
+import type { LabelIndexSource, SyncedLabelIndexV1 } from '@silentsuite/core'
+import {
+  COLLECTION_TYPE_LABEL_INDEX,
+  createEmptyLabelIndex,
+  deserializeLabelIndex,
+  mergeLabelIndexes,
+  recordLabelsUsed,
+  serializeLabelIndex,
+  suggestLabels,
+} from '@silentsuite/core'
+
+const LABEL_INDEX_COLLECTION_NAME = 'Label Suggestions'
+
+type SourceItems = {
+  calendar?: Array<{ categories?: string[] }>
+  tasks?: Array<{ categories?: string[] }>
+  contacts?: Array<{ categories?: string[] }>
+}
+
+interface LabelSuggestionsState {
+  index: SyncedLabelIndexV1
+  isLoaded: boolean
+  lastError: string | null
+  remoteCollection: any | null
+  remoteItem: any | null
+}
+
+interface LabelSuggestionsActions {
+  initialize: () => Promise<void>
+  refreshFromRemote: () => Promise<void>
+  seedFromVisibleItems: (items?: SourceItems) => void
+  suggestions: (query?: string, existingLabels?: string[], limit?: number) => string[]
+  recordUsage: (source: LabelIndexSource, labels: string[]) => Promise<void>
+  reset: () => void
+}
+
+function applyVisibleItems(index: SyncedLabelIndexV1, items: SourceItems, now = new Date()): SyncedLabelIndexV1 {
+  let next = index
+  for (const labelSource of ['calendar', 'tasks', 'contacts'] as const) {
+    for (const item of items[labelSource] ?? []) {
+      if (item.categories && item.categories.length > 0) {
+        next = recordLabelsUsed(next, labelSource, item.categories, now)
+      }
+    }
+  }
+  return next
+}
+
+function itemContentToString(content: string | Uint8Array): string {
+  return typeof content === 'string' ? content : new TextDecoder().decode(content)
+}
+
+async function readRemoteIndex(account: any, collection: any): Promise<{ index: SyncedLabelIndexV1; item: any | null }> {
+  const core = await import('@silentsuite/core')
+  let merged = createEmptyLabelIndex()
+  let newestItem: any | null = null
+  let stoken: string | null = null
+  let done = false
+  while (!done) {
+    const response = await core.listItems(account, collection, stoken)
+    for (const item of response.items) {
+      if ((item as any).isDeleted) continue
+      const parsed = deserializeLabelIndex(itemContentToString(await item.getContent()))
+      if (!parsed) continue
+      merged = mergeLabelIndexes(merged, parsed)
+      if (!newestItem) newestItem = item
+      else {
+        const current = deserializeLabelIndex(itemContentToString(await newestItem.getContent()))
+        if (current && new Date(parsed.updatedAt).getTime() > new Date(current.updatedAt).getTime()) {
+          newestItem = item
+        }
+      }
+    }
+    stoken = response.stoken
+    done = response.done
+  }
+  return { index: merged, item: newestItem }
+}
+
+async function findExistingCollection(account: any): Promise<any | null> {
+  const core = await import('@silentsuite/core')
+  const collections = await core.listCollections(account, COLLECTION_TYPE_LABEL_INDEX)
+  return collections[0] ?? null
+}
+
+async function ensureCollection(account: any): Promise<any> {
+  const existing = await findExistingCollection(account)
+  if (existing) return existing
+  const core = await import('@silentsuite/core')
+  return core.createCollection(account, COLLECTION_TYPE_LABEL_INDEX, { name: LABEL_INDEX_COLLECTION_NAME })
+}
+
+function trackCollection(collection: any) {
+  const syncEngine = useEtebaseStore.getState().syncEngine
+  if (collection?.uid) syncEngine?.trackCollection(COLLECTION_TYPE_LABEL_INDEX, collection.uid)
+}
+
+export const useLabelSuggestionsStore = create<LabelSuggestionsState & LabelSuggestionsActions>((set, get) => ({
+  index: createEmptyLabelIndex(),
+  isLoaded: false,
+  lastError: null,
+  remoteCollection: null,
+  remoteItem: null,
+
+  initialize: async () => {
+    const { account } = useEtebaseStore.getState()
+    if (!account) {
+      set({ isLoaded: true })
+      return
+    }
+
+    try {
+      const collection = await findExistingCollection(account)
+      if (collection) {
+        trackCollection(collection)
+        const remote = await readRemoteIndex(account, collection)
+        set({
+          index: mergeLabelIndexes(get().index, remote.index),
+          remoteCollection: collection,
+          remoteItem: remote.item,
+          isLoaded: true,
+          lastError: null,
+        })
+      } else {
+        set({ isLoaded: true, lastError: null })
+      }
+    } catch (err) {
+      logger.warn('[label-suggestions] Label index initialization failed', getSafeErrorDetails(err))
+      set({ isLoaded: true, lastError: 'Label suggestions are temporarily unavailable.' })
+    }
+  },
+
+  refreshFromRemote: async () => {
+    const { account } = useEtebaseStore.getState()
+    if (!account) return
+    try {
+      const collection = get().remoteCollection ?? await findExistingCollection(account)
+      if (!collection) return
+      trackCollection(collection)
+      const remote = await readRemoteIndex(account, collection)
+      set({
+        index: mergeLabelIndexes(get().index, remote.index),
+        remoteCollection: collection,
+        remoteItem: remote.item,
+        isLoaded: true,
+        lastError: null,
+      })
+    } catch (err) {
+      logger.warn('[label-suggestions] Label index refresh failed', getSafeErrorDetails(err))
+      set({ lastError: 'Label suggestions are temporarily unavailable.' })
+    }
+  },
+
+  seedFromVisibleItems: (items?: SourceItems) => {
+    const visibleItems = items ?? {
+      calendar: useCalendarStore.getState().events,
+      tasks: useTaskStore.getState().tasks,
+      contacts: useContactStore.getState().contacts,
+    }
+    set({ index: applyVisibleItems(get().index, visibleItems) })
+  },
+
+  suggestions: (query = '', existingLabels = [], limit = 8) => suggestLabels(get().index, query, existingLabels, limit),
+
+  recordUsage: async (source: LabelIndexSource, labels: string[]) => {
+    if (labels.length === 0) return
+    const next = recordLabelsUsed(get().index, source, labels)
+    set({ index: next })
+
+    const { account } = useEtebaseStore.getState()
+    if (!account) return
+
+    try {
+      const core = await import('@silentsuite/core')
+      const collection = get().remoteCollection ?? await ensureCollection(account)
+      trackCollection(collection)
+      const content = serializeLabelIndex(next)
+      const existingItem = get().remoteItem
+      if (existingItem) {
+        const updated = await core.updateItem(account, collection, existingItem, content)
+        set({ remoteCollection: collection, remoteItem: updated, lastError: null })
+      } else {
+        const created = await core.createItem(account, collection, content)
+        set({ remoteCollection: collection, remoteItem: created, lastError: null })
+      }
+    } catch (err) {
+      logger.warn('[label-suggestions] Label usage record failed', getSafeErrorDetails(err))
+      set({ lastError: 'Label suggestions are temporarily unavailable.' })
+    }
+  },
+
+  reset: () => set({
+    index: createEmptyLabelIndex(),
+    isLoaded: false,
+    lastError: null,
+    remoteCollection: null,
+    remoteItem: null,
+  }),
+}))
+
+export type { LabelIndexSource }

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -8,6 +8,7 @@ import { enqueue } from '@/app/lib/offline-queue'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
+import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
 
 interface NewTask {
   title: string
@@ -85,6 +86,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
             const content = serializeTask(task)
             const itemUid = await etebase.createItem('tasks', content, tempId, task.listId)
             if (itemUid) {
+              void useLabelSuggestionsStore.getState().recordUsage('tasks', task.categories ?? [])
               // Replace temp id with real Etebase item UID
               set((state) => ({
                 tasks: state.tasks.map((t) =>
@@ -122,6 +124,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               const { serializeTask } = await import('@silentsuite/core')
               const content = serializeTask(updated)
               await etebase.updateItem('tasks', id, content)
+              void useLabelSuggestionsStore.getState().recordUsage('tasks', updated.categories ?? [])
             } catch (err) {
               console.error('[task-store] Failed to sync task update to Etebase', getSafeErrorDetails(err))
               showErrorToast('Failed to save task. Please try again.')
@@ -187,6 +190,7 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               const { serializeTask } = await import('@silentsuite/core')
               const content = serializeTask(updated)
               await etebase.updateItem('tasks', id, content)
+              void useLabelSuggestionsStore.getState().recordUsage('tasks', updated.categories ?? [])
             } catch (err) {
               console.error('[task-store] Failed to sync task toggle to Etebase', getSafeErrorDetails(err))
               showErrorToast('Failed to save task. Please try again.')

--- a/packages/core/src/etebase/constants.ts
+++ b/packages/core/src/etebase/constants.ts
@@ -2,9 +2,11 @@ export const COLLECTION_TYPE_CALENDAR = 'etebase.vevent' as const;
 export const COLLECTION_TYPE_TASKS = 'etebase.vtodo' as const;
 export const COLLECTION_TYPE_CONTACTS = 'etebase.vcard' as const;
 export const COLLECTION_TYPE_PREFERENCES = 'silentsuite.preferences' as const;
+export const COLLECTION_TYPE_LABEL_INDEX = 'silentsuite.labelindex' as const;
 
 export type CollectionType =
   | typeof COLLECTION_TYPE_CALENDAR
   | typeof COLLECTION_TYPE_TASKS
   | typeof COLLECTION_TYPE_CONTACTS
-  | typeof COLLECTION_TYPE_PREFERENCES;
+  | typeof COLLECTION_TYPE_PREFERENCES
+  | typeof COLLECTION_TYPE_LABEL_INDEX;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export {
   COLLECTION_TYPE_TASKS,
   COLLECTION_TYPE_CONTACTS,
   COLLECTION_TYPE_PREFERENCES,
+  COLLECTION_TYPE_LABEL_INDEX,
 } from './etebase/constants.js';
 export type { CollectionType } from './etebase/constants.js';
 
@@ -128,6 +129,23 @@ export type {
   VersionedPreference,
   SyncedPreferencesV1,
 } from './models/preferences.js';
+
+// Synced label index model
+export {
+  createEmptyLabelIndex,
+  normalizeLabelKey,
+  normalizeLabelIndex,
+  recordLabelsUsed,
+  mergeLabelIndexes,
+  serializeLabelIndex,
+  deserializeLabelIndex,
+  suggestLabels,
+} from './models/label-index.js';
+export type {
+  LabelIndexSource,
+  SyncedLabelEntryV1,
+  SyncedLabelIndexV1,
+} from './models/label-index.js';
 
 // iCal parser
 export {

--- a/packages/core/src/models/label-index.test.ts
+++ b/packages/core/src/models/label-index.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEmptyLabelIndex,
+  deserializeLabelIndex,
+  mergeLabelIndexes,
+  normalizeLabelIndex,
+  recordLabelsUsed,
+  serializeLabelIndex,
+  suggestLabels,
+} from './label-index.js';
+
+describe('label index model', () => {
+  it('normalizes labels case-insensitively and drops malformed entries', () => {
+    const index = normalizeLabelIndex({
+      version: 99,
+      updatedAt: 'bad-date',
+      labels: {
+        Work: { label: ' Work ', count: 2.8, lastUsedAt: '2026-07-09T10:00:00Z', sources: { calendar: 2, nope: 9 } },
+        work: { label: 'work', count: 5, lastUsedAt: '2026-07-09T11:00:00Z', sources: { tasks: 1 } },
+        empty: { label: '   ', count: 1, lastUsedAt: '2026-07-09T10:00:00Z' },
+        bad: null,
+      },
+    });
+
+    expect(index.version).toBe(1);
+    expect(index.updatedAt).toBe('1970-01-01T00:00:00.000Z');
+    expect(Object.keys(index.labels)).toEqual(['work']);
+    expect(index.labels.work).toMatchObject({
+      label: 'work',
+      count: 5,
+      lastUsedAt: '2026-07-09T11:00:00.000Z',
+      sources: { calendar: 2, tasks: 1 },
+    });
+  });
+
+  it('records label usage with approximate per-source counters', () => {
+    const index = recordLabelsUsed(
+      createEmptyLabelIndex(),
+      'calendar',
+      [' Work ', 'work', 'Home'],
+      new Date('2026-07-09T12:00:00Z'),
+    );
+
+    expect(Object.keys(index.labels)).toEqual(['work', 'home']);
+    expect(index.labels.work).toMatchObject({
+      label: 'Work',
+      count: 1,
+      lastUsedAt: '2026-07-09T12:00:00.000Z',
+      sources: { calendar: 1 },
+    });
+    expect(index.labels.home?.count).toBe(1);
+  });
+
+  it('merges without count inflation by using max count and latest timestamp', () => {
+    const older = recordLabelsUsed(createEmptyLabelIndex(), 'calendar', ['Work'], new Date('2026-07-09T10:00:00Z'));
+    const newer = {
+      version: 1,
+      updatedAt: '2026-07-09T13:00:00.000Z',
+      labels: {
+        work: {
+          label: 'WORK',
+          count: 3,
+          lastUsedAt: '2026-07-09T13:00:00.000Z',
+          sources: { tasks: 3 },
+        },
+      },
+    } as const;
+
+    const merged = mergeLabelIndexes(older, newer, older);
+
+    expect(merged.labels.work).toMatchObject({
+      label: 'WORK',
+      count: 3,
+      lastUsedAt: '2026-07-09T13:00:00.000Z',
+      sources: { calendar: 1, tasks: 3 },
+    });
+  });
+
+  it('serializes and deserializes JSON safely', () => {
+    const index = recordLabelsUsed(createEmptyLabelIndex(), 'contacts', ['VIP'], new Date('2026-07-09T12:00:00Z'));
+    expect(deserializeLabelIndex(serializeLabelIndex(index))).toEqual(index);
+    expect(deserializeLabelIndex('not json')).toBeNull();
+  });
+
+  it('suggests ranked labels while excluding existing labels', () => {
+    const index = mergeLabelIndexes(
+      recordLabelsUsed(createEmptyLabelIndex(), 'calendar', ['Work'], new Date('2026-07-09T10:00:00Z')),
+      recordLabelsUsed(createEmptyLabelIndex(), 'tasks', ['Urgent', 'Personal'], new Date('2026-07-09T11:00:00Z')),
+      recordLabelsUsed(createEmptyLabelIndex(), 'tasks', ['Urgent'], new Date('2026-07-09T12:00:00Z')),
+    );
+
+    expect(suggestLabels(index, '', ['personal'], 5)).toEqual(['Urgent', 'Work']);
+    expect(suggestLabels(index, 'wo', [], 5)).toEqual(['Work']);
+    expect(suggestLabels(index, '', [], 1)).toEqual(['Urgent']);
+  });
+});

--- a/packages/core/src/models/label-index.ts
+++ b/packages/core/src/models/label-index.ts
@@ -1,0 +1,192 @@
+export type LabelIndexSource = 'calendar' | 'tasks' | 'contacts';
+
+export interface SyncedLabelEntryV1 {
+  label: string;
+  count: number;
+  lastUsedAt: string;
+  sources?: Partial<Record<LabelIndexSource, number>>;
+}
+
+export interface SyncedLabelIndexV1 {
+  version: 1;
+  updatedAt: string;
+  labels: Record<string, SyncedLabelEntryV1>;
+}
+
+const VALID_SOURCES: LabelIndexSource[] = ['calendar', 'tasks', 'contacts'];
+const DEFAULT_DATE = '1970-01-01T00:00:00.000Z';
+
+export function normalizeLabelKey(label: string): string {
+  return label.trim().toLocaleLowerCase();
+}
+
+function normalizeDisplayLabel(label: unknown): string | null {
+  if (typeof label !== 'string') return null;
+  const trimmed = label.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeCount(count: unknown): number {
+  if (typeof count !== 'number' || !Number.isFinite(count)) return 0;
+  return Math.max(0, Math.floor(count));
+}
+
+function normalizeDate(value: unknown): string {
+  if (typeof value !== 'string') return DEFAULT_DATE;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? DEFAULT_DATE : date.toISOString();
+}
+
+function newerIso(a: string, b: string): string {
+  return new Date(a).getTime() >= new Date(b).getTime() ? a : b;
+}
+
+function normalizeSources(value: unknown): Partial<Record<LabelIndexSource, number>> | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const result: Partial<Record<LabelIndexSource, number>> = {};
+  for (const source of VALID_SOURCES) {
+    const count = normalizeCount((value as Record<string, unknown>)[source]);
+    if (count > 0) result[source] = count;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function mergeEntry(a: SyncedLabelEntryV1, b: SyncedLabelEntryV1): SyncedLabelEntryV1 {
+  const sources: Partial<Record<LabelIndexSource, number>> = {};
+  for (const source of VALID_SOURCES) {
+    const count = Math.max(a.sources?.[source] ?? 0, b.sources?.[source] ?? 0);
+    if (count > 0) sources[source] = count;
+  }
+  const lastUsedAt = newerIso(a.lastUsedAt, b.lastUsedAt);
+  return {
+    label: a.lastUsedAt === lastUsedAt ? a.label : b.label,
+    count: Math.max(a.count, b.count),
+    lastUsedAt,
+    ...(Object.keys(sources).length > 0 ? { sources } : {}),
+  };
+}
+
+export function createEmptyLabelIndex(now: Date = new Date(0)): SyncedLabelIndexV1 {
+  return {
+    version: 1,
+    updatedAt: now.toISOString(),
+    labels: {},
+  };
+}
+
+export function normalizeLabelIndex(input: unknown): SyncedLabelIndexV1 {
+  if (!input || typeof input !== 'object') return createEmptyLabelIndex();
+  const raw = input as Record<string, unknown>;
+  const labels: Record<string, SyncedLabelEntryV1> = {};
+  const rawLabels = raw.labels && typeof raw.labels === 'object'
+    ? (raw.labels as Record<string, unknown>)
+    : {};
+
+  for (const [rawKey, rawEntry] of Object.entries(rawLabels)) {
+    if (!rawEntry || typeof rawEntry !== 'object') continue;
+    const entry = rawEntry as Record<string, unknown>;
+    const hasLabelField = Object.prototype.hasOwnProperty.call(entry, 'label');
+    const label = hasLabelField ? normalizeDisplayLabel(entry.label) : normalizeDisplayLabel(rawKey);
+    if (!label) continue;
+    const key = normalizeLabelKey(label);
+    if (!key) continue;
+    const normalized: SyncedLabelEntryV1 = {
+      label,
+      count: normalizeCount(entry.count),
+      lastUsedAt: normalizeDate(entry.lastUsedAt),
+      ...(normalizeSources(entry.sources) ? { sources: normalizeSources(entry.sources) } : {}),
+    };
+    labels[key] = labels[key] ? mergeEntry(labels[key], normalized) : normalized;
+  }
+
+  return {
+    version: 1,
+    updatedAt: normalizeDate(raw.updatedAt),
+    labels,
+  };
+}
+
+export function recordLabelsUsed(
+  index: SyncedLabelIndexV1,
+  source: LabelIndexSource,
+  rawLabels: string[],
+  now: Date = new Date(),
+): SyncedLabelIndexV1 {
+  const normalized = normalizeLabelIndex(index);
+  const timestamp = now.toISOString();
+  const labels = { ...normalized.labels };
+  const seen = new Set<string>();
+
+  for (const raw of rawLabels) {
+    const label = normalizeDisplayLabel(raw);
+    if (!label) continue;
+    const key = normalizeLabelKey(label);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    const existing = labels[key];
+    const sources = { ...(existing?.sources ?? {}) };
+    sources[source] = (sources[source] ?? 0) + 1;
+    labels[key] = {
+      label: existing?.label ?? label,
+      count: (existing?.count ?? 0) + 1,
+      lastUsedAt: timestamp,
+      sources,
+    };
+  }
+
+  return {
+    version: 1,
+    updatedAt: timestamp,
+    labels,
+  };
+}
+
+export function mergeLabelIndexes(...indexes: unknown[]): SyncedLabelIndexV1 {
+  let merged = createEmptyLabelIndex();
+  for (const input of indexes) {
+    const index = normalizeLabelIndex(input);
+    const labels = { ...merged.labels };
+    for (const [key, entry] of Object.entries(index.labels)) {
+      labels[key] = labels[key] ? mergeEntry(labels[key], entry) : entry;
+    }
+    merged = {
+      version: 1,
+      updatedAt: newerIso(merged.updatedAt, index.updatedAt),
+      labels,
+    };
+  }
+  return merged;
+}
+
+export function serializeLabelIndex(index: SyncedLabelIndexV1): string {
+  return JSON.stringify(normalizeLabelIndex(index));
+}
+
+export function deserializeLabelIndex(content: string): SyncedLabelIndexV1 | null {
+  try {
+    return normalizeLabelIndex(JSON.parse(content));
+  } catch {
+    return null;
+  }
+}
+
+export function suggestLabels(
+  index: SyncedLabelIndexV1,
+  query = '',
+  existingLabels: string[] = [],
+  limit = 8,
+): string[] {
+  const normalized = normalizeLabelIndex(index);
+  const needle = normalizeLabelKey(query);
+  const existing = new Set(existingLabels.map(normalizeLabelKey));
+  return Object.entries(normalized.labels)
+    .filter(([key, entry]) => !existing.has(key) && (!needle || key.includes(needle) || entry.label.toLocaleLowerCase().includes(needle)))
+    .sort(([, a], [, b]) => {
+      if (b.count !== a.count) return b.count - a.count;
+      const timeDelta = new Date(b.lastUsedAt).getTime() - new Date(a.lastUsedAt).getTime();
+      if (timeDelta !== 0) return timeDelta;
+      return a.label.localeCompare(b.label);
+    })
+    .slice(0, Math.max(0, limit))
+    .map(([, entry]) => entry.label);
+}


### PR DESCRIPTION
## Summary

- add a core encrypted label-index model for cross-device label suggestions
- add a web label suggestions store that passively reads/seeds suggestions and only writes on explicit label saves
- show label suggestions in LabelEditor for calendar events, tasks, and contacts
- refresh label suggestions on `silentsuite.labelindex` SyncEngine changes without blocking visible-domain sync

## Verification

- `pnpm --filter @silentsuite/core test -- src/models/label-index.test.ts`
- `pnpm --filter @silentsuite/core type-check`
- `pnpm --filter @silentsuite/web test -- app/components/__tests__/LabelEditor.test.tsx app/stores/__tests__/use-label-suggestions-store.test.ts app/providers/__tests__/sync-provider.timing.test.tsx app/stores/__tests__/use-etebase-store.test.ts`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint`
- `pnpm run build`
- `pnpm run test`
- `git diff --check`

## Notes

- No passive startup writes or user-visible toasts for label-index failures.
- Label text remains encrypted inside Etebase item content; no server-visible label metadata is introduced.
