### PR TITLE
release: prepare SilentSuite v0.4.0-beta

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
 
-        versionCode 10
-        versionName "0.3.2-beta"
+        versionCode 11
+        versionName "0.4.0-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/fastlane/metadata/android/en-US/changelogs/11.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/11.txt
@@ -1,0 +1,1 @@
+Updates SilentSuite Android for the 0.4.0-beta release while retaining Google Play 16 KB native library compatibility. This release primarily improves the wider SilentSuite web, sync, payment, and Bridge experience.

--- a/android/fastlane/metadata/android/en-US/google-play-listing-copy.md
+++ b/android/fastlane/metadata/android/en-US/google-play-listing-copy.md
@@ -1,4 +1,4 @@
-# Store listing paste copy for SilentSuite v0.3.0-beta
+# Store listing paste copy for SilentSuite v0.4.0-beta
 
 Use with the final 8 screenshots exported from Figma on 2026-06-27.
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/docs",
-  "version": "0.3.2-beta",
+  "version": "0.4.0-beta",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/apps/web/app/lib/constants.ts
+++ b/apps/web/app/lib/constants.ts
@@ -11,7 +11,7 @@
  * Update this on release so displayed versions don't go stale. Keep in sync
  * with the current release tag.
  */
-export const DISPLAY_VERSION = '0.3.2-beta'
+export const DISPLAY_VERSION = '0.4.0-beta'
 
 // ── Time unit multipliers (ms) ──────────────────────────────────────────
 export const MS_PER_SECOND = 1_000

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/web",
-  "version": "0.3.2-beta",
+  "version": "0.4.0-beta",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",

--- a/bridge/pyproject.toml
+++ b/bridge/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "silentsuite-bridge"
-version = "0.3.2-beta"
+version = "0.4.0-beta"
 description = "SilentSuite Bridge — Local E2EE CalDAV/CardDAV sync daemon"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/bridge/src/silentsuite_bridge/__init__.py
+++ b/bridge/src/silentsuite_bridge/__init__.py
@@ -13,7 +13,7 @@ from importlib import metadata as _metadata
 # Kept in sync with pyproject.toml [project].version. Used only as a
 # last-resort fallback when neither a build stamp nor package metadata is
 # available (e.g. running straight from source without an editable install).
-_FALLBACK_VERSION = "0.3.2-beta"
+_FALLBACK_VERSION = "0.4.0-beta"
 
 
 def _resolve_version() -> str:

--- a/fastlane/metadata/android/en-US/changelogs/11.txt
+++ b/fastlane/metadata/android/en-US/changelogs/11.txt
@@ -1,0 +1,1 @@
+Updates SilentSuite Android for the 0.4.0-beta release while retaining Google Play 16 KB native library compatibility. This release primarily improves the wider SilentSuite web, sync, payment, and Bridge experience.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silentsuite",
-  "version": "0.3.2-beta",
+  "version": "0.4.0-beta",
   "private": true,
   "author": "SilentSuite <info@silentsuite.io>",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/config",
-  "version": "0.3.2-beta",
+  "version": "0.4.0-beta",
   "private": true,
   "files": [
     "typescript",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/core",
-  "version": "0.3.2-beta",
+  "version": "0.4.0-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/ui",
-  "version": "0.3.2-beta",
+  "version": "0.4.0-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/tests/test_release_versions_static.py
+++ b/tests/test_release_versions_static.py
@@ -73,6 +73,9 @@ def test_android_release_metadata_matches_current_release():
     assert f"/silentsuite/v{CURRENT_RELEASE_VERSION}/android/fastlane/metadata/android/en-US/" in zapstore
     assert f"/changelogs/{CURRENT_ANDROID_VERSION_CODE}.txt" in zapstore
 
+    listing_copy = read("android/fastlane/metadata/android/en-US/google-play-listing-copy.md")
+    assert f"SilentSuite v{CURRENT_RELEASE_VERSION}" in listing_copy
+
 
 def test_bridge_release_workflow_validates_frozen_version_without_runtime_env_override():
     workflow = read(".github/workflows/build-bridge.yml")

--- a/tests/test_release_versions_static.py
+++ b/tests/test_release_versions_static.py
@@ -10,7 +10,7 @@ import json
 import re
 
 ROOT = Path(__file__).resolve().parents[1]
-CURRENT_RELEASE_VERSION = "0.3.2-beta"
+CURRENT_RELEASE_VERSION = "0.4.0-beta"
 
 PACKAGE_JSON_PATHS = [
     "package.json",

--- a/tests/test_release_versions_static.py
+++ b/tests/test_release_versions_static.py
@@ -11,6 +11,7 @@ import re
 
 ROOT = Path(__file__).resolve().parents[1]
 CURRENT_RELEASE_VERSION = "0.4.0-beta"
+CURRENT_ANDROID_VERSION_CODE = 11
 
 PACKAGE_JSON_PATHS = [
     "package.json",
@@ -54,6 +55,23 @@ def test_android_version_name_matches_current_release():
     match = re.search(r'versionName\s+"([^"]+)"', gradle)
     assert match, "android/app/build.gradle should declare versionName"
     assert match.group(1) == CURRENT_RELEASE_VERSION
+
+    code_match = re.search(r"versionCode\s+(\d+)", gradle)
+    assert code_match, "android/app/build.gradle should declare versionCode"
+    assert int(code_match.group(1)) == CURRENT_ANDROID_VERSION_CODE
+
+
+def test_android_release_metadata_matches_current_release():
+    for rel in (
+        f"android/fastlane/metadata/android/en-US/changelogs/{CURRENT_ANDROID_VERSION_CODE}.txt",
+        f"fastlane/metadata/android/en-US/changelogs/{CURRENT_ANDROID_VERSION_CODE}.txt",
+    ):
+        assert read(rel).strip(), rel
+
+    zapstore = read("zapstore.yaml")
+    assert f"/releases/download/v{CURRENT_RELEASE_VERSION}/silentsuite-android-v{CURRENT_RELEASE_VERSION}.apk" in zapstore
+    assert f"/silentsuite/v{CURRENT_RELEASE_VERSION}/android/fastlane/metadata/android/en-US/" in zapstore
+    assert f"/changelogs/{CURRENT_ANDROID_VERSION_CODE}.txt" in zapstore
 
 
 def test_bridge_release_workflow_validates_frozen_version_without_runtime_env_override():

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/silent-suite/silentsuite
-release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.3.1-beta/silentsuite-android-v0.3.1-beta.apk
+release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.4.0-beta/silentsuite-android-v0.4.0-beta.apk
 pubkey: npub1zuusadlzq6vehhaqhqpup0mhnx70q9cnf9hs48t79g6qn4wpg2eqsy8m35
 name: SilentSuite
 summary: End-to-end encrypted sync for calendar, contacts, and tasks
@@ -26,14 +26,14 @@ tags:
   - sync
 license: GPL-3.0-only
 website: https://silentsuite.io
-icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/icon.png
+icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/icon.png
 images:
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-calendar-contacts-tasks.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-personal-work.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-android-apps.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-import-export.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/5-open-source.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/6-encryption.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/7-built-for-android.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/8-server-choice.png
-release_notes: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.3.1-beta/android/fastlane/metadata/android/en-US/changelogs/9.txt
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-calendar-contacts-tasks.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-personal-work.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-android-apps.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-import-export.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/5-open-source.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/6-encryption.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/7-built-for-android.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/8-server-choice.png
+release_notes: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.0-beta/android/fastlane/metadata/android/en-US/changelogs/11.txt


### PR DESCRIPTION
## Summary
- promote the reviewed `v0.4.0-beta` version alignment to `main`
- bump Android to version code 11 and align Fastlane, Zapstore, and Google Play release metadata
- align Bridge, web, docs, and package version surfaces before tagging

## Release plan
After merge and green production CI, tag the exact `main` commit as `v0.4.0-beta`. The tag workflows will build and attach signed Android APK/AAB plus Bridge binaries for Windows, macOS, and Linux to one draft release. The release will be published only after assets, signatures, checksums, and embedded versions are verified.