### PR TITLE
fix(web): isolate account-scoped in-memory data

### DIFF
--- a/apps/web/app/lib/account-epoch.ts
+++ b/apps/web/app/lib/account-epoch.ts
@@ -1,0 +1,25 @@
+let accountEpoch = 0
+
+export function getAccountEpoch(): number {
+  return accountEpoch
+}
+
+export function bumpAccountEpoch(): number {
+  accountEpoch += 1
+  return accountEpoch
+}
+
+export function isCurrentAccountEpoch(epoch: number): boolean {
+  return epoch === accountEpoch
+}
+
+export class AccountBoundaryChangedError extends Error {
+  constructor() {
+    super('Account boundary changed while account-scoped work was in flight')
+    this.name = 'AccountBoundaryChangedError'
+  }
+}
+
+export function assertCurrentAccountEpoch(epoch: number): void {
+  if (!isCurrentAccountEpoch(epoch)) throw new AccountBoundaryChangedError()
+}

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -29,6 +29,7 @@ import {
   type SyncTimingPhase,
   type SyncTimingFields,
 } from '@/app/lib/sync-timing'
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 
 function reportSyncError(operation: string, err: unknown) {
   Sentry.captureException(createSafeOperationalError('sync-provider', operation), {
@@ -88,6 +89,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (didInit.current) return
     didInit.current = true
+    const accountEpoch = getAccountEpoch()
 
     let unsubChange: (() => void) | null = null
     let unsubStatus: (() => void) | null = null
@@ -114,6 +116,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             updatePartialLoadFlag()
           },
         })
+        assertCurrentAccountEpoch(accountEpoch)
         safeLogSyncTiming('etebase-initialize', etebaseStartedAt)
 
         // Wire SyncEngine change events
@@ -123,7 +126,10 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
 
         // Supporting metadata only: no passive writes and no visible restore blocking.
         void useLabelSuggestionsStore.getState().initialize()
-          .then(() => useLabelSuggestionsStore.getState().seedFromVisibleItems())
+          .then(() => {
+            assertCurrentAccountEpoch(accountEpoch)
+            useLabelSuggestionsStore.getState().seedFromVisibleItems()
+          })
           .catch((err) => logger.warn('[sync-provider] Label suggestions initialization failed', getSafeErrorDetails(err)))
         void usePreferencesSyncStore.getState().initialize()
           .catch((err) => logger.warn('[sync-provider] Preferences sync initialization failed', getSafeErrorDetails(err)))
@@ -137,6 +143,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         setLastSynced(new Date())
         safeLogSyncTiming('initial-sync-complete', initStartedAt)
       } catch (err) {
+        if (err instanceof AccountBoundaryChangedError) return
         safeLogSyncTiming('initial-sync-failed', initStartedAt, { errorCategory: safeTimingErrorCategory('unknown') })
         reportSyncError('init', err)
         setSyncStatus('error')
@@ -163,6 +170,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           cacheGetItemsByType('calendar'),
           import('@silentsuite/core'),
         ])
+        assertCurrentAccountEpoch(accountEpoch)
 
         if (taskItems.length > 0) {
           try {
@@ -209,6 +217,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           calendarItemCount: eventItems.length,
         })
       } catch (err) {
+        if (err instanceof AccountBoundaryChangedError) throw err
         logger.warn('[sync-provider] Cache hydration failed', getSafeErrorDetails(err))
         safeLogSyncTiming('cache-hydrate-failed', startedAt, { status: 'failed', errorCategory: 'cache' })
       }
@@ -253,9 +262,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       const cacheEnabled = isLocalCacheEnabled()
       try {
         const items = await useEtebaseStore.getState().fetchAllItems(type)
+        assertCurrentAccountEpoch(accountEpoch)
         let domainItemCount = 0
         if (useEtebaseStore.getState().domainLoadState[type] === 'loaded') {
           const core = await import('@silentsuite/core')
+          assertCurrentAccountEpoch(accountEpoch)
           if (type === 'tasks') {
             const tasks = items.map((item) => {
               // Use the Etebase item UID only as the local id so updates/deletes
@@ -293,6 +304,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           [countField]: domainItemCount,
         })
       } catch (err) {
+        if (err instanceof AccountBoundaryChangedError) return
         safeLogSyncTiming(TIMING_PHASE_BY_TYPE[type], startedAt, { source: 'server', status: 'failed', errorCategory: 'deserialize' })
         reportSyncError(`load ${type}`, err)
       }

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -7,9 +7,33 @@ vi.stubGlobal('fetch', vi.fn())
 
 // Mock data-cache (used on logout). We use vi.hoisted so the mock fn is
 // declared before vi.mock factory runs (vi.mock is hoisted to the top).
-const { dataCacheClearAll, offlineQueueClearAll } = vi.hoisted(() => {
-  return { dataCacheClearAll: vi.fn(async () => {}), offlineQueueClearAll: vi.fn(async () => {}) }
-})
+const {
+  dataCacheClearAll,
+  offlineQueueClearAll,
+  calendarSetState,
+  taskSetState,
+  contactSetState,
+  calendarListSetState,
+  taskListSetState,
+  contactListSetState,
+  labelSuggestionsReset,
+  labelColorSetState,
+  preferencesReset,
+  preferencesSyncDestroy,
+} = vi.hoisted(() => ({
+  dataCacheClearAll: vi.fn(async () => {}),
+  offlineQueueClearAll: vi.fn(async () => {}),
+  calendarSetState: vi.fn(),
+  taskSetState: vi.fn(),
+  contactSetState: vi.fn(),
+  calendarListSetState: vi.fn(),
+  taskListSetState: vi.fn(),
+  contactListSetState: vi.fn(),
+  labelSuggestionsReset: vi.fn(),
+  labelColorSetState: vi.fn(),
+  preferencesReset: vi.fn(),
+  preferencesSyncDestroy: vi.fn(),
+}))
 vi.mock('@/app/lib/data-cache', () => ({
   clearAll: dataCacheClearAll,
 }))
@@ -50,6 +74,23 @@ vi.mock('@/app/stores/use-etebase-store', () => ({
   },
 }))
 
+vi.mock('@/app/stores/use-calendar-store', () => ({ useCalendarStore: { setState: calendarSetState } }))
+vi.mock('@/app/stores/use-task-store', () => ({ useTaskStore: { setState: taskSetState } }))
+vi.mock('@/app/stores/use-contact-store', () => ({ useContactStore: { setState: contactSetState } }))
+vi.mock('@/app/stores/use-calendar-list-store', () => ({ useCalendarListStore: { setState: calendarListSetState } }))
+vi.mock('@/app/stores/use-task-list-store', () => ({ useTaskListStore: { setState: taskListSetState } }))
+vi.mock('@/app/stores/use-contact-list-store', () => ({ useContactListStore: { setState: contactListSetState } }))
+vi.mock('@/app/stores/use-label-suggestions-store', () => ({
+  useLabelSuggestionsStore: { getState: () => ({ reset: labelSuggestionsReset }) },
+}))
+vi.mock('@/app/stores/use-label-color-store', () => ({ useLabelColorStore: { setState: labelColorSetState } }))
+vi.mock('@/app/stores/use-preferences-store', () => ({
+  usePreferencesStore: { getState: () => ({ resetSyncedPreferences: preferencesReset }) },
+}))
+vi.mock('@/app/stores/use-preferences-sync-store', () => ({
+  usePreferencesSyncStore: { getState: () => ({ destroy: preferencesSyncDestroy }) },
+}))
+
 function resetStore() {
   useAuthStore.setState({
     user: null,
@@ -67,6 +108,16 @@ describe('useAuthStore', () => {
     vi.mocked(fetch).mockReset()
     dataCacheClearAll.mockClear()
     offlineQueueClearAll.mockClear()
+    calendarSetState.mockClear()
+    taskSetState.mockClear()
+    contactSetState.mockClear()
+    calendarListSetState.mockClear()
+    taskListSetState.mockClear()
+    contactListSetState.mockClear()
+    labelSuggestionsReset.mockClear()
+    labelColorSetState.mockClear()
+    preferencesReset.mockClear()
+    preferencesSyncDestroy.mockClear()
     vi.mocked(secureClear).mockClear()
     vi.mocked(secureClear).mockImplementation(async () => { secureStore = {} })
     vi.stubGlobal('BroadcastChannel', undefined)
@@ -659,6 +710,27 @@ describe('useAuthStore', () => {
     expect(state.isAuthenticated).toBe(false)
   })
 
+  it('logout clears decrypted account stores before another account can authenticate', async () => {
+    useAuthStore.setState({
+      user: { id: 'user-1', email: 'test@example.com', planId: 'pro' },
+      isAuthenticated: true,
+    })
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response)
+
+    await useAuthStore.getState().logout()
+
+    expect(calendarSetState).toHaveBeenCalledWith(expect.objectContaining({ events: [] }))
+    expect(taskSetState).toHaveBeenCalledWith(expect.objectContaining({ tasks: [] }))
+    expect(contactSetState).toHaveBeenCalledWith(expect.objectContaining({ contacts: [] }))
+    expect(calendarListSetState).toHaveBeenCalledWith(expect.objectContaining({ defaultCalendarId: 'default' }))
+    expect(taskListSetState).toHaveBeenCalledWith(expect.objectContaining({ activeListId: 'all' }))
+    expect(contactListSetState).toHaveBeenCalledWith(expect.objectContaining({ activeListId: 'all' }))
+    expect(labelSuggestionsReset).toHaveBeenCalledTimes(1)
+    expect(labelColorSetState).toHaveBeenCalledWith({ colors: {} })
+    expect(preferencesReset).toHaveBeenCalled()
+    expect(preferencesSyncDestroy).toHaveBeenCalled()
+  })
+
   it('logout wipes the local data cache', async () => {
     useAuthStore.setState({
       user: { id: 'user-1', email: 'test@example.com', planId: 'pro' },
@@ -1043,6 +1115,42 @@ describe('useAuthStore', () => {
   // tab focus while the user is unverified. A transient billing 5xx or a
   // network blip used to null the session, silently logging out users who
   // had only alt-tabbed away.
+
+  it('refreshSession clears account-scoped stores before publishing a different hosted user', async () => {
+    useAuthStore.setState({
+      user: { id: 'account-a', email: 'a@example.com', planId: 'pro' },
+      isAuthenticated: true,
+    })
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'account-b', email: 'b@example.com', planId: 'pro', rememberDevice: true }),
+    } as Response)
+
+    await useAuthStore.getState().refreshSession()
+
+    expect(useAuthStore.getState().user?.id).toBe('account-b')
+    expect(calendarSetState).toHaveBeenCalledWith(expect.objectContaining({ events: [] }))
+    expect(labelSuggestionsReset).toHaveBeenCalledTimes(1)
+    expect(preferencesReset).toHaveBeenCalledTimes(1)
+  })
+
+  it('refreshSession hides protected data before invalid-session deletion completes', async () => {
+    let resolveDelete!: (response: Response) => void
+    const pendingDelete = new Promise<Response>((resolve) => { resolveDelete = resolve })
+    useAuthStore.setState({
+      user: { id: 'account-a', email: 'a@example.com', planId: 'pro' },
+      isAuthenticated: true,
+    })
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({ ok: false, status: 401 } as Response)
+      .mockReturnValueOnce(pendingDelete)
+
+    const refresh = useAuthStore.getState().refreshSession()
+    await vi.waitFor(() => expect(useAuthStore.getState().isAuthenticated).toBe(false))
+    resolveDelete({ ok: true, status: 204 } as Response)
+    await refresh
+  })
 
   describe('refreshSession on transient errors', () => {
     function loggedIn() {

--- a/apps/web/app/stores/__tests__/use-label-suggestions-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-label-suggestions-store.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useLabelSuggestionsStore } from '../use-label-suggestions-store'
+import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 vi.mock('@/app/lib/logger', () => ({
   logger: { warn: vi.fn(), log: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -9,6 +10,20 @@ const etebaseState = vi.hoisted(() => ({
   account: null as any,
   syncEngine: { trackCollection: vi.fn() },
 }))
+const coreState = vi.hoisted(() => ({
+  collections: [] as any[],
+  items: [] as any[],
+  listCollections: vi.fn(async () => [] as any[]),
+}))
+
+vi.mock('@silentsuite/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@silentsuite/core')>()
+  return {
+    ...actual,
+    listCollections: (...args: any[]) => coreState.listCollections(...args),
+    listItems: vi.fn(async () => ({ items: coreState.items, stoken: null, done: true })),
+  }
+})
 
 vi.mock('@/app/stores/use-etebase-store', () => ({
   useEtebaseStore: {
@@ -29,6 +44,10 @@ vi.mock('@/app/stores/use-contact-store', () => ({
 describe('useLabelSuggestionsStore', () => {
   beforeEach(() => {
     etebaseState.account = null
+    coreState.collections = []
+    coreState.items = []
+    coreState.listCollections.mockReset()
+    coreState.listCollections.mockImplementation(async () => coreState.collections)
     etebaseState.syncEngine.trackCollection.mockClear()
     useLabelSuggestionsStore.getState().reset()
   })
@@ -45,6 +64,35 @@ describe('useLabelSuggestionsStore', () => {
 
     expect(useLabelSuggestionsStore.getState().isLoaded).toBe(true)
     expect(useLabelSuggestionsStore.getState().remoteCollection).toBeNull()
+  })
+
+  it('clears prior-account suggestions and remote handles when the current account has no index', async () => {
+    await useLabelSuggestionsStore.getState().recordUsage('calendar', ['Private Project'])
+    useLabelSuggestionsStore.setState({ remoteCollection: { uid: 'old-collection' }, remoteItem: { uid: 'old-item' } })
+    etebaseState.account = { uid: 'new-account' }
+
+    await useLabelSuggestionsStore.getState().initialize()
+
+    expect(useLabelSuggestionsStore.getState().suggestions('', [], 5)).toEqual([])
+    expect(useLabelSuggestionsStore.getState().remoteCollection).toBeNull()
+    expect(useLabelSuggestionsStore.getState().remoteItem).toBeNull()
+  })
+
+  it('does not publish a stale index after the account boundary changes', async () => {
+    let resolveCollections!: (collections: any[]) => void
+    coreState.listCollections.mockImplementationOnce(() => new Promise((resolve) => { resolveCollections = resolve }))
+    etebaseState.account = { uid: 'old-account' }
+
+    const initialization = useLabelSuggestionsStore.getState().initialize()
+    await vi.waitFor(() => expect(coreState.listCollections).toHaveBeenCalled())
+    bumpAccountEpoch()
+    useLabelSuggestionsStore.getState().reset()
+    resolveCollections([{ uid: 'old-collection' }])
+    await initialization
+
+    expect(useLabelSuggestionsStore.getState().suggestions('', [], 5)).toEqual([])
+    expect(useLabelSuggestionsStore.getState().remoteCollection).toBeNull()
+    expect(useLabelSuggestionsStore.getState().isLoaded).toBe(false)
   })
 
   it('records usage locally even when remote persistence is unavailable', async () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -10,6 +10,7 @@ import { clearAll as clearLocalDataCache } from '@/app/lib/data-cache'
 import { clearAll as clearOfflineQueue } from '@/app/lib/offline-queue'
 import { createLoginSessionPersistenceDiagnostics } from '@/app/lib/sync-restore-diagnostics'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 export interface User {
   isAdmin?: boolean
@@ -346,7 +347,79 @@ function readHostedValidationMarker(): HostedValidationMarker | null {
   }
 }
 
+async function resetInMemoryAccountState(reason: 'login' | 'logout' | 'invalid-hosted-auth') {
+  // Invalidate every account-scoped async publisher before clearing snapshots.
+  bumpAccountEpoch()
+  try {
+    const [
+      { useCalendarStore },
+      { useTaskStore },
+      { useContactStore },
+      { useCalendarListStore },
+      { useTaskListStore },
+      { useContactListStore },
+      { useLabelSuggestionsStore },
+      { useLabelColorStore },
+      { usePreferencesStore },
+      { usePreferencesSyncStore },
+      { useEtebaseStore },
+    ] = await Promise.all([
+      import('@/app/stores/use-calendar-store'),
+      import('@/app/stores/use-task-store'),
+      import('@/app/stores/use-contact-store'),
+      import('@/app/stores/use-calendar-list-store'),
+      import('@/app/stores/use-task-list-store'),
+      import('@/app/stores/use-contact-list-store'),
+      import('@/app/stores/use-label-suggestions-store'),
+      import('@/app/stores/use-label-color-store'),
+      import('@/app/stores/use-preferences-store'),
+      import('@/app/stores/use-preferences-sync-store'),
+      import('@/app/stores/use-etebase-store'),
+    ])
+
+    useEtebaseStore.getState().destroy()
+    useCalendarStore.setState({
+      events: [],
+      isLoading: false,
+      syncStatus: 'synced',
+      selectedEventId: null,
+      searchQuery: '',
+    })
+    useTaskStore.setState({ tasks: [], isLoading: false, syncStatus: 'synced' })
+    useContactStore.setState({ contacts: [], isLoading: false, syncStatus: 'synced', searchQuery: '' })
+    useCalendarListStore.setState({
+      calendars: [{ id: 'default', name: 'Personal', color: '#10b981', visible: true }],
+      defaultCalendarId: 'default',
+    })
+    useTaskListStore.setState({
+      lists: [{ id: 'default', name: 'My Tasks', color: '#3b82f6', visible: true }],
+      activeListId: 'all',
+    })
+    useContactListStore.setState({
+      lists: [{ id: 'default', name: 'My Contacts', color: '#8b5cf6', visible: true }],
+      activeListId: 'all',
+    })
+    useLabelSuggestionsStore.getState().reset()
+    useLabelColorStore.setState({ colors: {} })
+    usePreferencesSyncStore.getState().destroy()
+    usePreferencesStore.getState().resetSyncedPreferences()
+  } catch (err) {
+    logger.error(`[auth-store] Failed to reset decrypted account state during ${reason}:`, err)
+    throw err
+  }
+}
+
 async function clearLocalAuthMaterial(reason: 'logout' | 'invalid-hosted-auth') {
+  // Clear decrypted account-scoped state before persistent cleanup. This is
+  // required even when the next account's restore is only partially successful.
+  // Continue clearing persistent credentials if a store module fails to load;
+  // callers keep the protected UI unauthenticated in that failure mode.
+  try {
+    await resetInMemoryAccountState(reason)
+  } catch {
+    // resetInMemoryAccountState already emitted a reason-scoped error.
+  }
+
   try {
     const { useEtebaseStore } = await import('@/app/stores/use-etebase-store')
     useEtebaseStore.getState().destroy()
@@ -380,6 +453,10 @@ async function clearLocalAuthMaterial(reason: 'logout' | 'invalid-hosted-auth') 
   localStorage.removeItem('silentsuite-tasks')
   localStorage.removeItem('silentsuite-contacts')
   localStorage.removeItem('silentsuite-calendar')
+  localStorage.removeItem('silentsuite-calendar-lists')
+  localStorage.removeItem('silentsuite-task-lists')
+  localStorage.removeItem('silentsuite-contact-lists')
+  localStorage.removeItem('silentsuite-label-colors')
   localStorage.removeItem('etebase_session')
   clearHostedValidationMarkers()
   localStorage.setItem(HOSTED_AUTH_INVALIDATED_KEY, String(Date.now()))
@@ -731,6 +808,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // credentials are verified but before storing a new Etebase session, so
       // failed login attempts do not destroy the current account's offline work
       // and queued work from one account cannot replay into another account.
+      // Reset all decrypted account-scoped stores at the same verified account
+      // boundary so a partial restore cannot retain the prior account's data.
+      await resetInMemoryAccountState('login')
       await clearOfflineQueue()
       if (!isSelfHosted && !isCustomServer(serverUrl)) clearHostedValidationMarkers()
       await secureSet('etebase_session', savedSession)
@@ -821,14 +901,16 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   logout: async () => {
+    // Stop rendering protected account data before any network request or
+    // asynchronous storage cleanup can yield.
+    syncAdminCookie(false)
+    set({ user: null, isAuthenticated: false, error: null, subscriptionStatus: null })
+
     if (!isSelfHosted) {
       await deleteHostedServerSession('invalid-hosted-auth')
     }
 
     await clearLocalAuthMaterial('logout')
-
-    syncAdminCookie(false)
-    set({ user: null, isAuthenticated: false, error: null, subscriptionStatus: null })
   },
 
   refreshSession: async () => {
@@ -858,10 +940,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // user when the verify-banner re-checks on tab focus (see
       // EmailVerificationBanner).
       if (res.status === 401 || res.status === 403) {
-        await deleteHostedServerSession('refresh auth failure')
-        await clearLocalAuthMaterial('invalid-hosted-auth')
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, subscriptionStatus: null })
+        await deleteHostedServerSession('refresh auth failure')
+        await clearLocalAuthMaterial('invalid-hosted-auth')
         return false
       }
       if (!res.ok) {
@@ -873,14 +955,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       if (!rememberDevice) {
         const marker = readHostedValidationMarker()
         if ((!marker || marker.rememberDevice !== false || marker.userId !== data.id) && !(await hasLiveOtherHostedSessionTab(data.id))) {
-          await deleteHostedServerSession('invalid-hosted-auth')
-          await clearLocalAuthMaterial('invalid-hosted-auth')
           syncAdminCookie(false)
           set({ user: null, isAuthenticated: false, subscriptionStatus: null })
+          await deleteHostedServerSession('invalid-hosted-auth')
+          await clearLocalAuthMaterial('invalid-hosted-auth')
           return false
         }
       }
       const isAdmin = data.isAdmin === true
+      if (get().user?.id !== data.id) await resetInMemoryAccountState('login')
       syncAdminCookie(isAdmin, rememberDevice)
       markHostedValidation(data.id, rememberDevice)
       set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, rememberDevice, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true })
@@ -931,34 +1014,35 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         if (!rememberDevice) {
           const marker = readHostedValidationMarker()
           if ((!marker || marker.rememberDevice !== false || marker.userId !== data.id) && !(await hasLiveOtherHostedSessionTab(data.id))) {
-            await deleteHostedServerSession('invalid-hosted-auth')
-            await clearLocalAuthMaterial('invalid-hosted-auth')
             syncAdminCookie(false)
             set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
+            await deleteHostedServerSession('invalid-hosted-auth')
+            await clearLocalAuthMaterial('invalid-hosted-auth')
             return
           }
         }
         const isAdmin = data.isAdmin === true
+        if (get().user?.id !== data.id) await resetInMemoryAccountState('login')
         syncAdminCookie(isAdmin, rememberDevice)
         markHostedValidation(data.id, rememberDevice)
         set({ user: { id: data.id, email: data.email ?? '', planId: data.planId ?? 'free', isAdmin, emailVerified: data.emailVerified ?? false, rememberDevice, onboardedAt: data.onboardedAt ?? null }, isAuthenticated: true, isLoading: false })
       } else if (res.status === 401 || res.status === 403) {
-        await deleteHostedServerSession('restore auth failure')
-        await clearLocalAuthMaterial('invalid-hosted-auth')
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
+        await deleteHostedServerSession('restore auth failure')
+        await clearLocalAuthMaterial('invalid-hosted-auth')
       } else if (res.status === 429) {
+        syncAdminCookie(false)
+        set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
         const hasEtebaseSession = !!(await secureGet('etebase_session'))
         const marker = readHostedValidationMarker()
         const activeTabMarker = hasEtebaseSession ? readOtherActiveHostedSessionTab() : null
         if (hasEtebaseSession && !marker && !activeTabMarker) await clearLocalAuthMaterial('invalid-hosted-auth')
+      } else if (res.status >= 400 && res.status < 500) {
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
-      } else if (res.status >= 400 && res.status < 500) {
         await deleteHostedServerSession('restore auth failure')
         await clearLocalAuthMaterial('invalid-hosted-auth')
-        syncAdminCookie(false)
-        set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
       } else {
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, isLoading: false })
@@ -987,9 +1071,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           subscriptionStatus: 'billing_unavailable',
         })
       } else {
-        if (hasEtebaseSession) await clearLocalAuthMaterial('invalid-hosted-auth')
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, isLoading: false, subscriptionStatus: null })
+        if (hasEtebaseSession) await clearLocalAuthMaterial('invalid-hosted-auth')
       }
     }
   },
@@ -1024,10 +1108,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         fetch(`${BILLING_API_URL}/subscription`, { credentials: 'include' }),
       ])
       if (refreshRes.status === 401 || refreshRes.status === 403 || (refreshRes.status >= 400 && refreshRes.status < 500 && refreshRes.status !== 429)) {
-        await deleteHostedServerSession('retry auth failure')
-        await clearLocalAuthMaterial('invalid-hosted-auth')
         syncAdminCookie(false)
         set({ user: null, isAuthenticated: false, subscriptionStatus: null })
+        await deleteHostedServerSession('retry auth failure')
+        await clearLocalAuthMaterial('invalid-hosted-auth')
         return false
       }
       if (!refreshRes.ok || !subRes.ok) return false
@@ -1037,14 +1121,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       if (!rememberDevice) {
         const marker = readHostedValidationMarker()
         if ((!marker || marker.rememberDevice !== false || marker.userId !== refreshData.id) && !(await hasLiveOtherHostedSessionTab(refreshData.id))) {
-          await deleteHostedServerSession('invalid-hosted-auth')
-          await clearLocalAuthMaterial('invalid-hosted-auth')
           syncAdminCookie(false)
           set({ user: null, isAuthenticated: false, subscriptionStatus: null })
+          await deleteHostedServerSession('invalid-hosted-auth')
+          await clearLocalAuthMaterial('invalid-hosted-auth')
           return false
         }
       }
       const isAdmin = refreshData.isAdmin === true
+      if (get().user?.id !== refreshData.id) await resetInMemoryAccountState('login')
       syncAdminCookie(isAdmin, rememberDevice)
       markHostedValidation(refreshData.id, rememberDevice)
       set({

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -31,6 +31,7 @@ import {
 } from '@/app/lib/data-cache'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { RestoreDiagnosticsRecorder, classifySessionPersistence } from '@/app/lib/sync-restore-diagnostics'
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch, bumpAccountEpoch, getAccountEpoch, isCurrentAccountEpoch } from '@/app/lib/account-epoch'
 
 /**
  * Holds live Etebase SDK objects (Account, Collections, Items, SyncEngine).
@@ -340,12 +341,16 @@ function getCollectionColor(collection: any): string | undefined {
   }
 }
 
-async function hydrateListStores(collections: Record<CollectionTypeKey, any[]>): Promise<void> {
+async function hydrateListStores(
+  collections: Record<CollectionTypeKey, any[]>,
+  accountEpoch = getAccountEpoch(),
+): Promise<void> {
   const [calendarListStore, taskListStore, contactListStore] = await Promise.all([
     import('@/app/stores/use-calendar-list-store'),
     import('@/app/stores/use-task-list-store'),
     import('@/app/stores/use-contact-list-store'),
   ])
+  assertCurrentAccountEpoch(accountEpoch)
 
   calendarListStore.useCalendarListStore.getState().replaceCalendarsFromRemote(
     collections.calendar.map((collection, index) => ({
@@ -646,6 +651,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   syncEngine: null,
 
   initialize: async (options?: InitializeOptions) => {
+    const accountEpoch = getAccountEpoch()
     const serverUrl = getServerUrl()
     const diagnostics = new RestoreDiagnosticsRecorder({
       source: 'restore',
@@ -666,6 +672,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         diagnostics.persist()
         // Authenticated (initialize only runs under ProtectedRoute) but no local
         // vault to unlock -- re-entering credentials re-persists the session.
+        assertCurrentAccountEpoch(accountEpoch)
         set({ restoreBlocked: true })
         logger.debug('[etebase-store] No saved session, restore blocked')
         return
@@ -680,6 +687,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const account = await core.restoreSession(serverUrl, savedSession)
       const accountFingerprint = core.getAccountFingerprint(account)
       diagnostics.completePhase('restoreSession')
+      assertCurrentAccountEpoch(accountEpoch)
       set({ account, accountFingerprint })
       logger.debug('[etebase-store] Session restored')
 
@@ -707,9 +715,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         collectionCount: COLLECTION_DEFINITIONS.reduce((count, [key]) => count + collections[key].length, 0),
       })
 
+      assertCurrentAccountEpoch(accountEpoch)
       set({ collections })
       diagnostics.startPhase('hydrateLists')
-      await hydrateListStores(collections)
+      await hydrateListStores(collections, accountEpoch)
       diagnostics.completePhase('hydrateLists')
 
       // 3. Load items from each visible collection into the cache, one domain
@@ -761,6 +770,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
         // Publish incrementally using the current live maps. Do not overwrite
         // previously painted domains with the snapshot from earlier awaits.
+        assertCurrentAccountEpoch(accountEpoch)
         set((state) => buildInitialDomainPublish(state, key, loadedMaps, domainLoadState, status))
 
         await options?.onDomainLoaded?.({
@@ -770,6 +780,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           pageCount,
           collectionCount: typedCollections.length,
         })
+        assertCurrentAccountEpoch(accountEpoch)
       }
 
       logger.debug(`[etebase-store] Loaded ${totalLoadedItemCount} items into cache`)
@@ -805,11 +816,16 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
       diagnostics.startPhase('syncEngineStart')
       await engine.start(account)
+      if (!isCurrentAccountEpoch(accountEpoch)) {
+        engine.stop()
+        return
+      }
       diagnostics.completePhase('syncEngineStart')
       set({ syncEngine: engine, isInitialized: true })
       diagnostics.persist()
       logger.debug('[etebase-store] SyncEngine started')
     } catch (err) {
+      if (err instanceof AccountBoundaryChangedError) return
       diagnostics.failActivePhase(err)
       diagnostics.persist()
       console.error('[etebase-store] Initialization failed', getSafeErrorDetails(err))
@@ -1717,6 +1733,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   destroy: () => {
+    bumpAccountEpoch()
     const { syncEngine } = get()
     if (syncEngine) {
       syncEngine.stop()

--- a/apps/web/app/stores/use-label-suggestions-store.ts
+++ b/apps/web/app/stores/use-label-suggestions-store.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand'
 import { logger } from '@/app/lib/logger'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useCalendarStore } from '@/app/stores/use-calendar-store'
 import { useTaskStore } from '@/app/stores/use-task-store'
@@ -112,41 +113,57 @@ export const useLabelSuggestionsStore = create<LabelSuggestionsState & LabelSugg
   remoteItem: null,
 
   initialize: async () => {
+    const epoch = getAccountEpoch()
     const { account } = useEtebaseStore.getState()
     if (!account) {
+      assertCurrentAccountEpoch(epoch)
       set({ isLoaded: true })
       return
     }
 
     try {
       const collection = await findExistingCollection(account)
+      assertCurrentAccountEpoch(epoch)
       if (collection) {
         trackCollection(collection)
         const remote = await readRemoteIndex(account, collection)
+        assertCurrentAccountEpoch(epoch)
         set({
-          index: mergeLabelIndexes(get().index, remote.index),
+          // Initialization establishes the current account boundary. Replace
+          // any prior in-memory index instead of merging across accounts.
+          index: remote.index,
           remoteCollection: collection,
           remoteItem: remote.item,
           isLoaded: true,
           lastError: null,
         })
       } else {
-        set({ isLoaded: true, lastError: null })
+        set({
+          index: createEmptyLabelIndex(),
+          remoteCollection: null,
+          remoteItem: null,
+          isLoaded: true,
+          lastError: null,
+        })
       }
     } catch (err) {
+      if (err instanceof AccountBoundaryChangedError) return
       logger.warn('[label-suggestions] Label index initialization failed', getSafeErrorDetails(err))
       set({ isLoaded: true, lastError: 'Label suggestions are temporarily unavailable.' })
     }
   },
 
   refreshFromRemote: async () => {
+    const epoch = getAccountEpoch()
     const { account } = useEtebaseStore.getState()
     if (!account) return
     try {
       const collection = get().remoteCollection ?? await findExistingCollection(account)
+      assertCurrentAccountEpoch(epoch)
       if (!collection) return
       trackCollection(collection)
       const remote = await readRemoteIndex(account, collection)
+      assertCurrentAccountEpoch(epoch)
       set({
         index: mergeLabelIndexes(get().index, remote.index),
         remoteCollection: collection,
@@ -155,6 +172,7 @@ export const useLabelSuggestionsStore = create<LabelSuggestionsState & LabelSugg
         lastError: null,
       })
     } catch (err) {
+      if (err instanceof AccountBoundaryChangedError) return
       logger.warn('[label-suggestions] Label index refresh failed', getSafeErrorDetails(err))
       set({ lastError: 'Label suggestions are temporarily unavailable.' })
     }
@@ -172,6 +190,7 @@ export const useLabelSuggestionsStore = create<LabelSuggestionsState & LabelSugg
   suggestions: (query = '', existingLabels = [], limit = 8) => suggestLabels(get().index, query, existingLabels, limit),
 
   recordUsage: async (source: LabelIndexSource, labels: string[]) => {
+    const epoch = getAccountEpoch()
     if (labels.length === 0) return
     const next = recordLabelsUsed(get().index, source, labels)
     set({ index: next })
@@ -181,18 +200,23 @@ export const useLabelSuggestionsStore = create<LabelSuggestionsState & LabelSugg
 
     try {
       const core = await import('@silentsuite/core')
+      assertCurrentAccountEpoch(epoch)
       const collection = get().remoteCollection ?? await ensureCollection(account)
+      assertCurrentAccountEpoch(epoch)
       trackCollection(collection)
       const content = serializeLabelIndex(next)
       const existingItem = get().remoteItem
       if (existingItem) {
         const updated = await core.updateItem(account, collection, existingItem, content)
+        assertCurrentAccountEpoch(epoch)
         set({ remoteCollection: collection, remoteItem: updated, lastError: null })
       } else {
         const created = await core.createItem(account, collection, content)
+        assertCurrentAccountEpoch(epoch)
         set({ remoteCollection: collection, remoteItem: created, lastError: null })
       }
     } catch (err) {
+      if (err instanceof AccountBoundaryChangedError) return
       logger.warn('[label-suggestions] Label usage record failed', getSafeErrorDetails(err))
       set({ lastError: 'Label suggestions are temporarily unavailable.' })
     }

--- a/apps/web/app/stores/use-preferences-sync-store.ts
+++ b/apps/web/app/stores/use-preferences-sync-store.ts
@@ -10,6 +10,7 @@ import {
 import { logger } from '@/app/lib/logger'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
+import { assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 
 const COLLECTION_TYPE_PREFERENCES = 'silentsuite.preferences'
 const PREFERENCES_COLLECTION_NAME = 'Preferences'
@@ -94,18 +95,22 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
   lastSyncedAt: null,
 
   initialize: async () => {
+    const epoch = getAccountEpoch()
     if (get().isInitialized) return
     if (!useEtebaseStore.getState().account) return
 
     await get().loadFromRemote()
+    assertCurrentAccountEpoch(epoch)
     set({ isInitialized: true })
   },
 
   loadFromRemote: async (itemsFromRefresh) => {
+    const epoch = getAccountEpoch()
     const etebase = useEtebaseStore.getState()
     if (!etebase.account) return
 
     const items = itemsFromRefresh ?? await readRemotePreferenceItems()
+    assertCurrentAccountEpoch(epoch)
     const remoteItems = parseRemoteItems(items)
     const canonical = chooseCanonical(remoteItems)
     const mergedRemote = mergeRemoteItems(remoteItems)
@@ -117,22 +122,27 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
 
     set({ isApplyingRemote: true, remoteItemUid: canonical.uid })
     try {
+      assertCurrentAccountEpoch(epoch)
       usePreferencesStore.getState().applySyncedPreferences(mergedRemote)
     } finally {
+      assertCurrentAccountEpoch(epoch)
       set({ isApplyingRemote: false, lastSyncedAt: new Date() })
     }
   },
 
   pushNow: async () => {
+    const epoch = getAccountEpoch()
     if (get().isApplyingRemote) return false
 
     const etebase = useEtebaseStore.getState()
     if (!etebase.account) return false
 
     const collectionUid = await ensurePreferencesCollection()
+    assertCurrentAccountEpoch(epoch)
     if (!collectionUid) return false
 
     const remoteItems = parseRemoteItems(await readRemotePreferenceItems())
+    assertCurrentAccountEpoch(epoch)
     const mergedRemote = mergeRemoteItems(remoteItems)
     const merged = mergedRemote
       ? mergeSyncedPreferences([mergedRemote, usePreferencesStore.getState().toSyncedPreferences()])
@@ -149,6 +159,7 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
       }
       const beforeUpdateItem = useEtebaseStore.getState().itemCache.get(canonical.uid)
       await etebase.updateItem('preferences', canonical.uid, content)
+      assertCurrentAccountEpoch(epoch)
       const afterUpdateItem = useEtebaseStore.getState().itemCache.get(canonical.uid)
       if (!afterUpdateItem || afterUpdateItem === beforeUpdateItem) {
         return false
@@ -158,6 +169,7 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
     }
 
     const itemUid = await etebase.createItem('preferences', content, PREFERENCES_TEMP_ID, collectionUid)
+    assertCurrentAccountEpoch(epoch)
     if (itemUid) {
       set({ remoteItemUid: itemUid, lastSyncedAt: new Date() })
       return true


### PR DESCRIPTION
## Summary

- clear decrypted calendar, task, contact, collection-list, label suggestion, and label-color state at verified account boundaries
- hide protected account data immediately when logout starts
- replace label-index initialization state instead of merging prior-account metadata
- clear persisted account-scoped list/color keys during local auth cleanup

## Surface & Sibling-Path Map

### Surfaces & journeys
- Hosted and self-hosted login after another account used the same browser context
- Explicit logout before client-side navigation
- Hosted invalid-session cleanup and subsequent login
- Partial sync/restore where one domain fails after account switching
- Label suggestions with and without an existing remote label-index collection

### Sibling paths
- Calendar, Tasks, Contacts decrypted item stores
- Calendar/task/contact collection-list stores
- Label suggestion index and label color metadata
- Encrypted local data cache, offline queue, secure session storage, and legacy localStorage cleanup
- Same-account unlock remains non-destructive

### Contract impact
- A verified new login is an account boundary: prior decrypted account state must be cleared before the new session is persisted/authenticated.
- Logout removes protected rendering immediately and clears all account-scoped in-memory and persisted metadata.
- Label-index initialization replaces current state; it never merges an unverified prior in-memory index.

### Verification tier
- Privacy/account-isolation regression tests
- Full web unit suite, type-check, lint, and production build
- GitHub CI and deployed dev preview before promotion

## Verification

- `pnpm --filter @silentsuite/web test` — 49 files, 525 tests passed
- `pnpm --filter @silentsuite/web type-check` — passed
- `pnpm --filter @silentsuite/web lint` — passed with pre-existing warnings
- `pnpm --filter @silentsuite/web build` — passed; existing Sentry and traced-file warnings remain non-fatal

Promotion blocker follow-up for #508.
