### PR TITLE
Recover Stripe payment redirects on subscription return

### DIFF
--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -251,21 +251,27 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(screen.queryByRole('button', { name: /retry payment/i })).not.toBeInTheDocument()
   })
 
-  it('recovers a processing Stripe redirect on remount and polls until the subscription activates', async () => {
+  it('keeps polling a no-card trial until Stripe confirmation removes payment requirements', async () => {
     vi.useFakeTimers()
     window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&payment_intent_client_secret=secret_123&redirect_status=processing')
     let subscriptionFetches = 0
     vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
       if (url === 'https://billing.test/subscription' && !init?.method) {
         subscriptionFetches += 1
-        const active = subscriptionFetches >= 2
-        return { ok: true, json: async () => active
-          ? baseSubscription
+        const cardConfirmed = subscriptionFetches >= 2
+        return { ok: true, json: async () => cardConfirmed
+          ? {
+              ...baseSubscription,
+              status: 'trialing',
+              trial: { active: true, endsAt: '2026-07-30T00:00:00.000Z', daysRemaining: 20 },
+              capabilities: { ...baseSubscription.capabilities, trialActive: true },
+            }
           : {
               ...baseSubscription,
-              status: 'none',
-              renewalDate: null,
-              capabilities: { ...baseSubscription.capabilities, canRetryPayment: true, canStartPaidSubscription: true },
+              status: 'trialing',
+              trialPath: '7day',
+              trial: { active: true, endsAt: '2026-07-17T00:00:00.000Z', daysRemaining: 7 },
+              capabilities: { ...baseSubscription.capabilities, trialActive: true, needsPaymentMethod: true, canSetupCard: true },
             } }
       }
       return { ok: false, status: 404, json: async () => ({}) }
@@ -284,7 +290,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
       await Promise.resolve()
     })
 
-    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('Trialing')).toBeInTheDocument()
     expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
     expect(subscriptionFetches).toBeGreaterThanOrEqual(2)
   })
@@ -302,7 +308,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
       },
     })
 
-    render(<SubscriptionPage />)
+    render(<React.StrictMode><SubscriptionPage /></React.StrictMode>)
     await act(async () => { await Promise.resolve(); await Promise.resolve() })
     expect(screen.getByText(/confirming your payment/i)).toBeInTheDocument()
 
@@ -316,6 +322,40 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /retry payment/i })).toBeInTheDocument()
     expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
+  })
+
+  it('removes an incomplete Stripe client secret from the URL without suppressing the normal fetch', async () => {
+    window.history.replaceState({}, '', '/settings/subscription?payment_intent_client_secret=secret_123')
+    mockSubscription({})
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByText('Active')).toBeInTheDocument()
+    expect(window.location.search).toBe('')
+  })
+
+  it('offers a manual status retry when every redirect poll fails', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&redirect_status=processing')
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    })))
+
+    render(<SubscriptionPage />)
+    await act(async () => { await Promise.resolve(); await Promise.resolve() })
+    expect(screen.getByText(/confirming your payment/i)).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText(/payment needs attention/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    expect(screen.queryByText(/unable to load subscription details/i)).not.toBeInTheDocument()
   })
 
   it('shows an actionable retry path after a failed Stripe redirect', async () => {

--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react'
 import SubscriptionPage from '../page'
 
 vi.mock('next/dynamic', () => ({
@@ -103,6 +103,11 @@ function mockSubscription(subscription: Record<string, unknown>) {
 describe('SubscriptionPage billing recovery CTAs', () => {
   beforeEach(() => {
     vi.unstubAllGlobals()
+    window.history.replaceState({}, '', '/settings/subscription')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('shows choose payment for active no-card trials without making cancel the only action', async () => {
@@ -244,6 +249,94 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(await screen.findByText(/confirming your payment/i)).toBeInTheDocument()
     expect(screen.queryByText(/payment incomplete/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /retry payment/i })).not.toBeInTheDocument()
+  })
+
+  it('recovers a processing Stripe redirect on remount and polls until the subscription activates', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&payment_intent_client_secret=secret_123&redirect_status=processing')
+    let subscriptionFetches = 0
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === 'https://billing.test/subscription' && !init?.method) {
+        subscriptionFetches += 1
+        const active = subscriptionFetches >= 2
+        return { ok: true, json: async () => active
+          ? baseSubscription
+          : {
+              ...baseSubscription,
+              status: 'none',
+              renewalDate: null,
+              capabilities: { ...baseSubscription.capabilities, canRetryPayment: true, canStartPaidSubscription: true },
+            } }
+      }
+      return { ok: false, status: 404, json: async () => ({}) }
+    }))
+
+    render(<SubscriptionPage />)
+    await act(async () => { await Promise.resolve(); await Promise.resolve() })
+
+    expect(screen.getByText(/confirming your payment/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /retry payment/i })).not.toBeInTheDocument()
+    expect(window.location.search).toBe('')
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
+    expect(subscriptionFetches).toBeGreaterThanOrEqual(2)
+  })
+
+  it('stops bounded redirect polling with an actionable timeout', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&redirect_status=succeeded')
+    mockSubscription({
+      status: 'none',
+      renewalDate: null,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        canRetryPayment: true,
+        canStartPaidSubscription: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+    await act(async () => { await Promise.resolve(); await Promise.resolve() })
+    expect(screen.getByText(/confirming your payment/i)).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText(/payment needs attention/i)).toBeInTheDocument()
+    expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry payment/i })).toBeInTheDocument()
+    expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
+  })
+
+  it('shows an actionable retry path after a failed Stripe redirect', async () => {
+    window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&payment_intent_client_secret=secret_123&redirect_status=failed')
+    mockSubscription({
+      status: 'none',
+      renewalDate: null,
+      capabilities: {
+        ...baseSubscription.capabilities,
+        canRetryPayment: true,
+        canStartPaidSubscription: true,
+      },
+    })
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByText(/payment needs attention/i)).toBeInTheDocument()
+    expect(screen.getByText(/Stripe could not confirm this payment/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry payment/i })).toBeInTheDocument()
+    expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
+    expect(window.location.search).toBe('')
   })
 
   it('does not route cancel-at-period-end users into reactivation', async () => {

--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -353,12 +353,14 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     vi.useFakeTimers()
     window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&redirect_status=succeeded')
     mockSubscription({
-      status: 'none',
-      renewalDate: null,
+      status: 'trialing',
+      trialPath: '7day',
+      trial: { active: true, endsAt: '2026-07-17T00:00:00.000Z', daysRemaining: 7 },
       capabilities: {
         ...baseSubscription.capabilities,
-        canRetryPayment: true,
-        canStartPaidSubscription: true,
+        trialActive: true,
+        needsPaymentMethod: true,
+        canSetupCard: true,
       },
     })
 
@@ -376,6 +378,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^retry payment$/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /choose payment/i })).not.toBeInTheDocument()
     expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
   })
 
@@ -392,11 +395,12 @@ describe('SubscriptionPage billing recovery CTAs', () => {
   it('offers a manual status retry when every redirect poll fails', async () => {
     vi.useFakeTimers()
     window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&redirect_status=processing')
-    vi.stubGlobal('fetch', vi.fn(async () => ({
+    const fetchMock = vi.fn(async () => ({
       ok: false,
       status: 503,
       json: async () => ({}),
-    })))
+    }))
+    vi.stubGlobal('fetch', fetchMock)
 
     render(<SubscriptionPage />)
     await act(async () => { await Promise.resolve(); await Promise.resolve() })
@@ -411,6 +415,22 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(screen.getByText(/payment needs attention/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
     expect(screen.queryByText(/unable to load subscription details/i)).not.toBeInTheDocument()
+
+    const firstAttemptCalls = fetchMock.mock.calls.length
+    fireEvent.click(screen.getByRole('button', { name: /retry payment status/i }))
+    await act(async () => { await Promise.resolve(); await Promise.resolve() })
+
+    expect(screen.getByText(/confirming your payment/i)).toBeInTheDocument()
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(firstAttemptCalls)
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText(/payment needs attention/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
   })
 
   it('shows an actionable retry path after a failed Stripe redirect', async () => {

--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -244,11 +244,21 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
     expect(await screen.findByText('Amount due')).toBeInTheDocument()
     expect(screen.getByText('Powered by Stripe')).toBeInTheDocument()
-    fireEvent.click(await screen.findByRole('button', { name: /mock payment success/i }))
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: /mock payment success/i }))
 
-    expect(await screen.findByText(/confirming your payment/i)).toBeInTheDocument()
+    expect(screen.getByText(/confirming your payment/i)).toBeInTheDocument()
     expect(screen.queryByText(/payment incomplete/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /retry payment/i })).not.toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^retry payment$/i })).not.toBeInTheDocument()
   })
 
   it('keeps polling a no-card trial until Stripe confirmation removes payment requirements', async () => {
@@ -295,6 +305,50 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(subscriptionFetches).toBeGreaterThanOrEqual(2)
   })
 
+  it('ignores an older pending poll response after a newer response confirms payment', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&redirect_status=processing')
+    let subscriptionFetches = 0
+    let resolveFirst: ((response: { ok: boolean; json: () => Promise<Record<string, unknown>> }) => void) | undefined
+    vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+      if (url === 'https://billing.test/subscription' && !init?.method) {
+        subscriptionFetches += 1
+        if (subscriptionFetches === 1) {
+          return new Promise(resolve => { resolveFirst = resolve })
+        }
+        return Promise.resolve({ ok: true, json: async () => baseSubscription })
+      }
+      return Promise.resolve({ ok: false, status: 404, json: async () => ({}) })
+    }))
+
+    render(<SubscriptionPage />)
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(subscriptionFetches).toBe(2)
+
+    await act(async () => {
+      resolveFirst?.({
+        ok: true,
+        json: async () => ({
+          ...baseSubscription,
+          status: 'none',
+          renewalDate: null,
+          capabilities: { ...baseSubscription.capabilities, canRetryPayment: true, canStartPaidSubscription: true },
+        }),
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^retry payment$/i })).not.toBeInTheDocument()
+  })
+
   it('stops bounded redirect polling with an actionable timeout', async () => {
     vi.useFakeTimers()
     window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&redirect_status=succeeded')
@@ -320,7 +374,8 @@ describe('SubscriptionPage billing recovery CTAs', () => {
 
     expect(screen.getByText(/payment needs attention/i)).toBeInTheDocument()
     expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /retry payment/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^retry payment$/i })).not.toBeInTheDocument()
     expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
   })
 

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -142,7 +142,29 @@ const REACTIVATION_PLANS = [
 
 const PAYMENT_CONFIRMATION_POLL_DELAYS_MS = [2000, 5000, 10000] as const
 
+interface StripePaymentReturn {
+  hasStripeParameters: boolean
+  paymentIntent: string | null
+  redirectStatus: string | null
+}
+
+function getStripePaymentReturn(search: string): StripePaymentReturn {
+  const params = new URLSearchParams(search)
+  return {
+    hasStripeParameters: params.has('payment_intent')
+      || params.has('payment_intent_client_secret')
+      || params.has('redirect_status'),
+    paymentIntent: params.get('payment_intent'),
+    redirectStatus: params.get('redirect_status'),
+  }
+}
+
 export default function SubscriptionPage() {
+  const [stripePaymentReturn] = useState<StripePaymentReturn>(() => (
+    typeof window === 'undefined'
+      ? { hasStripeParameters: false, paymentIntent: null, redirectStatus: null }
+      : getStripePaymentReturn(window.location.search)
+  ))
   const [data, setData] = useState<SubscriptionData | null>(null)
   const [loading, setLoading] = useState(true)
   const [bannerDismissed, setBannerDismissed] = useState(false)
@@ -178,22 +200,20 @@ export default function SubscriptionPage() {
   }, [])
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    if (params.get('payment_intent') && params.get('redirect_status')) return
+    if (stripePaymentReturn.paymentIntent && stripePaymentReturn.redirectStatus) return
     void fetchSubscription()
-  }, [fetchSubscription])
+  }, [fetchSubscription, stripePaymentReturn])
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const paymentIntent = params.get('payment_intent')
-    const redirectStatus = params.get('redirect_status')
+    const { hasStripeParameters, paymentIntent, redirectStatus } = stripePaymentReturn
+    if (hasStripeParameters) {
+      const cleanedUrl = new URL(window.location.href)
+      cleanedUrl.searchParams.delete('payment_intent')
+      cleanedUrl.searchParams.delete('payment_intent_client_secret')
+      cleanedUrl.searchParams.delete('redirect_status')
+      window.history.replaceState({}, '', `${cleanedUrl.pathname}${cleanedUrl.search}${cleanedUrl.hash}`)
+    }
     if (!paymentIntent || !redirectStatus) return
-
-    const cleanedUrl = new URL(window.location.href)
-    cleanedUrl.searchParams.delete('payment_intent')
-    cleanedUrl.searchParams.delete('payment_intent_client_secret')
-    cleanedUrl.searchParams.delete('redirect_status')
-    window.history.replaceState({}, '', `${cleanedUrl.pathname}${cleanedUrl.search}${cleanedUrl.hash}`)
 
     if (redirectStatus !== 'succeeded' && redirectStatus !== 'processing') {
       setPaymentConfirmationPending(false)
@@ -212,7 +232,13 @@ export default function SubscriptionPage() {
     const pollSubscription = async (finalAttempt = false) => {
       const nextData = await fetchSubscription()
       if (cancelled) return
-      if (nextData?.status === 'active' || nextData?.status === 'trialing') {
+      const capabilities = nextData ? getCapabilities(nextData) : null
+      const paymentConfirmed = nextData?.status === 'active'
+        || (nextData?.status === 'trialing'
+          && capabilities?.canSetupCard === false
+          && capabilities.needsPaymentMethod === false
+          && capabilities.canRetryPayment === false)
+      if (paymentConfirmed) {
         settled = true
         setPaymentConfirmationPending(false)
         setPaymentReturnFailure(null)
@@ -235,14 +261,21 @@ export default function SubscriptionPage() {
       cancelled = true
       timers.forEach(timer => window.clearTimeout(timer))
     }
-  }, [fetchSubscription])
+  }, [fetchSubscription, stripePaymentReturn])
 
   useEffect(() => {
-    if (data?.status === 'active' || data?.status === 'trialing') {
+    if (!data) return
+    const capabilities = getCapabilities(data)
+    const paymentConfirmed = data.status === 'active'
+      || (data.status === 'trialing'
+        && !capabilities.canSetupCard
+        && !capabilities.needsPaymentMethod
+        && !capabilities.canRetryPayment)
+    if (paymentConfirmed) {
       setPaymentConfirmationPending(false)
       setPaymentReturnFailure(null)
     }
-  }, [data?.status])
+  }, [data])
 
   async function handleCancel() {
     setCancelling(true)
@@ -297,7 +330,23 @@ export default function SubscriptionPage() {
   if (!data) {
     return (
       <div className="space-y-6">
-        <p className="text-sm text-[rgb(var(--muted))]">Unable to load subscription details.</p>
+        {paymentConfirmationPending && (
+          <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
+            <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">Confirming your payment.</p>
+            <p className="mt-1 text-xs text-[rgb(var(--muted))]">This usually takes a few seconds. We will update this page automatically.</p>
+          </div>
+        )}
+        {paymentReturnFailure ? (
+          <div className="space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+            <div>
+              <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment needs attention.</p>
+              <p className="mt-1 text-xs text-[rgb(var(--muted))]">{paymentReturnFailure}</p>
+            </div>
+            <Button size="sm" onClick={() => { void fetchSubscription() }}>Retry payment status</Button>
+          </div>
+        ) : !paymentConfirmationPending && (
+          <p className="text-sm text-[rgb(var(--muted))]">Unable to load subscription details.</p>
+        )}
       </div>
     )
   }

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { Crown, Loader2, Check } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
 import { BILLING_API_URL } from '@/app/lib/config'
@@ -180,24 +180,29 @@ export default function SubscriptionPage() {
   const [billingInterval, setBillingInterval] = useState<'monthly' | 'annual'>('monthly')
   const [paymentConfirmationPending, setPaymentConfirmationPending] = useState(false)
   const [paymentReturnFailure, setPaymentReturnFailure] = useState<string | null>(null)
+  const [paymentConfirmationAttempt, setPaymentConfirmationAttempt] = useState(0)
+  const stripeReturnHandledRef = useRef(false)
 
-  const fetchSubscription = useCallback(async () => {
+  const requestSubscription = useCallback(async (): Promise<SubscriptionData | null> => {
     try {
       const res = await fetch(`${BILLING_API_URL}/subscription`, {
         credentials: 'include',
       })
       if (res.ok) {
-        const nextData = await res.json() as SubscriptionData
-        setData(nextData)
-        return nextData
+        return await res.json() as SubscriptionData
       }
     } catch {
       // API may not be running in dev
-    } finally {
-      setLoading(false)
     }
     return null
   }, [])
+
+  const fetchSubscription = useCallback(async () => {
+    const nextData = await requestSubscription()
+    if (nextData) setData(nextData)
+    setLoading(false)
+    return nextData
+  }, [requestSubscription])
 
   useEffect(() => {
     if (stripePaymentReturn.paymentIntent && stripePaymentReturn.redirectStatus) return
@@ -214,6 +219,8 @@ export default function SubscriptionPage() {
       window.history.replaceState({}, '', `${cleanedUrl.pathname}${cleanedUrl.search}${cleanedUrl.hash}`)
     }
     if (!paymentIntent || !redirectStatus) return
+    if (stripeReturnHandledRef.current) return
+    stripeReturnHandledRef.current = true
 
     if (redirectStatus !== 'succeeded' && redirectStatus !== 'processing') {
       setPaymentConfirmationPending(false)
@@ -222,16 +229,29 @@ export default function SubscriptionPage() {
       return
     }
 
-    let cancelled = false
-    let settled = false
-    const timers: number[] = []
     setPaymentConfirmationPending(true)
     setPaymentReturnFailure(null)
     setShowPlanSelection(false)
+    setPaymentConfirmationAttempt(attempt => attempt + 1)
+  }, [fetchSubscription, stripePaymentReturn])
+
+  useEffect(() => {
+    if (paymentConfirmationAttempt === 0) return
+
+    let cancelled = false
+    let settled = false
+    let requestSequence = 0
+    let latestCommittedSequence = 0
+    const timers: number[] = []
+    const clearTimers = () => timers.forEach(timer => window.clearTimeout(timer))
 
     const pollSubscription = async (finalAttempt = false) => {
-      const nextData = await fetchSubscription()
-      if (cancelled) return
+      const sequence = ++requestSequence
+      const nextData = await requestSubscription()
+      if (cancelled || settled || sequence < latestCommittedSequence) return
+      latestCommittedSequence = sequence
+      setLoading(false)
+      if (nextData) setData(nextData)
       const capabilities = nextData ? getCapabilities(nextData) : null
       const paymentConfirmed = nextData?.status === 'active'
         || (nextData?.status === 'trialing'
@@ -240,6 +260,7 @@ export default function SubscriptionPage() {
           && capabilities.canRetryPayment === false)
       if (paymentConfirmed) {
         settled = true
+        clearTimers()
         setPaymentConfirmationPending(false)
         setPaymentReturnFailure(null)
         return
@@ -259,9 +280,9 @@ export default function SubscriptionPage() {
 
     return () => {
       cancelled = true
-      timers.forEach(timer => window.clearTimeout(timer))
+      clearTimers()
     }
-  }, [fetchSubscription, stripePaymentReturn])
+  }, [paymentConfirmationAttempt, requestSubscription])
 
   useEffect(() => {
     if (!data) return
@@ -276,6 +297,13 @@ export default function SubscriptionPage() {
       setPaymentReturnFailure(null)
     }
   }, [data])
+
+  function startPaymentConfirmation() {
+    setPaymentConfirmationPending(true)
+    setPaymentReturnFailure(null)
+    setShowPlanSelection(false)
+    setPaymentConfirmationAttempt(attempt => attempt + 1)
+  }
 
   async function handleCancel() {
     setCancelling(true)
@@ -342,7 +370,7 @@ export default function SubscriptionPage() {
               <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment needs attention.</p>
               <p className="mt-1 text-xs text-[rgb(var(--muted))]">{paymentReturnFailure}</p>
             </div>
-            <Button size="sm" onClick={() => { void fetchSubscription() }}>Retry payment status</Button>
+            <Button size="sm" onClick={startPaymentConfirmation}>Retry payment status</Button>
           </div>
         ) : !paymentConfirmationPending && (
           <p className="text-sm text-[rgb(var(--muted))]">Unable to load subscription details.</p>
@@ -366,7 +394,7 @@ export default function SubscriptionPage() {
     && !capabilities.trialExpired
     && !capabilities.canRetryPayment
     && !capabilities.canStartPaidSubscription
-  const canOpenPaidRecovery = !paymentConfirmationPending && (
+  const canOpenPaidRecovery = !paymentConfirmationPending && !paymentReturnFailure && (
     capabilities.canRetryPayment
     || capabilities.canStartPaidSubscription
     || capabilities.canReactivate
@@ -483,7 +511,7 @@ export default function SubscriptionPage() {
       </section>
 
       {capabilities.canSetupCard && data.trial.daysRemaining != null && (
-        <AddCardBanner daysRemaining={data.trial.daysRemaining} onCardAdded={fetchSubscription} />
+        <AddCardBanner daysRemaining={data.trial.daysRemaining} onCardAdded={startPaymentConfirmation} />
       )}
 
       {paymentConfirmationPending && (
@@ -494,9 +522,12 @@ export default function SubscriptionPage() {
       )}
 
       {paymentReturnFailure && (
-        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
-          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment needs attention.</p>
-          <p className="mt-1 text-xs text-[rgb(var(--muted))]">{paymentReturnFailure}</p>
+        <div className="space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+          <div>
+            <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment needs attention.</p>
+            <p className="mt-1 text-xs text-[rgb(var(--muted))]">{paymentReturnFailure}</p>
+          </div>
+          <Button size="sm" onClick={startPaymentConfirmation}>Retry payment status</Button>
         </div>
       )}
 
@@ -536,17 +567,9 @@ export default function SubscriptionPage() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-[rgb(var(--background))]/80 backdrop-blur-sm">
           <div className="mx-4 w-full max-w-md rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-6">
             <PaymentChoicePanel
-              onSuccess={async () => {
-                setPaymentConfirmationPending(true)
-                setShowPlanSelection(false)
-                await fetchSubscription()
-                for (const delayMs of [2000, 5000, 10000]) {
-                  window.setTimeout(() => { void fetchSubscription() }, delayMs)
-                }
-              }}
+              onSuccess={startPaymentConfirmation}
               onCancel={() => setShowPlanSelection(false)}
               title="Continue with silentsuite.io"
-              successPoll={async () => { await fetchSubscription() }}
             />
           </div>
         </div>

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -140,6 +140,8 @@ const REACTIVATION_PLANS = [
   { id: 'standard_annual', name: 'Standard Annual', price: '48', period: '/yr', description: 'Save with annual billing', icon: Crown, badge: 'Best value', earlyOnly: false },
 ] as const
 
+const PAYMENT_CONFIRMATION_POLL_DELAYS_MS = [2000, 5000, 10000] as const
+
 export default function SubscriptionPage() {
   const [data, setData] = useState<SubscriptionData | null>(null)
   const [loading, setLoading] = useState(true)
@@ -155,6 +157,7 @@ export default function SubscriptionPage() {
   const [changePlanToast, setChangePlanToast] = useState<string | null>(null)
   const [billingInterval, setBillingInterval] = useState<'monthly' | 'annual'>('monthly')
   const [paymentConfirmationPending, setPaymentConfirmationPending] = useState(false)
+  const [paymentReturnFailure, setPaymentReturnFailure] = useState<string | null>(null)
 
   const fetchSubscription = useCallback(async () => {
     try {
@@ -162,22 +165,82 @@ export default function SubscriptionPage() {
         credentials: 'include',
       })
       if (res.ok) {
-        setData(await res.json())
+        const nextData = await res.json() as SubscriptionData
+        setData(nextData)
+        return nextData
       }
     } catch {
       // API may not be running in dev
     } finally {
       setLoading(false)
     }
+    return null
   }, [])
 
   useEffect(() => {
-    fetchSubscription()
+    const params = new URLSearchParams(window.location.search)
+    if (params.get('payment_intent') && params.get('redirect_status')) return
+    void fetchSubscription()
+  }, [fetchSubscription])
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const paymentIntent = params.get('payment_intent')
+    const redirectStatus = params.get('redirect_status')
+    if (!paymentIntent || !redirectStatus) return
+
+    const cleanedUrl = new URL(window.location.href)
+    cleanedUrl.searchParams.delete('payment_intent')
+    cleanedUrl.searchParams.delete('payment_intent_client_secret')
+    cleanedUrl.searchParams.delete('redirect_status')
+    window.history.replaceState({}, '', `${cleanedUrl.pathname}${cleanedUrl.search}${cleanedUrl.hash}`)
+
+    if (redirectStatus !== 'succeeded' && redirectStatus !== 'processing') {
+      setPaymentConfirmationPending(false)
+      setPaymentReturnFailure('Stripe could not confirm this payment. You can retry or choose another payment method.')
+      void fetchSubscription()
+      return
+    }
+
+    let cancelled = false
+    let settled = false
+    const timers: number[] = []
+    setPaymentConfirmationPending(true)
+    setPaymentReturnFailure(null)
+    setShowPlanSelection(false)
+
+    const pollSubscription = async (finalAttempt = false) => {
+      const nextData = await fetchSubscription()
+      if (cancelled) return
+      if (nextData?.status === 'active' || nextData?.status === 'trialing') {
+        settled = true
+        setPaymentConfirmationPending(false)
+        setPaymentReturnFailure(null)
+        return
+      }
+      if (finalAttempt && !settled) {
+        setPaymentConfirmationPending(false)
+        setPaymentReturnFailure('Payment confirmation is taking longer than expected. Retry the payment status or choose another payment method.')
+      }
+    }
+
+    void pollSubscription()
+    PAYMENT_CONFIRMATION_POLL_DELAYS_MS.forEach((delayMs, index) => {
+      timers.push(window.setTimeout(() => {
+        if (!settled) void pollSubscription(index === PAYMENT_CONFIRMATION_POLL_DELAYS_MS.length - 1)
+      }, delayMs))
+    })
+
+    return () => {
+      cancelled = true
+      timers.forEach(timer => window.clearTimeout(timer))
+    }
   }, [fetchSubscription])
 
   useEffect(() => {
     if (data?.status === 'active' || data?.status === 'trialing') {
       setPaymentConfirmationPending(false)
+      setPaymentReturnFailure(null)
     }
   }, [data?.status])
 
@@ -381,7 +444,14 @@ export default function SubscriptionPage() {
         </div>
       )}
 
-      {capabilities.canRetryPayment && !paymentConfirmationPending && (
+      {paymentReturnFailure && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment needs attention.</p>
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">{paymentReturnFailure}</p>
+        </div>
+      )}
+
+      {capabilities.canRetryPayment && !paymentConfirmationPending && !paymentReturnFailure && (
         <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
           <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment incomplete. Please try again.</p>
           <p className="mt-1 text-xs text-[rgb(var(--muted))]">Your subscription will activate after payment is completed.</p>
@@ -427,7 +497,7 @@ export default function SubscriptionPage() {
               }}
               onCancel={() => setShowPlanSelection(false)}
               title="Continue with silentsuite.io"
-              successPoll={fetchSubscription}
+              successPoll={async () => { await fetchSubscription() }}
             />
           </div>
         </div>

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -510,7 +510,10 @@ export default function SubscriptionPage() {
         </div>
       </section>
 
-      {capabilities.canSetupCard && data.trial.daysRemaining != null && (
+      {capabilities.canSetupCard
+        && data.trial.daysRemaining != null
+        && !paymentConfirmationPending
+        && !paymentReturnFailure && (
         <AddCardBanner daysRemaining={data.trial.daysRemaining} onCardAdded={startPaymentConfirmation} />
       )}
 


### PR DESCRIPTION
## Summary
- recognize Stripe PaymentIntent returns when the Settings subscription page remounts
- remove Stripe return credentials from the address bar immediately
- poll subscription state with bounded retries and converge to success or an actionable failure
- cover processing-to-active, bounded timeout, and failed redirect paths

## Verification
- web Vitest suite: 49 files, 515 tests passed
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint` (passed with existing unrelated warnings)
- `git diff --check`