### PR TITLE
Move restore diagnostics action into Settings

### DIFF
--- a/apps/web/app/(app)/settings/security/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/security/__tests__/page.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithIntl } from '@/src/__tests__/render-with-intl'
+import SecurityPage from '../page'
+
+const mocks = vi.hoisted(() => {
+  const logout = vi.fn()
+  const authStore = Object.assign(
+    (selector?: (state: any) => unknown) => (selector ? selector({ logout }) : { logout }),
+    { getState: () => ({ user: { email: 'fixture@example.test' }, logout }) },
+  )
+  const etebaseState = {
+    accountFingerprint: 'fp-test-123',
+    account: null,
+  }
+  const etebaseStore = Object.assign(
+    (selector: (state: typeof etebaseState) => unknown) => selector(etebaseState),
+    { getState: () => etebaseState },
+  )
+  return { logout, authStore, etebaseStore }
+})
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: mocks.authStore,
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: mocks.etebaseStore,
+}))
+
+vi.mock('@/app/lib/self-hosted', () => ({
+  isSelfHosted: false,
+}))
+
+vi.mock('@/app/lib/config', () => ({
+  BILLING_API_URL: 'https://api.silentsuite.io',
+  ETEBASE_SERVER_URL: 'https://server.silentsuite.io',
+}))
+
+describe('SecurityPage diagnostics', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.unstubAllGlobals()
+  })
+
+  it('copies restore diagnostics from Settings instead of app chrome', async () => {
+    const writeText = vi.fn(async () => {})
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    Object.defineProperty(window, 'location', {
+      value: { hostname: 'previewapp.silentsuite.io', search: '' },
+      configurable: true,
+    })
+    sessionStorage.setItem('silentsuite.restore-diagnostics.v1', JSON.stringify({
+      version: 1,
+      source: 'restore',
+      generatedAtMs: 1,
+      etebaseHost: 'server.silentsuite.io',
+      billingHost: 'api.silentsuite.io',
+      failedPhase: null,
+      entries: [{ phase: 'syncEngineStart', status: 'ok' }],
+    }))
+
+    renderWithIntl(<SecurityPage />)
+
+    expect(screen.getByRole('heading', { name: 'Restore diagnostics' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Copy diagnostics' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
+    expect(writeText.mock.calls[0]![0]).toContain('"failedPhase":null')
+    expect(await screen.findByRole('button', { name: 'Diagnostics copied' })).toBeInTheDocument()
+  })
+})

--- a/apps/web/app/(app)/settings/security/page.tsx
+++ b/apps/web/app/(app)/settings/security/page.tsx
@@ -12,6 +12,11 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { isSelfHosted } from '@/app/lib/self-hosted'
 import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
+import {
+  buildRestoreDiagnosticsCopyText,
+  canExposeRestoreDiagnosticsCopy,
+  readRestoreDiagnostics,
+} from '@/app/lib/sync-restore-diagnostics'
 
 // ---------------------------------------------------------------------------
 // Validation (same rules as signup)
@@ -92,6 +97,44 @@ function AccountFingerprintSection() {
           </Button>
         </div>
       </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Restore Diagnostics Section
+// ---------------------------------------------------------------------------
+
+function RestoreDiagnosticsSection() {
+  const t = useTranslations('SettingsSecurity.RestoreDiagnostics')
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle')
+  const canCopyDiagnostics = canExposeRestoreDiagnosticsCopy()
+
+  if (!canCopyDiagnostics) return null
+
+  const copyDiagnostics = async () => {
+    try {
+      if (!navigator.clipboard) throw new Error('Clipboard API unavailable')
+      await navigator.clipboard.writeText(buildRestoreDiagnosticsCopyText(readRestoreDiagnostics()))
+      setCopyStatus('copied')
+    } catch {
+      setCopyStatus('failed')
+    }
+
+    window.setTimeout(() => setCopyStatus('idle'), 2000)
+  }
+
+  return (
+    <section className="rounded-lg border border-[rgb(var(--border))] p-4 space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-sm font-semibold text-[rgb(var(--foreground))]">{t('title')}</h2>
+        <p className="text-xs text-[rgb(var(--muted))]">
+          {t('description')}
+        </p>
+      </div>
+      <Button type="button" variant="secondary" size="sm" onClick={copyDiagnostics}>
+        {copyStatus === 'copied' ? t('copied') : copyStatus === 'failed' ? t('copyFailed') : t('copy')}
+      </Button>
     </section>
   )
 }
@@ -347,6 +390,7 @@ export default function SecurityPage() {
   return (
     <div className="space-y-6">
       <AccountFingerprintSection />
+      <RestoreDiagnosticsSection />
       <ChangePasswordSection />
       <DeleteAccountSection />
     </div>

--- a/apps/web/app/components/SyncIndicator.tsx
+++ b/apps/web/app/components/SyncIndicator.tsx
@@ -5,11 +5,6 @@ import { RefreshCw } from 'lucide-react'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 import { formatTimeAgo } from '@/app/lib/format-time-ago'
 import type { SyncStatus } from '@silentsuite/core'
-import {
-  buildRestoreDiagnosticsCopyText,
-  canExposeRestoreDiagnosticsCopy,
-  readRestoreDiagnostics,
-} from '@/app/lib/sync-restore-diagnostics'
 
 const dotStyles: Record<SyncStatus, string> = {
   synced: 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.5)]',
@@ -54,19 +49,10 @@ export function SyncIndicator() {
   const isSyncing = syncStatus === 'syncing'
   const isOffline = syncStatus === 'offline'
   const isError = syncStatus === 'error'
-  const canCopyDiagnostics = canExposeRestoreDiagnosticsCopy()
-
   const handleSync = useCallback(() => {
     if (isSyncing || isOffline) return
     simulateSyncCycle()
   }, [isSyncing, isOffline, simulateSyncCycle])
-
-  const handleCopyDiagnostics = useCallback(async () => {
-    const copyText = buildRestoreDiagnosticsCopyText(readRestoreDiagnostics())
-    await navigator.clipboard?.writeText(copyText)
-    setTooltipText('Restore diagnostics copied')
-    setShowTooltip(true)
-  }, [])
 
   // Update tooltip text on an interval while visible so relative times stay fresh
   useEffect(() => {
@@ -110,17 +96,6 @@ export function SyncIndicator() {
           Sync error
         </button>
       )}
-      {canCopyDiagnostics && (
-        <button
-          onClick={handleCopyDiagnostics}
-          className="hidden rounded border border-rose-500/40 px-1.5 py-0.5 text-[10px] text-rose-300 hover:border-rose-400 hover:text-rose-200 md:inline"
-          aria-label="Copy sync restore diagnostics"
-          type="button"
-        >
-          Copy diagnostics
-        </button>
-      )}
-
       {/* Pending count label */}
       {!isError && pendingQueueCount > 0 && (
         <span className="hidden text-xs text-amber-400 md:inline">

--- a/apps/web/app/components/__tests__/SyncIndicator.test.tsx
+++ b/apps/web/app/components/__tests__/SyncIndicator.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { SyncIndicator } from '../SyncIndicator'
 import type { SyncStatus } from '@silentsuite/core'
 
@@ -73,12 +73,7 @@ describe('SyncIndicator', () => {
     expect(dot.className).toContain('bg-red-500')
   })
 
-  it('copies redacted restore diagnostics on preview/local sync errors', async () => {
-    const writeText = vi.fn(async () => {})
-    Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText },
-      configurable: true,
-    })
+  it('does not render diagnostics copy in the app chrome', () => {
     mockSyncState.syncStatus = 'error'
     sessionStorage.setItem('silentsuite.restore-diagnostics.v1', JSON.stringify({
       version: 1,
@@ -91,57 +86,16 @@ describe('SyncIndicator', () => {
     }))
 
     render(<SyncIndicator />)
-    fireEvent.click(screen.getByRole('button', { name: 'Copy sync restore diagnostics' }))
-
-    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
-    const copied = writeText.mock.calls[0]![0] as string
-    expect(copied).toContain('"failedPhase":"restoreSession"')
-    expect(copied).not.toContain('session-secret')
-  })
-
-  it('copies successful restore diagnostics in debug-exposed healthy states', async () => {
-    const writeText = vi.fn(async () => {})
-    Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText },
-      configurable: true,
-    })
-    mockSyncState.syncStatus = 'synced'
-    sessionStorage.setItem('silentsuite.restore-diagnostics.v1', JSON.stringify({
-      version: 1,
-      source: 'restore',
-      generatedAtMs: 1,
-      etebaseHost: 'server.silentsuite.io',
-      billingHost: 'api.silentsuite.io',
-      failedPhase: null,
-      entries: [{ phase: 'syncEngineStart', status: 'ok' }],
-    }))
-
-    render(<SyncIndicator />)
-    fireEvent.click(screen.getByRole('button', { name: 'Copy sync restore diagnostics' }))
-
-    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1))
-    expect(writeText.mock.calls[0]![0]).toContain('"failedPhase":null')
-  })
-
-  it('hides diagnostics copy in production-like contexts without debug opt-in', () => {
-    vi.stubGlobal('window', {
-      location: { hostname: 'app.silentsuite.io', search: '' },
-      sessionStorage,
-      localStorage,
-    })
-    sessionStorage.setItem('silentsuite.restore-diagnostics.v1', JSON.stringify({
-      version: 1,
-      source: 'restore',
-      generatedAtMs: 1,
-      etebaseHost: 'server.silentsuite.io',
-      billingHost: 'api.silentsuite.io',
-      failedPhase: null,
-      entries: [{ phase: 'syncEngineStart', status: 'ok' }],
-    }))
-
-    render(<SyncIndicator />)
 
     expect(screen.queryByRole('button', { name: 'Copy sync restore diagnostics' })).toBeNull()
-    vi.unstubAllGlobals()
+    expect(screen.queryByText('Copy diagnostics')).toBeNull()
+  })
+
+  it('clicking sync button triggers simulateSyncCycle when available', () => {
+    mockSyncState.syncStatus = 'synced'
+    render(<SyncIndicator />)
+    const button = screen.getByRole('button', { name: 'Sync now' })
+    fireEvent.click(button)
+    expect(mockSyncState.simulateSyncCycle).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -31,6 +31,13 @@
       "copy": "Copy fingerprint",
       "copied": "Fingerprint copied",
       "copyFailed": "Copy failed"
+    },
+    "RestoreDiagnostics": {
+      "title": "Restore diagnostics",
+      "description": "Copy a privacy-safe restore report when support asks for sync diagnostics. This action appears only when restore diagnostics are available in debug-enabled preview or local sessions.",
+      "copy": "Copy diagnostics",
+      "copied": "Diagnostics copied",
+      "copyFailed": "Copy failed"
     }
   },
   "Labels": {


### PR DESCRIPTION
## Summary
- remove the visible Copy diagnostics button from the app chrome
- add a gated Restore diagnostics action to Settings > Security
- keep the existing privacy-safe restore diagnostics copy path and expose gate

## Verification
- pnpm --filter @silentsuite/web test -- app/components/__tests__/SyncIndicator.test.tsx app/(app)/settings/security/__tests__/page.test.tsx
- pnpm --filter @silentsuite/web type-check
- git diff --check
