### PR TITLE
fix(web): clear stale cache and gate signup payment recovery

### DIFF
--- a/apps/web/app/(auth)/signup/pending-payment/__tests__/page.test.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/__tests__/page.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import PendingPaymentPage from '../page'
 
 const authState = {
@@ -34,6 +34,7 @@ vi.mock('../components/step-create-paid-account', () => ({
 
 describe('PendingPaymentPage Bitcoin restart', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     vi.clearAllMocks()
     sessionStorage.clear()
     vi.stubGlobal('location', { href: 'https://app.silentsuite.io/signup/pending-payment' })
@@ -44,6 +45,9 @@ describe('PendingPaymentPage Bitcoin restart', () => {
       const url = String(input)
       if (url === 'https://billing.test/subscription/crypto/invoice/latest') {
         return { ok: true, json: async () => ({ status: 'expired' }) } as Response
+      }
+      if (url === 'https://billing.test/subscription/payment-flows/current') {
+        return { ok: true, json: async () => ({ flow: null }) } as Response
       }
       if (url === 'https://billing.test/subscription/payment-flows' && init?.method === 'POST') {
         return {
@@ -79,5 +83,102 @@ describe('PendingPaymentPage Bitcoin restart', () => {
     expect(sessionStorage.getItem('silentsuite-pending-crypto-invoice')).toBe('inv_restart')
     expect(sessionStorage.getItem('silentsuite-pending-crypto-token')).toBe('lookup_restart')
     expect(sessionStorage.getItem('silentsuite-signup-in-progress')).toBe('true')
+  })
+
+  it('fails closed when the current-flow lookup fails and only enables restart after retry succeeds', async () => {
+    let currentFlowAttempts = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === 'https://billing.test/subscription/crypto/invoice/latest') {
+        return { ok: true, json: async () => ({ status: 'expired' }) } as Response
+      }
+      if (url === 'https://billing.test/subscription/payment-flows/current') {
+        currentFlowAttempts += 1
+        if (currentFlowAttempts === 1) return { ok: false, status: 503, json: async () => ({}) } as Response
+        return { ok: true, json: async () => ({ flow: null }) } as Response
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as Response
+    }))
+
+    render(<PendingPaymentPage />)
+
+    expect(await screen.findByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /start new bitcoin invoice/i })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /retry payment status/i }))
+    expect(await screen.findByRole('button', { name: /start new bitcoin invoice/i })).toBeInTheDocument()
+    expect(fetch).not.toHaveBeenCalledWith(
+      'https://billing.test/subscription/payment-flows',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('requires explicit cancellation when an active payment flow exists', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url === 'https://billing.test/subscription/crypto/invoice/latest') {
+        return { ok: true, json: async () => ({ status: 'expired' }) } as Response
+      }
+      if (url === 'https://billing.test/subscription/payment-flows/current') {
+        return { ok: true, json: async () => ({ flow: {
+          flowKind: 'btcpay_annual',
+          provider: 'btcpay',
+          status: 'processing',
+          cancellable: true,
+          checkoutUrl: 'https://btcpay.silentsuite.io/i/inv_existing',
+        } }) } as Response
+      }
+      if (url === 'https://billing.test/subscription/payment-flows/cancel' && init?.method === 'POST') {
+        return { ok: true, json: async () => ({ cancelled: true }) } as Response
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as Response
+    }))
+
+    render(<PendingPaymentPage />)
+
+    expect(await screen.findByText(/payment already in progress/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /continue bitcoin checkout/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /start new bitcoin invoice/i })).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel and start another invoice/i }))
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      'https://billing.test/subscription/payment-flows/cancel',
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
+    ))
+    expect(await screen.findByRole('button', { name: /start new bitcoin invoice/i })).toBeInTheDocument()
+  })
+
+  it('does not offer a new invoice after timeout when the current flow is still active', async () => {
+    vi.useFakeTimers()
+    sessionStorage.setItem('silentsuite-pending-crypto-invoice', 'inv_pending')
+    sessionStorage.setItem('silentsuite-pending-crypto-token', 'lookup_pending')
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url === 'https://billing.test/subscription/crypto/invoice/inv_pending') {
+        return { ok: true, json: async () => ({ status: 'pending', invoiceId: 'inv_pending' }) } as Response
+      }
+      if (url === 'https://billing.test/subscription/payment-flows/current') {
+        return { ok: true, json: async () => ({ flow: {
+          flowKind: 'btcpay_annual',
+          provider: 'btcpay',
+          status: 'processing',
+          cancellable: true,
+          checkoutUrl: 'https://btcpay.silentsuite.io/i/inv_pending',
+        } }) } as Response
+      }
+      return { ok: false, status: 404, json: async () => ({}) } as Response
+    }))
+
+    render(<PendingPaymentPage />)
+
+    await act(async () => {
+      await vi.runAllTimersAsync()
+    })
+
+    expect(screen.getByText(/still waiting for settlement/i)).toBeInTheDocument()
+    expect(screen.getByText(/payment already in progress/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /check again/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /start new bitcoin invoice/i })).not.toBeInTheDocument()
+    vi.useRealTimers()
   })
 })

--- a/apps/web/app/(auth)/signup/pending-payment/page.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import Link from 'next/link'
 import { AlertTriangle, Check, Loader2 } from 'lucide-react'
 import { BILLING_API_URL } from '@/app/lib/config'
@@ -10,6 +10,15 @@ import { StepCreateVault } from '../components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from '../components/step-create-paid-account'
 
 type PaymentState = 'pending' | 'settled' | 'account' | 'vault' | 'expired' | 'timeout' | 'unknown'
+type PaymentFlowCheckState = 'idle' | 'loading' | 'ready' | 'failed'
+
+type CurrentPaymentFlow = {
+  flowKind: 'stripe_pay_now' | 'btcpay_annual'
+  provider: 'stripe' | 'btcpay'
+  status: string
+  cancellable: boolean
+  checkoutUrl?: string | null
+}
 
 const BTCPAY_CHECKOUT_ORIGIN = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ORIGIN ?? 'https://btcpay.silentsuite.io'
 
@@ -38,6 +47,33 @@ export default function PendingPaymentPage() {
   const [pollNonce, setPollNonce] = useState(0)
   const [restarting, setRestarting] = useState(false)
   const [restartError, setRestartError] = useState<string | null>(null)
+  const [currentFlow, setCurrentFlow] = useState<CurrentPaymentFlow | null>(null)
+  const [flowCheckState, setFlowCheckState] = useState<PaymentFlowCheckState>('idle')
+
+  const loadCurrentFlow = useCallback(async (isCancelled: () => boolean = () => false) => {
+    if (!isCancelled()) {
+      setFlowCheckState('loading')
+      setCurrentFlow(null)
+      setRestartError(null)
+    }
+    try {
+      const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows/current`, {
+        credentials: 'include',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      })
+      if (!res.ok) throw new Error('Could not verify the current payment flow.')
+      const data = await res.json()
+      if (!isCancelled()) {
+        setCurrentFlow(data.flow ?? null)
+        setFlowCheckState('ready')
+      }
+    } catch {
+      if (!isCancelled()) {
+        setFlowCheckState('failed')
+        setRestartError('Could not verify whether a payment is already in progress. Retry before starting another invoice.')
+      }
+    }
+  }, [])
 
   useEffect(() => {
     if (state !== 'pending') return
@@ -128,6 +164,18 @@ export default function PendingPaymentPage() {
     }
   }, [pendingSignup?.email, pollNonce, restoreSignupStateFromRedirect, state])
 
+  useEffect(() => {
+    if (state !== 'expired' && state !== 'timeout' && state !== 'unknown') {
+      setCurrentFlow(null)
+      setFlowCheckState('idle')
+      return
+    }
+
+    let cancelled = false
+    void loadCurrentFlow(() => cancelled)
+    return () => { cancelled = true }
+  }, [loadCurrentFlow, state])
+
   function handleVaultComplete() {
     completeSignup()
     if (returnTo) {
@@ -181,6 +229,10 @@ export default function PendingPaymentPage() {
           : 'Crypto payments can take a little time to settle. Your app access stays locked until the BTCPay webhook activates the account.'
 
   async function restartBitcoinCheckout() {
+    if (flowCheckState !== 'ready' || currentFlow) {
+      setRestartError('Check the current payment status before starting another invoice.')
+      return
+    }
     setRestarting(true)
     setRestartError(null)
     try {
@@ -194,6 +246,10 @@ export default function PendingPaymentPage() {
           returnUrl: '/signup/pending-payment',
         }),
       })
+      if (res.status === 409) {
+        await loadCurrentFlow()
+        throw new Error('A payment is already in progress. Review or cancel it before starting another invoice.')
+      }
       if (!res.ok) throw new Error('Could not start a new Bitcoin invoice. Please log in or contact support.')
       const data = await res.json()
       if (!data.checkoutUrl || !data.invoiceId || !data.invoiceLookupToken) {
@@ -211,6 +267,85 @@ export default function PendingPaymentPage() {
       setRestartError(err instanceof Error ? err.message : 'Could not start a new Bitcoin invoice.')
       setRestarting(false)
     }
+  }
+
+  async function cancelCurrentFlow() {
+    setRestarting(true)
+    setRestartError(null)
+    try {
+      const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows/cancel`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      })
+      if (!res.ok) throw new Error('Could not cancel the payment in progress.')
+      clearPendingCryptoPaymentSession()
+      setCurrentFlow(null)
+      setFlowCheckState('ready')
+    } catch (err) {
+      setRestartError(err instanceof Error ? err.message : 'Could not cancel the payment in progress.')
+    } finally {
+      setRestarting(false)
+    }
+  }
+
+  function currentCheckoutUrl(): string | null {
+    if (currentFlow?.provider !== 'btcpay' || !currentFlow.checkoutUrl) return null
+    try {
+      const checkoutUrl = new URL(currentFlow.checkoutUrl)
+      return checkoutUrl.origin === BTCPAY_CHECKOUT_ORIGIN && checkoutUrl.protocol === 'https:'
+        ? checkoutUrl.toString()
+        : null
+    } catch {
+      return null
+    }
+  }
+
+  function renderBitcoinRecoveryAction() {
+    if (flowCheckState === 'idle' || flowCheckState === 'loading') {
+      return (
+        <button type="button" disabled className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium opacity-60">
+          Checking current payment...
+        </button>
+      )
+    }
+    if (flowCheckState === 'failed') {
+      return (
+        <button type="button" onClick={() => { void loadCurrentFlow() }} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100">
+          Retry payment status
+        </button>
+      )
+    }
+    if (currentFlow) {
+      const checkoutUrl = currentCheckoutUrl()
+      return (
+        <div className="space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-left">
+          <div>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Payment already in progress</p>
+            <p className="mt-1 text-xs text-[rgb(var(--muted))]">Continue the existing payment or cancel it before starting another invoice.</p>
+          </div>
+          {checkoutUrl && (
+            <button type="button" onClick={() => { window.location.href = checkoutUrl }} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600">
+              Continue Bitcoin checkout
+            </button>
+          )}
+          {currentFlow.cancellable ? (
+            <button type="button" onClick={cancelCurrentFlow} disabled={restarting} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100 disabled:cursor-not-allowed disabled:opacity-60">
+              {restarting ? 'Cancelling payment...' : 'Cancel and start another invoice'}
+            </button>
+          ) : !checkoutUrl && (
+            <button type="button" onClick={() => { void loadCurrentFlow() }} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100">
+              Check payment status again
+            </button>
+          )}
+        </div>
+      )
+    }
+    return (
+      <button type="button" onClick={restartBitcoinCheckout} disabled={restarting} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600 disabled:cursor-not-allowed disabled:opacity-60">
+        {restarting ? 'Starting new invoice...' : 'Start new Bitcoin invoice'}
+      </button>
+    )
   }
 
   if (state === 'vault') {
@@ -292,14 +427,10 @@ export default function PendingPaymentPage() {
             <button type="button" onClick={() => { setState('pending'); setPollNonce((value) => value + 1) }} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600">
               Check again
             </button>
-            <button type="button" onClick={restartBitcoinCheckout} disabled={restarting} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100 disabled:cursor-not-allowed disabled:opacity-60">
-              {restarting ? 'Starting new invoice...' : 'Start new Bitcoin invoice'}
-            </button>
+            {renderBitcoinRecoveryAction()}
           </>
         ) : state === 'expired' || state === 'unknown' ? (
-          <button type="button" onClick={restartBitcoinCheckout} disabled={restarting} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600 disabled:cursor-not-allowed disabled:opacity-60">
-            {restarting ? 'Starting new invoice...' : 'Start new Bitcoin invoice'}
-          </button>
+          renderBitcoinRecoveryAction()
         ) : (
           <Link href="/login" className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100">
             Go to login

--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -312,6 +312,9 @@ describe('SyncProvider timing instrumentation', () => {
       'cacheGet:calendar',
       'fetchAllItems:calendar',
     ])
+    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('calendar', [])
+    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('tasks', [])
+    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('contacts', [])
   })
 
   it('lets cache hydrate first and then overwrites calendar with server truth', async () => {

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -218,7 +218,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       type: 'tasks' | 'contacts' | 'calendar',
       items: { uid: string; content: string; collectionUid: string }[],
     ) {
-      if (!isLocalCacheEnabled() || items.length === 0) return
+      if (!isLocalCacheEnabled()) return
       const startedAt = nowMs()
       const records: CachedItem[] = items.map((it) => ({
         itemUid: it.uid,


### PR DESCRIPTION
## Summary

Clear authoritative empty-domain results from the encrypted browser cache and make signup Bitcoin recovery verify the current payment flow before permitting a new invoice.

## Surface and sibling-path map

- Web cache-first restore: successful empty calendar, task, or contact loads replace the corresponding cache with an empty set.
- Failed or unknown sync domains: continue preserving existing visible and cached data.
- Settings card and Bitcoin recovery: unchanged shared current-flow gate.
- Signup pending Bitcoin recovery: current-flow lookup must succeed before restart; lookup failure exposes retry only; active flows require explicit cancellation.
- Android, Bridge, and DAV: unaffected.

## Verification

- 49 web test files, 523 tests passed
- Type-check passed
- Lint passed with existing warnings only
- Production web build passed
- `git diff --check` passed

## Promotion context

This PR addresses the final blockers found during the fixed-object review of promotion PR #508. It targets `dev`; PR #508 must be refreshed and re-reviewed after this merges.
