### PR TITLE
fix(web): stop stale sync work at account boundaries

### DIFF
--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -25,6 +25,7 @@ import {
   _setEnvelopeKeyForTests,
   type CachedItem,
 } from '../data-cache'
+import { AccountBoundaryChangedError, bumpAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 
 beforeEach(async () => {
   await _resetForTests()
@@ -278,6 +279,68 @@ describe('data-cache', () => {
       expect(tasks.map((item) => item.itemUid).sort()).toEqual(['b', 'z'])
       expect(tasks.find((item) => item.itemUid === 'b')!.collectionUid).toBe('col-b')
     })
+
+    it('aborts a collection replacement when encryption crosses an account boundary', async () => {
+      await putItem(makeItem('existing', 'tasks', 'current cache', 'col-a'))
+      await ensureFingerprint('current-account')
+      const accountEpoch = getAccountEpoch()
+      const originalEncrypt = globalThis.crypto.subtle.encrypt.bind(globalThis.crypto.subtle)
+      let releaseEncryption!: () => void
+      let markEncryptionStarted!: () => void
+      const encryptionStarted = new Promise<void>((resolve) => {
+        markEncryptionStarted = resolve
+      })
+      const encryptionGate = new Promise<void>((resolve) => {
+        releaseEncryption = resolve
+      })
+      const encryptSpy = vi.spyOn(globalThis.crypto.subtle, 'encrypt').mockImplementationOnce(async (algorithm, key, data) => {
+        markEncryptionStarted()
+        await encryptionGate
+        return originalEncrypt(algorithm, key, data)
+      })
+
+      const replacement = replaceItemsForCollection(
+        'col-a',
+        [makeItem('stale', 'tasks', 'old account cache', 'col-a')],
+        accountEpoch,
+      )
+      await encryptionStarted
+      bumpAccountEpoch()
+      releaseEncryption()
+
+      await expect(replacement).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      const tasks = await getItemsByType('tasks')
+      expect(tasks.map((item) => item.itemUid)).toEqual(['existing'])
+      encryptSpy.mockRestore()
+    })
+
+    it('serializes an account fingerprint switch after a queued stale cache write', async () => {
+      await ensureFingerprint('old-account')
+      const accountEpoch = getAccountEpoch()
+      const originalPut = IDBObjectStore.prototype.put
+      let accountSwitch: Promise<boolean> | null = null
+      const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (value, key) {
+        const request = key === undefined
+          ? originalPut.call(this, value)
+          : originalPut.call(this, value, key)
+        if (!accountSwitch && (value as { itemUid?: string }).itemUid === 'stale') {
+          bumpAccountEpoch()
+          accountSwitch = ensureFingerprint('new-account')
+        }
+        return request
+      })
+
+      await expect(replaceItemsForCollection(
+        'col-a',
+        [makeItem('stale', 'tasks', 'old account cache', 'col-a')],
+        accountEpoch,
+      )).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      await accountSwitch!
+
+      expect(await getItemsByType('tasks')).toEqual([])
+      expect((await getMeta())?.accountFingerprint).toBe('new-account')
+      putSpy.mockRestore()
+    })
   })
 
   describe('collections / stokens', () => {
@@ -297,6 +360,26 @@ describe('data-cache', () => {
       expect(col).not.toBeNull()
       expect(col!.stoken).toBe('stk-1')
       expect(col!.collectionUid).toBe('col-tasks')
+    })
+
+    it('aborts a queued stoken write when the account epoch changes before commit', async () => {
+      await ensureFingerprint('current-account')
+      const accountEpoch = getAccountEpoch()
+      const originalPut = IDBObjectStore.prototype.put
+      const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (value, key) {
+        const request = key === undefined
+          ? originalPut.call(this, value)
+          : originalPut.call(this, value, key)
+        if ((value as { collectionUid?: string }).collectionUid === 'old-collection') {
+          bumpAccountEpoch()
+        }
+        return request
+      })
+
+      await expect(setStoken('calendar', 'old-collection', 'old-stoken', accountEpoch))
+        .rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      expect(await getCollection('old-collection')).toBeNull()
+      putSpy.mockRestore()
     })
 
     it('setStoken creates and updates the cursor', async () => {

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -17,6 +17,7 @@
  * encrypted-envelope availability check.
  */
 import { logger } from '@/app/lib/logger'
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch } from '@/app/lib/account-epoch'
 
 export type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
 
@@ -323,6 +324,79 @@ export async function deleteItem(itemUid: string): Promise<void> {
   }
 }
 
+async function replaceItemsForIndex(
+  indexName: 'byCollectionType' | 'byCollectionUid',
+  indexKey: IDBValidKey,
+  items: CachedItem[],
+  accountEpoch: number | undefined,
+  operation: 'replaceItemsForType' | 'replaceItemsForCollection',
+): Promise<void> {
+  if (!canWriteItemContent(operation)) return
+  try {
+    const expectedFingerprint = accountEpoch === undefined ? undefined : (await getMeta())?.accountFingerprint
+    if (accountEpoch !== undefined) {
+      assertCurrentAccountEpoch(accountEpoch)
+      if (!expectedFingerprint) throw new AccountBoundaryChangedError()
+    }
+    const storedItems = await Promise.all(items.map(toStoredItem))
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+    const db = await openDB()
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([STORE_ITEMS, STORE_META], 'readwrite')
+      const store = tx.objectStore(STORE_ITEMS)
+      const metaReq = tx.objectStore(STORE_META).get(META_KEY)
+
+      const abortForBoundary = () => {
+        const err = new AccountBoundaryChangedError()
+        reject(err)
+        tx.abort()
+      }
+
+      metaReq.onsuccess = () => {
+        const currentFingerprint = (metaReq.result as CacheMeta | undefined)?.accountFingerprint
+        if (accountEpoch !== undefined && currentFingerprint !== expectedFingerprint) {
+          abortForBoundary()
+          return
+        }
+
+        const cursorReq = store.index(indexName).openCursor(indexKey)
+        cursorReq.onsuccess = () => {
+          try {
+            if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+          } catch {
+            abortForBoundary()
+            return
+          }
+          const cursor = cursorReq.result
+          if (cursor) {
+            cursor.delete()
+            cursor.continue()
+          } else {
+            for (const item of storedItems) store.put(item)
+            const commitGuard = store.get('__account-epoch-commit-guard__')
+            commitGuard.onsuccess = () => {
+              try {
+                if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+              } catch {
+                abortForBoundary()
+              }
+            }
+            commitGuard.onerror = () => reject(commitGuard.error)
+          }
+        }
+        cursorReq.onerror = () => reject(cursorReq.error)
+      }
+      metaReq.onerror = () => reject(metaReq.error)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) throw err
+    logger.warn(`[data-cache] ${operation} failed`, err)
+  }
+}
+
 /**
  * Replace all cached items for a collection type with the given list.
  * Used after a full refresh so removed-on-server items don't linger.
@@ -330,32 +404,9 @@ export async function deleteItem(itemUid: string): Promise<void> {
 export async function replaceItemsForType(
   type: CollectionTypeKey,
   items: CachedItem[],
+  accountEpoch?: number,
 ): Promise<void> {
-  if (!canWriteItemContent('replaceItemsForType')) return
-  try {
-    const storedItems = await Promise.all(items.map(toStoredItem))
-    const db = await openDB()
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(STORE_ITEMS, 'readwrite')
-      const store = tx.objectStore(STORE_ITEMS)
-      const idx = store.index('byCollectionType')
-      const cursorReq = idx.openCursor(type)
-      cursorReq.onsuccess = () => {
-        const cursor = cursorReq.result
-        if (cursor) {
-          cursor.delete()
-          cursor.continue()
-        } else {
-          for (const item of storedItems) store.put(item)
-        }
-      }
-      cursorReq.onerror = () => reject(cursorReq.error)
-      tx.oncomplete = () => resolve()
-      tx.onerror = () => reject(tx.error)
-    })
-  } catch (err) {
-    logger.warn('[data-cache] replaceItemsForType failed', err)
-  }
+  return replaceItemsForIndex('byCollectionType', type, items, accountEpoch, 'replaceItemsForType')
 }
 
 /**
@@ -365,32 +416,9 @@ export async function replaceItemsForType(
 export async function replaceItemsForCollection(
   collectionUid: string,
   items: CachedItem[],
+  accountEpoch?: number,
 ): Promise<void> {
-  if (!canWriteItemContent('replaceItemsForCollection')) return
-  try {
-    const storedItems = await Promise.all(items.map(toStoredItem))
-    const db = await openDB()
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(STORE_ITEMS, 'readwrite')
-      const store = tx.objectStore(STORE_ITEMS)
-      const idx = store.index('byCollectionUid')
-      const cursorReq = idx.openCursor(collectionUid)
-      cursorReq.onsuccess = () => {
-        const cursor = cursorReq.result
-        if (cursor) {
-          cursor.delete()
-          cursor.continue()
-        } else {
-          for (const item of storedItems) store.put(item)
-        }
-      }
-      cursorReq.onerror = () => reject(cursorReq.error)
-      tx.oncomplete = () => resolve()
-      tx.onerror = () => reject(tx.error)
-    })
-  } catch (err) {
-    logger.warn('[data-cache] replaceItemsForCollection failed', err)
-  }
+  return replaceItemsForIndex('byCollectionUid', collectionUid, items, accountEpoch, 'replaceItemsForCollection')
 }
 
 // ── Collections / stokens ──
@@ -422,14 +450,71 @@ export async function setStoken(
   type: CollectionTypeKey,
   collectionUid: string,
   stoken: string | null,
+  accountEpoch?: number,
 ): Promise<void> {
-  const existing = await getCollection(collectionUid)
-  await putCollection({
-    collectionType: type,
-    collectionUid,
-    stoken,
-    lastFullSyncAt: existing?.lastFullSyncAt ?? Date.now(),
-  })
+  if (accountEpoch === undefined) {
+    const existing = await getCollection(collectionUid)
+    await putCollection({
+      collectionType: type,
+      collectionUid,
+      stoken,
+      lastFullSyncAt: existing?.lastFullSyncAt ?? Date.now(),
+    })
+    return
+  }
+
+  try {
+    const expectedFingerprint = (await getMeta())?.accountFingerprint
+    assertCurrentAccountEpoch(accountEpoch)
+    if (!expectedFingerprint) throw new AccountBoundaryChangedError()
+    const db = await openDB()
+    assertCurrentAccountEpoch(accountEpoch)
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([STORE_COLLECTIONS, STORE_META], 'readwrite')
+      const collectionStore = tx.objectStore(STORE_COLLECTIONS)
+      const metaStore = tx.objectStore(STORE_META)
+      const metaReq = metaStore.get(META_KEY)
+
+      const abortForBoundary = () => {
+        reject(new AccountBoundaryChangedError())
+        tx.abort()
+      }
+
+      metaReq.onsuccess = () => {
+        const currentFingerprint = (metaReq.result as CacheMeta | undefined)?.accountFingerprint
+        if (currentFingerprint !== expectedFingerprint) {
+          abortForBoundary()
+          return
+        }
+        const collectionReq = collectionStore.get(collectionUid)
+        collectionReq.onsuccess = () => {
+          const existing = collectionReq.result as CachedCollection | undefined
+          collectionStore.put({
+            collectionType: type,
+            collectionUid,
+            stoken,
+            lastFullSyncAt: existing?.lastFullSyncAt ?? Date.now(),
+          })
+          const commitGuard = metaStore.get(META_KEY)
+          commitGuard.onsuccess = () => {
+            try {
+              assertCurrentAccountEpoch(accountEpoch)
+            } catch {
+              abortForBoundary()
+            }
+          }
+          commitGuard.onerror = () => reject(commitGuard.error)
+        }
+        collectionReq.onerror = () => reject(collectionReq.error)
+      }
+      metaReq.onerror = () => reject(metaReq.error)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) throw err
+    logger.warn('[data-cache] setStoken failed', err)
+  }
 }
 
 /**
@@ -514,8 +599,21 @@ export async function ensureFingerprint(accountFingerprint: string): Promise<boo
       fingerprintMismatch,
       schemaMismatch,
     })
-    await clearAll()
-    await putMeta({ ...current, lastInvalidatedAt: Date.now() })
+    envelopeKey = null
+    envelopeReady = false
+    const replacementMeta = { ...current, lastInvalidatedAt: Date.now() }
+    const db = await openDB()
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([STORE_ITEMS, STORE_COLLECTIONS, STORE_META, STORE_CRYPTO], 'readwrite')
+      tx.objectStore(STORE_ITEMS).clear()
+      tx.objectStore(STORE_COLLECTIONS).clear()
+      const metaStore = tx.objectStore(STORE_META)
+      metaStore.clear()
+      metaStore.put(replacementMeta, META_KEY)
+      tx.objectStore(STORE_CRYPTO).clear()
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
     return false
   }
 

--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -2,6 +2,7 @@ import { render, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SyncProvider } from '../sync-provider'
+import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 const order: string[] = []
 
@@ -28,6 +29,7 @@ type OnCacheHydrate = () => void | Promise<void>
 
 const etebaseMock = vi.hoisted(() => {
   let syncChangeHandler: ((event: { collectionType: string; collectionUid: string; itemUids: string[]; changeType: string }) => Promise<void>) | null = null
+  let syncStatusHandler: ((status: string) => void) | null = null
   // Default initialize replays the real store contract: calendar → tasks →
   // contacts, one terminal callback each, statuses driven by domainLoadState.
   async function defaultInitialize(options?: { onCacheHydrate?: OnCacheHydrate; onDomainLoaded?: OnDomainLoaded }) {
@@ -48,8 +50,9 @@ const etebaseMock = vi.hoisted(() => {
       syncChangeHandler = handler ?? null
       return vi.fn()
     }),
-    onStatusChange: vi.fn(() => {
+    onStatusChange: vi.fn((handler?: typeof syncStatusHandler) => {
       order.push('wireStatusHandler')
+      syncStatusHandler = handler ?? null
       return vi.fn()
     }),
     isInitialized: false,
@@ -60,6 +63,10 @@ const etebaseMock = vi.hoisted(() => {
     state,
     defaultInitialize,
     getSyncChangeHandler: () => syncChangeHandler,
+    getSyncStatusHandler: () => syncStatusHandler,
+    setSyncStatusHandler: (handler: typeof syncStatusHandler) => {
+      syncStatusHandler = handler
+    },
     setSyncChangeHandler: (handler: typeof syncChangeHandler) => {
       syncChangeHandler = handler
     },
@@ -184,8 +191,9 @@ describe('SyncProvider timing instrumentation', () => {
       etebaseMock.setSyncChangeHandler(handler ?? null)
       return vi.fn()
     })
-    etebaseMock.state.onStatusChange.mockImplementation(() => {
+    etebaseMock.state.onStatusChange.mockImplementation((handler?: Parameters<typeof etebaseMock.state.onStatusChange>[0]) => {
       order.push('wireStatusHandler')
+      etebaseMock.setSyncStatusHandler(handler ?? null)
       return vi.fn()
     })
     cacheMock.isCacheEnabled.mockReturnValue(false)
@@ -312,9 +320,9 @@ describe('SyncProvider timing instrumentation', () => {
       'cacheGet:calendar',
       'fetchAllItems:calendar',
     ])
-    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('calendar', [])
-    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('tasks', [])
-    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('contacts', [])
+    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('calendar', [], expect.any(Number))
+    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('tasks', [], expect.any(Number))
+    expect(cacheMock.replaceItemsForType).toHaveBeenCalledWith('contacts', [], expect.any(Number))
   })
 
   it('lets cache hydrate first and then overwrites calendar with server truth', async () => {
@@ -396,5 +404,131 @@ describe('SyncProvider timing instrumentation', () => {
     expect(syncStoreMock.setPartialLoad).toHaveBeenCalledWith(true, 1)
     expect(order).toContain('refreshCalendarScoped')
     expect(order).not.toContain('syncCalendar')
+  })
+
+  it('does not publish an in-flight old-account change after the account epoch changes', async () => {
+    renderProvider()
+
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+    vi.clearAllMocks()
+    order.length = 0
+
+    let releaseRefresh!: (items: never[]) => void
+    let markRefreshStarted!: () => void
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve
+    })
+    etebaseMock.state.refreshCollection.mockImplementation(() => {
+      markRefreshStarted()
+      return new Promise<never[]>((resolve) => {
+        releaseRefresh = resolve
+      })
+    })
+    etebaseMock.state.fetchAllItems.mockResolvedValue([
+      { uid: 'old-account-event', content: 'VEVENT:OLD', collectionUid: 'old-calendar' },
+    ])
+
+    const handler = etebaseMock.getSyncChangeHandler()
+    const change = handler!({
+      collectionType: 'etebase.vevent',
+      collectionUid: 'old-calendar',
+      itemUids: ['old-account-event'],
+      changeType: 'change',
+    })
+    await refreshStarted
+
+    bumpAccountEpoch()
+    releaseRefresh([])
+    await change
+
+    expect(calendarStoreMock.syncFromRemote).not.toHaveBeenCalled()
+    expect(syncStoreMock.setLastSynced).not.toHaveBeenCalled()
+    expect(sentryMock.captureException).not.toHaveBeenCalled()
+  })
+
+  it('ignores status callbacks from an old account epoch', async () => {
+    renderProvider()
+    await waitFor(() => expect(syncStoreMock.setLastSynced).toHaveBeenCalledTimes(1))
+
+    const statusHandler = etebaseMock.getSyncStatusHandler()
+    expect(statusHandler).toBeTruthy()
+    vi.clearAllMocks()
+
+    bumpAccountEpoch()
+    statusHandler!('error')
+
+    expect(syncStoreMock.setSyncStatus).not.toHaveBeenCalled()
+    expect(syncStoreMock.setLastSynced).not.toHaveBeenCalled()
+    expect(syncStoreMock.setError).not.toHaveBeenCalled()
+  })
+
+  it('does not publish partial-load state after an initialization callback crosses the account boundary', async () => {
+    let releaseFetch!: (items: never[]) => void
+    let markFetchStarted!: () => void
+    const fetchStarted = new Promise<void>((resolve) => {
+      markFetchStarted = resolve
+    })
+    let markInitializeFinished!: () => void
+    const initializeFinished = new Promise<void>((resolve) => {
+      markInitializeFinished = resolve
+    })
+    etebaseMock.state.fetchAllItems.mockImplementation(() => {
+      markFetchStarted()
+      return new Promise<never[]>((resolve) => {
+        releaseFetch = resolve
+      })
+    })
+    etebaseMock.state.initialize.mockImplementation(async (options) => {
+      try {
+        await options?.onDomainLoaded?.({
+          type: 'calendar',
+          status: 'loaded',
+          itemCount: 1,
+          pageCount: 1,
+          collectionCount: 1,
+        })
+      } finally {
+        markInitializeFinished()
+      }
+    })
+
+    renderProvider()
+    await fetchStarted
+    vi.clearAllMocks()
+
+    bumpAccountEpoch()
+    releaseFetch([])
+    await initializeFinished
+
+    expect(syncStoreMock.setPartialLoad).not.toHaveBeenCalled()
+    expect(syncStoreMock.setSyncStatus).not.toHaveBeenCalled()
+    expect(syncStoreMock.setError).not.toHaveBeenCalled()
+  })
+
+  it('suppresses an ordinary initialization rejection after the account epoch changes', async () => {
+    let rejectInitialize!: (error: Error) => void
+    let markInitializeStarted!: () => void
+    const initializeStarted = new Promise<void>((resolve) => {
+      markInitializeStarted = resolve
+    })
+    etebaseMock.state.initialize.mockImplementation(() => {
+      markInitializeStarted()
+      return new Promise<void>((_resolve, reject) => {
+        rejectInitialize = reject
+      })
+    })
+
+    renderProvider()
+    await initializeStarted
+    vi.clearAllMocks()
+
+    bumpAccountEpoch()
+    rejectInitialize(new Error('old account request failed'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(sentryMock.captureException).not.toHaveBeenCalled()
+    expect(syncStoreMock.setSyncStatus).not.toHaveBeenCalled()
+    expect(syncStoreMock.setError).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -29,7 +29,12 @@ import {
   type SyncTimingPhase,
   type SyncTimingFields,
 } from '@/app/lib/sync-timing'
-import { AccountBoundaryChangedError, assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
+import {
+  AccountBoundaryChangedError,
+  assertCurrentAccountEpoch,
+  getAccountEpoch,
+  isCurrentAccountEpoch,
+} from '@/app/lib/account-epoch'
 
 function reportSyncError(operation: string, err: unknown) {
   Sentry.captureException(createSafeOperationalError('sync-provider', operation), {
@@ -113,6 +118,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           },
           onDomainLoaded: async (event) => {
             await loadDomainIntoStore(event.type)
+            assertCurrentAccountEpoch(accountEpoch)
             updatePartialLoadFlag()
           },
         })
@@ -139,10 +145,12 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         unsubStatus = wireStatusHandler()
         safeLogSyncTiming('wire-status-handler', statusHandlerStartedAt, { status: unsubStatus ? 'ok' : 'skipped' })
 
+        assertCurrentAccountEpoch(accountEpoch)
         setSyncStatus('synced')
         setLastSynced(new Date())
         safeLogSyncTiming('initial-sync-complete', initStartedAt)
       } catch (err) {
+        if (!isCurrentAccountEpoch(accountEpoch)) return
         if (err instanceof AccountBoundaryChangedError) return
         safeLogSyncTiming('initial-sync-failed', initStartedAt, { errorCategory: safeTimingErrorCategory('unknown') })
         reportSyncError('init', err)
@@ -237,9 +245,11 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         lastModified: Date.now(),
       }))
       try {
-        await cacheReplaceItemsForType(type, records)
+        await cacheReplaceItemsForType(type, records, accountEpoch)
+        assertCurrentAccountEpoch(accountEpoch)
         safeLogSyncTiming('cache-mirror', startedAt, { type, itemCount: items.length })
       } catch (err) {
+        if (err instanceof AccountBoundaryChangedError) return
         logger.warn(`[sync-provider] Failed to mirror ${type} to cache`, getSafeErrorDetails(err))
         safeLogSyncTiming('cache-mirror-failed', startedAt, { type, itemCount: items.length, errorCategory: 'cache' })
       }
@@ -313,6 +323,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     function wireChangeHandler(): (() => void) | null {
       const etebase = useEtebaseStore.getState()
       return etebase.onSyncChange(async (event) => {
+        if (!isCurrentAccountEpoch(accountEpoch)) return
         logger.log('[sync-provider] Sync change:', event.changeType, event.collectionType, event.itemUids.length, 'items')
 
         // Re-fetch ALL items from the Etebase server for the changed collection.
@@ -320,67 +331,86 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
         const collectionType = event.collectionType
         const refresher = useEtebaseStore.getState().refreshCollection
         const core = await import('@silentsuite/core')
+        if (!isCurrentAccountEpoch(accountEpoch)) return
 
         if (collectionType === 'etebase.vtodo') {
           try {
             await refresher('tasks', event.collectionUid)
+            assertCurrentAccountEpoch(accountEpoch)
             updatePartialLoadFlag()
             if (useEtebaseStore.getState().domainLoadState.tasks === 'loaded') {
               const taskItems = await useEtebaseStore.getState().fetchAllItems('tasks')
+              assertCurrentAccountEpoch(accountEpoch)
               const tasks = taskItems.map((item) => {
                 const task = core.deserializeTask(item.content)
                 return { ...task, id: item.uid, listId: item.collectionUid }
               })
+              assertCurrentAccountEpoch(accountEpoch)
               useTaskStore.getState().syncFromRemote(tasks)
             }
           } catch (err) {
+            if (err instanceof AccountBoundaryChangedError) return
             reportSyncError('sync tasks', err)
           }
         } else if (collectionType === 'etebase.vcard') {
           try {
             await refresher('contacts', event.collectionUid)
+            assertCurrentAccountEpoch(accountEpoch)
             updatePartialLoadFlag()
             if (useEtebaseStore.getState().domainLoadState.contacts === 'loaded') {
               const contactItems = await useEtebaseStore.getState().fetchAllItems('contacts')
+              assertCurrentAccountEpoch(accountEpoch)
               const contacts = contactItems.map((item) => {
                 const contact = core.deserializeContact(item.content)
                 return { ...contact, id: item.uid, listId: item.collectionUid }
               })
+              assertCurrentAccountEpoch(accountEpoch)
               useContactStore.getState().syncFromRemote(contacts)
             }
           } catch (err) {
+            if (err instanceof AccountBoundaryChangedError) return
             reportSyncError('sync contacts', err)
           }
         } else if (collectionType === 'etebase.vevent') {
           try {
             await refresher('calendar', event.collectionUid)
+            assertCurrentAccountEpoch(accountEpoch)
             updatePartialLoadFlag()
             if (useEtebaseStore.getState().domainLoadState.calendar === 'loaded') {
               const eventItems = await useEtebaseStore.getState().fetchAllItems('calendar')
+              assertCurrentAccountEpoch(accountEpoch)
               const events = eventItems.map((item) => {
                 const event = core.deserializeCalendarEvent(item.content)
                 return { ...event, id: item.uid, calendarId: item.collectionUid }
               })
+              assertCurrentAccountEpoch(accountEpoch)
               useCalendarStore.getState().syncFromRemote(events)
             }
           } catch (err) {
+            if (err instanceof AccountBoundaryChangedError) return
             reportSyncError('sync calendar events', err)
           }
         } else if (collectionType === 'silentsuite.labelindex') {
           try {
             await useLabelSuggestionsStore.getState().refreshFromRemote()
+            assertCurrentAccountEpoch(accountEpoch)
           } catch (err) {
+            if (err instanceof AccountBoundaryChangedError) return
             logger.warn('[sync-provider] Label suggestions refresh failed', getSafeErrorDetails(err))
           }
         } else if (collectionType === 'silentsuite.preferences') {
           try {
             const preferenceItems = await refresher('preferences', event.collectionUid)
+            assertCurrentAccountEpoch(accountEpoch)
             await usePreferencesSyncStore.getState().loadFromRemote(preferenceItems)
+            assertCurrentAccountEpoch(accountEpoch)
           } catch (err) {
+            if (err instanceof AccountBoundaryChangedError) return
             logger.warn('[sync-provider] Preferences refresh failed', getSafeErrorDetails(err))
           }
         }
 
+        assertCurrentAccountEpoch(accountEpoch)
         setLastSynced(new Date())
       })
     }
@@ -388,6 +418,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     function wireStatusHandler(): (() => void) | null {
       const etebase = useEtebaseStore.getState()
       return etebase.onStatusChange((status: string) => {
+        if (!isCurrentAccountEpoch(accountEpoch)) return
         setSyncStatus(status as any)
         if (status === 'synced') {
           setLastSynced(new Date())

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -4,6 +4,7 @@ import { useCalendarStore } from '../use-calendar-store'
 import { useCalendarListStore } from '../use-calendar-list-store'
 import { useTaskListStore } from '../use-task-list-store'
 import { useContactListStore } from '../use-contact-list-store'
+import { AccountBoundaryChangedError, bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 const offlineQueueMock = vi.hoisted(() => ({
   enqueue: vi.fn(async () => {}),
@@ -206,6 +207,36 @@ describe('useEtebaseStore.initialize restore diagnostics', () => {
     expect(raw).not.toContain('user@example.com')
     expect(toastStoreMock.showErrorToast).toHaveBeenCalledWith('Failed to restore session. Please try signing in again.')
   })
+
+  it('does not publish initialization failure state when an old secure read rejects after an account boundary', async () => {
+    const { secureGet } = await import('@/app/lib/secure-storage')
+    let rejectRead!: (error: Error) => void
+    let markReadStarted!: () => void
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve
+    })
+    vi.mocked(secureGet).mockImplementationOnce(() => {
+      markReadStarted()
+      return new Promise((_resolve, reject) => {
+        rejectRead = reject
+      })
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const initialize = useEtebaseStore.getState().initialize()
+    await readStarted
+    bumpAccountEpoch()
+    useEtebaseStore.setState({ isInitialized: false, restoreBlocked: false })
+    rejectRead(new Error('old account read failed'))
+    await initialize
+
+    expect(useEtebaseStore.getState().isInitialized).toBe(false)
+    expect(useEtebaseStore.getState().restoreBlocked).toBe(false)
+    expect(sessionStorage.getItem('silentsuite.restore-diagnostics.v1')).toBeNull()
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
 })
 
 describe('useEtebaseStore.initialize restoreBlocked flag', () => {
@@ -401,6 +432,30 @@ describe('useEtebaseStore.initialize incremental domain loading', () => {
     expect(calendarStatusAtCalendarCallback).toBe('loaded')
     expect(calendarItemsAtCalendarCallback).toBe(1)
     expect(useEtebaseStore.getState().isInitialized).toBe(true)
+  })
+
+  it('ignores SyncEngine stoken callbacks from an old account epoch', async () => {
+    await primeSuccessfulRestore()
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+    dataCacheMock.isCacheEnabled.mockReturnValue(true)
+    let stokenHandler!: (event: { collectionType: string; collectionUid: string; stoken: string | null }) => void
+    coreMock.SyncEngine.mockImplementation(function (this: any) {
+      this.trackCollection = vi.fn()
+      this.onStokenAdvance = vi.fn((handler) => {
+        stokenHandler = handler
+      })
+      this.start = vi.fn(async () => {})
+    })
+
+    await useEtebaseStore.getState().initialize()
+    expect(stokenHandler).toBeTruthy()
+    dataCacheMock.setStoken.mockClear()
+
+    bumpAccountEpoch()
+    stokenHandler({ collectionType: 'etebase.vevent', collectionUid: 'old-calendar', stoken: 'old-stoken' })
+    await Promise.resolve()
+
+    expect(dataCacheMock.setStoken).not.toHaveBeenCalled()
   })
 
   it('marks a failed domain without aborting later domains and still starts sync', async () => {
@@ -1137,6 +1192,106 @@ describe('useEtebaseStore.refreshCollection', () => {
     await useEtebaseStore.getState().refreshCollection('calendar')
     expect(useEtebaseStore.getState().domainLoadState.calendar).toBe('loaded')
     expect(itemManagers['col-2'].list).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not publish an old-account refresh after the account epoch changes', async () => {
+    let releaseList!: (value: { data: any[]; stoken: null; done: true }) => void
+    let markListStarted!: () => void
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve
+    })
+    const staleItem = mockItem('stale-account-item', 'old account calendar')
+    const oldAccount = {
+      getCollectionManager: () => ({
+        fetch: vi.fn(async (uid: string) => ({ uid })),
+        getItemManager: () => ({
+          list: vi.fn(() => {
+            markListStarted()
+            return new Promise<{ data: any[]; stoken: null; done: true }>((resolve) => {
+              releaseList = resolve
+            })
+          }),
+        }),
+      }),
+    }
+
+    dataCacheMock.isCacheEnabled.mockReturnValue(true)
+    useEtebaseStore.setState({
+      account: oldAccount as any,
+      collections: { calendar: [{ uid: 'old-calendar' }] as any[], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
+      syncEngine: null,
+    })
+
+    const refresh = useEtebaseStore.getState().refreshCollection('calendar', 'old-calendar')
+    await listStarted
+
+    bumpAccountEpoch()
+    useEtebaseStore.setState({
+      account: { id: 'new-account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      domainLoadState: loadedDomainLoadState(),
+    })
+    releaseList({ data: [staleItem], stoken: null, done: true })
+
+    await expect(refresh).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+    expect(useEtebaseStore.getState().itemCache.size).toBe(0)
+    expect(useEtebaseStore.getState().collections.calendar).toEqual([])
+    expect(dataCacheMock.replaceItemsForCollection).not.toHaveBeenCalled()
+  })
+
+  it('does not mark the new account failed when an old-account refresh rejects', async () => {
+    let rejectList!: (error: Error) => void
+    let markListStarted!: () => void
+    const listStarted = new Promise<void>((resolve) => {
+      markListStarted = resolve
+    })
+    const oldAccount = {
+      getCollectionManager: () => ({
+        fetch: vi.fn(async (uid: string) => ({ uid })),
+        getItemManager: () => ({
+          list: vi.fn(() => {
+            markListStarted()
+            return new Promise((_resolve, reject) => {
+              rejectList = reject
+            })
+          }),
+        }),
+      }),
+    }
+
+    useEtebaseStore.setState({
+      account: oldAccount as any,
+      collections: { calendar: [{ uid: 'old-calendar' }] as any[], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      isInitialized: true,
+      domainLoadState: loadedDomainLoadState(),
+      syncEngine: null,
+    })
+
+    const refresh = useEtebaseStore.getState().refreshCollection('calendar', 'old-calendar')
+    await listStarted
+
+    bumpAccountEpoch()
+    useEtebaseStore.setState({
+      account: { id: 'new-account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      domainLoadState: loadedDomainLoadState(),
+    })
+    rejectList(new Error('old account request failed'))
+
+    await expect(refresh).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+    expect(useEtebaseStore.getState().domainLoadState.calendar).toBe('loaded')
+    expect(useEtebaseStore.getState().itemCache.size).toBe(0)
   })
 })
 

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -807,10 +807,13 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       // advance handler so subsequent stoken updates are persisted too.
       if (cacheEnabled) {
         engine.onStokenAdvance((event: { collectionType: string; collectionUid: string; stoken: string | null }) => {
+          if (!isCurrentAccountEpoch(accountEpoch)) return
           const key = collectionTypeToKey(event.collectionType)
           if (!key) return
-          // Fire-and-forget — persistence failures are logged inside the cache module.
-          void cacheSetStoken(key, event.collectionUid, event.stoken)
+          void cacheSetStoken(key, event.collectionUid, event.stoken, accountEpoch).catch((err) => {
+            if (err instanceof AccountBoundaryChangedError) return
+            logger.warn('[etebase-store] Failed to persist sync cursor', getSafeErrorDetails(err))
+          })
         })
       }
 
@@ -825,6 +828,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       diagnostics.persist()
       logger.debug('[etebase-store] SyncEngine started')
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch)) return
       if (err instanceof AccountBoundaryChangedError) return
       diagnostics.failActivePhase(err)
       diagnostics.persist()
@@ -1627,6 +1631,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   refreshCollection: async (type: CollectionTypeKey, collectionUid?: string) => {
+    const accountEpoch = getAccountEpoch()
     const { account, collections } = get()
     const targetCollections = collectionUid
       ? [resolveCollection(collections, type, collectionUid)].filter(Boolean)
@@ -1641,6 +1646,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       for (const collection of targetCollections) {
         // Fetch fresh collection reference from server
         const freshCollection = await colManager.fetch(collection.uid)
+        assertCurrentAccountEpoch(accountEpoch)
 
         // Fetch ALL items (no stoken = full fetch)
         const itemManager = colManager.getItemManager(freshCollection)
@@ -1651,14 +1657,17 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         let done = false
         while (!done) {
           const response: { data: any[]; stoken: string | null; done: boolean } = await itemManager.list({ stoken })
+          assertCurrentAccountEpoch(accountEpoch)
           for (const item of response.data) {
             if (!item.isDeleted) {
               try {
                 const content = await item.getContent()
+                assertCurrentAccountEpoch(accountEpoch)
                 const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
                 collectionItems.push({ item, content: contentStr })
                 allResults.push({ uid: item.uid, content: contentStr, collectionUid: freshCollection.uid })
-              } catch {
+              } catch (err) {
+                if (err instanceof AccountBoundaryChangedError) throw err
                 // Skip items that fail to decode
               }
             }
@@ -1671,6 +1680,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       }
 
       const refreshedUids = new Set(refreshed.map((entry) => entry.collection.uid))
+      assertCurrentAccountEpoch(accountEpoch)
       const newItemCache = new Map(get().itemCache)
       const newItemTypeMap = new Map(get().itemTypeMap)
       const newItemCollectionMap = new Map(get().itemCollectionMap)
@@ -1700,6 +1710,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       )
       const nextDomainStatus = collectionUid ? get().domainLoadState[type] : 'loaded'
 
+      assertCurrentAccountEpoch(accountEpoch)
       set((state) => ({
         itemCache: newItemCache,
         itemTypeMap: newItemTypeMap,
@@ -1711,6 +1722,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       // Mirror the refresh into the local cache. Use replace-style writes so
       // items deleted upstream are also dropped from disk.
       for (const { collection, items } of refreshed) {
+        assertCurrentAccountEpoch(accountEpoch)
         if (isLocalCacheEnabled()) {
           const cached: CachedItem[] = items.map(({ item, content }) => ({
             itemUid: item.uid,
@@ -1719,13 +1731,16 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
             content,
             lastModified: Date.now(),
           }))
-          void cacheReplaceItemsForCollection(collection.uid, cached)
+          await cacheReplaceItemsForCollection(collection.uid, cached, accountEpoch)
+          assertCurrentAccountEpoch(accountEpoch)
         }
       }
 
       logger.debug(`[etebase-store] Refreshed ${type}: ${allResults.length} items`)
       return allResults
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch)) throw new AccountBoundaryChangedError()
+      if (err instanceof AccountBoundaryChangedError) throw err
       console.error(`[etebase-store] Failed to refresh ${type}`, getSafeErrorDetails(err))
       set((state) => ({ domainLoadState: { ...state.domainLoadState, [type]: 'failed' } }))
       return get().fetchAllItems(type)


### PR DESCRIPTION
## Summary

- stop stale SyncEngine change callbacks when the verified account epoch changes
- guard `refreshCollection()` after every asynchronous boundary and before shared in-memory or encrypted-cache publication
- preserve normal sync error handling while treating account-boundary invalidation as an expected cancellation
- add deterministic regressions for both stale backend refreshes and visible-store callback publication

## Surface & Sibling-Path Map

### Surfaces
- SyncEngine calendar, task, contact, label-index, and preferences callbacks
- scoped Etebase collection refreshes
- visible calendar/task/contact stores
- encrypted local item cache

### Sibling paths
- explicit logout
- invalid hosted-auth cleanup
- verified login after another account used the browser
- in-flight server and item-content requests during an account switch

### Contract
Old-account asynchronous work must not mutate current-account Etebase maps, collection references, visible stores, encrypted cache, partial-load state, or last-sync timestamps after the account epoch changes.

## Verification

- new test demonstrated RED before implementation: stale refresh resolved and published old-account data
- `pnpm --filter @silentsuite/web test` — 49 files, 530 tests passed
- `pnpm --filter @silentsuite/web type-check` — passed
- `pnpm --filter @silentsuite/web lint` — passed with existing warnings
- `git diff --check` — passed

Promotion blocker follow-up for #521.
