### PR TITLE
Preserve Stripe redirect payment flows

### DIFF
--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -3,8 +3,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import AddCardBanner from '../add-card-banner'
 
 vi.mock('next/dynamic', () => ({
-  default: () => function MockStripePaymentForm({ mode, submitLabel }: { mode: string; submitLabel: string }) {
-    return <div data-testid="stripe-payment-form">{mode}:{submitLabel}</div>
+  default: () => function MockStripePaymentForm({ mode, submitLabel, returnPath }: { mode: string; submitLabel: string; returnPath?: string }) {
+    return <div data-testid="stripe-payment-form">{mode}:{submitLabel}:{returnPath ?? 'signup'}</div>
   },
 }))
 
@@ -70,7 +70,7 @@ describe('AddCardBanner', () => {
     expect(await screen.findByText('14 bonus days included after today\'s payment.')).toBeInTheDocument()
     expect(screen.getByText('Amount due')).toBeInTheDocument()
     expect(screen.getByText('Powered by Stripe')).toBeInTheDocument()
-    expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €3.60')
+    expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €3.60:/settings/subscription')
   })
 
   it('switches monthly Bitcoin banner to annual and starts annual BTCPay flow', async () => {
@@ -140,7 +140,7 @@ describe('AddCardBanner', () => {
     ))
   })
 
-  it('best-effort cancels an active payment flow when the page is hidden during unload', async () => {
+  it('keeps an active card flow intact during pagehide for Stripe redirect authentication', async () => {
     vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       if (url.includes('/subscription/payment-flows/current')) return { ok: true, json: async () => ({ flow: null }) } as Response
@@ -157,9 +157,6 @@ describe('AddCardBanner', () => {
 
     window.dispatchEvent(new Event('pagehide'))
 
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
-      'https://billing.example.test/subscription/payment-flows/cancel',
-      expect.objectContaining({ method: 'POST', credentials: 'include', keepalive: true }),
-    ))
+    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes('/subscription/payment-flows/cancel'))).toBe(false)
   })
 })

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { Crown, Lock, Zap } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
@@ -143,7 +143,6 @@ export default function PaymentChoicePanel({
   const [error, setError] = useState<string | null>(null)
   const [options, setOptions] = useState<PaymentOption[]>([])
   const [optionsLoaded, setOptionsLoaded] = useState(false)
-  const shouldCancelOnPageExitRef = useRef(false)
 
   async function loadOptionsForInterval(nextInterval: BillingInterval, isCancelled: () => boolean = () => false) {
     setOptionsLoaded(false)
@@ -179,7 +178,6 @@ export default function PaymentChoicePanel({
       if (!res.ok) return
       const data = await res.json()
       const flow = data.flow ?? null
-      shouldCancelOnPageExitRef.current = Boolean(flow?.cancellable && flow.flowKind === 'stripe_pay_now')
       setCurrentFlow(flow)
     } catch {
       // Payment options still render if the recovery endpoint is temporarily unavailable.
@@ -211,7 +209,6 @@ export default function PaymentChoicePanel({
       setClientSecret(null)
       setStripePaymentSummary(null)
       setBitcoinSession(null)
-      shouldCancelOnPageExitRef.current = false
       await loadOptionsForInterval(interval)
       await loadCurrentFlow()
     } catch (err) {
@@ -220,24 +217,6 @@ export default function PaymentChoicePanel({
       setLoading(null)
     }
   }
-
-  useEffect(() => {
-    shouldCancelOnPageExitRef.current = Boolean(clientSecret || (currentFlow?.cancellable && currentFlow.flowKind === 'stripe_pay_now'))
-  }, [clientSecret, currentFlow])
-
-  useEffect(() => {
-    function cancelOnPageExit() {
-      if (!shouldCancelOnPageExitRef.current) return
-      void fetch(`${BILLING_API_URL}/subscription/payment-flows/cancel`, {
-        method: 'POST',
-        credentials: 'include',
-        keepalive: true,
-      }).catch(() => undefined)
-    }
-
-    window.addEventListener('pagehide', cancelOnPageExit)
-    return () => window.removeEventListener('pagehide', cancelOnPageExit)
-  }, [])
 
   const startStripe = async () => {
     setLoading('stripe')
@@ -258,7 +237,6 @@ export default function PaymentChoicePanel({
         throw new Error(data?.detail ?? 'Failed to set up payment')
       }
       const data = await res.json()
-      shouldCancelOnPageExitRef.current = true
       setClientSecret(data.clientSecret)
       setStripePaymentSummary({
         planId: typeof data.planId === 'string' ? data.planId : planId,
@@ -317,7 +295,6 @@ export default function PaymentChoicePanel({
         settledMessage="Payment settled. Refreshing your subscription..."
         onBack={cancelCurrentFlow}
         onPaymentComplete={async () => {
-          shouldCancelOnPageExitRef.current = false
           await onSuccess()
           await successPoll?.()
         }}
@@ -359,12 +336,12 @@ export default function PaymentChoicePanel({
         <StripePaymentForm
           clientSecret={clientSecret}
           onSuccess={async () => {
-            shouldCancelOnPageExitRef.current = false
             await onSuccess()
             await successPoll?.()
           }}
           submitLabel={`Pay ${formatAmount(stripePaymentSummary?.amount ?? amountForInterval(interval), stripePaymentSummary?.currency ?? 'EUR')}`}
           mode="payment"
+          returnPath="/settings/subscription"
         />
         <button
           onClick={() => { void cancelCurrentFlow() }}

--- a/apps/web/app/components/stripe-payment-form.tsx
+++ b/apps/web/app/components/stripe-payment-form.tsx
@@ -7,7 +7,7 @@ import type { Stripe, Appearance } from '@stripe/stripe-js'
 import { useTheme } from 'next-themes'
 import { Button } from '@silentsuite/ui'
 import { useAuthStore } from '@/app/stores/use-auth-store'
-import { signupSuccessUrl } from '@/app/lib/signup-return'
+import { paymentReturnUrl } from '@/app/lib/signup-return'
 
 const STRIPE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
 
@@ -46,9 +46,11 @@ interface PaymentFormProps {
   mode?: 'setup' | 'payment'
   /** Billing interval to persist before a potential 3DS redirect. */
   selectedInterval?: 'monthly' | 'annual'
+  /** Same-origin path for non-signup payment redirects. */
+  returnPath?: string
 }
 
-function PaymentFormInner({ onSuccess, onError, submitLabel, mode, selectedInterval }: Omit<PaymentFormProps, 'clientSecret'>) {
+function PaymentFormInner({ onSuccess, onError, submitLabel, mode, selectedInterval, returnPath }: Omit<PaymentFormProps, 'clientSecret'>) {
   const stripe = useStripe()
   const elements = useElements()
   const [loading, setLoading] = useState(false)
@@ -88,7 +90,7 @@ function PaymentFormInner({ onSuccess, onError, submitLabel, mode, selectedInter
     const billingName = authState.pendingSignup?.email || authState.user?.email || 'Customer'
     const currentReturnTo = new URLSearchParams(window.location.search).get('return_to')
     const confirmParams = {
-      return_url: signupSuccessUrl(window.location.origin, currentReturnTo),
+      return_url: paymentReturnUrl(window.location.origin, returnPath, currentReturnTo),
       payment_method_data: { billing_details: { name: billingName } },
     }
 
@@ -235,6 +237,7 @@ export default function StripePaymentForm(props: PaymentFormProps) {
         submitLabel={props.submitLabel}
         mode={props.mode}
         selectedInterval={props.selectedInterval}
+        returnPath={props.returnPath}
       />
     </Elements>
   )

--- a/apps/web/app/lib/__tests__/signup-return.test.ts
+++ b/apps/web/app/lib/__tests__/signup-return.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeSignupReturnTo, signupSuccessUrl } from '../signup-return'
+import { normalizeSignupReturnTo, paymentReturnUrl, signupSuccessUrl } from '../signup-return'
 
 describe('signup return helpers', () => {
   it('allows the Android signup completion deep link', () => {
@@ -26,5 +26,22 @@ describe('signup return helpers', () => {
     expect(url.origin).toBe('https://app.silentsuite.io')
     expect(url.pathname).toBe('/signup/success')
     expect(url.searchParams.get('return_to')).toBe('silentsuite://signup-complete')
+  })
+
+  it('uses a same-origin settings path for subscription payment redirects', () => {
+    expect(paymentReturnUrl('https://app.silentsuite.io', '/settings/subscription')).toBe(
+      'https://app.silentsuite.io/settings/subscription',
+    )
+  })
+
+  it('keeps signup payment redirects on the signup success route by default', () => {
+    expect(paymentReturnUrl('https://app.silentsuite.io', undefined, 'silentsuite://signup-complete')).toBe(
+      'https://app.silentsuite.io/signup/success?return_to=silentsuite%3A%2F%2Fsignup-complete',
+    )
+  })
+
+  it('rejects external and protocol-relative payment return paths', () => {
+    expect(() => paymentReturnUrl('https://app.silentsuite.io', 'https://evil.example/')).toThrow(/app origin/)
+    expect(() => paymentReturnUrl('https://app.silentsuite.io', '//evil.example/')).toThrow(/app origin/)
   })
 })

--- a/apps/web/app/lib/signup-return.ts
+++ b/apps/web/app/lib/signup-return.ts
@@ -24,3 +24,15 @@ export function signupSuccessUrl(origin: string, returnTo?: string | null): stri
   }
   return url.toString()
 }
+
+export function paymentReturnUrl(origin: string, returnPath?: string, signupReturnTo?: string | null): string {
+  if (!returnPath) return signupSuccessUrl(origin, signupReturnTo)
+
+  const appOrigin = new URL(origin).origin
+  const returnUrl = new URL(returnPath, appOrigin)
+  if (!returnPath.startsWith('/') || returnPath.startsWith('//') || returnUrl.origin !== appOrigin) {
+    throw new Error('Payment return path must stay on the SilentSuite app origin.')
+  }
+
+  return returnUrl.toString()
+}


### PR DESCRIPTION
## Summary
- keep pending Stripe payment flows intact during pagehide so redirect/SCA authentication can complete
- return Settings card payments to `/settings/subscription`
- retain explicit Back cancellation and reject cross-origin payment return paths

## Verification
- `pnpm --filter @silentsuite/web test -- app/components/__tests__/AddCardBanner.test.tsx app/lib/__tests__/signup-return.test.ts` (49 files, 512 tests passed)
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint` (passed with existing unrelated warnings)
- `git diff --check`