### PR TITLE
fix(web): recover terminal payment failures

### DIFF
--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -420,11 +420,15 @@ describe('SubscriptionPage billing recovery CTAs', () => {
   it('offers a manual status retry when every redirect poll fails', async () => {
     vi.useFakeTimers()
     window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&redirect_status=processing')
-    const fetchMock = vi.fn(async () => ({
-      ok: false,
-      status: 503,
-      json: async () => ({}),
-    }))
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://billing.test/subscription/payment-flows/current') {
+        return { ok: true, json: async () => ({ flow: pendingStripeFlow }) }
+      }
+      if (url === 'https://billing.test/subscription/payment-options?interval=monthly') {
+        return { ok: true, json: async () => ({ selectedInterval: 'monthly', options: [] }) }
+      }
+      return { ok: false, status: 503, json: async () => ({}) }
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     render(<SubscriptionPage />)
@@ -456,6 +460,37 @@ describe('SubscriptionPage billing recovery CTAs', () => {
 
     expect(screen.getByText(/payment needs attention/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /review payment options/i })).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /review payment options/i }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText(/card payment in progress/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+  })
+
+  it('opens current-flow recovery after a failed Stripe redirect when subscription data is unavailable', async () => {
+    window.history.replaceState({}, '', '/settings/subscription?payment_intent=pi_123&payment_intent_client_secret=secret_123&redirect_status=failed')
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url === 'https://billing.test/subscription/payment-flows/current') {
+        return { ok: true, json: async () => ({ flow: pendingStripeFlow }) }
+      }
+      if (url === 'https://billing.test/subscription/payment-options?interval=monthly') {
+        return { ok: true, json: async () => ({ selectedInterval: 'monthly', options: [] }) }
+      }
+      return { ok: false, status: 503, json: async () => ({}) }
+    }))
+
+    render(<SubscriptionPage />)
+
+    expect(await screen.findByText(/payment needs attention/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /review payment options/i }))
+    expect(await screen.findByText(/card payment in progress/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+    expect(window.location.search).toBe('')
   })
 
   it('shows an actionable retry path after a failed Stripe redirect', async () => {

--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -60,14 +60,29 @@ const baseSubscription = {
   },
 }
 
-function mockSubscription(subscription: Record<string, unknown>) {
+const pendingStripeFlow = {
+  flowKind: 'stripe_pay_now',
+  provider: 'stripe',
+  status: 'processing',
+  planId: 'early_monthly',
+  billingInterval: 'monthly',
+  amount: '3.60',
+  currency: 'EUR',
+  createdAt: '2026-07-10T00:00:00.000Z',
+  cancellable: true,
+}
+
+function mockSubscription(
+  subscription: Record<string, unknown>,
+  currentFlow: Record<string, unknown> | null = null,
+) {
   const response = { ...baseSubscription, ...subscription }
   vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
     if (url === 'https://billing.test/subscription' && !init?.method) {
       return { ok: true, json: async () => response }
     }
     if (url === 'https://billing.test/subscription/payment-flows/current') {
-      return { ok: true, json: async () => ({ flow: null }) }
+      return { ok: true, json: async () => ({ flow: currentFlow }) }
     }
     if (url === 'https://billing.test/subscription/payment-options?interval=monthly') {
       return { ok: true, json: async () => ({
@@ -362,7 +377,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
         needsPaymentMethod: true,
         canSetupCard: true,
       },
-    })
+    }, pendingStripeFlow)
 
     render(<React.StrictMode><SubscriptionPage /></React.StrictMode>)
     await act(async () => { await Promise.resolve(); await Promise.resolve() })
@@ -377,9 +392,19 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(screen.getByText(/payment needs attention/i)).toBeInTheDocument()
     expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /review payment options/i })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /^retry payment$/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /choose payment/i })).not.toBeInTheDocument()
     expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /review payment options/i }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(screen.getByText(/card payment in progress/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+    expect(screen.queryByText(/taking longer than expected/i)).not.toBeInTheDocument()
   })
 
   it('removes an incomplete Stripe client secret from the URL without suppressing the normal fetch', async () => {
@@ -443,13 +468,17 @@ describe('SubscriptionPage billing recovery CTAs', () => {
         canRetryPayment: true,
         canStartPaidSubscription: true,
       },
-    })
+    }, pendingStripeFlow)
 
     render(<SubscriptionPage />)
 
     expect(await screen.findByText(/payment needs attention/i)).toBeInTheDocument()
     expect(screen.getByText(/Stripe could not confirm this payment/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /retry payment/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /review payment options/i }))
+    expect(await screen.findByText(/card payment in progress/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+    expect(screen.queryByText(/Stripe could not confirm this payment/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
     expect(window.location.search).toBe('')
   })

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -305,6 +305,12 @@ export default function SubscriptionPage() {
     setPaymentConfirmationAttempt(attempt => attempt + 1)
   }
 
+  function openPaymentRecovery() {
+    setPaymentConfirmationPending(false)
+    setPaymentReturnFailure(null)
+    setShowPlanSelection(true)
+  }
+
   async function handleCancel() {
     setCancelling(true)
     try {
@@ -525,12 +531,17 @@ export default function SubscriptionPage() {
       )}
 
       {paymentReturnFailure && (
-        <div className="space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3">
-          <div>
-            <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment needs attention.</p>
-            <p className="mt-1 text-xs text-[rgb(var(--muted))]">{paymentReturnFailure}</p>
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4">
+          <p className="text-sm font-medium text-amber-700 dark:text-amber-300">Payment needs attention</p>
+          <p className="mt-1 text-sm text-[rgb(var(--muted))]">{paymentReturnFailure}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Button size="sm" onClick={startPaymentConfirmation}>
+              Retry payment status
+            </Button>
+            <Button size="sm" variant="outline" onClick={openPaymentRecovery}>
+              Review payment options
+            </Button>
           </div>
-          <Button size="sm" onClick={startPaymentConfirmation}>Retry payment status</Button>
         </div>
       )}
 

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -376,10 +376,23 @@ export default function SubscriptionPage() {
               <p className="text-sm font-medium text-amber-700 dark:text-amber-400">Payment needs attention.</p>
               <p className="mt-1 text-xs text-[rgb(var(--muted))]">{paymentReturnFailure}</p>
             </div>
-            <Button size="sm" onClick={startPaymentConfirmation}>Retry payment status</Button>
+            <div className="flex flex-wrap gap-2">
+              <Button size="sm" onClick={startPaymentConfirmation}>Retry payment status</Button>
+              <Button size="sm" variant="outline" onClick={openPaymentRecovery}>Review payment options</Button>
+            </div>
           </div>
         ) : !paymentConfirmationPending && (
           <p className="text-sm text-[rgb(var(--muted))]">Unable to load subscription details.</p>
+        )}
+        {showPlanSelection && (
+          <section className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-5">
+            <PaymentChoicePanel
+              initialInterval={billingInterval}
+              onSuccess={startPaymentConfirmation}
+              onCancel={() => setShowPlanSelection(false)}
+              title="Review payment options"
+            />
+          </section>
         )}
       </div>
     )

--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -73,7 +73,7 @@ describe('AddCardBanner', () => {
     expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €3.60:/settings/subscription')
   })
 
-  it('does not enable payment creation before the current-flow lookup completes', async () => {
+  it('does not enable card or Bitcoin payment creation before the current-flow lookup completes', async () => {
     let resolveCurrentFlow: ((response: Response) => void) | undefined
     vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input)
@@ -82,6 +82,9 @@ describe('AddCardBanner', () => {
       }
       if (url.includes('/subscription/payment-options?interval=monthly')) {
         return { ok: true, json: async () => monthlyOptions } as Response
+      }
+      if (url.includes('/subscription/payment-options?interval=annual')) {
+        return { ok: true, json: async () => annualOptions } as Response
       }
       return { ok: false, json: async () => ({}) } as Response
     })
@@ -92,12 +95,15 @@ describe('AddCardBanner', () => {
     expect(await screen.findByText('Checking current payment...')).toBeInTheDocument()
     expect(screen.queryByText('Continue to card payment')).not.toBeInTheDocument()
 
+    fireEvent.click(screen.getByText('Annual'))
+    expect(screen.queryByText('Pay annual with Bitcoin')).not.toBeInTheDocument()
+
     await act(async () => {
       resolveCurrentFlow?.({ ok: true, json: async () => ({ flow: null }) } as Response)
       await Promise.resolve()
     })
 
-    expect(await screen.findByText('Continue to card payment')).toBeInTheDocument()
+    expect(await screen.findByText('Pay annual with Bitcoin')).toBeInTheDocument()
   })
 
   it('switches monthly Bitcoin banner to annual and starts annual BTCPay flow', async () => {

--- a/apps/web/app/components/__tests__/AddCardBanner.test.tsx
+++ b/apps/web/app/components/__tests__/AddCardBanner.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import AddCardBanner from '../add-card-banner'
 
 vi.mock('next/dynamic', () => ({
@@ -71,6 +71,33 @@ describe('AddCardBanner', () => {
     expect(screen.getByText('Amount due')).toBeInTheDocument()
     expect(screen.getByText('Powered by Stripe')).toBeInTheDocument()
     expect(screen.getByTestId('stripe-payment-form')).toHaveTextContent('payment:Pay €3.60:/settings/subscription')
+  })
+
+  it('does not enable payment creation before the current-flow lookup completes', async () => {
+    let resolveCurrentFlow: ((response: Response) => void) | undefined
+    vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/subscription/payment-flows/current')) {
+        return new Promise<Response>(resolve => { resolveCurrentFlow = resolve })
+      }
+      if (url.includes('/subscription/payment-options?interval=monthly')) {
+        return { ok: true, json: async () => monthlyOptions } as Response
+      }
+      return { ok: false, json: async () => ({}) } as Response
+    })
+
+    render(<AddCardBanner daysRemaining={3} onCardAdded={vi.fn()} />)
+    fireEvent.click(screen.getByText('Choose payment'))
+
+    expect(await screen.findByText('Checking current payment...')).toBeInTheDocument()
+    expect(screen.queryByText('Continue to card payment')).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveCurrentFlow?.({ ok: true, json: async () => ({ flow: null }) } as Response)
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByText('Continue to card payment')).toBeInTheDocument()
   })
 
   it('switches monthly Bitcoin banner to annual and starts annual BTCPay flow', async () => {

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -431,7 +431,7 @@ export default function PaymentChoicePanel({
         </div>
       )}
 
-      {bitcoinSwitchOption && interval === 'monthly' && (
+      {currentFlowLoaded && bitcoinSwitchOption && interval === 'monthly' && (
         <button
           type="button"
           onClick={() => setInterval('annual')}
@@ -442,7 +442,7 @@ export default function PaymentChoicePanel({
         </button>
       )}
 
-      {interval === 'annual' && btcpayAnnualOption && (
+      {currentFlowLoaded && interval === 'annual' && btcpayAnnualOption && (
         <Button onClick={startBtcpay} disabled={loading !== null} variant="outline" className="w-full">
           {loading === 'btcpay' ? 'Opening Bitcoin checkout...' : 'Pay annual with Bitcoin'}
         </Button>

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -143,6 +143,8 @@ export default function PaymentChoicePanel({
   const [error, setError] = useState<string | null>(null)
   const [options, setOptions] = useState<PaymentOption[]>([])
   const [optionsLoaded, setOptionsLoaded] = useState(false)
+  const [currentFlowLoaded, setCurrentFlowLoaded] = useState(false)
+  const [currentFlowLoadFailed, setCurrentFlowLoadFailed] = useState(false)
 
   async function loadOptionsForInterval(nextInterval: BillingInterval, isCancelled: () => boolean = () => false) {
     setOptionsLoaded(false)
@@ -172,20 +174,32 @@ export default function PaymentChoicePanel({
   const bitcoinSwitchOption = useMemo(() => options.find(option => option.id === 'bitcoin_annual_switch' && option.enabled), [options])
   const planId = stripeOption?.planIds?.[0] ?? (interval === 'monthly' ? 'early_monthly' : 'early_annual')
 
-  async function loadCurrentFlow() {
+  async function loadCurrentFlow(isCancelled: () => boolean = () => false) {
+    if (!isCancelled()) {
+      setCurrentFlowLoaded(false)
+      setCurrentFlowLoadFailed(false)
+    }
     try {
       const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows/current`, { credentials: 'include' })
-      if (!res.ok) return
+      if (!res.ok) throw new Error('Could not verify the current payment flow.')
       const data = await res.json()
       const flow = data.flow ?? null
-      setCurrentFlow(flow)
+      if (!isCancelled()) {
+        setCurrentFlow(flow)
+        setCurrentFlowLoaded(true)
+      }
     } catch {
-      // Payment options still render if the recovery endpoint is temporarily unavailable.
+      if (!isCancelled()) {
+        setCurrentFlowLoadFailed(true)
+        setError('Could not verify whether a payment is already in progress. Retry before starting another payment.')
+      }
     }
   }
 
   useEffect(() => {
-    void loadCurrentFlow()
+    let cancelled = false
+    void loadCurrentFlow(() => cancelled)
+    return () => { cancelled = true }
   }, [])
 
   async function handleFlowInProgress() {
@@ -206,6 +220,7 @@ export default function PaymentChoicePanel({
         throw new Error(data?.detail ?? 'Could not cancel the pending payment flow.')
       }
       setCurrentFlow(null)
+      setCurrentFlowLoaded(true)
       setClientSecret(null)
       setStripePaymentSummary(null)
       setBitcoinSession(null)
@@ -433,7 +448,16 @@ export default function PaymentChoicePanel({
         </Button>
       )}
 
-      {!optionsLoaded ? (
+      {!currentFlowLoaded ? (
+        <Button
+          disabled={!currentFlowLoadFailed || loading !== null}
+          onClick={() => { void loadCurrentFlow() }}
+          variant="outline"
+          className="w-full"
+        >
+          {currentFlowLoadFailed ? 'Retry payment status' : 'Checking current payment...'}
+        </Button>
+      ) : !optionsLoaded ? (
         <Button disabled className="w-full">
           Loading payment options...
         </Button>


### PR DESCRIPTION
## Summary
- add an explicit terminal payment recovery action after failed redirects and confirmation timeouts
- route recovery through the existing current-flow panel so an active flow must be cancelled before another method
- cover failed redirect and timeout recovery without page reload

## Verification
- `pnpm --filter @silentsuite/web test -- app/\(app\)/settings/subscription/__tests__/page.test.tsx` (49 files, 518 tests passed)
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint`
- `git diff --check`