### PR TITLE
Sync account preferences explicitly

### DIFF
--- a/apps/web/app/(app)/settings/account/page.tsx
+++ b/apps/web/app/(app)/settings/account/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { usePreferencesSyncStore } from '@/app/stores/use-preferences-sync-store'
 import { formatDate } from '@/app/lib/date'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
@@ -20,6 +21,7 @@ export default function AccountPage() {
   const { user } = useAuthStore()
   const [account, setAccount] = useState<AccountDetails | null>(null)
   const [loading, setLoading] = useState(true)
+  const [preferencesSyncStatus, setPreferencesSyncStatus] = useState<'idle' | 'syncing' | 'synced' | 'failed'>('idle')
 
   const timeFormat = usePreferencesStore((s) => s.timeFormat)
   const firstDayOfWeek = usePreferencesStore((s) => s.firstDayOfWeek)
@@ -36,6 +38,7 @@ export default function AccountPage() {
   const setNotificationSound = usePreferencesStore((s) => s.setNotificationSound)
   const setDefaultTimezone = usePreferencesStore((s) => s.setDefaultTimezone)
   const setDayBounds = usePreferencesStore((s) => s.setDayBounds)
+  const pushPreferencesNow = usePreferencesSyncStore((s) => s.pushNow)
 
   const hourOptions = useMemo(() => Array.from({ length: 25 }, (_, hour) => hour as DayBoundaryHour), [])
 
@@ -87,6 +90,16 @@ export default function AccountPage() {
       })()
     : '—'
   const status = isSelfHosted ? 'Self-Hosted' : (account?.provisioningStatus ?? 'Free trial')
+
+  const syncPreferencesNow = async () => {
+    setPreferencesSyncStatus('syncing')
+    try {
+      const synced = await pushPreferencesNow()
+      setPreferencesSyncStatus(synced ? 'synced' : 'failed')
+    } catch {
+      setPreferencesSyncStatus('failed')
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -283,6 +296,29 @@ export default function AccountPage() {
                     className="h-4 w-4 rounded border-[rgb(var(--border))] accent-emerald-500"
                   />
                 </label>
+              </div>
+
+              <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-3 space-y-3">
+                <div className="space-y-1">
+                  <p className="text-xs font-medium text-[rgb(var(--foreground))]">Account preference sync</p>
+                  <p className="text-xs text-[rgb(var(--muted))]">
+                    Save these account preferences to your encrypted vault so your other SilentSuite web sessions can use them. Notification sound stays local to this device.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={syncPreferencesNow}
+                  disabled={preferencesSyncStatus === 'syncing'}
+                  className="rounded-md border border-emerald-500/60 px-3 py-2 text-sm font-medium text-emerald-300 transition-colors hover:border-emerald-400 hover:text-emerald-200 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {preferencesSyncStatus === 'syncing' ? 'Syncing preferences...' : 'Sync account preferences'}
+                </button>
+                {preferencesSyncStatus === 'synced' && (
+                  <p className="text-xs text-emerald-300">Preferences synced.</p>
+                )}
+                {preferencesSyncStatus === 'failed' && (
+                  <p className="text-xs text-rose-300">Could not sync preferences. Check your connection and try again.</p>
+                )}
               </div>
             </div>
           </section>

--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -150,6 +150,12 @@ vi.mock('@/app/stores/use-label-suggestions-store', () => ({
   },
 }))
 
+vi.mock('@/app/stores/use-preferences-sync-store', () => ({
+  usePreferencesSyncStore: {
+    getState: () => ({ initialize: vi.fn(async () => {}), loadFromRemote: vi.fn(async () => {}), destroy: vi.fn() }),
+  },
+}))
+
 function renderProvider() {
   return render(<SyncProvider><div>child</div></SyncProvider>)
 }

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -9,6 +9,7 @@ import { useTaskStore } from '@/app/stores/use-task-store'
 import { useContactStore } from '@/app/stores/use-contact-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
+import { usePreferencesSyncStore } from '@/app/stores/use-preferences-sync-store'
 import {
   getItemsByType as cacheGetItemsByType,
   replaceItemsForType as cacheReplaceItemsForType,
@@ -124,6 +125,8 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         void useLabelSuggestionsStore.getState().initialize()
           .then(() => useLabelSuggestionsStore.getState().seedFromVisibleItems())
           .catch((err) => logger.warn('[sync-provider] Label suggestions initialization failed', getSafeErrorDetails(err)))
+        void usePreferencesSyncStore.getState().initialize()
+          .catch((err) => logger.warn('[sync-provider] Preferences sync initialization failed', getSafeErrorDetails(err)))
 
         // Wire SyncEngine status
         const statusHandlerStartedAt = nowMs()
@@ -357,6 +360,13 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           } catch (err) {
             logger.warn('[sync-provider] Label suggestions refresh failed', getSafeErrorDetails(err))
           }
+        } else if (collectionType === 'silentsuite.preferences') {
+          try {
+            const preferenceItems = await refresher('preferences', event.collectionUid)
+            await usePreferencesSyncStore.getState().loadFromRemote(preferenceItems)
+          } catch (err) {
+            logger.warn('[sync-provider] Preferences refresh failed', getSafeErrorDetails(err))
+          }
         }
 
         setLastSynced(new Date())
@@ -381,6 +391,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     return () => {
       if (unsubChange) unsubChange()
       if (unsubStatus) unsubStatus()
+      usePreferencesSyncStore.getState().destroy()
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSyncedPreferences, serializePreferences } from '@silentsuite/core'
+import { useEtebaseStore } from '../use-etebase-store'
+import { usePreferencesStore } from '../use-preferences-store'
+import { usePreferencesSyncStore } from '../use-preferences-sync-store'
+
+vi.mock('@/app/stores/use-toast-store', () => ({
+  showErrorToast: vi.fn(),
+}))
+
+vi.mock('@/app/lib/secure-storage', () => ({
+  secureGet: vi.fn(async () => null),
+  secureSet: vi.fn(async () => {}),
+  secureRemove: vi.fn(async () => {}),
+  secureClear: vi.fn(async () => {}),
+  migrateFromLocalStorage: vi.fn(async () => {}),
+}))
+
+vi.mock('@silentsuite/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@silentsuite/core')>()
+  return {
+    ...actual,
+    listCollections: vi.fn(),
+  }
+})
+
+const core = await import('@silentsuite/core')
+const listCollectionsMock = vi.mocked(core.listCollections)
+
+function resetStores() {
+  usePreferencesSyncStore.getState().destroy()
+  usePreferencesStore.getState().resetSyncedPreferences()
+  usePreferencesStore.setState({ notificationSound: true })
+  useEtebaseStore.setState({
+    account: null,
+    collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+    itemCache: new Map(),
+    itemTypeMap: new Map(),
+    itemCollectionMap: new Map(),
+    domainLoadState: { calendar: 'loaded', tasks: 'loaded', contacts: 'loaded', preferences: 'unknown' },
+    isInitialized: false,
+    syncEngine: null,
+  })
+}
+
+function mockItem(uid: string, content: string) {
+  return {
+    uid,
+    isDeleted: false,
+    getContent: vi.fn(async () => content),
+  }
+}
+
+describe('usePreferencesSyncStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    resetStores()
+  })
+
+  it('initializes read-only when no remote preferences collection exists', async () => {
+    const createItem = vi.fn()
+    const updateItem = vi.fn()
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      createItem: createItem as any,
+      updateItem: updateItem as any,
+    })
+    listCollectionsMock.mockResolvedValue([] as any)
+
+    await usePreferencesSyncStore.getState().initialize()
+
+    expect(listCollectionsMock).toHaveBeenCalledWith(expect.anything(), 'silentsuite.preferences')
+    expect(createItem).not.toHaveBeenCalled()
+    expect(updateItem).not.toHaveBeenCalled()
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ isInitialized: true, remoteItemUid: null })
+  })
+
+  it('loads remote preferences without changing local notification sound or writing back', async () => {
+    const remote = createSyncedPreferences(
+      {
+        timeFormat: '24h',
+        firstDayOfWeek: 'sunday',
+        defaultReminder: '30',
+        defaultTimezone: 'Europe/Amsterdam',
+      },
+      {
+        timeFormat: 10,
+        firstDayOfWeek: 10,
+        defaultReminder: 10,
+        defaultTimezone: 10,
+      },
+      10,
+    )
+    const item = mockItem('pref-1', serializePreferences(remote))
+    const updateItem = vi.fn()
+    usePreferencesStore.setState({ notificationSound: false })
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      itemCache: new Map([['pref-1', item]]),
+      itemTypeMap: new Map([['pref-1', 'preferences']]),
+      itemCollectionMap: new Map([['pref-1', 'prefs-col']]),
+      updateItem: updateItem as any,
+    })
+
+    await usePreferencesSyncStore.getState().loadFromRemote()
+
+    expect(usePreferencesStore.getState()).toMatchObject({
+      timeFormat: '24h',
+      firstDayOfWeek: 'sunday',
+      defaultReminder: '30',
+      defaultTimezone: 'Europe/Amsterdam',
+      notificationSound: false,
+    })
+    expect(updateItem).not.toHaveBeenCalled()
+    expect(usePreferencesSyncStore.getState().remoteItemUid).toBe('pref-1')
+  })
+
+  it('pushNow creates a preferences collection and item only on explicit action', async () => {
+    const createCollection = vi.fn(async () => 'prefs-col')
+    const createItem = vi.fn(async () => 'pref-1')
+    usePreferencesStore.getState().setTimeFormat('24h')
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      createCollection: createCollection as any,
+      createItem: createItem as any,
+    })
+    listCollectionsMock.mockResolvedValue([] as any)
+
+    const pushed = await usePreferencesSyncStore.getState().pushNow()
+
+    expect(pushed).toBe(true)
+    expect(createCollection).toHaveBeenCalledWith('preferences', 'Preferences')
+    expect(createItem).toHaveBeenCalledWith('preferences', expect.stringContaining('timeFormat'), 'silentsuite-preferences', 'prefs-col')
+    expect(usePreferencesSyncStore.getState().remoteItemUid).toBe('pref-1')
+  })
+
+  it('pushNow merges local and remote per-field timestamps before updating the canonical item', async () => {
+    const remote = createSyncedPreferences(
+      {
+        timeFormat: '12h',
+        firstDayOfWeek: 'sunday',
+        defaultReminder: '15',
+        defaultTimezone: 'UTC',
+      },
+      {
+        timeFormat: 10,
+        firstDayOfWeek: 200,
+        defaultReminder: 10,
+        defaultTimezone: 10,
+      },
+      200,
+    )
+    const item = mockItem('pref-1', serializePreferences(remote))
+    const updatedItem = mockItem('pref-1', serializePreferences(remote))
+    const updateItem = vi.fn(async () => {
+      useEtebaseStore.setState({ itemCache: new Map([['pref-1', updatedItem]]) })
+    })
+    usePreferencesStore.setState({
+      timeFormat: '24h',
+      firstDayOfWeek: 'monday',
+      syncedPreferenceUpdatedAt: {
+        timeFormat: 100,
+        firstDayOfWeek: 50,
+        defaultReminder: 0,
+        defaultTimezone: 0,
+        dateFormat: 0,
+        dayStartHour: 0,
+        dayEndHour: 0,
+      },
+    })
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      itemCache: new Map([['pref-1', item]]),
+      itemTypeMap: new Map([['pref-1', 'preferences']]),
+      itemCollectionMap: new Map([['pref-1', 'prefs-col']]),
+      updateItem: updateItem as any,
+    })
+
+    await usePreferencesSyncStore.getState().pushNow()
+
+    expect(updateItem).toHaveBeenCalledTimes(1)
+    const content = updateItem.mock.calls[0]?.[2] as string
+    expect(content).toContain('24h')
+    expect(content).toContain('sunday')
+  })
+
+  it('pushNow reports failure when updateItem leaves the canonical item unchanged', async () => {
+    const remote = createSyncedPreferences(
+      { timeFormat: '12h' },
+      { timeFormat: 10 },
+      10,
+    )
+    const item = mockItem('pref-1', serializePreferences(remote))
+    const updateItem = vi.fn(async () => {})
+    usePreferencesStore.setState({
+      timeFormat: '24h',
+      syncedPreferenceUpdatedAt: {
+        timeFormat: 100,
+        firstDayOfWeek: 0,
+        defaultReminder: 0,
+        defaultTimezone: 0,
+        dateFormat: 0,
+        dayStartHour: 0,
+        dayEndHour: 0,
+      },
+    })
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      itemCache: new Map([['pref-1', item]]),
+      itemTypeMap: new Map([['pref-1', 'preferences']]),
+      itemCollectionMap: new Map([['pref-1', 'prefs-col']]),
+      updateItem: updateItem as any,
+    })
+
+    const pushed = await usePreferencesSyncStore.getState().pushNow()
+
+    expect(pushed).toBe(false)
+    expect(updateItem).toHaveBeenCalledTimes(1)
+    expect(usePreferencesSyncStore.getState().remoteItemUid).toBeNull()
+  })
+
+  it('pushNow skips remote update when merged preferences match the canonical item', async () => {
+    const remote = usePreferencesStore.getState().toSyncedPreferences()
+    const item = mockItem('pref-1', serializePreferences(remote))
+    const updateItem = vi.fn(async () => {})
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      itemCache: new Map([['pref-1', item]]),
+      itemTypeMap: new Map([['pref-1', 'preferences']]),
+      itemCollectionMap: new Map([['pref-1', 'prefs-col']]),
+      updateItem: updateItem as any,
+    })
+
+    const pushed = await usePreferencesSyncStore.getState().pushNow()
+
+    expect(pushed).toBe(true)
+    expect(updateItem).not.toHaveBeenCalled()
+    expect(usePreferencesSyncStore.getState().remoteItemUid).toBe('pref-1')
+  })
+
+  it('pushNow refuses to write while remote preferences are being applied', async () => {
+    const createItem = vi.fn(async () => 'pref-1')
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      createItem: createItem as any,
+    })
+    usePreferencesSyncStore.setState({ isApplyingRemote: true })
+
+    const pushed = await usePreferencesSyncStore.getState().pushNow()
+
+    expect(pushed).toBe(false)
+    expect(createItem).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -18,6 +18,12 @@ const calendarStoreMock = vi.hoisted(() => ({
   syncFromRemote: vi.fn(),
 }))
 
+const preferencesSyncMock = vi.hoisted(() => ({
+  loadFromRemote: vi.fn(async () => {}),
+  pushNow: vi.fn(async () => true),
+  setRemoteItemUid: vi.fn(),
+}))
+
 // Mock the heavy dependencies that simulateSyncCycle imports dynamically
 vi.mock('@/app/stores/use-etebase-store', () => ({
   useEtebaseStore: {
@@ -51,6 +57,12 @@ vi.mock('@/app/stores/use-calendar-store', () => ({
   },
 }))
 
+vi.mock('@/app/stores/use-preferences-sync-store', () => ({
+  usePreferencesSyncStore: {
+    getState: () => preferencesSyncMock,
+  },
+}))
+
 vi.mock('@/app/lib/offline-queue', () => ({
   replay: vi.fn().mockResolvedValue([]),
   getPendingCount: vi.fn().mockResolvedValue(0),
@@ -73,6 +85,9 @@ function resetStore() {
   etebaseMock.state.moveItem.mockReset()
   calendarStoreMock.events = []
   calendarStoreMock.syncFromRemote.mockReset()
+  preferencesSyncMock.loadFromRemote.mockClear()
+  preferencesSyncMock.pushNow.mockClear()
+  preferencesSyncMock.setRemoteItemUid.mockClear()
   useSyncStore.setState({
     syncStatus: 'synced',
     lastSyncedAt: null,
@@ -123,6 +138,8 @@ describe('useSyncStore', () => {
     await flushPromises()
     expect(useSyncStore.getState().syncStatus).toBe('synced')
     expect(useSyncStore.getState().lastSyncedAt).toBeInstanceOf(Date)
+    expect(preferencesSyncMock.loadFromRemote).toHaveBeenCalledTimes(1)
+    expect(preferencesSyncMock.pushNow).not.toHaveBeenCalled()
   })
 
   it('simulateSyncCycle does nothing when offline', () => {

--- a/apps/web/app/stores/use-preferences-sync-store.ts
+++ b/apps/web/app/stores/use-preferences-sync-store.ts
@@ -1,0 +1,178 @@
+'use client'
+
+import { create } from 'zustand'
+import {
+  deserializePreferences,
+  mergeSyncedPreferences,
+  serializePreferences,
+  type SyncedPreferencesV1,
+} from '@silentsuite/core'
+import { logger } from '@/app/lib/logger'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+
+const COLLECTION_TYPE_PREFERENCES = 'silentsuite.preferences'
+const PREFERENCES_COLLECTION_NAME = 'Preferences'
+const PREFERENCES_TEMP_ID = 'silentsuite-preferences'
+
+interface RemotePreferenceItem {
+  uid: string
+  preferences: SyncedPreferencesV1
+}
+
+interface PreferencesSyncState {
+  remoteItemUid: string | null
+  isInitialized: boolean
+  isApplyingRemote: boolean
+  lastSyncedAt: Date | null
+}
+
+interface PreferencesSyncActions {
+  initialize: () => Promise<void>
+  loadFromRemote: (items?: { uid: string; content: string }[]) => Promise<void>
+  pushNow: () => Promise<boolean>
+  setRemoteItemUid: (uid: string) => void
+  destroy: () => void
+}
+
+function parseRemoteItems(items: { uid: string; content: string }[]): RemotePreferenceItem[] {
+  const parsed: RemotePreferenceItem[] = []
+  for (const item of items) {
+    try {
+      parsed.push({ uid: item.uid, preferences: deserializePreferences(item.content) })
+    } catch (err) {
+      logger.warn('[preferences-sync] Ignoring invalid preferences item', { errorName: err instanceof Error ? err.name : 'unknown' })
+    }
+  }
+  return parsed
+}
+
+function chooseCanonical(items: RemotePreferenceItem[]): RemotePreferenceItem | null {
+  if (items.length === 0) return null
+  return [...items].sort((a, b) => b.preferences.updatedAt - a.preferences.updatedAt)[0] ?? null
+}
+
+function mergeRemoteItems(items: RemotePreferenceItem[]): SyncedPreferencesV1 | null {
+  if (items.length === 0) return null
+  return mergeSyncedPreferences(items.map((item) => item.preferences))
+}
+
+async function listPreferencesCollections(): Promise<any[]> {
+  const etebase = useEtebaseStore.getState()
+  if (!etebase.account) return []
+  if (etebase.collections.preferences.length > 0) return etebase.collections.preferences
+
+  const core = await import('@silentsuite/core')
+  const collections = await core.listCollections(etebase.account, COLLECTION_TYPE_PREFERENCES)
+  if (collections.length > 0) {
+    useEtebaseStore.setState((state) => ({
+      collections: { ...state.collections, preferences: collections },
+    }))
+    for (const collection of collections) {
+      etebase.syncEngine?.trackCollection(COLLECTION_TYPE_PREFERENCES as any, collection.uid)
+    }
+  }
+  return collections
+}
+
+async function ensurePreferencesCollection(): Promise<string | null> {
+  const existing = await listPreferencesCollections()
+  if (existing[0]?.uid) return existing[0].uid
+  return useEtebaseStore.getState().createCollection('preferences', PREFERENCES_COLLECTION_NAME)
+}
+
+async function readRemotePreferenceItems(): Promise<{ uid: string; content: string }[]> {
+  const collections = await listPreferencesCollections()
+  if (collections.length === 0) return []
+  return useEtebaseStore.getState().refreshCollection('preferences')
+}
+
+export const usePreferencesSyncStore = create<PreferencesSyncState & PreferencesSyncActions>((set, get) => ({
+  remoteItemUid: null,
+  isInitialized: false,
+  isApplyingRemote: false,
+  lastSyncedAt: null,
+
+  initialize: async () => {
+    if (get().isInitialized) return
+    if (!useEtebaseStore.getState().account) return
+
+    await get().loadFromRemote()
+    set({ isInitialized: true })
+  },
+
+  loadFromRemote: async (itemsFromRefresh) => {
+    const etebase = useEtebaseStore.getState()
+    if (!etebase.account) return
+
+    const items = itemsFromRefresh ?? await readRemotePreferenceItems()
+    const remoteItems = parseRemoteItems(items)
+    const canonical = chooseCanonical(remoteItems)
+    const mergedRemote = mergeRemoteItems(remoteItems)
+
+    if (!canonical || !mergedRemote) {
+      set({ remoteItemUid: null, lastSyncedAt: new Date() })
+      return
+    }
+
+    set({ isApplyingRemote: true, remoteItemUid: canonical.uid })
+    try {
+      usePreferencesStore.getState().applySyncedPreferences(mergedRemote)
+    } finally {
+      set({ isApplyingRemote: false, lastSyncedAt: new Date() })
+    }
+  },
+
+  pushNow: async () => {
+    if (get().isApplyingRemote) return false
+
+    const etebase = useEtebaseStore.getState()
+    if (!etebase.account) return false
+
+    const collectionUid = await ensurePreferencesCollection()
+    if (!collectionUid) return false
+
+    const remoteItems = parseRemoteItems(await readRemotePreferenceItems())
+    const mergedRemote = mergeRemoteItems(remoteItems)
+    const merged = mergedRemote
+      ? mergeSyncedPreferences([mergedRemote, usePreferencesStore.getState().toSyncedPreferences()])
+      : usePreferencesStore.getState().toSyncedPreferences()
+    const content = serializePreferences(merged)
+    const canonical = chooseCanonical(remoteItems)
+
+    if (canonical) {
+      const canonicalContent = serializePreferences(canonical.preferences)
+      if (content === canonicalContent) {
+        usePreferencesStore.getState().applySyncedPreferences(merged)
+        set({ remoteItemUid: canonical.uid, lastSyncedAt: new Date() })
+        return true
+      }
+      const beforeUpdateItem = useEtebaseStore.getState().itemCache.get(canonical.uid)
+      await etebase.updateItem('preferences', canonical.uid, content)
+      const afterUpdateItem = useEtebaseStore.getState().itemCache.get(canonical.uid)
+      if (!afterUpdateItem || afterUpdateItem === beforeUpdateItem) {
+        return false
+      }
+      set({ remoteItemUid: canonical.uid, lastSyncedAt: new Date() })
+      return true
+    }
+
+    const itemUid = await etebase.createItem('preferences', content, PREFERENCES_TEMP_ID, collectionUid)
+    if (itemUid) {
+      set({ remoteItemUid: itemUid, lastSyncedAt: new Date() })
+      return true
+    }
+    return false
+  },
+
+  setRemoteItemUid: (uid) => set({ remoteItemUid: uid }),
+
+  destroy: () => {
+    set({
+      remoteItemUid: null,
+      isInitialized: false,
+      isApplyingRemote: false,
+      lastSyncedAt: null,
+    })
+  },
+}))

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -230,6 +230,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       const { useTaskStore } = await import('@/app/stores/use-task-store')
       const { useContactStore } = await import('@/app/stores/use-contact-store')
       const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
+      const { usePreferencesSyncStore } = await import('@/app/stores/use-preferences-sync-store')
 
       const refreshedEtebase = useEtebaseStore.getState()
       const domainLoadState = refreshedEtebase.domainLoadState
@@ -264,6 +265,13 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       } else {
         partialDomainCount += 1
       }
+
+      try {
+        await usePreferencesSyncStore.getState().loadFromRemote()
+      } catch (err) {
+        logger.warn('[sync-store] Preferences refresh failed during sync cycle', getSafeErrorDetails(err))
+      }
+
       // Purge stale queue entries (older than 24h) that may cause phantom indicators
       const stale = await getStaleEntries()
       for (const entry of stale) {


### PR DESCRIPTION
## Summary
- add encrypted web account preference sync with read-only startup/sync-cycle loading
- add Settings → Account explicit “Sync account preferences” action as the only remote write path
- guard preference writes against unchanged canonical content and remote-apply races

## Safety
- startup/reconnect/sync cycles do not call the write path
- notification sound remains local-only
- preference payloads and remote IDs are not exposed in UI/logs

## Verification
- pnpm --filter @silentsuite/web test -- app/stores/__tests__/use-preferences-sync-store.test.ts app/stores/__tests__/use-sync-store.test.ts app/providers/__tests__/sync-provider.timing.test.tsx
- pnpm run test
- pnpm --filter @silentsuite/web type-check
- pnpm --filter @silentsuite/web lint
- pnpm --filter @silentsuite/web build
- git diff --check

BMAD spec: tech-spec-cross-device-account-preferences-sync-2026-07-09.md