### PR TITLE
fix(bridge): make user-facing URLs scheme-aware

### DIFF
--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -463,7 +463,7 @@ def setup_macos_apple_accounts() -> int:
         print("  1. In Keychain Access, add the certificate to your login keychain.")
         print("     Set Trust > Secure Sockets Layer (SSL) to Always Trust.")
         print("  2. Restart the bridge: silentsuite-bridge")
-        print(f"  3. Open the dashboard: {config.dav_scheme()}://localhost:{config.LISTEN_PORT}/")
+        print(f"  3. Open the dashboard: {config.local_base_url()}/")
         print("  4. System Settings > Internet Accounts > Add Account > Other >")
         print("     CalDAV/CardDAV Account > Advanced:")
         print(f"       - Server Address: localhost (or 127.0.0.1), Port: {config.LISTEN_PORT}")
@@ -490,7 +490,7 @@ def setup_macos_apple_accounts() -> int:
     print()
     print("macOS setup steps (run on the Mac that hosts the bridge):")
     print("  1. Trust this certificate in Keychain with SSL set to Always Trust.")
-    print("  2. Restart the bridge and open https://localhost:37358/.")
+    print("  2. Enable SSL as above, restart the bridge, and open the dashboard URL printed at startup.")
     print("  3. Use Apple Internet Accounts > Advanced with Use SSL checked.")
     return 0
 

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -46,10 +46,8 @@ class AuthenticationError(Exception):
 
 def _auth_error_message(exc):
     error_text = str(exc)
-    if "401" in error_text or "Unauthorized" in error_text:
+    if any(marker in error_text for marker in ("401", "Unauthorized", "404", "Not Found")):
         return "Invalid email or password."
-    if "404" in error_text:
-        return "Account not found."
     return "Authentication failed. Check the server URL and try again."
 
 

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -671,9 +671,9 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
             if not email:
                 self.send_error(404)
                 return
-            bridge_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{email}/"
+            bridge_url = f"{config.local_base_url()}/{email}/"
             if config.is_dashboard_enabled():
-                dashboard_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/"
+                dashboard_url = f"{config.local_base_url()}/"
                 dashboard_bookmark = (
                     '<div class="bookmark-box">&#11088; Bookmark '
                     f'<a href="{html_mod.escape(dashboard_url)}">{html_mod.escape(dashboard_url)}</a> '
@@ -811,7 +811,7 @@ def browser_login(running_bridge=False):
     email = server.authenticated_email
     if email:
         used_server = server.authenticated_server_url
-        base_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{email}/"
+        base_url = f"{config.local_base_url()}/{email}/"
         if running_bridge:
             print(f"\n  Login successful! The bridge is already running.")
         else:
@@ -820,7 +820,7 @@ def browser_login(running_bridge=False):
         print()
         print(f"  Etebase server: {used_server}")
         if config.is_dashboard_enabled():
-            dashboard_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/"
+            dashboard_url = f"{config.local_base_url()}/"
             print(f"  Dashboard will be available at: {dashboard_url}")
         else:
             print("  Dashboard is disabled for remote bridge binds.")

--- a/bridge/src/silentsuite_bridge/auth_cli.py
+++ b/bridge/src/silentsuite_bridge/auth_cli.py
@@ -62,7 +62,7 @@ def manual_login():
     print()
     print("Account saved! Existing accounts were left unchanged.")
     print(f"Etebase server: {config.ETEBASE_SERVER_URL}")
-    print(f"CalDAV/CardDAV URL: http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}/{result.username}/")
+    print(f"CalDAV/CardDAV URL: {config.local_base_url()}/{result.username}/")
     print(f"Username: {result.username}")
     print("Password: (your account password)")
     print()

--- a/bridge/src/silentsuite_bridge/tray.py
+++ b/bridge/src/silentsuite_bridge/tray.py
@@ -23,10 +23,9 @@ import threading
 import webbrowser
 
 try:
-    from PIL import Image, ImageDraw
-
     # pystray may fail to import if no display is available
     import pystray
+    from PIL import Image, ImageDraw
 
     TRAY_AVAILABLE = True
 except (ImportError, Exception):
@@ -45,6 +44,16 @@ COLOR_GREEN = "#4ade80"
 COLOR_YELLOW = "#fbbf24"
 COLOR_RED = "#ef4444"
 COLOR_GRAY = "#666666"
+
+
+def _dashboard_url():
+    """Return the configured local dashboard URL."""
+    return f"{config.local_base_url()}/"
+
+
+def _account_dav_url(email):
+    """Return the configured local DAV URL for one account."""
+    return f"{config.local_base_url()}/{email}/"
 
 
 def _create_icon_image(color, size=64):
@@ -98,7 +107,6 @@ class BridgeTray:
     def _build_menu(self):
         """Build the tray menu."""
         accounts = _get_accounts()
-        base_url = f"http://{config.LISTEN_ADDRESS}:{config.LISTEN_PORT}"
 
         status_text = {
             "connected": "Connected",
@@ -110,17 +118,17 @@ class BridgeTray:
         if accounts:
             account_items = []
             for email in accounts:
-                dav_url = f"{base_url}/{email}/"
+                dav_url = _account_dav_url(email)
                 account_items.append(pystray.MenuItem(
                     email,
                     pystray.Menu(
                         pystray.MenuItem(
                             "Copy CalDAV URL",
-                            lambda url=dav_url: self._copy_to_clipboard(url),
+                            lambda _icon=None, _item=None, url=dav_url: self._copy_to_clipboard(url),
                         ),
                         pystray.MenuItem(
                             "Copy CardDAV URL",
-                            lambda url=dav_url: self._copy_to_clipboard(url),
+                            lambda _icon=None, _item=None, url=dav_url: self._copy_to_clipboard(url),
                         ),
                     ),
                 ))
@@ -145,16 +153,16 @@ class BridgeTray:
             pystray.Menu.SEPARATOR,
             pystray.MenuItem(
                 "Open Dashboard",
-                lambda: webbrowser.open(f"{base_url}/"),
+                lambda _icon=None, _item=None: webbrowser.open(_dashboard_url()),
             ),
             pystray.MenuItem(
                 "Add / Re-authenticate Account",
-                lambda: self._reauthenticate(),
+                lambda _icon=None, _item=None: self._reauthenticate(),
             ),
             pystray.Menu.SEPARATOR,
             pystray.MenuItem(
                 "Quit SilentSuite Bridge",
-                lambda: self.quit(),
+                lambda _icon=None, _item=None: self.quit(),
             ),
         )
 

--- a/bridge/tests/test_auth_browser_csrf.py
+++ b/bridge/tests/test_auth_browser_csrf.py
@@ -92,6 +92,25 @@ def test_auth_post_with_valid_csrf_reaches_login():
     assert login.called
 
 
+def test_auth_post_does_not_distinguish_unknown_account_from_wrong_password():
+    server, thread = _serve_one_auth_request()
+    try:
+        with patch("silentsuite_bridge.auth_browser.Account.login", side_effect=Exception("404 Not Found")) as login:
+            status, payload = _post_auth(server, {
+                "email": "unknown@example.com",
+                "password": "secret",
+                "server_url": "https://server.silentsuite.io",
+                "csrf_token": "expected-token",
+            })
+    finally:
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 401
+    assert payload == {"success": False, "error": "Invalid email or password."}
+    assert login.called
+
+
 def test_auth_success_redirect_does_not_include_email_query():
     server, thread = _serve_one_auth_request()
     etebase = MagicMock()

--- a/bridge/tests/test_auth_browser_csrf.py
+++ b/bridge/tests/test_auth_browser_csrf.py
@@ -9,7 +9,7 @@ import urllib.request
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from silentsuite_bridge.auth_browser import AUTH_PAGE_HTML, AuthCallbackHandler
+from silentsuite_bridge.auth_browser import AUTH_PAGE_HTML, AuthCallbackHandler, browser_login
 
 
 def _post_auth(server, fields):
@@ -149,3 +149,48 @@ def test_success_page_links_root_dashboard():
     assert status == 200
     assert "http://127.0.0.1:37358/" in body
     assert "/.web/" not in body
+
+
+def test_success_page_uses_https_bridge_urls_when_ssl_enabled():
+    server = http.server.HTTPServer(("127.0.0.1", 0), AuthCallbackHandler)
+    server.csrf_token = "expected-token"
+    server.authenticated_email = "alice@example.com"
+    thread = threading.Thread(target=server.handle_request)
+    thread.start()
+    try:
+        with patch("silentsuite_bridge.auth_browser.config.SSL_ENABLED", True):
+            status, body = _get_auth_path(server, "/success")
+    finally:
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert status == 200
+    assert "https://127.0.0.1:37358/" in body
+    assert "https://127.0.0.1:37358/alice@example.com/" in body
+    assert "http://127.0.0.1:37358/" not in body
+
+
+def test_browser_login_completion_prints_https_bridge_urls(capsys):
+    server = MagicMock()
+    event = MagicMock()
+
+    def complete_auth(*_args, **_kwargs):
+        server.authenticated_email = "alice@example.com"
+        server.authenticated_server_url = "https://server.silentsuite.io"
+        return True
+
+    event.wait.side_effect = complete_auth
+    with (
+        patch("silentsuite_bridge.auth_browser.config.ensure_data_dir"),
+        patch("silentsuite_bridge.auth_browser.config.SSL_ENABLED", True),
+        patch("silentsuite_bridge.auth_browser.http.server.HTTPServer", return_value=server),
+        patch("silentsuite_bridge.auth_browser.threading.Event", return_value=event),
+        patch("silentsuite_bridge.auth_browser.threading.Thread"),
+        patch("silentsuite_bridge.auth_browser.webbrowser.open"),
+        patch("silentsuite_bridge.auth_browser._find_free_port", return_value=43999),
+    ):
+        assert browser_login(running_bridge=True) == "alice@example.com"
+
+    output = capsys.readouterr().out
+    assert "Dashboard will be available at: https://127.0.0.1:37358/" in output
+    assert "CalDAV/CardDAV URL for your apps: https://127.0.0.1:37358/alice@example.com/" in output

--- a/bridge/tests/test_auth_cli.py
+++ b/bridge/tests/test_auth_cli.py
@@ -1,0 +1,28 @@
+"""Tests for scheme-aware manual bridge login output."""
+
+from types import SimpleNamespace
+
+from silentsuite_bridge import auth_cli, config
+
+
+def test_manual_login_prints_https_ipv6_dav_url(monkeypatch, capsys):
+    etebase = SimpleNamespace(save=lambda _unused: "stored-session")
+    monkeypatch.setattr(config, "ensure_data_dir", lambda: None)
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "::1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    monkeypatch.setattr("builtins.input", lambda _prompt: "alice@example.com")
+    monkeypatch.setattr(auth_cli.getpass, "getpass", lambda _prompt: "secret")
+    monkeypatch.setattr(auth_cli, "Client", lambda *_args: object())
+    monkeypatch.setattr(auth_cli.Account, "login", lambda *_args: etebase)
+    monkeypatch.setattr(
+        auth_cli,
+        "store_authenticated_account",
+        lambda *_args: SimpleNamespace(username="alice@example.com"),
+    )
+
+    auth_cli.manual_login()
+
+    output = capsys.readouterr().out
+    assert "CalDAV/CardDAV URL: https://[::1]:37358/alice@example.com/" in output
+    assert "http://::1" not in output

--- a/bridge/tests/test_main_accounts.py
+++ b/bridge/tests/test_main_accounts.py
@@ -131,6 +131,7 @@ def test_setup_macos_apple_accounts_success_non_darwin(tmp_path, monkeypatch, ca
     assert "Use SSL" in out
     assert "Keychain" in out or "Always Trust" in out
     assert "restart" in out.lower() or "Restart" in out
+    assert "https://localhost:37358/" not in out
     # Non-Darwin must not silently persist sslEnabled=true.
     assert config.SSL_ENABLED is False
     assert not settings_path.exists()
@@ -157,7 +158,7 @@ def test_setup_macos_apple_accounts_failure_exits_nonzero(monkeypatch, capsys):
     assert "Traceback" not in out
 
 
-def test_setup_macos_apple_accounts_persists_ssl_settings_on_darwin(tmp_path, monkeypatch):
+def test_setup_macos_apple_accounts_persists_ssl_settings_on_darwin(tmp_path, monkeypatch, capsys):
     cert_path = str(tmp_path / "cert.pem")
     key_path = str(tmp_path / "key.pem")
     settings_path = tmp_path / "settings.json"
@@ -165,7 +166,8 @@ def test_setup_macos_apple_accounts_persists_ssl_settings_on_darwin(tmp_path, mo
     monkeypatch.setattr(config, "SETTINGS_FILE", str(settings_path))
     monkeypatch.setattr(config, "SSL_CERT_FILE", cert_path)
     monkeypatch.setattr(config, "SSL_KEY_FILE", key_path)
-    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "::1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 45454)
     monkeypatch.setattr(config, "SSL_ENABLED", False)
     monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(main_module, "_open_certificate_for_trust", lambda c: True)
@@ -180,8 +182,10 @@ def test_setup_macos_apple_accounts_persists_ssl_settings_on_darwin(tmp_path, mo
 
     code = main_module.setup_macos_apple_accounts()
 
+    out = capsys.readouterr().out
     settings = config.get_settings()
     assert code == 0
+    assert "Open the dashboard: https://[::1]:45454/" in out
     assert config.SSL_ENABLED is True
     assert settings["sslEnabled"] is True
     assert settings["sslCertFile"] == cert_path

--- a/bridge/tests/test_tray_urls.py
+++ b/bridge/tests/test_tray_urls.py
@@ -1,0 +1,67 @@
+"""Tests for scheme-aware DAV and dashboard URLs in tray actions."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from silentsuite_bridge import config, tray
+
+
+class FakeMenu:
+    SEPARATOR = object()
+
+    def __init__(self, *items):
+        self.items = items
+
+
+class FakeMenuItem:
+    def __init__(self, text, action, **kwargs):
+        self.text = text
+        self.action = action
+        self.kwargs = kwargs
+
+
+def _menu_item(menu, text):
+    return next(item for item in menu.items if isinstance(item, FakeMenuItem) and item.text == text)
+
+
+def test_tray_url_helpers_follow_ssl_config(monkeypatch):
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    assert tray._dashboard_url() == "http://127.0.0.1:37358/"
+    assert tray._account_dav_url("alice@example.com") == "http://127.0.0.1:37358/alice@example.com/"
+
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+    assert tray._dashboard_url() == "https://127.0.0.1:37358/"
+    assert tray._account_dav_url("alice@example.com") == "https://127.0.0.1:37358/alice@example.com/"
+
+
+def test_https_tray_actions_copy_and_open_configured_urls(monkeypatch):
+    monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
+    monkeypatch.setattr(tray, "pystray", SimpleNamespace(Menu=FakeMenu, MenuItem=FakeMenuItem))
+    monkeypatch.setattr(tray, "_get_accounts", lambda: ["alice@example.com"])
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+
+    manager = tray.BridgeTray()
+    manager._copy_to_clipboard = MagicMock()
+    open_browser = MagicMock()
+    monkeypatch.setattr(tray.webbrowser, "open", open_browser)
+
+    menu = manager._build_menu()
+    account_item = _menu_item(menu, "alice@example.com")
+    copy_caldav = _menu_item(account_item.action, "Copy CalDAV URL")
+    copy_carddav = _menu_item(account_item.action, "Copy CardDAV URL")
+    open_dashboard = _menu_item(menu, "Open Dashboard")
+
+    copy_caldav.action("icon", "item")
+    copy_carddav.action("icon", "item")
+    open_dashboard.action("icon", "item")
+
+    expected_dav = "https://127.0.0.1:37358/alice@example.com/"
+    assert manager._copy_to_clipboard.call_args_list == [
+        ((expected_dav,), {}),
+        ((expected_dav,), {}),
+    ]
+    open_browser.assert_called_once_with("https://127.0.0.1:37358/")


### PR DESCRIPTION
## Summary

Make every user-facing bridge-listener URL follow the configured HTTP/HTTPS scheme. This fixes macOS Apple Accounts setup after local SSL is enabled.

## Surface and sibling-path map

- Browser-auth callback server: remains intentional HTTP on its separate random loopback port.
- Browser-auth success page: DAV link, dashboard bookmark, and redirect use the configured bridge base URL.
- Browser-login CLI completion: DAV and dashboard URLs use the configured bridge base URL.
- Tray: CalDAV/CardDAV copy actions and Open Dashboard use the configured bridge base URL.
- Dashboard/startup/docs: already scheme-aware and unchanged.
- Remote-bind fail-closed behavior: unchanged.

## Verification

- 11 targeted browser-auth/tray tests passed.
- Full bridge suite: 239 passed; 2 unrelated local-environment failures from incompatible shared `playhouse.sqlite_ext` and Radicale versions. CI is authoritative for the full suite.
- Touched test/tray Ruff checks passed.
- Changed auth-browser URL lines have no Ruff findings.
- Python compileall and `git diff --check` passed.

## Promotion context

Addresses the remaining blocker from the fixed-object review of promotion PR #508. PR #508 must be regenerated and re-reviewed after this merges.
