### PR TITLE
fix(bridge): add authenticated Apple DAV discovery

### DIFF
--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -282,6 +282,12 @@ silentsuite-bridge --login
 3. Check the dashboard sync log for errors
 4. If you installed on Windows, also check `%LOCALAPPDATA%\SilentSuite\install.log` and `%LOCALAPPDATA%\SilentSuite\bridge.log`
 
+### `SSL: WRONG_VERSION_NUMBER`
+
+A client connected using HTTP while bridge HTTPS is enabled. Enable SSL in the DAV client and use an `https://` URL. TLS fails before the request reaches the Bridge application, so an HTTPS-only listener cannot redirect that plaintext HTTP request.
+
+If HTTPS is not enabled for this bridge profile, use the `http://` URL shown by the dashboard instead. All clients using one bridge profile must use the listener's configured scheme.
+
 ### The sign-in page and dashboard show different ports
 
 This is expected during browser sign-in. `silentsuite-bridge --login` opens a temporary local sign-in page on a random port such as `65486`. The actual CalDAV/CardDAV bridge always uses `http://127.0.0.1:37358/` unless you changed `SILENTSUITE_LISTEN_PORT`.

--- a/apps/docs/user-guide/apps/macos.md
+++ b/apps/docs/user-guide/apps/macos.md
@@ -82,17 +82,23 @@ Make sure the SilentSuite Bridge is running. Open the dashboard URL shown by the
 3. Set **Trust > Secure Sockets Layer (SSL)** to **Always Trust**.
 4. Restart the bridge and retry Apple Internet Accounts.
 
+### `SSL: WRONG_VERSION_NUMBER`
+
+A client connected using HTTP while bridge HTTPS is enabled. Enable SSL in the DAV client and use an `https://` URL. The bridge has one listener, so it cannot redirect plaintext HTTP after HTTPS is enabled.
+
+An initial anonymous `401 Unauthorized` followed by a successful authenticated request is the normal Basic authentication challenge. An explicit `Invalid password for configured user` message is a separate credentials failure.
+
 ### Calendar shows but events are missing
 
 macOS may limit sync to recent events. Open **Calendar > Settings > Accounts**, select your DAV account, and check the sync range.
 
 ### Apple Internet Accounts still fails with `/principals/`
 
-If HTTPS + Advanced setup still fails, collect a redacted bridge log for support. Include paths such as:
+Current Bridge builds provide an authenticated, non-enumerating `/principals/` discovery container while keeping your account's normal `/your@email.com/` path canonical. If HTTPS + Advanced setup still fails, collect an ordered, redacted bridge trace for support. Include the method, path, Depth value, status, and returned href classes for paths such as:
 
 - `/principals/`
 - `/.well-known/caldav`
 - `/.well-known/carddav`
 - `/your@email.com/`
 
-Do **not** include passwords, session tokens, or full private logs. This evidence determines whether SilentSuite needs a follow-up DAV principal-discovery compatibility shim.
+Do **not** include passwords, Authorization headers, session tokens, contact/calendar contents, or full private logs. Record whether macOS requests `/principals/your@email.com/`; that account-specific alias remains denied unless real Apple protocol evidence proves it is required.

--- a/bridge/src/silentsuite_bridge/radicale/rights.py
+++ b/bridge/src/silentsuite_bridge/radicale/rights.py
@@ -20,11 +20,14 @@ class Rights(OwnerOnlyRights):
     """Owner-only rights with read-only shared collection write gating."""
 
     def authorization(self, user: str, path: str) -> str:
+        sane_path = pathutils.strip_path(path)
+        if user and sane_path == "principals":
+            return "R"
+
         permissions = super().authorization(user, path)
         if "w" not in permissions:
             return permissions
 
-        sane_path = pathutils.strip_path(path)
         parts = sane_path.split("/", maxsplit=2)
         if len(parts) < 2 or not user or parts[0] != user:
             return permissions

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -26,8 +26,6 @@ from radicale.storage import (
 )
 
 from .. import config
-from ..local_cache import Etebase
-from ..local_cache import models as cache_models
 from ..local_cache.models import HrefMapper, ItemEntity
 from ..web import log_sync_event, update_status
 from .etesync_cache import etesync_for_user, forget_etesync_user
@@ -542,6 +540,18 @@ class Collection(BaseCollection):
         return " "
 
 
+class PrincipalDiscoveryCollection(Collection):
+    """Static authenticated DAV discovery container with no account children."""
+
+    @property
+    def is_principal(self) -> bool:
+        return False
+
+    @property
+    def owner(self) -> str:
+        return ""
+
+
 # --- Radicale Storage ---
 
 
@@ -566,14 +576,37 @@ class Storage(BaseStorage):
 
     def discover(self, path, depth="0"):
         """Discover collections and items under the given path."""
+        attributes = _get_attributes_from_path(path)
+        if self.user and attributes == ["principals"]:
+            yield PrincipalDiscoveryCollection(self, "/principals/")
+            return
+
+        if (
+            self.user
+            and self.etesync is None
+            and (not attributes or attributes == [self.user])
+        ):
+            yield Collection(self, path)
+            if depth == "0":
+                return
+            if self.etesync is None:
+                with self._acquire_read_backend():
+                    discovered = self.discover(path, depth)
+                    next(discovered, None)
+                    yield from discovered
+                return
+
+        if self.user and self.etesync is None:
+            with self._acquire_read_backend():
+                yield from self.discover(path, depth)
+            return
+
         if not self._path_belongs_to_user(path):
             logger.warning(
                 "Rejecting DAV path %s authenticated as configured account",
                 path,
             )
             return
-
-        attributes = _get_attributes_from_path(path)
 
         if len(attributes) == 3:
             if path.endswith("/"):
@@ -683,7 +716,7 @@ class Storage(BaseStorage):
         col_mgr.upload(col)
 
         # Cache it locally
-        from ..local_cache import models, db
+        from ..local_cache import db, models
         with db.database_proxy:
             cache_col = models.CollectionEntity(
                 local_user=self.etesync.user,
@@ -712,6 +745,15 @@ class Storage(BaseStorage):
         """Acquire storage lock and sync with Etebase server."""
         if not user:
             yield
+            return
+
+        if mode == "r":
+            with self._etesync_user_lock:
+                self.user = user
+                try:
+                    yield
+                finally:
+                    self.user = None
             return
 
         sync_thread = start_sync_thread(user)
@@ -746,3 +788,24 @@ class Storage(BaseStorage):
 
             self.etesync = None
             self.user = None
+
+    @contextmanager
+    def _acquire_read_backend(self):
+        """Initialize sync/cache lazily after static discovery paths are handled."""
+        user = self.user
+        sync_thread = start_sync_thread(user)
+        logger.info("acquire_lock(r): pre-yield sync")
+        sync_thread.force_sync()
+        try:
+            sync_thread.wait_for_sync(20)
+        except Exception as e:
+            logger.warning(
+                "Sync failed for configured account, continuing with local cache: %s", e
+            )
+
+        with self._etesync_user_lock, etesync_for_user(user) as (etesync, _):
+            self.etesync = etesync
+            try:
+                yield
+            finally:
+                self.etesync = None

--- a/bridge/tests/test_macos_dav_discovery.py
+++ b/bridge/tests/test_macos_dav_discovery.py
@@ -1,0 +1,330 @@
+"""Protocol-level tests for macOS Apple Accounts DAV discovery."""
+
+import base64
+import hashlib
+import io
+import xml.etree.ElementTree as ET
+from unittest.mock import MagicMock
+from urllib.parse import quote
+
+from radicale.app import Application
+
+from silentsuite_bridge import __main__ as bridge_main
+from silentsuite_bridge import config
+from silentsuite_bridge.radicale import storage as bridge_storage
+from silentsuite_bridge.radicale.creds import Credentials
+
+USERNAME = "alice@example.test"
+PASSWORD = "correct-test-password"
+DAV = "{DAV:}"
+CALDAV = "{urn:ietf:params:xml:ns:caldav}"
+CARDDAV = "{urn:ietf:params:xml:ns:carddav}"
+
+APPLE_PRINCIPAL_BODY = b"""<?xml version="1.0" encoding="utf-8"?>
+<d:propfind xmlns:d="DAV:"
+            xmlns:c="urn:ietf:params:xml:ns:caldav"
+            xmlns:cr="urn:ietf:params:xml:ns:carddav">
+  <d:prop>
+    <d:current-user-principal />
+    <d:principal-URL />
+    <c:calendar-home-set />
+    <cr:addressbook-home-set />
+    <d:resourcetype />
+  </d:prop>
+</d:propfind>
+"""
+ALLPROP_BODY = b'<d:propfind xmlns:d="DAV:"><d:allprop /></d:propfind>'
+PROPNAME_BODY = b'<d:propfind xmlns:d="DAV:"><d:propname /></d:propfind>'
+
+
+def _seed_user(credentials_file: str) -> None:
+    credentials = Credentials(filename=credentials_file)
+    credentials.set_etebase(USERNAME, "fake-session", "https://server.test")
+    credentials.set_password_hash(
+        USERNAME,
+        hashlib.sha256(PASSWORD.encode()).hexdigest(),
+    )
+    credentials.save()
+
+
+def _basic_auth(username: str = USERNAME, password: str = PASSWORD) -> str:
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {token}"
+
+
+def _request(
+    app,
+    path: str,
+    *,
+    method: str = "PROPFIND",
+    body: bytes = b"",
+    depth: str | None = "0",
+    auth: str | None = None,
+    scheme: str = "http",
+    user_agent: str | None = "macOS/15.7.7 accountsd/1.0",
+    query: str = "",
+):
+    captured = {}
+
+    def start_response(status, headers):
+        captured["status"] = status
+        captured["headers"] = dict(headers)
+
+    environ = {
+        "REQUEST_METHOD": method,
+        "PATH_INFO": path,
+        "QUERY_STRING": query,
+        "SCRIPT_NAME": "",
+        "HTTP_HOST": "127.0.0.1:37358",
+        "SERVER_NAME": "127.0.0.1",
+        "SERVER_PORT": "37358",
+        "SERVER_PROTOCOL": "HTTP/1.1",
+        "REMOTE_ADDR": "127.0.0.1",
+        "CONTENT_LENGTH": str(len(body)),
+        "CONTENT_TYPE": "application/xml; charset=utf-8",
+        "wsgi.version": (1, 0),
+        "wsgi.url_scheme": scheme,
+        "wsgi.input": io.BytesIO(body),
+        "wsgi.errors": io.StringIO(),
+        "wsgi.multithread": False,
+        "wsgi.multiprocess": False,
+        "wsgi.run_once": False,
+    }
+    if depth is not None:
+        environ["HTTP_DEPTH"] = depth
+    if auth is not None:
+        environ["HTTP_AUTHORIZATION"] = auth
+    if user_agent is not None:
+        environ["HTTP_USER_AGENT"] = user_agent
+
+    response_body = b"".join(app(environ, start_response))
+    return captured["status"], captured["headers"], response_body
+
+
+def _application(tmp_path, monkeypatch):
+    credentials_file = str(tmp_path / "credentials.json")
+    monkeypatch.setattr(config, "CREDS_FILE", credentials_file)
+    monkeypatch.setattr(config, "DATABASE_FILE", str(tmp_path / "bridge.sqlite"))
+    monkeypatch.setattr(config, "SETTINGS_FILE", str(tmp_path / "settings.json"))
+    monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:37358")
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    _seed_user(credentials_file)
+
+    thread = MagicMock()
+    thread.wait_for_sync.return_value = True
+    monkeypatch.setattr(
+        "silentsuite_bridge.radicale.storage.start_sync_thread",
+        lambda _user: thread,
+    )
+    etesync = MagicMock()
+    etesync.list.return_value = []
+    context = MagicMock()
+    context.__enter__.return_value = (etesync, False)
+    context.__exit__.return_value = False
+    monkeypatch.setattr(
+        "silentsuite_bridge.radicale.storage.etesync_for_user",
+        lambda _user: context,
+    )
+    return Application(bridge_main.build_radicale_configuration())
+
+
+def _response_hrefs(body: bytes) -> list[str]:
+    return [element.text or "" for element in ET.fromstring(body).iter(f"{DAV}href")]
+
+
+def _prop_names(body: bytes) -> set[str]:
+    root = ET.fromstring(body)
+    prop = root.find(f"{DAV}response/{DAV}propstat/{DAV}prop")
+    assert prop is not None
+    return {child.tag for child in prop}
+
+
+def test_authenticated_apple_principal_container_points_to_canonical_home(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    start_sync_thread = MagicMock()
+    etesync_for_user = MagicMock()
+    monkeypatch.setattr(bridge_storage, "start_sync_thread", start_sync_thread)
+    monkeypatch.setattr(bridge_storage, "etesync_for_user", etesync_for_user)
+    status, _headers, body = _request(
+        app, "/principals/", body=APPLE_PRINCIPAL_BODY, auth=_basic_auth()
+    )
+
+    assert status == "207 Multi-Status"
+    root = ET.fromstring(body)
+    responses = root.findall(f"{DAV}response")
+    assert len(responses) == 1
+    assert responses[0].findtext(f"{DAV}href") == "/principals/"
+    principal_href = responses[0].find(
+        f"{DAV}propstat/{DAV}prop/{DAV}current-user-principal/{DAV}href"
+    )
+    assert principal_href is not None
+    assert principal_href.text == f"/{quote(USERNAME)}/"
+    resource_type = responses[0].find(f"{DAV}propstat/{DAV}prop/{DAV}resourcetype")
+    assert resource_type is not None
+    assert resource_type.find(f"{DAV}collection") is not None
+    assert resource_type.find(f"{DAV}principal") is None
+    assert responses[0].find(f"{DAV}propstat/{DAV}prop/{DAV}principal-URL/{DAV}href") is None
+    assert responses[0].find(f"{DAV}propstat/{DAV}prop/{CALDAV}calendar-home-set/{DAV}href") is None
+    assert responses[0].find(f"{DAV}propstat/{DAV}prop/{CARDDAV}addressbook-home-set/{DAV}href") is None
+    start_sync_thread.assert_not_called()
+    etesync_for_user.assert_not_called()
+
+
+def test_anonymous_principal_discovery_forms_are_challenged(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    for body in (APPLE_PRINCIPAL_BODY, ALLPROP_BODY, PROPNAME_BODY, b""):
+        status, headers, response_body = _request(app, "/principals/", body=body)
+        assert status == "401 Unauthorized"
+        assert headers["WWW-Authenticate"] == 'Basic realm="Radicale - Password Required"'
+        assert response_body == b"Access to the requested resource forbidden."
+
+
+def test_invalid_credentials_have_identical_responses(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    attempts = (
+        _basic_auth("unknown@example.test", PASSWORD),
+        _basic_auth(USERNAME, ""),
+        _basic_auth(USERNAME, "wrong-password"),
+    )
+    responses = [_request(app, "/principals/", auth=auth) for auth in attempts]
+    assert responses[0] == responses[1] == responses[2]
+    status, headers, body = responses[0]
+    assert status == "401 Unauthorized"
+    assert headers == {
+        "Content-Type": "text/plain; charset=utf-8",
+        "WWW-Authenticate": 'Basic realm="Radicale - Password Required"',
+        "Content-Length": "43",
+    }
+    assert body == b"Access to the requested resource forbidden."
+
+
+def test_authenticated_allprop_and_empty_body_expose_only_static_metadata(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    expected_properties = {
+        f"{DAV}principal-collection-set",
+        f"{DAV}current-user-principal",
+        f"{DAV}current-user-privilege-set",
+        f"{DAV}supported-report-set",
+        f"{DAV}resourcetype",
+        f"{DAV}owner",
+    }
+    for body in (ALLPROP_BODY, b""):
+        status, _headers, response_body = _request(
+            app, "/principals/", body=body, auth=_basic_auth()
+        )
+        assert status == "207 Multi-Status"
+        assert _prop_names(response_body) == expected_properties
+        assert _response_hrefs(response_body) == [
+            "/principals/",
+            "/",
+            f"/{quote(USERNAME)}/",
+        ]
+
+
+def test_authenticated_propname_exposes_only_static_property_names(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    status, _headers, body = _request(
+        app, "/principals/", body=PROPNAME_BODY, auth=_basic_auth()
+    )
+    assert status == "207 Multi-Status"
+    assert _prop_names(body) == {
+        f"{DAV}principal-collection-set",
+        f"{DAV}current-user-principal",
+        f"{DAV}current-user-privilege-set",
+        f"{DAV}supported-report-set",
+        f"{DAV}resourcetype",
+        f"{DAV}owner",
+    }
+    assert _response_hrefs(body) == ["/principals/"]
+
+
+def test_authenticated_depth_forms_never_enumerate_principals(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    for depth in ("0", "1", "infinity", None, "", "2", "unknown"):
+        status, _headers, body = _request(
+            app,
+            "/principals/",
+            body=APPLE_PRINCIPAL_BODY,
+            depth=depth,
+            auth=_basic_auth(),
+        )
+        assert status == "207 Multi-Status"
+        assert _response_hrefs(body) == ["/principals/", f"/{quote(USERNAME)}/"]
+
+
+def test_principal_aliases_do_not_reveal_account_existence(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    responses = [
+        _request(app, "/principals/bob@example.test/", auth=_basic_auth()),
+        _request(app, "/principals/nobody@example.test/", auth=_basic_auth()),
+        _request(app, f"/principals/{USERNAME}/", auth=_basic_auth()),
+    ]
+    assert responses[0] == responses[1] == responses[2]
+    assert responses[0][0] == "403 Forbidden"
+
+
+def test_principal_path_sanitation_preserves_existing_owner_boundary(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    for path in (
+        "/principals",
+        "/principals/",
+        "//principals//",
+        "/./principals/",
+        "/principals/./",
+    ):
+        status, _headers, body = _request(app, path, auth=_basic_auth())
+        assert status == "207 Multi-Status"
+        assert _response_hrefs(body)[0] == "/principals/"
+
+    for path in (
+        f"/principals/{USERNAME}/",
+        f"/principals//{USERNAME}/",
+        f"/principals%2F{USERNAME}/",
+        f"/principals/%2F{USERNAME}/",
+        f"/principals/%2e%2e/{USERNAME}/",
+        f"/principals\\{USERNAME}/",
+        "/Principals/",
+        "/príncipals/",
+    ):
+        status, _headers, _body = _request(app, path, auth=_basic_auth())
+        assert status == "403 Forbidden"
+
+    status, _headers, body = _request(
+        app, f"/principals/../{USERNAME}/", auth=_basic_auth()
+    )
+    assert status == "207 Multi-Status"
+    assert _response_hrefs(body)[0] == f"/{quote(USERNAME)}/"
+    status, _headers, _body = _request(
+        app, "/principals/../bob@example.test/", auth=_basic_auth()
+    )
+    assert status == "403 Forbidden"
+
+
+def test_direct_dav_paths_and_user_agent_behavior_are_unchanged(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    for user_agent in ("macOS/15.7.7 AddressBookCore/2695.500.71", None):
+        root_status, _headers, root_body = _request(
+            app, "/", auth=_basic_auth(), user_agent=user_agent
+        )
+        home_status, _headers, home_body = _request(
+            app, f"/{USERNAME}/", auth=_basic_auth(), user_agent=user_agent
+        )
+        assert root_status == home_status == "207 Multi-Status"
+        assert f"/{quote(USERNAME)}/" in _response_hrefs(root_body)
+        assert _response_hrefs(home_body)[0] == f"/{quote(USERNAME)}/"
+
+
+def test_existing_well_known_redirects_are_preserved(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    for path in ("/.well-known/carddav", "/.well-known/caldav"):
+        for auth in (None, _basic_auth()):
+            for scheme in ("http", "https"):
+                status, headers, _body = _request(
+                    app,
+                    path,
+                    auth=auth,
+                    scheme=scheme,
+                    query="source=apple",
+                )
+                assert status == "301 Moved Permanently"
+                assert headers["Location"] == "/"

--- a/bridge/tests/test_storage.py
+++ b/bridge/tests/test_storage.py
@@ -114,8 +114,8 @@ class TestMetaMapping:
 # ---------------------------------------------------------------------------
 
 
-class TestAcquireLockForcesSync:
-    """Verify that acquire_lock calls force_sync, not request_sync."""
+class TestBackendDiscoveryForcesSync:
+    """Verify backend-backed reads force sync lazily."""
 
     @patch("silentsuite_bridge.radicale.storage.etesync_for_user")
     @patch("silentsuite_bridge.radicale.storage.start_sync_thread")
@@ -136,7 +136,7 @@ class TestAcquireLockForcesSync:
         storage = Storage(configuration)
 
         with storage.acquire_lock("r", user="test@example.com"):
-            pass
+            list(storage.discover("/test@example.com", depth="1"))
 
         mock_thread.force_sync.assert_called()
         mock_thread.request_sync.assert_not_called()
@@ -160,7 +160,7 @@ class TestAcquireLockForcesSync:
         storage = Storage(configuration)
 
         with storage.acquire_lock("r", user="test@example.com"):
-            pass
+            list(storage.discover("/test@example.com", depth="1"))
 
         mock_thread.wait_for_sync.assert_called_with(20)
 


### PR DESCRIPTION
## Summary

- add an authenticated, non-enumerating `/principals/` DAV discovery container for macOS Apple Internet Accounts
- advertise the existing canonical account principal without adding an account-specific alias namespace
- keep anonymous requests on the normal Basic authentication challenge path and preserve cross-account denial
- defer Bridge sync/cache initialization until backend-backed discovery is actually consumed, so static principal discovery performs no Etebase or cache access
- preserve existing direct DAV paths and well-known redirects
- clarify normal anonymous challenge behavior and HTTP-to-HTTPS `WRONG_VERSION_NUMBER` troubleshooting

Addresses #498.

Related customer symptom tracking: #488.

Separate Tailscale/MagicDNS certificate SAN scope: #518.

## Root-cause split

- **Transport:** localhost and Tailscale connectivity can reach the listener; transport alone does not explain the localhost Apple Accounts failure.
- **Authentication:** an initial anonymous 401 followed by an authenticated retry is normal Basic challenge behavior. Explicit invalid-password logs remain a separate credentials failure.
- **Discovery:** authenticated `/principals/` was denied with 403, while the canonical account home already returned correct principal and home-set properties.
- **Certificate identity:** the existing generated certificate covers localhost identities, not an explicitly selected Tailscale MagicDNS hostname/IP. That remains separate in #518.

## Security and privacy

- anonymous `/principals/` requests remain challenged and expose no configured account data
- the static discovery container never enumerates accounts, collections, items, or decrypted PIM data
- exact authenticated discovery does not start sync or enter the Etebase/cache context
- `/principals/<account>/` aliases remain denied, including same-account aliases
- configured-other and nonexistent aliases have equivalent denial behavior
- canonical owner-only account boundaries remain unchanged

## Verification

- focused TDD regression: authenticated `/principals/` reproduced as 403 before implementation
- protocol-level discovery suite: 10 passed
- full Bridge suite: 253 passed
- Ruff: changed production files and new protocol test passed
- `git diff --check`: passed
- CLI version/help and Python compile smoke: passed
- wheel build: passed

## Manual smoke status

**Implementation and CI complete, awaiting authenticated macOS smoke.**

Before release readiness, test the built macOS artifact through Apple Internet Accounts using Advanced CardDAV and CalDAV setup, verify collections and data, and capture an ordered redacted request/status/href trace. Keep #498 open until that smoke confirms the actual Apple request sequence. If Apple requests `/principals/<account>/`, revise the protocol contract before adding an alias namespace.

## Not included

- Tailscale/MagicDNS certificate SAN configuration
- public remote exposure
- a second HTTP listener or plaintext-to-HTTPS redirect
- release, tag, or `main` promotion
