### PR TITLE
fix(web): bind mutations to account epochs

### DIFF
--- a/apps/web/app/components/PendingSyncBanner.tsx
+++ b/apps/web/app/components/PendingSyncBanner.tsx
@@ -4,12 +4,16 @@ import { useState, useEffect } from 'react'
 import { AlertTriangle, CloudOff, RefreshCw, Trash2 } from 'lucide-react'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 import { clearFailed, retryFailed, getStaleEntries, MAX_QUEUE_SIZE } from '@/app/lib/offline-queue'
+import { useEtebaseStore } from '@/app/stores/use-etebase-store'
+import { AccountBoundaryChangedError, getAccountEpoch } from '@/app/lib/account-epoch'
 
 export function PendingSyncBanner() {
   const pendingCount = useSyncStore((s) => s.pendingQueueCount)
   const failedCount = useSyncStore((s) => s.failedQueueCount)
   const isOnline = useSyncStore((s) => s.isOnline)
   const replayOfflineQueue = useSyncStore((s) => s.replayOfflineQueue)
+  const account = useEtebaseStore((s) => s.account)
+  const accountFingerprint = useEtebaseStore((s) => s.accountFingerprint)
 
   const [hasStaleEntries, setHasStaleEntries] = useState(false)
 
@@ -22,9 +26,11 @@ export function PendingSyncBanner() {
 
     let cancelled = false
     const check = () => {
-      getStaleEntries().then((stale) => {
+      if (!account || !accountFingerprint) return
+      const guard = { accountEpoch: getAccountEpoch(), accountFingerprint }
+      getStaleEntries(guard).then((stale) => {
         if (!cancelled) setHasStaleEntries(stale.length > 0)
-      })
+      }).catch(() => {})
     }
     check()
     const interval = setInterval(check, 60_000) // re-check every minute
@@ -32,21 +38,33 @@ export function PendingSyncBanner() {
       cancelled = true
       clearInterval(interval)
     }
-  }, [pendingCount])
+  }, [pendingCount, account, accountFingerprint])
 
   if (pendingCount === 0 && failedCount === 0) return null
 
   const isQueueNearLimit = pendingCount >= MAX_QUEUE_SIZE
 
   const handleRetryFailed = async () => {
-    await retryFailed()
-    if (isOnline) {
-      await replayOfflineQueue()
+    if (!account || !accountFingerprint) return
+    try {
+      await retryFailed({ accountEpoch: getAccountEpoch(), accountFingerprint })
+      if (isOnline) {
+        await replayOfflineQueue()
+      }
+    } catch (err) {
+      if (err instanceof AccountBoundaryChangedError) return
+      throw err
     }
   }
 
   const handleDiscardFailed = async () => {
-    await clearFailed()
+    if (!account || !accountFingerprint) return
+    try {
+      await clearFailed({ accountEpoch: getAccountEpoch(), accountFingerprint })
+    } catch (err) {
+      if (err instanceof AccountBoundaryChangedError) return
+      throw err
+    }
   }
 
   return (

--- a/apps/web/app/lib/__tests__/data-cache.test.ts
+++ b/apps/web/app/lib/__tests__/data-cache.test.ts
@@ -250,6 +250,32 @@ describe('data-cache', () => {
       expect(items.map((i) => i.itemUid)).toEqual(['y'])
     })
 
+    it('aborts queued single-item put and delete commits when the account epoch changes', async () => {
+      await ensureFingerprint('current-account')
+      const putEpoch = getAccountEpoch()
+      const originalPut = IDBObjectStore.prototype.put
+      const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (value, key) {
+        const request = key === undefined ? originalPut.call(this, value) : originalPut.call(this, value, key)
+        if ((value as { itemUid?: string }).itemUid === 'stale-put') bumpAccountEpoch()
+        return request
+      })
+      await expect(putItem(makeItem('stale-put'), putEpoch)).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      expect((await getItemsByType('tasks')).some((item) => item.itemUid === 'stale-put')).toBe(false)
+      putSpy.mockRestore()
+
+      await putItem(makeItem('keep-delete'))
+      const deleteEpoch = getAccountEpoch()
+      const originalDelete = IDBObjectStore.prototype.delete
+      const deleteSpy = vi.spyOn(IDBObjectStore.prototype, 'delete').mockImplementation(function (query) {
+        const request = originalDelete.call(this, query)
+        if (query === 'keep-delete') bumpAccountEpoch()
+        return request
+      })
+      await expect(deleteItem('keep-delete', deleteEpoch)).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      expect((await getItemsByType('tasks')).some((item) => item.itemUid === 'keep-delete')).toBe(true)
+      deleteSpy.mockRestore()
+    })
+
     it('replaceItemsForType drops existing of that type and inserts the new set', async () => {
       await putItems([
         makeItem('a', 'tasks'),
@@ -454,6 +480,27 @@ describe('data-cache', () => {
       const ok = await ensureFingerprint('alice@example.com')
       expect(ok).toBe(true)
       expect(await getStoken('col-tasks')).toBe('stk-a')
+    })
+
+    it('aborts a stale destructive fingerprint switch without touching the new account cache', async () => {
+      await ensureFingerprint('account-b')
+      await setStoken('tasks', 'b-collection', 'b-stoken')
+      await putItem(makeItem('b-item', 'tasks', 'B PRIVATE', 'b-collection'))
+      const cryptoKeys = await rawCryptoKeys()
+      const accountEpoch = getAccountEpoch()
+      const originalClear = IDBObjectStore.prototype.clear
+      const clearSpy = vi.spyOn(IDBObjectStore.prototype, 'clear').mockImplementation(function (this: IDBObjectStore) {
+        if (this.name === 'items') bumpAccountEpoch()
+        return originalClear.call(this)
+      })
+
+      await expect(ensureFingerprint('account-a', accountEpoch)).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      clearSpy.mockRestore()
+
+      expect((await getMeta())?.accountFingerprint).toBe('account-b')
+      expect(await getStoken('b-collection')).toBe('b-stoken')
+      expect((await getItemsByType('tasks')).map((item) => item.content)).toEqual(['B PRIVATE'])
+      expect(await rawCryptoKeys()).toEqual(cryptoKeys)
     })
 
     it('upgrades and clears the rolled-back v4 encrypted cache schema', async () => {

--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import 'fake-indexeddb/auto'
+import { AccountBoundaryChangedError, bumpAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 import {
   enqueue,
   getAll,
@@ -147,7 +148,7 @@ describe('offline-queue', () => {
 
       _setEncryptedQueuePersistenceAvailableForTests(false)
 
-      expect(await getAll()).toHaveLength(0)
+      expect(await getAll({ accountEpoch: getAccountEpoch(), accountFingerprint: 'different-account' })).toHaveLength(0)
       expect(JSON.stringify(await readRawMutations())).not.toContain('PRIVATE_SENTINEL_TASK')
     })
 
@@ -159,6 +160,102 @@ describe('offline-queue', () => {
 
       expect(await getAll()).toHaveLength(0)
       expect(await getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('transactional account boundary', () => {
+    const guard = (fingerprint: string) => ({ accountEpoch: getAccountEpoch(), accountFingerprint: fingerprint })
+
+    it('aborts an enqueue after the actual put is issued without records or listeners', async () => {
+      const counts: number[] = []
+      const enqueues: number[] = []
+      onCountChange((count) => counts.push(count))
+      onEnqueue(() => enqueues.push(1))
+      const originalPut = IDBObjectStore.prototype.put
+      const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (...args: Parameters<IDBObjectStore['put']>) {
+        const request = originalPut.apply(this, args)
+        bumpAccountEpoch()
+        return request
+      })
+
+      await expect(enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: 'same', itemUid: 'same' }, guard('old')))
+        .rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      putSpy.mockRestore()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(await getAll()).toEqual([])
+      expect(counts).toEqual([])
+      expect(enqueues).toEqual([])
+    })
+
+    it('aborts a guarded removal after the actual delete is issued', async () => {
+      const owner = guard('old')
+      const id = await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: 'same', itemUid: 'same' }, owner)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const counts: number[] = []
+      onCountChange((count) => counts.push(count))
+      const originalDelete = IDBObjectStore.prototype.delete
+      const deleteSpy = vi.spyOn(IDBObjectStore.prototype, 'delete').mockImplementation(function (...args: Parameters<IDBObjectStore['delete']>) {
+        const request = originalDelete.apply(this, args)
+        bumpAccountEpoch()
+        return request
+      })
+
+      await expect(remove(id, owner)).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      deleteSpy.mockRestore()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect((await getAll()).map((entry) => entry.id)).toEqual([id])
+      expect(counts).toEqual([])
+    })
+
+    it('aborts a compaction update after its actual put is issued', async () => {
+      const owner = guard('old')
+      const id = await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: 'same', itemUid: 'same', content: 'before' }, owner)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const counts: number[] = []
+      onCountChange((count) => counts.push(count))
+      const originalPut = IDBObjectStore.prototype.put
+      const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (...args: Parameters<IDBObjectStore['put']>) {
+        const request = originalPut.apply(this, args)
+        bumpAccountEpoch()
+        return request
+      })
+
+      await expect(enqueue({ type: 'update', collectionType: 'tasks', collectionUid: 'same', itemUid: 'same', content: 'after' }, owner))
+        .rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      putSpy.mockRestore()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(await getAll()).toEqual([expect.objectContaining({ id, content: 'before' })])
+      expect(counts).toEqual([])
+    })
+
+    it('isolates compaction for different fingerprints sharing collection and item UIDs', async () => {
+      await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: 'same', itemUid: 'same', content: 'account A' }, guard('A'))
+      await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: 'same', itemUid: 'same' }, guard('B'))
+
+      const entries = await getAll()
+      expect(entries).toHaveLength(2)
+      expect(entries.find((entry) => entry.accountFingerprint === 'A')).toMatchObject({ type: 'update', content: 'account A' })
+      expect(entries.find((entry) => entry.accountFingerprint === 'B')).toMatchObject({ type: 'delete' })
+    })
+
+    it('notifies listeners with only the committing account queue count', async () => {
+      await enqueue({ type: 'delete', collectionType: 'tasks', itemUid: 'a' }, guard('A'))
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const counts: number[] = []
+      onCountChange((count) => counts.push(count))
+
+      await enqueue({ type: 'delete', collectionType: 'tasks', itemUid: 'b' }, guard('B'))
+      await vi.waitFor(() => expect(counts).toEqual([1]))
+    })
+
+    it('fails closed when a guarded operation has no fingerprint', async () => {
+      await expect(enqueue({ type: 'delete', collectionType: 'tasks', itemUid: 'x' }, {
+        accountEpoch: getAccountEpoch(),
+        accountFingerprint: '',
+      })).rejects.toBeInstanceOf(AccountBoundaryChangedError)
     })
   })
 
@@ -623,6 +720,37 @@ describe('offline-queue', () => {
       expect(results).toHaveLength(2)
       expect(results.every((r) => r.success)).toBe(true)
       expect(await getPendingCount()).toBe(0)
+    })
+  })
+
+  describe('account-bound replay', () => {
+    it('never executes or removes entries owned by another account fingerprint', async () => {
+      const oldGuard = { accountEpoch: getAccountEpoch(), accountFingerprint: 'old-account' }
+      const id = await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: 'shared', itemUid: 'same-id' }, oldGuard)
+      const newGuard = { accountEpoch: getAccountEpoch(), accountFingerprint: 'new-account' }
+      const execute = vi.fn().mockResolvedValue({})
+
+      expect(await replay(execute, newGuard)).toEqual([])
+      expect(execute).not.toHaveBeenCalled()
+      expect((await getAll()).map((entry) => entry.id)).toContain(id)
+    })
+
+    it('quietly stops when the boundary changes during execute without retry mutation or publication', async () => {
+      const guard = { accountEpoch: getAccountEpoch(), accountFingerprint: 'current-account' }
+      const id = await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: 'tasks', itemUid: 'task-1' }, guard)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const listener = vi.fn()
+      const unsubscribe = onCountChange(listener)
+      const results = await replay(async () => {
+        bumpAccountEpoch()
+        return { itemUid: 'must-not-publish' }
+      }, guard)
+      unsubscribe()
+
+      expect(results).toEqual([])
+      const entry = (await getAll()).find((candidate) => candidate.id === id)
+      expect(entry).toMatchObject({ retryCount: 0, status: 'pending' })
+      expect(listener).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -165,15 +165,60 @@ async function getStoredEnvelopeKey(): Promise<CryptoKey | null> {
   }
 }
 
-async function putStoredEnvelopeKey(key: CryptoKey): Promise<void> {
-  await withStore<IDBValidKey>(STORE_CRYPTO, 'readwrite', (store) => store.put(key, ENVELOPE_KEY))
+async function putStoredEnvelopeKey(key: CryptoKey, accountEpoch?: number): Promise<void> {
+  if (accountEpoch === undefined) {
+    await withStore<IDBValidKey>(STORE_CRYPTO, 'readwrite', (store) => store.put(key, ENVELOPE_KEY))
+    return
+  }
+  const expectedFingerprint = (await getMeta())?.accountFingerprint
+  assertCurrentAccountEpoch(accountEpoch)
+  if (!expectedFingerprint) throw new AccountBoundaryChangedError()
+  const db = await openDB()
+  assertCurrentAccountEpoch(accountEpoch)
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction([STORE_CRYPTO, STORE_META], 'readwrite')
+    const cryptoStore = tx.objectStore(STORE_CRYPTO)
+    const metaStore = tx.objectStore(STORE_META)
+    const metaReq = metaStore.get(META_KEY)
+    let settled = false
+    const fail = (error: unknown) => {
+      if (settled) return
+      settled = true
+      reject(error)
+    }
+    const abortForBoundary = () => {
+      fail(new AccountBoundaryChangedError())
+      try { tx.abort() } catch { /* transaction already finished */ }
+    }
+    metaReq.onsuccess = () => {
+      if ((metaReq.result as CacheMeta | undefined)?.accountFingerprint !== expectedFingerprint) {
+        abortForBoundary()
+        return
+      }
+      cryptoStore.put(key, ENVELOPE_KEY)
+      const commitGuard = metaStore.get(META_KEY)
+      commitGuard.onsuccess = () => {
+        try { assertCurrentAccountEpoch(accountEpoch) } catch { abortForBoundary() }
+      }
+      commitGuard.onerror = () => fail(commitGuard.error)
+    }
+    metaReq.onerror = () => fail(metaReq.error)
+    tx.oncomplete = () => {
+      if (settled) return
+      settled = true
+      resolve()
+    }
+    tx.onerror = () => fail(tx.error)
+    tx.onabort = () => fail(tx.error ?? new DOMException('Transaction aborted', 'AbortError'))
+  })
 }
 
 /**
  * Ensure the encrypted cache envelope is ready for this browser session.
  * Returns false instead of throwing so cache enablement always fails closed.
  */
-export async function ensureEncryptedEnvelope(): Promise<boolean> {
+export async function ensureEncryptedEnvelope(accountEpoch?: number): Promise<boolean> {
+  if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
   if (!hasWebCrypto()) {
     envelopeKey = null
     envelopeReady = false
@@ -184,6 +229,7 @@ export async function ensureEncryptedEnvelope(): Promise<boolean> {
 
   try {
     const existing = await getStoredEnvelopeKey()
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
     if (existing) {
       envelopeKey = existing
       envelopeReady = true
@@ -195,11 +241,14 @@ export async function ensureEncryptedEnvelope(): Promise<boolean> {
       false,
       ['encrypt', 'decrypt'],
     )
-    await putStoredEnvelopeKey(generated)
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+    await putStoredEnvelopeKey(generated, accountEpoch)
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
     envelopeKey = generated
     envelopeReady = true
     return true
   } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) throw err
     logger.warn('[data-cache] encrypted envelope unavailable', err)
     envelopeKey = null
     envelopeReady = false
@@ -286,42 +335,107 @@ export async function getItemsByType(type: CollectionTypeKey): Promise<CachedIte
   }
 }
 
+async function commitItemMutations(
+  puts: StoredItem[],
+  deletes: string[],
+  accountEpoch: number | undefined,
+  operation: 'putItem' | 'putItems' | 'deleteItem',
+): Promise<void> {
+  try {
+    if (accountEpoch === undefined) {
+      const db = await openDB()
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(STORE_ITEMS, 'readwrite')
+        const store = tx.objectStore(STORE_ITEMS)
+        for (const itemUid of deletes) store.delete(itemUid)
+        for (const item of puts) store.put(item)
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error)
+      })
+      return
+    }
+
+    const expectedFingerprint = (await getMeta())?.accountFingerprint
+    assertCurrentAccountEpoch(accountEpoch)
+    if (!expectedFingerprint) throw new AccountBoundaryChangedError()
+    const db = await openDB()
+    assertCurrentAccountEpoch(accountEpoch)
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([STORE_ITEMS, STORE_META], 'readwrite')
+      const itemStore = tx.objectStore(STORE_ITEMS)
+      const metaReq = tx.objectStore(STORE_META).get(META_KEY)
+      let settled = false
+      const fail = (error: unknown) => {
+        if (settled) return
+        settled = true
+        reject(error)
+      }
+      const abortForBoundary = () => {
+        fail(new AccountBoundaryChangedError())
+        try { tx.abort() } catch { /* transaction already finished */ }
+      }
+      metaReq.onsuccess = () => {
+        const currentFingerprint = (metaReq.result as CacheMeta | undefined)?.accountFingerprint
+        if (currentFingerprint !== expectedFingerprint) {
+          abortForBoundary()
+          return
+        }
+        for (const itemUid of deletes) itemStore.delete(itemUid)
+        for (const item of puts) itemStore.put(item)
+        const commitGuard = itemStore.get('__account-epoch-commit-guard__')
+        commitGuard.onsuccess = () => {
+          try {
+            assertCurrentAccountEpoch(accountEpoch)
+          } catch {
+            abortForBoundary()
+          }
+        }
+        commitGuard.onerror = () => fail(commitGuard.error)
+      }
+      metaReq.onerror = () => fail(metaReq.error)
+      tx.oncomplete = () => {
+        if (settled) return
+        settled = true
+        resolve()
+      }
+      tx.onerror = () => fail(tx.error)
+      tx.onabort = () => fail(tx.error ?? new DOMException('Transaction aborted', 'AbortError'))
+    })
+  } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) throw err
+    logger.warn(`[data-cache] ${operation} failed`, err)
+  }
+}
+
 /** Insert/update a single item. Failures are logged and swallowed. */
-export async function putItem(item: CachedItem): Promise<void> {
+export async function putItem(item: CachedItem, accountEpoch?: number): Promise<void> {
   if (!canWriteItemContent('putItem')) return
   try {
     const stored = await toStoredItem(item)
-    await withStore(STORE_ITEMS, 'readwrite', (store) => store.put(stored))
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+    await commitItemMutations([stored], [], accountEpoch, 'putItem')
   } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) throw err
     logger.warn('[data-cache] putItem failed', err)
   }
 }
 
 /** Bulk insert/update — single transaction for efficiency. */
-export async function putItems(items: CachedItem[]): Promise<void> {
+export async function putItems(items: CachedItem[], accountEpoch?: number): Promise<void> {
   if (items.length === 0) return
   if (!canWriteItemContent('putItems')) return
   try {
     const storedItems = await Promise.all(items.map(toStoredItem))
-    const db = await openDB()
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(STORE_ITEMS, 'readwrite')
-      const store = tx.objectStore(STORE_ITEMS)
-      for (const item of storedItems) store.put(item)
-      tx.oncomplete = () => resolve()
-      tx.onerror = () => reject(tx.error)
-    })
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+    await commitItemMutations(storedItems, [], accountEpoch, 'putItems')
   } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) throw err
     logger.warn('[data-cache] putItems failed', err)
   }
 }
 
-export async function deleteItem(itemUid: string): Promise<void> {
-  try {
-    await withStore(STORE_ITEMS, 'readwrite', (store) => store.delete(itemUid))
-  } catch (err) {
-    logger.warn('[data-cache] deleteItem failed', err)
-  }
+export async function deleteItem(itemUid: string, accountEpoch?: number): Promise<void> {
+  await commitItemMutations([], [itemUid], accountEpoch, 'deleteItem')
 }
 
 async function replaceItemsForIndex(
@@ -475,9 +589,15 @@ export async function setStoken(
       const metaStore = tx.objectStore(STORE_META)
       const metaReq = metaStore.get(META_KEY)
 
+      let settled = false
+      const fail = (error: unknown) => {
+        if (settled) return
+        settled = true
+        reject(error)
+      }
       const abortForBoundary = () => {
-        reject(new AccountBoundaryChangedError())
-        tx.abort()
+        fail(new AccountBoundaryChangedError())
+        try { tx.abort() } catch { /* transaction already finished */ }
       }
 
       metaReq.onsuccess = () => {
@@ -577,51 +697,80 @@ export async function clearAll(): Promise<void> {
  * schema version. If not, wipe and reseed the meta record. Returns true if
  * the cache survived the check (callers can use it), false if it was wiped.
  */
-export async function ensureFingerprint(accountFingerprint: string): Promise<boolean> {
-  const meta = await getMeta()
-  const current: CacheMeta = {
-    accountFingerprint,
-    cacheSchemaVersion: CACHE_SCHEMA_VERSION,
-    lastInvalidatedAt: meta?.lastInvalidatedAt ?? null,
-  }
+export async function ensureFingerprint(accountFingerprint: string, accountEpoch?: number): Promise<boolean> {
+  if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+  const db = await openDB()
+  if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
 
-  if (!meta) {
-    await putMeta(current)
-    return true
-  }
+  const result = await new Promise<{ survived: boolean; invalidated: boolean }>((resolve, reject) => {
+    const tx = db.transaction([STORE_ITEMS, STORE_COLLECTIONS, STORE_META, STORE_CRYPTO], 'readwrite')
+    const metaStore = tx.objectStore(STORE_META)
+    const metaReq = metaStore.get(META_KEY)
+    let settled = false
+    let survived = true
+    let invalidated = false
+    const fail = (error: unknown) => {
+      if (settled) return
+      settled = true
+      reject(error)
+    }
+    const abortForBoundary = () => {
+      fail(new AccountBoundaryChangedError())
+      try { tx.abort() } catch { /* transaction already finished */ }
+    }
 
-  const fingerprintMismatch =
-    meta.accountFingerprint !== null && meta.accountFingerprint !== accountFingerprint
-  const schemaMismatch = meta.cacheSchemaVersion !== CACHE_SCHEMA_VERSION
+    metaReq.onsuccess = () => {
+      try {
+        if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+      } catch {
+        abortForBoundary()
+        return
+      }
+      const meta = metaReq.result as CacheMeta | undefined
+      const fingerprintMismatch = Boolean(meta?.accountFingerprint && meta.accountFingerprint !== accountFingerprint)
+      const schemaMismatch = Boolean(meta && meta.cacheSchemaVersion !== CACHE_SCHEMA_VERSION)
+      invalidated = fingerprintMismatch || schemaMismatch
+      survived = !invalidated
+      const current: CacheMeta = {
+        accountFingerprint,
+        cacheSchemaVersion: CACHE_SCHEMA_VERSION,
+        lastInvalidatedAt: invalidated ? Date.now() : (meta?.lastInvalidatedAt ?? null),
+      }
 
-  if (fingerprintMismatch || schemaMismatch) {
-    logger.warn('[data-cache] fingerprint or schema mismatch, clearing cache', {
-      fingerprintMismatch,
-      schemaMismatch,
-    })
+      if (invalidated) {
+        tx.objectStore(STORE_ITEMS).clear()
+        tx.objectStore(STORE_COLLECTIONS).clear()
+        metaStore.clear()
+        tx.objectStore(STORE_CRYPTO).clear()
+      }
+      if (!meta || invalidated || meta.accountFingerprint === null) metaStore.put(current, META_KEY)
+
+      const commitGuard = metaStore.get(META_KEY)
+      commitGuard.onsuccess = () => {
+        try {
+          if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
+        } catch {
+          abortForBoundary()
+        }
+      }
+      commitGuard.onerror = () => fail(commitGuard.error)
+    }
+    metaReq.onerror = () => fail(metaReq.error)
+    tx.oncomplete = () => {
+      if (settled) return
+      settled = true
+      resolve({ survived, invalidated })
+    }
+    tx.onerror = () => fail(tx.error)
+    tx.onabort = () => fail(tx.error ?? new DOMException('Transaction aborted', 'AbortError'))
+  })
+
+  if (result.invalidated) {
     envelopeKey = null
     envelopeReady = false
-    const replacementMeta = { ...current, lastInvalidatedAt: Date.now() }
-    const db = await openDB()
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction([STORE_ITEMS, STORE_COLLECTIONS, STORE_META, STORE_CRYPTO], 'readwrite')
-      tx.objectStore(STORE_ITEMS).clear()
-      tx.objectStore(STORE_COLLECTIONS).clear()
-      const metaStore = tx.objectStore(STORE_META)
-      metaStore.clear()
-      metaStore.put(replacementMeta, META_KEY)
-      tx.objectStore(STORE_CRYPTO).clear()
-      tx.oncomplete = () => resolve()
-      tx.onerror = () => reject(tx.error)
-    })
-    return false
+    logger.warn('[data-cache] fingerprint or schema mismatch, clearing cache')
   }
-
-  // First-time fingerprint write (e.g. legacy cache without fingerprint)
-  if (meta.accountFingerprint === null) {
-    await putMeta(current)
-  }
-  return true
+  return result.survived
 }
 
 // ── Feature flag helper ──

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -4,6 +4,7 @@
  * and replays them in FIFO order when connectivity returns.
  */
 import { logger } from '@/app/lib/logger'
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch } from '@/app/lib/account-epoch'
 
 type CollectionTypeKey = 'calendar' | 'tasks' | 'contacts' | 'preferences'
 type MutationType = 'create' | 'update' | 'delete' | 'move'
@@ -20,6 +21,12 @@ export interface QueueEntry {
   createdAt: number
   retryCount: number
   status: 'pending' | 'failed'
+  accountFingerprint?: string
+}
+
+export interface OfflineQueueAccountGuard {
+  accountEpoch: number
+  accountFingerprint: string
 }
 
 export interface ReplayResult {
@@ -67,6 +74,20 @@ function assertCanPersistEntry(
   )
 }
 
+function assertGuard(guard?: OfflineQueueAccountGuard): void {
+  if (!guard) return
+  if (!guard.accountFingerprint) throw new AccountBoundaryChangedError()
+  assertCurrentAccountEpoch(guard.accountEpoch)
+}
+
+function queueCommitGuard(store: IDBObjectStore, tx: IDBTransaction, guard?: OfflineQueueAccountGuard): void {
+  if (!guard) return
+  const request = store.get('__account_boundary_commit_guard__')
+  request.onsuccess = () => {
+    try { assertGuard(guard) } catch { tx.abort() }
+  }
+}
+
 function openDB(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise
   dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
@@ -88,12 +109,20 @@ function generateId(): string {
   return `${Date.now()}-${++counter}-${Math.random().toString(36).slice(2, 9)}`
 }
 
-function notifyListeners(): void {
-  // Read count async then notify — fire and forget
-  getPendingCount().then((count) => {
-    for (const fn of listeners) {
+function notifyListeners(guard?: OfflineQueueAccountGuard): void {
+  // Snapshot subscribers at commit notification time so listeners registered
+  // later cannot observe an earlier account transaction.
+  const subscribers = [...listeners]
+  const entriesPromise = guard ? getAll(guard) : getAll()
+  entriesPromise.then((entries) => entries.filter((entry) => entry.status === 'pending').length).then((count) => {
+    for (const fn of subscribers) {
       try { fn(count) } catch (err) { logger.warn('OfflineQueue', 'Listener callback failed', err) }
     }
+  }).catch((err) => {
+    if (err instanceof AccountBoundaryChangedError) return
+    logger.warn('OfflineQueue', 'Listener count refresh failed', {
+      errorName: err instanceof Error ? err.name : 'UnknownError',
+    })
   })
 }
 
@@ -116,10 +145,13 @@ function notifyListeners(): void {
  */
 async function compact(
   incoming: Omit<QueueEntry, 'id' | 'createdAt' | 'retryCount' | 'status'>,
+  guard?: OfflineQueueAccountGuard,
 ): Promise<string | null> {
   assertCanPersistEntry(incoming)
-  const entries = await getAll()
-  const pending = entries.filter((e) => e.status === 'pending')
+  assertGuard(guard)
+  const entries = await getAll(guard)
+  assertGuard(guard)
+  const pending = entries.filter((e) => e.status === 'pending' && (!guard || e.accountFingerprint === guard.accountFingerprint))
 
   // Match by tempId (for items created offline that haven't synced yet)
   if (incoming.tempId) {
@@ -129,17 +161,17 @@ async function compact(
     if (existing) {
       if (existing.type === 'create' && incoming.type === 'update') {
         // Merge: update content and target collection in the existing create entry.
-        await updateEntry({ ...existing, collectionUid: incoming.collectionUid ?? existing.collectionUid, content: incoming.content })
+        await updateEntry({ ...existing, collectionUid: incoming.collectionUid ?? existing.collectionUid, content: incoming.content }, guard)
         return existing.id
       }
       if (existing.type === 'create' && incoming.type === 'create') {
         // Merge duplicate creates for the same optimistic item, keeping latest content.
-        await updateEntry({ ...existing, collectionUid: incoming.collectionUid ?? existing.collectionUid, content: incoming.content })
+        await updateEntry({ ...existing, collectionUid: incoming.collectionUid ?? existing.collectionUid, content: incoming.content }, guard)
         return existing.id
       }
       if (existing.type === 'create' && incoming.type === 'delete') {
         // Cancel both: the item was created and deleted offline
-        await remove(existing.id)
+        await remove(existing.id, guard)
         return 'cancelled'
       }
     }
@@ -158,15 +190,15 @@ async function compact(
           collectionUid: incoming.collectionUid ?? moveRelated.collectionUid,
           targetCollectionUid: incoming.targetCollectionUid,
           content: incoming.content,
-        })
+        }, guard)
         return moveRelated.id
       }
       if (moveRelated.type === 'move' && incoming.type === 'update') {
         if (incoming.collectionUid && incoming.collectionUid === moveRelated.collectionUid) {
-          await updateEntry({ ...moveRelated, type: 'update', targetCollectionUid: undefined, content: incoming.content })
+          await updateEntry({ ...moveRelated, type: 'update', targetCollectionUid: undefined, content: incoming.content }, guard)
           return moveRelated.id
         }
-        await updateEntry({ ...moveRelated, content: incoming.content ?? moveRelated.content })
+        await updateEntry({ ...moveRelated, content: incoming.content ?? moveRelated.content }, guard)
         return moveRelated.id
       }
       if (moveRelated.type === 'move' && incoming.type === 'move') {
@@ -175,11 +207,11 @@ async function compact(
           collectionUid: incoming.collectionUid ?? moveRelated.collectionUid,
           targetCollectionUid: incoming.targetCollectionUid ?? moveRelated.targetCollectionUid,
           content: incoming.content ?? moveRelated.content,
-        })
+        }, guard)
         return moveRelated.id
       }
       if (moveRelated.type === 'move' && incoming.type === 'delete') {
-        await updateEntry({ ...moveRelated, type: 'delete', targetCollectionUid: undefined, content: undefined })
+        await updateEntry({ ...moveRelated, type: 'delete', targetCollectionUid: undefined, content: undefined }, guard)
         return moveRelated.id
       }
     }
@@ -190,12 +222,12 @@ async function compact(
     if (existing) {
       if (existing.type === 'update' && incoming.type === 'update') {
         // Merge: keep latest content
-        await updateEntry({ ...existing, content: incoming.content })
+        await updateEntry({ ...existing, content: incoming.content }, guard)
         return existing.id
       }
       if (existing.type === 'update' && incoming.type === 'delete') {
         // Replace update with delete
-        await updateEntry({ ...existing, type: 'delete', content: undefined })
+        await updateEntry({ ...existing, type: 'delete', content: undefined }, guard)
         return existing.id
       }
     }
@@ -206,39 +238,50 @@ async function compact(
 
 export async function enqueue(
   entry: Omit<QueueEntry, 'id' | 'createdAt' | 'retryCount' | 'status'>,
+  guard?: OfflineQueueAccountGuard,
 ): Promise<string> {
+  assertGuard(guard)
   // Try compaction first
-  const compactedId = await compact(entry)
+  const compactedId = await compact(entry, guard)
+  assertGuard(guard)
   if (compactedId) return compactedId
 
   // Enforce queue size limit (count only pending entries)
-  if (await isQueueFull()) {
+  if (await isQueueFull(guard)) {
     throw new Error(`Offline queue is full (max ${MAX_QUEUE_SIZE} pending entries). Connect to the internet to sync your changes.`)
   }
+  assertGuard(guard)
 
   const db = await openDB()
+  assertGuard(guard)
   const record: QueueEntry = {
     ...entry,
     id: generateId(),
     createdAt: Date.now(),
     retryCount: 0,
     status: 'pending',
+    ...(guard ? { accountFingerprint: guard.accountFingerprint } : {}),
   }
   assertCanPersistEntry(record)
   return new Promise<string>((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite')
-    tx.objectStore(STORE_NAME).put(record)
+    const store = tx.objectStore(STORE_NAME)
+    store.put(record)
+    queueCommitGuard(store, tx, guard)
     tx.oncomplete = () => {
-      notifyListeners()
+      notifyListeners(guard)
       notifyEnqueueListeners()
       resolve(record.id)
     }
     tx.onerror = () => reject(tx.error)
+    tx.onabort = () => reject(guard ? new AccountBoundaryChangedError() : tx.error)
   })
 }
 
-export async function getAll(): Promise<QueueEntry[]> {
+export async function getAll(guard?: OfflineQueueAccountGuard): Promise<QueueEntry[]> {
+  assertGuard(guard)
   const db = await openDB()
+  assertGuard(guard)
   return new Promise((resolve, reject) => {
     // Use a readwrite transaction so legacy plaintext records can be purged
     // atomically before callers observe the queue.
@@ -247,58 +290,86 @@ export async function getAll(): Promise<QueueEntry[]> {
     const request = store.getAll()
     let safeEntries: QueueEntry[] = []
     request.onsuccess = () => {
-      const entries = (request.result as QueueEntry[]).sort(
+      const allEntries = (request.result as QueueEntry[]).sort(
         (a, b) => a.createdAt - b.createdAt || a.id.localeCompare(b.id),
       )
       if (!isEncryptedQueuePersistenceAvailable()) {
-        safeEntries = entries.filter((entry) => !hasPersistedPlaintextContent(entry))
-        for (const entry of entries) {
+        const safeAllEntries = allEntries.filter((entry) => !hasPersistedPlaintextContent(entry))
+        for (const entry of allEntries) {
           if (hasPersistedPlaintextContent(entry)) store.delete(entry.id)
         }
+        safeEntries = safeAllEntries.filter((entry) => !guard || entry.accountFingerprint === guard.accountFingerprint)
         return
       }
-      safeEntries = entries
+      safeEntries = allEntries.filter((entry) => !guard || entry.accountFingerprint === guard.accountFingerprint)
     }
     request.onerror = () => reject(request.error)
+    queueCommitGuard(store, tx, guard)
     tx.oncomplete = () => resolve(safeEntries)
     tx.onerror = () => reject(tx.error)
+    tx.onabort = () => reject(guard ? new AccountBoundaryChangedError() : tx.error)
   })
 }
 
-export async function getPendingCount(): Promise<number> {
-  const entries = await getAll()
+export async function getPendingCount(guard: OfflineQueueAccountGuard): Promise<number> {
+  const entries = await getAll(guard)
+  assertGuard(guard)
   return entries.filter((e) => e.status === 'pending').length
 }
 
-export async function remove(id: string): Promise<void> {
+export async function remove(id: string, guard?: OfflineQueueAccountGuard): Promise<void> {
+  assertGuard(guard)
   const db = await openDB()
+  assertGuard(guard)
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite')
-    tx.objectStore(STORE_NAME).delete(id)
+    const store = tx.objectStore(STORE_NAME)
+    if (guard) {
+      const lookup = store.get(id)
+      lookup.onsuccess = () => {
+        try {
+          assertGuard(guard)
+          const entry = lookup.result as QueueEntry | undefined
+          if (entry?.accountFingerprint === guard.accountFingerprint) store.delete(id)
+          queueCommitGuard(store, tx, guard)
+        } catch { tx.abort() }
+      }
+      lookup.onerror = () => reject(lookup.error)
+    } else {
+      store.delete(id)
+    }
     tx.oncomplete = () => {
-      notifyListeners()
+      notifyListeners(guard)
       resolve()
     }
     tx.onerror = () => reject(tx.error)
+    tx.onabort = () => reject(guard ? new AccountBoundaryChangedError() : tx.error)
   })
 }
 
-async function updateEntry(entry: QueueEntry): Promise<void> {
+async function updateEntry(entry: QueueEntry, guard?: OfflineQueueAccountGuard): Promise<void> {
   assertCanPersistEntry(entry)
+  assertGuard(guard)
+  if (guard && entry.accountFingerprint !== guard.accountFingerprint) throw new AccountBoundaryChangedError()
   const db = await openDB()
+  assertGuard(guard)
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite')
-    tx.objectStore(STORE_NAME).put(entry)
+    const store = tx.objectStore(STORE_NAME)
+    store.put(entry)
+    queueCommitGuard(store, tx, guard)
     tx.oncomplete = () => {
-      notifyListeners()
+      notifyListeners(guard)
       resolve()
     }
     tx.onerror = () => reject(tx.error)
+    tx.onabort = () => reject(guard ? new AccountBoundaryChangedError() : tx.error)
   })
 }
 
-export async function getFailedCount(): Promise<number> {
-  const entries = await getAll()
+export async function getFailedCount(guard: OfflineQueueAccountGuard): Promise<number> {
+  const entries = await getAll(guard)
+  assertGuard(guard)
   return entries.filter((e) => e.status === 'failed').length
 }
 
@@ -315,31 +386,26 @@ export async function clearAll(): Promise<void> {
   })
 }
 
-export async function clearFailed(): Promise<void> {
-  const entries = await getAll()
-  const db = await openDB()
-  return new Promise((resolve, reject) => {
-    const tx = db.transaction(STORE_NAME, 'readwrite')
-    const store = tx.objectStore(STORE_NAME)
-    for (const entry of entries) {
-      if (entry.status === 'failed') {
-        store.delete(entry.id)
-      }
-    }
-    tx.oncomplete = () => {
-      notifyListeners()
-      resolve()
-    }
-    tx.onerror = () => reject(tx.error)
-  })
+export async function clearFailed(guard: OfflineQueueAccountGuard): Promise<void> {
+  const entries = await getAll(guard)
+  assertGuard(guard)
+  for (const entry of entries) {
+    if (entry.status !== 'failed') continue
+    assertGuard(guard)
+    await remove(entry.id, guard)
+    assertGuard(guard)
+  }
 }
 
 /** Reset failed entries back to pending so they can be retried */
-export async function retryFailed(): Promise<void> {
-  const entries = await getAll()
+export async function retryFailed(guard: OfflineQueueAccountGuard): Promise<void> {
+  const entries = await getAll(guard)
+  assertGuard(guard)
   for (const entry of entries) {
     if (entry.status === 'failed') {
-      await updateEntry({ ...entry, status: 'pending', retryCount: 0 })
+      assertGuard(guard)
+      await updateEntry({ ...entry, status: 'pending', retryCount: 0 }, guard)
+      assertGuard(guard)
     }
   }
 }
@@ -351,20 +417,30 @@ export async function retryFailed(): Promise<void> {
  */
 export async function replay(
   executeMutation: (entry: QueueEntry) => Promise<{ itemUid?: string }>,
+  guard: OfflineQueueAccountGuard,
 ): Promise<ReplayResult[]> {
-  const entries = await getAll()
+  try {
+  assertGuard(guard)
+  const entries = await getAll(guard)
+  assertGuard(guard)
   const pending = entries.filter((e) => e.status === 'pending')
   const results: ReplayResult[] = []
 
   for (const entry of pending) {
     try {
+      assertGuard(guard)
       const result = await executeMutation(entry)
-      await remove(entry.id)
+      assertGuard(guard)
+      await remove(entry.id, guard)
+      assertGuard(guard)
       results.push({ entry, success: true, itemUid: result.itemUid })
     } catch (err) {
+      if (err instanceof AccountBoundaryChangedError) return []
+      assertGuard(guard)
       const retryCount = entry.retryCount + 1
       const status = retryCount >= MAX_RETRIES ? 'failed' : 'pending'
-      await updateEntry({ ...entry, retryCount, status })
+      await updateEntry({ ...entry, retryCount, status }, guard)
+      assertGuard(guard)
       results.push({
         entry,
         success: false,
@@ -375,7 +451,12 @@ export async function replay(
     }
   }
 
+  assertGuard(guard)
   return results
+  } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) return []
+    throw err
+  }
 }
 
 export function onCountChange(fn: CountListener): () => void {
@@ -384,14 +465,16 @@ export function onCountChange(fn: CountListener): () => void {
 }
 
 /** Returns true if pending entries have reached or exceeded MAX_QUEUE_SIZE */
-export async function isQueueFull(): Promise<boolean> {
-  const entries = await getAll()
+export async function isQueueFull(guard?: OfflineQueueAccountGuard): Promise<boolean> {
+  const entries = await getAll(guard)
+  assertGuard(guard)
   return entries.filter((e) => e.status === 'pending').length >= MAX_QUEUE_SIZE
 }
 
 /** Returns pending entries older than the given threshold (defaults to 24h) */
-export async function getStaleEntries(thresholdMs: number = STALE_THRESHOLD_MS): Promise<QueueEntry[]> {
-  const entries = await getAll()
+export async function getStaleEntries(guard: OfflineQueueAccountGuard, thresholdMs: number = STALE_THRESHOLD_MS): Promise<QueueEntry[]> {
+  const entries = await getAll(guard)
+  assertGuard(guard)
   const cutoff = Date.now() - thresholdMs
   return entries.filter((e) => e.status === 'pending' && e.createdAt < cutoff)
 }

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -138,7 +138,10 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
           })
           .catch((err) => logger.warn('[sync-provider] Label suggestions initialization failed', getSafeErrorDetails(err)))
         void usePreferencesSyncStore.getState().initialize()
-          .catch((err) => logger.warn('[sync-provider] Preferences sync initialization failed', getSafeErrorDetails(err)))
+          .catch((err) => {
+            if (err instanceof AccountBoundaryChangedError || !isCurrentAccountEpoch(accountEpoch)) return
+            logger.warn('[sync-provider] Preferences sync initialization failed', getSafeErrorDetails(err))
+          })
 
         // Wire SyncEngine status
         const statusHandlerStartedAt = nowMs()
@@ -271,7 +274,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
       const startedAt = nowMs()
       const cacheEnabled = isLocalCacheEnabled()
       try {
-        const items = await useEtebaseStore.getState().fetchAllItems(type)
+        const items = await useEtebaseStore.getState().fetchAllItems(type, accountEpoch)
         assertCurrentAccountEpoch(accountEpoch)
         let domainItemCount = 0
         if (useEtebaseStore.getState().domainLoadState[type] === 'loaded') {
@@ -339,7 +342,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             assertCurrentAccountEpoch(accountEpoch)
             updatePartialLoadFlag()
             if (useEtebaseStore.getState().domainLoadState.tasks === 'loaded') {
-              const taskItems = await useEtebaseStore.getState().fetchAllItems('tasks')
+              const taskItems = await useEtebaseStore.getState().fetchAllItems('tasks', accountEpoch)
               assertCurrentAccountEpoch(accountEpoch)
               const tasks = taskItems.map((item) => {
                 const task = core.deserializeTask(item.content)
@@ -358,7 +361,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             assertCurrentAccountEpoch(accountEpoch)
             updatePartialLoadFlag()
             if (useEtebaseStore.getState().domainLoadState.contacts === 'loaded') {
-              const contactItems = await useEtebaseStore.getState().fetchAllItems('contacts')
+              const contactItems = await useEtebaseStore.getState().fetchAllItems('contacts', accountEpoch)
               assertCurrentAccountEpoch(accountEpoch)
               const contacts = contactItems.map((item) => {
                 const contact = core.deserializeContact(item.content)
@@ -377,7 +380,7 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             assertCurrentAccountEpoch(accountEpoch)
             updatePartialLoadFlag()
             if (useEtebaseStore.getState().domainLoadState.calendar === 'loaded') {
-              const eventItems = await useEtebaseStore.getState().fetchAllItems('calendar')
+              const eventItems = await useEtebaseStore.getState().fetchAllItems('calendar', accountEpoch)
               assertCurrentAccountEpoch(accountEpoch)
               const events = eventItems.map((item) => {
                 const event = core.deserializeCalendarEvent(item.content)

--- a/apps/web/app/stores/__tests__/use-etebase-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store.test.ts
@@ -23,6 +23,17 @@ const coreMock = vi.hoisted(() => ({
   createItem: vi.fn(),
   deleteItem: vi.fn(),
   updateCollectionMeta: vi.fn(),
+  updateItem: vi.fn(),
+  listIncomingInvitations: vi.fn(),
+  listOutgoingInvitations: vi.fn(),
+  cancelOutgoingInvitation: vi.fn(),
+  acceptInvitation: vi.fn(),
+  rejectInvitation: vi.fn(),
+  inviteToCollection: vi.fn(),
+  listCollectionMembers: vi.fn(),
+  removeCollectionMember: vi.fn(),
+  leaveCollection: vi.fn(),
+  modifyCollectionMemberAccess: vi.fn(),
 }))
 
 const toastStoreMock = vi.hoisted(() => ({
@@ -79,6 +90,17 @@ beforeEach(() => {
   coreMock.createItem.mockReset()
   coreMock.deleteItem.mockReset()
   coreMock.updateCollectionMeta.mockReset()
+  coreMock.updateItem.mockReset()
+  coreMock.listIncomingInvitations.mockReset()
+  coreMock.listOutgoingInvitations.mockReset()
+  coreMock.cancelOutgoingInvitation.mockReset()
+  coreMock.acceptInvitation.mockReset()
+  coreMock.rejectInvitation.mockReset()
+  coreMock.inviteToCollection.mockReset()
+  coreMock.listCollectionMembers.mockReset()
+  coreMock.removeCollectionMember.mockReset()
+  coreMock.leaveCollection.mockReset()
+  coreMock.modifyCollectionMemberAccess.mockReset()
   toastStoreMock.showErrorToast.mockReset()
   dataCacheMock.ensureEncryptedEnvelope.mockReset().mockResolvedValue(true)
   dataCacheMock.ensureFingerprint.mockReset().mockResolvedValue(true)
@@ -90,6 +112,7 @@ beforeEach(() => {
   dataCacheMock.deleteItem.mockReset().mockResolvedValue(undefined)
   dataCacheMock.replaceItemsForCollection.mockReset().mockResolvedValue(undefined)
   dataCacheMock.isCacheEnabled.mockReset().mockReturnValue(false)
+  useEtebaseStore.setState({ accountFingerprint: 'test-account-fingerprint' })
   sessionStorage.clear()
 })
 
@@ -400,6 +423,41 @@ describe('useEtebaseStore.initialize incremental domain loading', () => {
     mockSuccessfulSyncEngine()
   }
 
+  it('quietly cancels deferred initial item enumeration after an account boundary', async () => {
+    await primeSuccessfulRestore()
+    let resolveList!: (value: { items: any[]; stoken: null; done: boolean }) => void
+    let markStarted!: () => void
+    const started = new Promise<void>((resolve) => { markStarted = resolve })
+    coreMock.listItems.mockImplementationOnce(() => {
+      markStarted()
+      return new Promise((resolve) => { resolveList = resolve })
+    })
+    const onDomainLoaded = vi.fn()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const initialize = useEtebaseStore.getState().initialize({ onDomainLoaded })
+    await started
+    bumpAccountEpoch()
+    useEtebaseStore.setState({
+      account: { id: 'new-account' },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      domainLoadState: unknownDomainLoadState(),
+      isInitialized: false,
+    })
+    sessionStorage.removeItem('silentsuite.restore-diagnostics.v1')
+    resolveList({ items: [mockItem('old-private-item', 'PRIVATE_OLD_PLAINTEXT')], stoken: null, done: true })
+    await initialize
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('silentsuite.restore-diagnostics.v1')).toBeNull()
+    expect(onDomainLoaded).not.toHaveBeenCalled()
+    expect(useEtebaseStore.getState().itemCache.size).toBe(0)
+    expect(useEtebaseStore.getState().isInitialized).toBe(false)
+    warnSpy.mockRestore()
+  })
+
   it('invokes onDomainLoaded in calendar → tasks → contacts order with completed state visible', async () => {
     await primeSuccessfulRestore()
     coreMock.listItems.mockImplementation(async (_account: unknown, collection: { uid: string }) => {
@@ -561,8 +619,8 @@ describe('useEtebaseStore.initialize incremental domain loading', () => {
       onDomainLoaded: (event) => calls.push(`domain:${event.type}`),
     })
 
-    expect(dataCacheMock.ensureFingerprint).toHaveBeenCalledWith('fingerprint')
-    expect(dataCacheMock.ensureEncryptedEnvelope).toHaveBeenCalledTimes(1)
+    expect(dataCacheMock.ensureFingerprint).toHaveBeenCalledWith('fingerprint', expect.any(Number))
+    expect(dataCacheMock.ensureEncryptedEnvelope).toHaveBeenCalledWith(expect.any(Number))
     expect(calls).toEqual(['cacheHydrate', 'domain:calendar', 'domain:tasks', 'domain:contacts'])
   })
 
@@ -577,8 +635,8 @@ describe('useEtebaseStore.initialize incremental domain loading', () => {
     const onCacheHydrate = vi.fn()
     await useEtebaseStore.getState().initialize({ onCacheHydrate })
 
-    expect(dataCacheMock.ensureFingerprint).toHaveBeenCalledWith('fingerprint')
-    expect(dataCacheMock.ensureEncryptedEnvelope).toHaveBeenCalledTimes(1)
+    expect(dataCacheMock.ensureFingerprint).toHaveBeenCalledWith('fingerprint', expect.any(Number))
+    expect(dataCacheMock.ensureEncryptedEnvelope).toHaveBeenCalledWith(expect.any(Number))
     expect(onCacheHydrate).not.toHaveBeenCalled()
     expect(useEtebaseStore.getState().isInitialized).toBe(true)
   })
@@ -598,6 +656,46 @@ describe('useEtebaseStore.initialize incremental domain loading', () => {
     expect(useEtebaseStore.getState().domainLoadState).toMatchObject({ calendar: 'loaded', tasks: 'loaded', contacts: 'loaded' })
   })
 
+  it('quietly cancels cache setup after an account boundary without logging or hydrating', async () => {
+    await primeSuccessfulRestore()
+    dataCacheMock.getCacheCapabilityStatus.mockReturnValue({ featureFlagEnabled: true, encryptedEnvelopeAvailable: false, enabled: false })
+    let releaseFingerprint!: () => void
+    dataCacheMock.ensureFingerprint.mockImplementationOnce(() => new Promise<boolean>((resolve) => {
+      releaseFingerprint = () => resolve(true)
+    }))
+    const onCacheHydrate = vi.fn()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const initialize = useEtebaseStore.getState().initialize({ onCacheHydrate })
+    await vi.waitFor(() => expect(dataCacheMock.ensureFingerprint).toHaveBeenCalled())
+    bumpAccountEpoch()
+    releaseFingerprint()
+    await initialize
+
+    expect(dataCacheMock.ensureEncryptedEnvelope).not.toHaveBeenCalled()
+    expect(onCacheHydrate).not.toHaveBeenCalled()
+    expect(coreMock.listCollections).not.toHaveBeenCalled()
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('does not create default collections when the account changes during listing', async () => {
+    await primeSuccessfulRestore()
+    let releaseList!: (collections: unknown[]) => void
+    coreMock.listCollections.mockImplementationOnce(() => new Promise((resolve) => { releaseList = resolve }))
+    const onCacheHydrate = vi.fn()
+
+    const initialize = useEtebaseStore.getState().initialize({ onCacheHydrate })
+    await vi.waitFor(() => expect(coreMock.listCollections).toHaveBeenCalledTimes(1))
+    bumpAccountEpoch()
+    releaseList([])
+    await initialize
+
+    expect(coreMock.createCollection).not.toHaveBeenCalled()
+    expect(coreMock.listCollections).toHaveBeenCalledTimes(1)
+    expect(onCacheHydrate).not.toHaveBeenCalled()
+  })
+
   it('remains backwards-compatible when called with no options', async () => {
     await primeSuccessfulRestore()
     coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
@@ -607,6 +705,30 @@ describe('useEtebaseStore.initialize incremental domain loading', () => {
     const state = useEtebaseStore.getState()
     expect(state.isInitialized).toBe(true)
     expect(state.domainLoadState).toMatchObject({ calendar: 'loaded', tasks: 'loaded', contacts: 'loaded' })
+  })
+})
+
+describe('useEtebaseStore nested offline queue boundary errors', () => {
+  it('quietly cancels a stale nested enqueue rejection', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    coreMock.createItem.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    offlineQueueMock.isOfflineError.mockReturnValue(true)
+    offlineQueueMock.enqueue.mockRejectedValueOnce(new AccountBoundaryChangedError())
+    useEtebaseStore.setState({
+      account: { id: 'old' } as any,
+      accountFingerprint: 'old-fingerprint',
+      collections: { calendar: [{ uid: 'old-calendar' }] as any[], tasks: [], contacts: [], preferences: [] },
+    })
+
+    await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'old-temp')).resolves.toBeNull()
+
+    expect(offlineQueueMock.enqueue).toHaveBeenCalledWith(expect.objectContaining({ tempId: 'old-temp' }), {
+      accountEpoch: expect.any(Number),
+      accountFingerprint: 'old-fingerprint',
+    })
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
   })
 })
 
@@ -791,6 +913,125 @@ describe('useEtebaseStore.createItemsBatch', () => {
     expect(uids.slice(0, 20).every((u) => typeof u === 'string')).toBe(true)
     expect(uids.slice(20).every((u) => u === null)).toBe(true)
   })
+  it('cancels after an item create crosses the account boundary', async () => {
+    let releaseCreate!: () => void
+    const itemManager: MockItemManager = {
+      create: vi.fn(() => new Promise((resolve) => { releaseCreate = () => resolve({ uid: 'old-created' }) })),
+      batch: vi.fn(async () => {}),
+    }
+    setupStoreWithMocks(itemManager, { pause: vi.fn(), resume: vi.fn() })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const mutation = useEtebaseStore.getState().createItemsBatch('calendar', [{ content: 'OLD', tempId: 'old' }])
+    await vi.waitFor(() => expect(itemManager.create).toHaveBeenCalled())
+    bumpAccountEpoch()
+    releaseCreate()
+
+    await expect(mutation).resolves.toEqual([null])
+    expect(itemManager.batch).not.toHaveBeenCalled()
+    expect(dataCacheMock.putItems).not.toHaveBeenCalled()
+    expect(useEtebaseStore.getState().itemCache.has('old-created')).toBe(false)
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('cancels after the cooperative yield crosses the account boundary', async () => {
+    let nextUid = 0
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: `old-${nextUid++}` })),
+      batch: vi.fn(async () => {}),
+    }
+    setupStoreWithMocks(itemManager, { pause: vi.fn(), resume: vi.fn() })
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: () => void) => {
+      bumpAccountEpoch()
+      callback()
+      return 1
+    }) as typeof setTimeout)
+
+    const result = await useEtebaseStore.getState().createItemsBatch('calendar',
+      Array.from({ length: 26 }, (_, i) => ({ content: `OLD-${i}`, tempId: `old-${i}` })))
+    timerSpy.mockRestore()
+
+    expect(result).toEqual(Array(26).fill(null))
+    expect(itemManager.batch).not.toHaveBeenCalled()
+    expect(dataCacheMock.putItems).not.toHaveBeenCalled()
+    expect(useEtebaseStore.getState().itemCache.size).toBe(0)
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+  })
+
+  it('cancels after retry backoff crosses the account boundary without another batch attempt', async () => {
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: 'old-retry' })),
+      batch: vi.fn(async () => { throw new Error('transient') }),
+    }
+    setupStoreWithMocks(itemManager, { pause: vi.fn(), resume: vi.fn() })
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((callback: () => void) => {
+      bumpAccountEpoch()
+      callback()
+      return 1
+    }) as typeof setTimeout)
+
+    const result = await useEtebaseStore.getState().createItemsBatch('calendar', [{ content: 'OLD', tempId: 'old' }])
+    timerSpy.mockRestore()
+
+    expect(result).toEqual([null])
+    expect(itemManager.batch).toHaveBeenCalledTimes(1)
+    expect(dataCacheMock.putItems).not.toHaveBeenCalled()
+    expect(useEtebaseStore.getState().itemCache.size).toBe(0)
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+  })
+
+  it('does not publish or cache batch-created items after the account epoch changes', async () => {
+    let releaseBatch!: () => void
+    const batchGate = new Promise<void>((resolve) => { releaseBatch = resolve })
+    const itemManager: MockItemManager = {
+      create: vi.fn(async () => ({ uid: 'old-batch-item' })),
+      batch: vi.fn(() => batchGate),
+    }
+    const syncEngine: MockSyncEngine = { pause: vi.fn(), resume: vi.fn() }
+    setupStoreWithMocks(itemManager, syncEngine)
+    dataCacheMock.isCacheEnabled.mockReturnValue(true)
+
+    const mutation = useEtebaseStore.getState().createItemsBatch('calendar', [{ content: 'OLD', tempId: 'old-temp' }])
+    await vi.waitFor(() => expect(itemManager.batch).toHaveBeenCalled())
+    bumpAccountEpoch()
+    useEtebaseStore.setState({ itemCache: new Map(), itemTypeMap: new Map(), itemCollectionMap: new Map() })
+    releaseBatch()
+
+    await expect(mutation).resolves.toEqual([null])
+    expect(useEtebaseStore.getState().itemCache.has('old-batch-item')).toBe(false)
+    expect(dataCacheMock.putItems).not.toHaveBeenCalled()
+    expect(syncEngine.resume).not.toHaveBeenCalled()
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+  })
+})
+
+describe('useEtebaseStore.updateItem account boundary', () => {
+  it('does not publish or cache an update that resolves after the account epoch changes', async () => {
+    let releaseUpdate!: (item: unknown) => void
+    coreMock.updateItem.mockImplementationOnce(() => new Promise((resolve) => { releaseUpdate = resolve }))
+    const oldItem = { uid: 'item-old' }
+    useEtebaseStore.setState({
+      account: { id: 'old-account' } as any,
+      collections: { calendar: [{ uid: 'col-1' }] as any[], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map([['item-old', oldItem]]),
+      itemTypeMap: new Map([['item-old', 'calendar']]),
+      itemCollectionMap: new Map([['item-old', 'col-1']]),
+    })
+    dataCacheMock.isCacheEnabled.mockReturnValue(true)
+
+    const mutation = useEtebaseStore.getState().updateItem('calendar', 'item-old', 'OLD CONTENT')
+    await vi.waitFor(() => expect(coreMock.updateItem).toHaveBeenCalled())
+    bumpAccountEpoch()
+    useEtebaseStore.setState({ itemCache: new Map(), itemTypeMap: new Map(), itemCollectionMap: new Map() })
+    releaseUpdate({ uid: 'item-old', oldAccount: true })
+    await mutation
+
+    expect(useEtebaseStore.getState().itemCache.size).toBe(0)
+    expect(dataCacheMock.putItem).not.toHaveBeenCalled()
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+  })
 })
 
 describe('useEtebaseStore.moveItem', () => {
@@ -873,11 +1114,70 @@ describe('useEtebaseStore.moveItem', () => {
       collectionType: 'calendar',
       collectionUid: 'col-1',
       itemUid: 'item-old',
+    }, {
+      accountEpoch: expect.any(Number),
+      accountFingerprint: 'test-account-fingerprint',
     })
     expect(state.itemCache.get('item-old')).toBe(sourceItem)
     expect(state.itemCache.get('item-new')).toBe(targetItem)
     expect(state.itemCollectionMap.get('item-old')).toBe('col-1')
     expect(state.itemCollectionMap.get('item-new')).toBe('col-2')
+  })
+
+  it('quietly cancels when the source delete completes after an account switch', async () => {
+    let releaseDelete!: () => void
+    coreMock.createItem.mockResolvedValue({ uid: 'old-target' })
+    coreMock.deleteItem.mockImplementationOnce(() => new Promise<void>((resolve) => { releaseDelete = resolve }))
+    useEtebaseStore.setState({
+      account: { id: 'old' } as any,
+      collections: { calendar: [{ uid: 'source' }, { uid: 'target' }] as any[], tasks: [], contacts: [], preferences: [] },
+      itemCache: new Map([['old-source', { uid: 'old-source' }]]),
+      itemTypeMap: new Map([['old-source', 'calendar']]),
+      itemCollectionMap: new Map([['old-source', 'source']]),
+    })
+
+    const move = useEtebaseStore.getState().moveItem('calendar', 'old-source', 'OLD', 'target')
+    await vi.waitFor(() => expect(coreMock.deleteItem).toHaveBeenCalledTimes(1))
+    bumpAccountEpoch()
+    useEtebaseStore.setState({ itemCache: new Map(), itemTypeMap: new Map(), itemCollectionMap: new Map() })
+    releaseDelete()
+
+    await expect(move).resolves.toBeNull()
+    expect(useEtebaseStore.getState().itemCache.size).toBe(0)
+    expect(offlineQueueMock.enqueue).not.toHaveBeenCalled()
+    expect(dataCacheMock.putItem).not.toHaveBeenCalled()
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+  })
+})
+
+describe('useEtebaseStore sharing account boundary', () => {
+  it('does not return stale invitation results', async () => {
+    let release!: (value: any[]) => void
+    coreMock.listIncomingInvitations.mockImplementationOnce(() => new Promise((resolve) => { release = resolve }))
+    useEtebaseStore.setState({ account: { id: 'old' } as any })
+    const listing = useEtebaseStore.getState().listIncomingInvitations()
+    await vi.waitFor(() => expect(coreMock.listIncomingInvitations).toHaveBeenCalled())
+    bumpAccountEpoch()
+    release([{ uid: 'old-invite' }])
+    await expect(listing).resolves.toEqual([])
+  })
+
+  it('does not log or toast an old-account sharing error', async () => {
+    let reject!: (error: Error) => void
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    coreMock.listCollectionMembers.mockImplementationOnce(() => new Promise((_resolve, rejectPromise) => { reject = rejectPromise }))
+    useEtebaseStore.setState({
+      account: { id: 'old' } as any,
+      collections: { calendar: [{ uid: 'old-col' }] as any[], tasks: [], contacts: [], preferences: [] },
+    })
+    const listing = useEtebaseStore.getState().listCollectionMembers('calendar', 'old-col')
+    await vi.waitFor(() => expect(coreMock.listCollectionMembers).toHaveBeenCalled())
+    bumpAccountEpoch()
+    reject(new Error('old failure'))
+    await expect(listing).resolves.toEqual([])
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toastStoreMock.showErrorToast).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
   })
 })
 
@@ -1008,7 +1308,10 @@ describe('useEtebaseStore.deleteItemsInCollection', () => {
     const deleted = await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
 
     expect(deleted).toBe(1)
-    expect(offlineQueueMock.remove).toHaveBeenCalledWith('queue-1')
+    expect(offlineQueueMock.remove).toHaveBeenCalledWith('queue-1', {
+      accountEpoch: expect.any(Number),
+      accountFingerprint: 'test-account-fingerprint',
+    })
     expect(useCalendarStore.getState().events).toHaveLength(0)
     expect(useCalendarStore.getState().selectedEventId).toBeNull()
   })
@@ -1293,6 +1596,25 @@ describe('useEtebaseStore.refreshCollection', () => {
     expect(useEtebaseStore.getState().domainLoadState.calendar).toBe('loaded')
     expect(useEtebaseStore.getState().itemCache.size).toBe(0)
   })
+
+  it('does not return old-account plaintext when cached content resolves after a boundary', async () => {
+    let resolveContent!: (content: string) => void
+    const getContent = vi.fn(() => new Promise<string>((resolve) => { resolveContent = resolve }))
+    useEtebaseStore.setState({
+      itemCache: new Map([['old-item', { getContent }]]),
+      itemTypeMap: new Map([['old-item', 'calendar']]),
+      itemCollectionMap: new Map([['old-item', 'old-calendar']]),
+    })
+
+    const fetch = useEtebaseStore.getState().fetchAllItems('calendar')
+    await vi.waitFor(() => expect(getContent).toHaveBeenCalled())
+    bumpAccountEpoch()
+    useEtebaseStore.setState({ itemCache: new Map(), itemTypeMap: new Map(), itemCollectionMap: new Map() })
+    resolveContent('PRIVATE_OLD_ACCOUNT_PLAINTEXT')
+
+    await expect(fetch).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+    expect(useEtebaseStore.getState().itemCache.size).toBe(0)
+  })
 })
 
 describe('useEtebaseStore.reconcileCollections', () => {
@@ -1380,6 +1702,44 @@ describe('useEtebaseStore.reconcileCollections', () => {
     expect(syncEngine.resume).toHaveBeenCalledTimes(1)
     expect(syncEngine.untrackCollection).toHaveBeenCalledWith('deleted-cal')
     expect(syncEngine.trackCollection).toHaveBeenCalledWith('etebase.vevent', 'new-default-cal')
+  })
+
+  it('does not continue queued cleanup after the account changes', async () => {
+    let releaseQueue!: (entries: any[]) => void
+    offlineQueueMock.getAll.mockImplementationOnce(() => new Promise((resolve) => { releaseQueue = resolve }))
+    const oldCalendar = mockCollection('old-cal')
+    const newCalendar = mockCollection('replacement-cal')
+    const tasks = mockCollection('tasks-1')
+    const contacts = mockCollection('contacts-1')
+    coreMock.listCollections.mockImplementation(async (_account: unknown, collectionType: string) => {
+      if (collectionType === 'etebase.vevent') return [newCalendar]
+      if (collectionType === 'etebase.vtodo') return [tasks]
+      if (collectionType === 'etebase.vcard') return [contacts]
+      return []
+    })
+    const oldSyncEngine = { pause: vi.fn(), resume: vi.fn(), untrackCollection: vi.fn(), trackCollection: vi.fn() }
+    useEtebaseStore.setState({
+      account: { id: 'old' } as any,
+      collections: { calendar: [oldCalendar] as any[], tasks: [tasks] as any[], contacts: [contacts] as any[], preferences: [] },
+      itemCache: new Map(),
+      itemTypeMap: new Map(),
+      itemCollectionMap: new Map(),
+      syncEngine: oldSyncEngine as any,
+    })
+
+    const reconcile = useEtebaseStore.getState().reconcileCollections()
+    await vi.waitFor(() => expect(offlineQueueMock.getAll).toHaveBeenCalled())
+    bumpAccountEpoch()
+    useEtebaseStore.setState({
+      account: { id: 'new' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+    })
+    releaseQueue([{ id: 'old-queued', type: 'create', collectionType: 'calendar', collectionUid: 'old-cal' }])
+
+    await expect(reconcile).resolves.toBeUndefined()
+    expect(offlineQueueMock.remove).not.toHaveBeenCalled()
+    expect(oldSyncEngine.resume).not.toHaveBeenCalled()
+    expect(useEtebaseStore.getState().collections.calendar).toEqual([])
   })
 })
 

--- a/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
@@ -3,6 +3,7 @@ import { createSyncedPreferences, serializePreferences } from '@silentsuite/core
 import { useEtebaseStore } from '../use-etebase-store'
 import { usePreferencesStore } from '../use-preferences-store'
 import { usePreferencesSyncStore } from '../use-preferences-sync-store'
+import { AccountBoundaryChangedError, bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 vi.mock('@/app/stores/use-toast-store', () => ({
   showErrorToast: vi.fn(),
@@ -74,6 +75,34 @@ describe('usePreferencesSyncStore', () => {
     expect(createItem).not.toHaveBeenCalled()
     expect(updateItem).not.toHaveBeenCalled()
     expect(usePreferencesSyncStore.getState()).toMatchObject({ isInitialized: true, remoteItemUid: null })
+  })
+
+  it('does not publish or track stale preferences collections after an account switch', async () => {
+    let releaseList!: (collections: any[]) => void
+    const oldTrack = vi.fn()
+    const newTrack = vi.fn()
+    listCollectionsMock.mockImplementationOnce(() => new Promise<any[]>((resolve) => {
+      releaseList = resolve
+    }))
+    useEtebaseStore.setState({
+      account: { id: 'old' } as any,
+      syncEngine: { trackCollection: oldTrack } as any,
+    })
+
+    const initialization = usePreferencesSyncStore.getState().initialize()
+    await vi.waitFor(() => expect(listCollectionsMock).toHaveBeenCalled())
+    bumpAccountEpoch()
+    useEtebaseStore.setState({
+      account: { id: 'new' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [] },
+      syncEngine: { trackCollection: newTrack } as any,
+    })
+    releaseList([{ uid: 'old-preferences' }])
+
+    await expect(initialization).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+    expect(useEtebaseStore.getState().collections.preferences).toEqual([])
+    expect(oldTrack).not.toHaveBeenCalled()
+    expect(newTrack).not.toHaveBeenCalled()
   })
 
   it('loads remote preferences without changing local notification sound or writing back', async () => {

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useSyncStore } from '../use-sync-store'
 import { getPendingCount, replay } from '@/app/lib/offline-queue'
+import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 const etebaseMock = vi.hoisted(() => ({
   state: {
-    account: null as unknown,
+    account: {} as unknown,
+    accountFingerprint: 'test-account',
     syncEngine: null as { syncNow: ReturnType<typeof vi.fn> } | null,
     domainLoadState: { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' },
     reconcileCollections: vi.fn().mockResolvedValue(undefined),
@@ -77,7 +79,8 @@ vi.mock('@/app/stores/use-toast-store', () => ({
 }))
 
 function resetStore() {
-  etebaseMock.state.account = null
+  etebaseMock.state.account = {}
+  etebaseMock.state.accountFingerprint = 'test-account'
   etebaseMock.state.syncEngine = null
   etebaseMock.state.domainLoadState = { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' }
   etebaseMock.state.reconcileCollections.mockReset().mockResolvedValue(undefined)
@@ -148,6 +151,25 @@ describe('useSyncStore', () => {
 
     // Should remain synced (not transition to syncing)
     expect(useSyncStore.getState().syncStatus).toBe('synced')
+  })
+
+  it('quietly cancels a manual sync cycle when the account epoch changes', async () => {
+    let releaseReconcile!: () => void
+    etebaseMock.state.reconcileCollections.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      releaseReconcile = resolve
+    }))
+
+    useSyncStore.getState().simulateSyncCycle()
+    await flushPromises()
+    bumpAccountEpoch()
+    useSyncStore.setState({ syncStatus: 'synced', error: null, lastSyncedAt: null })
+    releaseReconcile()
+    await flushPromises()
+    await flushPromises()
+
+    expect(etebaseMock.state.refreshCollection).not.toHaveBeenCalled()
+    expect(preferencesSyncMock.loadFromRemote).not.toHaveBeenCalled()
+    expect(useSyncStore.getState()).toMatchObject({ syncStatus: 'synced', error: null, lastSyncedAt: null })
   })
 
   it('supports offline→syncing→synced transition', async () => {

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -157,6 +157,7 @@ function keyToCollectionType(type: CollectionTypeKey): string {
 async function ensureCollectionsForAccount(
   account: any,
   core: EtebaseCore,
+  accountEpoch?: number,
 ): Promise<Record<CollectionTypeKey, any[]>> {
   const collections: Record<CollectionTypeKey, any[]> = {
     calendar: [],
@@ -167,11 +168,14 @@ async function ensureCollectionsForAccount(
 
   for (const [key, colType, defaultName] of COLLECTION_DEFINITIONS) {
     const existing = await core.listCollections(account, colType)
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
     if (existing.length > 0) {
       collections[key] = existing
       logger.debug(`[etebase-store] Found ${existing.length} existing ${key} collection(s)`)
     } else {
+      if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
       const created = await core.createCollection(account, colType, { name: defaultName })
+      if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
       collections[key] = [created]
       logger.debug(`[etebase-store] Created ${key} collection: ${created.uid}`)
     }
@@ -195,6 +199,7 @@ async function loadInitialDomainItems(
     itemTypeMap: Map<string, CollectionTypeKey>
     itemCollectionMap: Map<string, string>
   },
+  accountEpoch: number,
 ): Promise<{ itemCount: number; pageCount: number }> {
   let itemCount = 0
   let pageCount = 0
@@ -205,8 +210,10 @@ async function loadInitialDomainItems(
 
     while (!done) {
       const response = await core.listItems(account, collection, stoken)
+      assertCurrentAccountEpoch(accountEpoch)
       pageCount += 1
       for (const item of response.items) {
+        assertCurrentAccountEpoch(accountEpoch)
         if (!item.isDeleted) {
           maps.itemCache.set(item.uid, item)
           maps.itemTypeMap.set(item.uid, key)
@@ -272,17 +279,21 @@ async function trackCollectionWithSyncEngine(
   collectionType: string,
   type: CollectionTypeKey,
   collectionUid: string,
+  accountEpoch?: number,
 ): Promise<void> {
+  if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
   if (!syncEngine) return
   syncEngine.trackCollection(collectionType as CollectionType, collectionUid)
   if (!isLocalCacheEnabled()) return
   try {
     const stoken = await cacheGetStoken(collectionUid)
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
     if (stoken) {
       syncEngine.setStoken?.(collectionUid, stoken)
       logger.debug(`[etebase-store] Seeded ${type} stoken from cache`)
     }
   } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) throw err
     logger.warn(`[etebase-store] Failed to seed ${type} stoken`, err)
   }
 }
@@ -297,6 +308,7 @@ async function writeItemToCache(
   collectionUid: string,
   itemUid: string,
   content: string,
+  accountEpoch: number,
 ): Promise<void> {
   if (!isLocalCacheEnabled()) return
   const record: CachedItem = {
@@ -306,7 +318,7 @@ async function writeItemToCache(
     content,
     lastModified: Date.now(),
   }
-  await cachePutItem(record)
+  await cachePutItem(record, accountEpoch)
 }
 
 function resolveCollection(
@@ -378,13 +390,15 @@ async function hydrateListStores(
   )
 }
 
-async function removeItemsFromDomainStore(type: CollectionTypeKey, collectionUid: string, itemUids?: string[]): Promise<number> {
+async function removeItemsFromDomainStore(type: CollectionTypeKey, collectionUid: string, itemUids?: string[], accountEpoch?: number): Promise<number> {
   if (type === 'preferences') return 0
+  if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
 
   const itemUidSet = itemUids ? new Set(itemUids) : null
 
   if (type === 'calendar') {
     const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
     let removed = 0
     useCalendarStore.setState((state) => {
       const events = state.events.filter((event) => {
@@ -405,6 +419,7 @@ async function removeItemsFromDomainStore(type: CollectionTypeKey, collectionUid
   }
   if (type === 'tasks') {
     const { useTaskStore } = await import('@/app/stores/use-task-store')
+    if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
     let removed = 0
     useTaskStore.setState((state) => ({
       tasks: state.tasks.filter((task) => {
@@ -418,6 +433,7 @@ async function removeItemsFromDomainStore(type: CollectionTypeKey, collectionUid
     return removed
   }
   const { useContactStore } = await import('@/app/stores/use-contact-store')
+  if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)
   let removed = 0
   useContactStore.setState((state) => ({
     contacts: state.contacts.filter((contact) => {
@@ -431,19 +447,31 @@ async function removeItemsFromDomainStore(type: CollectionTypeKey, collectionUid
   return removed
 }
 
-async function removeQueuedMutationsForCollection(type: CollectionTypeKey, collectionUid: string, includeDeletes: boolean): Promise<number> {
+async function removeQueuedMutationsForCollection(
+  type: CollectionTypeKey,
+  collectionUid: string,
+  includeDeletes: boolean,
+  accountEpoch: number,
+  accountFingerprint: string | null,
+): Promise<number> {
   try {
-    const entries = await getQueuedMutations()
+    const guard = { accountEpoch, accountFingerprint: accountFingerprint ?? '' }
+    assertCurrentAccountEpoch(accountEpoch)
+    const entries = await getQueuedMutations(guard)
+    assertCurrentAccountEpoch(accountEpoch)
     const matching = entries.filter((entry) => (
       entry.collectionType === type
       && entry.collectionUid === collectionUid
       && (includeDeletes || entry.type !== 'delete')
     ))
     for (const entry of matching) {
-      await removeQueuedMutation(entry.id)
+      assertCurrentAccountEpoch(accountEpoch)
+      await removeQueuedMutation(entry.id, guard)
+      assertCurrentAccountEpoch(accountEpoch)
     }
     return matching.length
   } catch (err) {
+    if (err instanceof AccountBoundaryChangedError) throw err
     logger.warn(`[etebase-store] Failed to prune queued mutations for ${type}/${collectionUid}`, err)
     return 0
   }
@@ -612,7 +640,7 @@ interface EtebaseActions {
   /**
    * Fetch all items from the local cache for a collection type.
    */
-  fetchAllItems: (type: CollectionTypeKey) => Promise<CachedContentItem[]>
+  fetchAllItems: (type: CollectionTypeKey, accountEpoch?: number) => Promise<CachedContentItem[]>
 
   /**
    * Re-fetch all items from the Etebase server for a collection type.
@@ -697,20 +725,27 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       let cacheEnabled = isLocalCacheEnabled()
       if (getCacheCapabilityStatus().featureFlagEnabled) {
         try {
-          const cacheSurvived = await cacheEnsureFingerprint(accountFingerprint)
-          await cacheEnsureEncryptedEnvelope()
+          const cacheSurvived = await cacheEnsureFingerprint(accountFingerprint, accountEpoch)
+          assertCurrentAccountEpoch(accountEpoch)
+          await cacheEnsureEncryptedEnvelope(accountEpoch)
+          assertCurrentAccountEpoch(accountEpoch)
           cacheEnabled = isLocalCacheEnabled()
           if (cacheSurvived && cacheEnabled) {
             await options?.onCacheHydrate?.()
+            assertCurrentAccountEpoch(accountEpoch)
           }
         } catch (err) {
+          if (err instanceof AccountBoundaryChangedError || !isCurrentAccountEpoch(accountEpoch)) {
+            throw new AccountBoundaryChangedError()
+          }
           logger.warn('[etebase-store] Cache fingerprint check failed', err)
         }
       }
 
       // 2. Ensure collections exist (create if first login, fetch if returning)
       diagnostics.startPhase('ensureCollections')
-      const collections = await ensureCollectionsForAccount(account, core)
+      const collections = await ensureCollectionsForAccount(account, core, accountEpoch)
+      assertCurrentAccountEpoch(accountEpoch)
       diagnostics.completePhase('ensureCollections', {
         collectionCount: COLLECTION_DEFINITIONS.reduce((count, [key]) => count + collections[key].length, 0),
       })
@@ -719,6 +754,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       set({ collections })
       diagnostics.startPhase('hydrateLists')
       await hydrateListStores(collections, accountEpoch)
+      assertCurrentAccountEpoch(accountEpoch)
       diagnostics.completePhase('hydrateLists')
 
       // 3. Load items from each visible collection into the cache, one domain
@@ -749,7 +785,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
             itemCache: loadedMaps.itemCache,
             itemTypeMap: loadedMaps.itemTypeMap,
             itemCollectionMap: loadedMaps.itemCollectionMap,
-          })
+          }, accountEpoch)
           itemCount = counts.itemCount
           pageCount = counts.pageCount
           totalLoadedItemCount += itemCount
@@ -762,6 +798,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
             pageCount,
           })
         } catch (err) {
+          if (err instanceof AccountBoundaryChangedError || !isCurrentAccountEpoch(accountEpoch)) {
+            throw new AccountBoundaryChangedError()
+          }
           domainLoadState[key] = 'failed'
           status = 'failed'
           diagnostics.failActivePhase(err)
@@ -795,7 +834,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       diagnostics.startPhase('syncEngineTrackCollections')
       for (const [key, colType] of COLLECTION_DEFINITIONS) {
         for (const collection of collections[key]) {
-          await trackCollectionWithSyncEngine(engine, colType, key, collection.uid)
+          await trackCollectionWithSyncEngine(engine, colType, key, collection.uid, accountEpoch)
+          assertCurrentAccountEpoch(accountEpoch)
         }
       }
       diagnostics.completePhase('syncEngineTrackCollections', {
@@ -849,6 +889,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   createCollection: async (type: CollectionTypeKey, name: string, color?: string) => {
+    const accountEpoch = getAccountEpoch()
     const { account, collections, syncEngine } = get()
     if (!account) {
       logger.warn('[etebase-store] Cannot create collection: no account')
@@ -859,15 +900,17 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const core = await import('@silentsuite/core')
       const colType = keyToCollectionType(type)
       const collection = await core.createCollection(account, colType, { name, color })
+      assertCurrentAccountEpoch(accountEpoch)
       const newCollections = {
         ...collections,
         [type]: [...collections[type], collection],
       }
       syncEngine?.trackCollection(colType as CollectionType, collection.uid)
       set({ collections: newCollections })
-      await hydrateListStores(newCollections)
+      await hydrateListStores(newCollections, accountEpoch)
       return collection.uid
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
       console.error(`[etebase-store] Failed to create ${type} collection`, getSafeErrorDetails(err))
       showErrorToast(`Failed to create ${collectionDisplayName(type)}. Please try again.`)
       return null
@@ -875,7 +918,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   deleteCollection: async (type: CollectionTypeKey, collectionUid: string) => {
-    const { account, collections, domainLoadState, syncEngine } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, domainLoadState, syncEngine, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot delete ${type} collection ${collectionUid}: missing account or collection`)
@@ -894,6 +938,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.deleteCollection(account, collection)
+      assertCurrentAccountEpoch(accountEpoch)
 
       const newItemCache = new Map(get().itemCache)
       const newItemTypeMap = new Map(get().itemTypeMap)
@@ -918,13 +963,17 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         itemCollectionMap: newItemCollectionMap,
       })
       if (isLocalCacheEnabled()) {
-        void cacheReplaceItemsForCollection(collection.uid, [])
+        await cacheReplaceItemsForCollection(collection.uid, [], accountEpoch)
       }
-      await removeQueuedMutationsForCollection(type, collection.uid, true)
-      await removeItemsFromDomainStore(type, collection.uid)
-      await hydrateListStores(newCollections)
+      assertCurrentAccountEpoch(accountEpoch)
+      await removeQueuedMutationsForCollection(type, collection.uid, true, accountEpoch, accountFingerprint)
+      assertCurrentAccountEpoch(accountEpoch)
+      await removeItemsFromDomainStore(type, collection.uid, undefined, accountEpoch)
+      assertCurrentAccountEpoch(accountEpoch)
+      await hydrateListStores(newCollections, accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error(`[etebase-store] Failed to delete ${type} collection`, getSafeErrorDetails(err))
       showErrorToast(`Failed to delete ${collectionDisplayName(type)}. Please try again.`)
       return false
@@ -932,7 +981,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   updateCollectionMeta: async (type: CollectionTypeKey, collectionUid: string, updates: CollectionMetaUpdates) => {
-    const { account, collections } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot update ${type} collection ${collectionUid}: missing account or collection`)
@@ -950,6 +1000,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (updates.color !== undefined) updatedMeta.color = updates.color
       else if (currentMeta.color !== undefined) updatedMeta.color = currentMeta.color
       const updatedCollection = await core.updateCollectionMeta(account, collection, updatedMeta)
+      assertCurrentAccountEpoch(accountEpoch)
       const newCollections = {
         ...get().collections,
         [type]: get().collections[type].map((existing) =>
@@ -957,9 +1008,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         ),
       }
       set({ collections: newCollections })
-      await hydrateListStores(newCollections)
+      await hydrateListStores(newCollections, accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error(`[etebase-store] Failed to update ${type} collection`, getSafeErrorDetails(err))
       showErrorToast(`Failed to update ${collectionDisplayName(type)}. Please try again.`)
       return false
@@ -967,7 +1019,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   reconcileCollections: async () => {
-    const { account, syncEngine } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, syncEngine, accountFingerprint } = get()
     if (!account) {
       logger.warn('[etebase-store] Cannot reconcile collections: no account')
       return
@@ -977,7 +1030,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       const previousCollections = get().collections
-      const activeCollections = await ensureCollectionsForAccount(account, core)
+      const activeCollections = await ensureCollectionsForAccount(account, core, accountEpoch)
+      assertCurrentAccountEpoch(accountEpoch)
       const newItemCache = new Map(get().itemCache)
       const newItemTypeMap = new Map(get().itemTypeMap)
       const newItemCollectionMap = new Map(get().itemCollectionMap)
@@ -1000,6 +1054,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         }
 
         for (const collectionUid of removedUids) {
+          assertCurrentAccountEpoch(accountEpoch)
           removedCollectionCount++
           syncEngine?.untrackCollection(collectionUid)
           for (const [itemUid, mappedCollectionUid] of Array.from(newItemCollectionMap.entries())) {
@@ -1008,20 +1063,21 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
             newItemTypeMap.delete(itemUid)
             newItemCollectionMap.delete(itemUid)
           }
-          cleanupPromises.push(removeQueuedMutationsForCollection(type, collectionUid, true))
-          cleanupPromises.push(removeItemsFromDomainStore(type, collectionUid))
+          cleanupPromises.push(removeQueuedMutationsForCollection(type, collectionUid, true, accountEpoch, accountFingerprint))
+          cleanupPromises.push(removeItemsFromDomainStore(type, collectionUid, undefined, accountEpoch))
           if (isLocalCacheEnabled()) {
-            cleanupPromises.push(cacheReplaceItemsForCollection(collectionUid, []))
+            cleanupPromises.push(cacheReplaceItemsForCollection(collectionUid, [], accountEpoch))
           }
         }
 
         for (const collection of activeCollections[type]) {
           if (!previousUids.has(collection.uid)) {
-            await trackCollectionWithSyncEngine(syncEngine, colType, type, collection.uid)
+            await trackCollectionWithSyncEngine(syncEngine, colType, type, collection.uid, accountEpoch)
           }
         }
       }
 
+      assertCurrentAccountEpoch(accountEpoch)
       set({
         collections: activeCollections,
         itemCache: newItemCache,
@@ -1029,24 +1085,30 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         itemCollectionMap: newItemCollectionMap,
       })
       await Promise.all(cleanupPromises)
-      await hydrateListStores(activeCollections)
+      assertCurrentAccountEpoch(accountEpoch)
+      await hydrateListStores(activeCollections, accountEpoch)
       logger.debug(`[etebase-store] Reconciled collections (${removedCollectionCount} removed)`)
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return
       console.error('[etebase-store] Failed to reconcile collections', getSafeErrorDetails(err))
       throw err
     } finally {
-      syncEngine?.resume?.()
+      if (isCurrentAccountEpoch(accountEpoch) && get().syncEngine === syncEngine) syncEngine?.resume?.()
     }
   },
 
   listIncomingInvitations: async () => {
+    const accountEpoch = getAccountEpoch()
     const { account } = get()
     if (!account) return []
 
     try {
       const core = await import('@silentsuite/core')
-      return await core.listIncomingInvitations(account)
+      const invitations = await core.listIncomingInvitations(account)
+      assertCurrentAccountEpoch(accountEpoch)
+      return invitations
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return []
       console.error('[etebase-store] Failed to list incoming invitations', getSafeErrorDetails(err))
       showErrorToast('Failed to load sharing invitations. Please try again.')
       return []
@@ -1054,13 +1116,17 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   listOutgoingInvitations: async () => {
+    const accountEpoch = getAccountEpoch()
     const { account } = get()
     if (!account) return []
 
     try {
       const core = await import('@silentsuite/core')
-      return await core.listOutgoingInvitations(account)
+      const invitations = await core.listOutgoingInvitations(account)
+      assertCurrentAccountEpoch(accountEpoch)
+      return invitations
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return []
       console.error('[etebase-store] Failed to list outgoing invitations', getSafeErrorDetails(err))
       showErrorToast('Failed to load sent sharing invitations. Please try again.')
       return []
@@ -1068,6 +1134,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   cancelOutgoingInvitation: async (invitation: any) => {
+    const accountEpoch = getAccountEpoch()
     const { account } = get()
     if (!account) {
       logger.warn('[etebase-store] Cannot cancel outgoing invitation: no account')
@@ -1077,8 +1144,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.cancelOutgoingInvitation(account, invitation)
+      assertCurrentAccountEpoch(accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error('[etebase-store] Failed to cancel outgoing invitation', getSafeErrorDetails(err))
       showErrorToast('Failed to cancel sharing invitation. Please try again.')
       return false
@@ -1086,6 +1155,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   acceptInvitation: async (invitation: any) => {
+    const accountEpoch = getAccountEpoch()
     const { account } = get()
     if (!account) {
       logger.warn('[etebase-store] Cannot accept invitation: no account')
@@ -1095,9 +1165,12 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.acceptInvitation(account, invitation)
+      assertCurrentAccountEpoch(accountEpoch)
       await get().reconcileCollections()
+      assertCurrentAccountEpoch(accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error('[etebase-store] Failed to accept invitation', getSafeErrorDetails(err))
       showErrorToast('Failed to accept sharing invitation. Please try again.')
       return false
@@ -1105,6 +1178,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   rejectInvitation: async (invitation: any) => {
+    const accountEpoch = getAccountEpoch()
     const { account } = get()
     if (!account) {
       logger.warn('[etebase-store] Cannot reject invitation: no account')
@@ -1114,8 +1188,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.rejectInvitation(account, invitation)
+      assertCurrentAccountEpoch(accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error('[etebase-store] Failed to reject invitation', getSafeErrorDetails(err))
       showErrorToast('Failed to reject sharing invitation. Please try again.')
       return false
@@ -1123,7 +1199,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   inviteToCollection: async (type: CollectionTypeKey, collectionUid: string, username: string, accessLevel: CollectionAccessLevel) => {
-    const { account, collections } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot invite to ${type} collection ${collectionUid}: missing account or collection`)
@@ -1133,8 +1210,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.inviteToCollection(account, collection, username, accessLevel)
+      assertCurrentAccountEpoch(accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error('[etebase-store] Failed to create sharing invitation', getSafeErrorDetails(err))
       showErrorToast('Failed to create sharing invitation. Please verify the username and try again.')
       return false
@@ -1142,14 +1221,18 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   listCollectionMembers: async (type: CollectionTypeKey, collectionUid: string) => {
-    const { account, collections } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) return []
 
     try {
       const core = await import('@silentsuite/core')
-      return await core.listCollectionMembers(account, collection)
+      const members = await core.listCollectionMembers(account, collection)
+      assertCurrentAccountEpoch(accountEpoch)
+      return members
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return []
       console.error('[etebase-store] Failed to list collection members', getSafeErrorDetails(err))
       showErrorToast('Failed to load collection members. Please try again.')
       return []
@@ -1157,7 +1240,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   removeCollectionMember: async (type: CollectionTypeKey, collectionUid: string, username: string) => {
-    const { account, collections } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot remove member from ${type} collection ${collectionUid}: missing account or collection`)
@@ -1167,8 +1251,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.removeCollectionMember(account, collection, username)
+      assertCurrentAccountEpoch(accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error('[etebase-store] Failed to remove collection member', getSafeErrorDetails(err))
       showErrorToast('Failed to remove collection member. Please try again.')
       return false
@@ -1176,7 +1262,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   leaveCollection: async (type: CollectionTypeKey, collectionUid: string) => {
-    const { account, collections } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot leave ${type} collection ${collectionUid}: missing account or collection`)
@@ -1186,9 +1273,12 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.leaveCollection(account, collection)
+      assertCurrentAccountEpoch(accountEpoch)
       await get().reconcileCollections()
+      assertCurrentAccountEpoch(accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error('[etebase-store] Failed to leave collection', getSafeErrorDetails(err))
       showErrorToast('Failed to leave shared collection. Please try again.')
       return false
@@ -1196,7 +1286,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   modifyCollectionMemberAccess: async (type: CollectionTypeKey, collectionUid: string, username: string, accessLevel: CollectionAccessLevel) => {
-    const { account, collections } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot modify member access for ${type} collection ${collectionUid}: missing account or collection`)
@@ -1206,8 +1297,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.modifyCollectionMemberAccess(account, collection, username, accessLevel)
+      assertCurrentAccountEpoch(accountEpoch)
       return true
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       console.error('[etebase-store] Failed to change collection member access', getSafeErrorDetails(err))
       showErrorToast('Failed to update collection member access. Please try again.')
       return false
@@ -1215,7 +1308,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   deleteItemsInCollection: async (type: CollectionTypeKey, collectionUid: string) => {
-    const { account, collections, domainLoadState, itemCache, itemCollectionMap } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, domainLoadState, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot clear ${type} collection ${collectionUid}: missing account or collection`)
@@ -1227,8 +1321,9 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       return 0
     }
 
-    const removeCachedItems = (uids: string[]) => {
+    const removeCachedItems = async (uids: string[]) => {
       if (uids.length === 0) return
+      assertCurrentAccountEpoch(accountEpoch)
       const uidSet = new Set(uids)
       const newItemCache = new Map(get().itemCache)
       const newItemTypeMap = new Map(get().itemTypeMap)
@@ -1238,9 +1333,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         newItemTypeMap.delete(uid)
         newItemCollectionMap.delete(uid)
         if (isLocalCacheEnabled()) {
-          void cacheDeleteItem(uid)
+          await cacheDeleteItem(uid, accountEpoch)
+          assertCurrentAccountEpoch(accountEpoch)
         }
       }
+      assertCurrentAccountEpoch(accountEpoch)
       set({ itemCache: newItemCache, itemTypeMap: newItemTypeMap, itemCollectionMap: newItemCollectionMap })
     }
 
@@ -1250,8 +1347,13 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       .filter((entry): entry is { uid: string; item: any } => Boolean(entry.item))
 
     if (itemEntries.length === 0) {
-      await removeQueuedMutationsForCollection(type, collection.uid, true)
-      return await removeItemsFromDomainStore(type, collection.uid)
+      try {
+        await removeQueuedMutationsForCollection(type, collection.uid, true, accountEpoch, accountFingerprint)
+        return await removeItemsFromDomainStore(type, collection.uid, undefined, accountEpoch)
+      } catch (err) {
+        if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return 0
+        throw err
+      }
     }
 
     const successfulUids: string[] = []
@@ -1266,51 +1368,68 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const batchItems = batchEntries.map(({ item }) => item)
         for (const item of batchItems) item.delete()
         await itemManager.batch(batchItems)
+        assertCurrentAccountEpoch(accountEpoch)
         successfulUids.push(...batchEntries.map(({ uid }) => uid))
       }
 
-      removeCachedItems(successfulUids)
+      await removeCachedItems(successfulUids)
       if (isLocalCacheEnabled()) {
-        void cacheReplaceItemsForCollection(collection.uid, [])
+        await cacheReplaceItemsForCollection(collection.uid, [], accountEpoch)
+        assertCurrentAccountEpoch(accountEpoch)
       }
-      await removeQueuedMutationsForCollection(type, collection.uid, true)
-      const removedLocal = await removeItemsFromDomainStore(type, collection.uid)
+      await removeQueuedMutationsForCollection(type, collection.uid, true, accountEpoch, accountFingerprint)
+      const removedLocal = await removeItemsFromDomainStore(type, collection.uid, undefined, accountEpoch)
+      assertCurrentAccountEpoch(accountEpoch)
       return Math.max(successfulUids.length, removedLocal)
     } catch (err) {
-      if (isOfflineError(err)) {
-        logger.warn(`[etebase-store] Offline — queuing clear for ${type}/${collection.uid}`)
-        await removeQueuedMutationsForCollection(type, collection.uid, false)
-        const alreadyDeleted = new Set(successfulUids)
-        for (const { uid } of itemEntries) {
-          if (alreadyDeleted.has(uid)) continue
-          try {
-            await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid })
-          } catch (queueErr) {
-            console.error('[etebase-store] Failed to enqueue collection item delete', getSafeErrorDetails(queueErr))
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return 0
+      try {
+        if (isOfflineError(err)) {
+          assertCurrentAccountEpoch(accountEpoch)
+          logger.warn(`[etebase-store] Offline — queuing clear for ${type}/${collection.uid}`)
+          await removeQueuedMutationsForCollection(type, collection.uid, false, accountEpoch, accountFingerprint)
+          const alreadyDeleted = new Set(successfulUids)
+          for (const { uid } of itemEntries) {
+            if (alreadyDeleted.has(uid)) continue
+            try {
+              assertCurrentAccountEpoch(accountEpoch)
+              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+              assertCurrentAccountEpoch(accountEpoch)
+            } catch (queueErr) {
+              if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return 0
+              console.error('[etebase-store] Failed to enqueue collection item delete', getSafeErrorDetails(queueErr))
+            }
           }
+          await removeCachedItems(itemEntries.map(({ uid }) => uid))
+          if (isLocalCacheEnabled()) {
+            await cacheReplaceItemsForCollection(collection.uid, [], accountEpoch)
+            assertCurrentAccountEpoch(accountEpoch)
+          }
+          const removedLocal = await removeItemsFromDomainStore(type, collection.uid, undefined, accountEpoch)
+          assertCurrentAccountEpoch(accountEpoch)
+          return Math.max(itemEntries.length, removedLocal)
         }
-        removeCachedItems(itemEntries.map(({ uid }) => uid))
-        if (isLocalCacheEnabled()) {
-          void cacheReplaceItemsForCollection(collection.uid, [])
-        }
-        const removedLocal = await removeItemsFromDomainStore(type, collection.uid)
-        return Math.max(itemEntries.length, removedLocal)
-      }
 
-      console.error(`[etebase-store] Failed to clear ${type} collection`, getSafeErrorDetails(err))
-      if (successfulUids.length > 0) {
-        removeCachedItems(successfulUids)
-        await removeItemsFromDomainStore(type, collection.uid, successfulUids)
-        showErrorToast(`Deleted ${successfulUids.length} of ${itemEntries.length} ${collectionItemNoun(type)}. Please try again to delete the rest.`)
-      } else {
-        showErrorToast(`Failed to delete ${collectionItemNoun(type)}. Please try again.`)
+        console.error(`[etebase-store] Failed to clear ${type} collection`, getSafeErrorDetails(err))
+        if (successfulUids.length > 0) {
+          await removeCachedItems(successfulUids)
+          await removeItemsFromDomainStore(type, collection.uid, successfulUids, accountEpoch)
+          assertCurrentAccountEpoch(accountEpoch)
+          showErrorToast(`Deleted ${successfulUids.length} of ${itemEntries.length} ${collectionItemNoun(type)}. Please try again to delete the rest.`)
+        } else {
+          showErrorToast(`Failed to delete ${collectionItemNoun(type)}. Please try again.`)
+        }
+        return 0
+      } catch (cleanupErr) {
+        if (!isCurrentAccountEpoch(accountEpoch) || cleanupErr instanceof AccountBoundaryChangedError) return 0
+        throw cleanupErr
       }
-      return 0
     }
   },
 
   createItem: async (type: CollectionTypeKey, content: string, tempId?: string, collectionUid?: string) => {
-    const { account, collections } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot create item: no account or ${type} collection`)
@@ -1320,6 +1439,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       const item = await core.createItem(account, collection, content)
+      assertCurrentAccountEpoch(accountEpoch)
       // Cache the item for future update/delete
       const itemCache = new Map(get().itemCache)
       const itemTypeMap = new Map(get().itemTypeMap)
@@ -1329,15 +1449,18 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       itemCollectionMap.set(item.uid, collection.uid)
       set({ itemCache, itemTypeMap, itemCollectionMap })
       // Write through to the local persistence cache so a reload paints it.
-      void writeItemToCache(type, collection.uid, item.uid, content)
+      await writeItemToCache(type, collection.uid, item.uid, content, accountEpoch)
       return item.uid
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
       if (isOfflineError(err)) {
         const queueTempId = tempId ?? `pending-${Date.now()}`
         logger.warn(`[etebase-store] Offline — queuing create for ${type} (tempId: ${queueTempId})`)
         try {
-          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId })
+          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
+          if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return null
           console.error('[etebase-store] Failed to enqueue create', getSafeErrorDetails(queueErr))
         }
       } else {
@@ -1349,7 +1472,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   createItemsBatch: async (type: CollectionTypeKey, contents: { content: string; tempId: string }[], collectionUid?: string) => {
-    const { account, collections } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
     if (!account || !collection) {
       logger.warn(`[etebase-store] Cannot create items: no account or ${type} collection`)
@@ -1374,9 +1498,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       const items: any[] = []
       for (let i = 0; i < contents.length; i++) {
         const item = await itemManager.create({}, contents[i]!.content)
+        assertCurrentAccountEpoch(accountEpoch)
         items.push(item)
         if (i > 0 && i % YIELD_EVERY === 0) {
           await new Promise((r) => setTimeout(r, 0))
+          assertCurrentAccountEpoch(accountEpoch)
         }
       }
 
@@ -1396,11 +1522,14 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
         while (attempt < MAX_BATCH_RETRIES) {
           try {
+            assertCurrentAccountEpoch(accountEpoch)
             await itemManager.batch(batch)
+            assertCurrentAccountEpoch(accountEpoch)
             succeeded = true
             lastSuccessfulItemIndex = i + batch.length - 1
             break
           } catch (err) {
+            if (err instanceof AccountBoundaryChangedError || !isCurrentAccountEpoch(accountEpoch)) throw new AccountBoundaryChangedError()
             // Offline errors are handled by the outer catch + offline queue —
             // bubble out instead of retrying on a known-down network.
             if (isOfflineError(err)) throw err
@@ -1415,6 +1544,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
               err,
             )
             await new Promise((r) => setTimeout(r, backoffMs))
+            assertCurrentAccountEpoch(accountEpoch)
           }
         }
 
@@ -1449,9 +1579,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
           uids.push(null)
         }
       }
+      assertCurrentAccountEpoch(accountEpoch)
       set({ itemCache, itemTypeMap, itemCollectionMap })
       if (isLocalCacheEnabled() && cachedRecords.length > 0) {
-        void cachePutItems(cachedRecords)
+        await cachePutItems(cachedRecords, accountEpoch)
+        assertCurrentAccountEpoch(accountEpoch)
       }
 
       if (permanentFailure) {
@@ -1468,12 +1600,15 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
       return uids
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return contents.map(() => null)
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing ${contents.length} creates for ${type}`)
         for (const { content, tempId } of contents) {
           try {
-            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId })
+            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+            assertCurrentAccountEpoch(accountEpoch)
           } catch (queueErr) {
+            if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return contents.map(() => null)
             console.error('[etebase-store] Failed to enqueue create', getSafeErrorDetails(queueErr))
           }
         }
@@ -1483,12 +1618,13 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       }
       return contents.map(() => null)
     } finally {
-      syncEngine?.resume()
+      if (isCurrentAccountEpoch(accountEpoch) && get().syncEngine === syncEngine) syncEngine?.resume()
     }
   },
 
   updateItem: async (type: CollectionTypeKey, itemUid: string, content: string) => {
-    const { account, collections, itemCache, itemCollectionMap } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
     if (!account || !collection || !item) {
@@ -1498,17 +1634,22 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
 
     try {
       const core = await import('@silentsuite/core')
+      assertCurrentAccountEpoch(accountEpoch)
       const updated = await core.updateItem(account, collection, item, content)
+      assertCurrentAccountEpoch(accountEpoch)
       const newCache = new Map(get().itemCache)
       newCache.set(itemUid, updated)
       set({ itemCache: newCache })
-      void writeItemToCache(type, collection.uid, itemUid, content)
+      await writeItemToCache(type, collection.uid, itemUid, content, accountEpoch)
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid })
+          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
+          if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
           console.error('[etebase-store] Failed to enqueue update', getSafeErrorDetails(queueErr))
         }
       } else {
@@ -1519,7 +1660,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   },
 
   moveItem: async (type: CollectionTypeKey, itemUid: string, content: string, targetCollectionUid: string, sourceCollectionUid?: string) => {
-    const { account, collections, itemCache, itemCollectionMap } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
     const resolvedSourceCollectionUid = itemCollectionMap.get(itemUid) ?? sourceCollectionUid
     const sourceCollection = resolveCollection(collections, type, resolvedSourceCollectionUid)
     const targetCollection = resolveCollection(collections, type, targetCollectionUid)
@@ -1529,53 +1671,75 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       return null
     }
 
-    if (sourceCollection.uid === targetCollection.uid) {
-      await get().updateItem(type, itemUid, content)
-      return itemUid
-    }
-
-    const core = await import('@silentsuite/core')
-    const created = await core.createItem(account, targetCollection, content)
-    let keepSourceUntilQueuedDelete = false
-
     try {
-      await core.deleteItem(account, sourceCollection, item)
-    } catch (err) {
-      if (isOfflineError(err)) {
-        logger.warn(`[etebase-store] Offline after moving ${type}/${itemUid} - queuing source delete`)
-        await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid })
-        keepSourceUntilQueuedDelete = true
-      } else {
-        try {
-          await core.deleteItem(account, targetCollection, created)
-        } catch (rollbackErr) {
-          logger.warn(`[etebase-store] Failed to roll back moved ${type} item ${created.uid}`, rollbackErr)
-        }
-        throw err
+      if (sourceCollection.uid === targetCollection.uid) {
+        await get().updateItem(type, itemUid, content)
+        assertCurrentAccountEpoch(accountEpoch)
+        return itemUid
       }
-    }
 
-    const newCache = new Map(get().itemCache)
-    const newTypeMap = new Map(get().itemTypeMap)
-    const newCollectionMap = new Map(get().itemCollectionMap)
-    if (!keepSourceUntilQueuedDelete) {
-      newCache.delete(itemUid)
-      newTypeMap.delete(itemUid)
-      newCollectionMap.delete(itemUid)
+      const core = await import('@silentsuite/core')
+      assertCurrentAccountEpoch(accountEpoch)
+      const created = await core.createItem(account, targetCollection, content)
+      assertCurrentAccountEpoch(accountEpoch)
+      let keepSourceUntilQueuedDelete = false
+
+      try {
+        await core.deleteItem(account, sourceCollection, item)
+        assertCurrentAccountEpoch(accountEpoch)
+      } catch (err) {
+        if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
+        if (isOfflineError(err)) {
+          assertCurrentAccountEpoch(accountEpoch)
+          logger.warn(`[etebase-store] Offline after moving ${type}/${itemUid} - queuing source delete`)
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          assertCurrentAccountEpoch(accountEpoch)
+          keepSourceUntilQueuedDelete = true
+        } else {
+          try {
+            assertCurrentAccountEpoch(accountEpoch)
+            await core.deleteItem(account, targetCollection, created)
+            assertCurrentAccountEpoch(accountEpoch)
+          } catch (rollbackErr) {
+            if (!isCurrentAccountEpoch(accountEpoch) || rollbackErr instanceof AccountBoundaryChangedError) return null
+            logger.warn(`[etebase-store] Failed to roll back moved ${type} item ${created.uid}`, rollbackErr)
+          }
+          throw err
+        }
+      }
+
+      assertCurrentAccountEpoch(accountEpoch)
+      const newCache = new Map(get().itemCache)
+      const newTypeMap = new Map(get().itemTypeMap)
+      const newCollectionMap = new Map(get().itemCollectionMap)
+      if (!keepSourceUntilQueuedDelete) {
+        newCache.delete(itemUid)
+        newTypeMap.delete(itemUid)
+        newCollectionMap.delete(itemUid)
+      }
+      newCache.set(created.uid, created)
+      newTypeMap.set(created.uid, type)
+      newCollectionMap.set(created.uid, targetCollection.uid)
+      assertCurrentAccountEpoch(accountEpoch)
+      set({ itemCache: newCache, itemTypeMap: newTypeMap, itemCollectionMap: newCollectionMap })
+      if (isLocalCacheEnabled()) {
+        if (!keepSourceUntilQueuedDelete) await cacheDeleteItem(itemUid, accountEpoch)
+        assertCurrentAccountEpoch(accountEpoch)
+        await writeItemToCache(type, targetCollection.uid, created.uid, content, accountEpoch)
+        assertCurrentAccountEpoch(accountEpoch)
+      }
+      return created.uid
+    } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
+      console.error(`[etebase-store] Failed to move ${type} item`, getSafeErrorDetails(err))
+      showErrorToast(`Failed to move ${collectionItemNoun(type).replace(/s$/, '')}. Please try again.`)
+      return null
     }
-    newCache.set(created.uid, created)
-    newTypeMap.set(created.uid, type)
-    newCollectionMap.set(created.uid, targetCollection.uid)
-    set({ itemCache: newCache, itemTypeMap: newTypeMap, itemCollectionMap: newCollectionMap })
-    if (isLocalCacheEnabled()) {
-      if (!keepSourceUntilQueuedDelete) void cacheDeleteItem(itemUid)
-      void writeItemToCache(type, targetCollection.uid, created.uid, content)
-    }
-    return created.uid
   },
 
   deleteItem: async (type: CollectionTypeKey, itemUid: string) => {
-    const { account, collections, itemCache, itemCollectionMap } = get()
+    const accountEpoch = getAccountEpoch()
+    const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
     if (!account || !collection || !item) {
@@ -1586,6 +1750,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     try {
       const core = await import('@silentsuite/core')
       await core.deleteItem(account, collection, item)
+      assertCurrentAccountEpoch(accountEpoch)
       const newCache = new Map(get().itemCache)
       const newTypeMap = new Map(get().itemTypeMap)
       const newCollectionMap = new Map(get().itemCollectionMap)
@@ -1594,14 +1759,18 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       newCollectionMap.delete(itemUid)
       set({ itemCache: newCache, itemTypeMap: newTypeMap, itemCollectionMap: newCollectionMap })
       if (isLocalCacheEnabled()) {
-        void cacheDeleteItem(itemUid)
+        await cacheDeleteItem(itemUid, accountEpoch)
+        assertCurrentAccountEpoch(accountEpoch)
       }
     } catch (err) {
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing delete for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid })
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
+          if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
           console.error('[etebase-store] Failed to enqueue delete', getSafeErrorDetails(queueErr))
         }
       } else {
@@ -1611,7 +1780,8 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     }
   },
 
-  fetchAllItems: async (type: CollectionTypeKey) => {
+  fetchAllItems: async (type: CollectionTypeKey, accountEpoch = getAccountEpoch()) => {
+    assertCurrentAccountEpoch(accountEpoch)
     const { itemCache, itemTypeMap, itemCollectionMap } = get()
     const results: CachedContentItem[] = []
 
@@ -1619,20 +1789,23 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (itemTypeMap.get(uid) !== type) continue
       try {
         const content = await item.getContent()
+        assertCurrentAccountEpoch(accountEpoch)
         const contentStr = typeof content === 'string' ? content : new TextDecoder().decode(content)
         const collectionUid = itemCollectionMap.get(uid)
         if (collectionUid) results.push({ uid, content: contentStr, collectionUid })
-      } catch {
+      } catch (err) {
+        if (err instanceof AccountBoundaryChangedError || !isCurrentAccountEpoch(accountEpoch)) throw new AccountBoundaryChangedError()
         // Skip items that fail to decode
       }
     }
 
+    assertCurrentAccountEpoch(accountEpoch)
     return results
   },
 
   refreshCollection: async (type: CollectionTypeKey, collectionUid?: string) => {
     const accountEpoch = getAccountEpoch()
-    const { account, collections } = get()
+    const { account, collections, accountFingerprint } = get()
     const targetCollections = collectionUid
       ? [resolveCollection(collections, type, collectionUid)].filter(Boolean)
       : collections[type]
@@ -1741,9 +1914,12 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     } catch (err) {
       if (!isCurrentAccountEpoch(accountEpoch)) throw new AccountBoundaryChangedError()
       if (err instanceof AccountBoundaryChangedError) throw err
+      assertCurrentAccountEpoch(accountEpoch)
       console.error(`[etebase-store] Failed to refresh ${type}`, getSafeErrorDetails(err))
+      assertCurrentAccountEpoch(accountEpoch)
       set((state) => ({ domainLoadState: { ...state.domainLoadState, [type]: 'failed' } }))
-      return get().fetchAllItems(type)
+      assertCurrentAccountEpoch(accountEpoch)
+      return get().fetchAllItems(type, accountEpoch)
     }
   },
 

--- a/apps/web/app/stores/use-preferences-sync-store.ts
+++ b/apps/web/app/stores/use-preferences-sync-store.ts
@@ -30,7 +30,7 @@ interface PreferencesSyncState {
 
 interface PreferencesSyncActions {
   initialize: () => Promise<void>
-  loadFromRemote: (items?: { uid: string; content: string }[]) => Promise<void>
+  loadFromRemote: (items?: { uid: string; content: string }[], accountEpoch?: number) => Promise<void>
   pushNow: () => Promise<boolean>
   setRemoteItemUid: (uid: string) => void
   destroy: () => void
@@ -58,32 +58,42 @@ function mergeRemoteItems(items: RemotePreferenceItem[]): SyncedPreferencesV1 | 
   return mergeSyncedPreferences(items.map((item) => item.preferences))
 }
 
-async function listPreferencesCollections(): Promise<any[]> {
+async function listPreferencesCollections(accountEpoch: number): Promise<any[]> {
+  assertCurrentAccountEpoch(accountEpoch)
   const etebase = useEtebaseStore.getState()
   if (!etebase.account) return []
   if (etebase.collections.preferences.length > 0) return etebase.collections.preferences
 
   const core = await import('@silentsuite/core')
+  assertCurrentAccountEpoch(accountEpoch)
   const collections = await core.listCollections(etebase.account, COLLECTION_TYPE_PREFERENCES)
+  assertCurrentAccountEpoch(accountEpoch)
   if (collections.length > 0) {
+    const currentEtebase = useEtebaseStore.getState()
+    if (currentEtebase.account !== etebase.account || currentEtebase.syncEngine !== etebase.syncEngine) return []
     useEtebaseStore.setState((state) => ({
       collections: { ...state.collections, preferences: collections },
     }))
+    assertCurrentAccountEpoch(accountEpoch)
     for (const collection of collections) {
+      assertCurrentAccountEpoch(accountEpoch)
+      if (useEtebaseStore.getState().syncEngine !== etebase.syncEngine) return []
       etebase.syncEngine?.trackCollection(COLLECTION_TYPE_PREFERENCES as any, collection.uid)
     }
   }
   return collections
 }
 
-async function ensurePreferencesCollection(): Promise<string | null> {
-  const existing = await listPreferencesCollections()
+async function ensurePreferencesCollection(accountEpoch: number): Promise<string | null> {
+  const existing = await listPreferencesCollections(accountEpoch)
+  assertCurrentAccountEpoch(accountEpoch)
   if (existing[0]?.uid) return existing[0].uid
   return useEtebaseStore.getState().createCollection('preferences', PREFERENCES_COLLECTION_NAME)
 }
 
-async function readRemotePreferenceItems(): Promise<{ uid: string; content: string }[]> {
-  const collections = await listPreferencesCollections()
+async function readRemotePreferenceItems(accountEpoch: number): Promise<{ uid: string; content: string }[]> {
+  const collections = await listPreferencesCollections(accountEpoch)
+  assertCurrentAccountEpoch(accountEpoch)
   if (collections.length === 0) return []
   return useEtebaseStore.getState().refreshCollection('preferences')
 }
@@ -99,17 +109,18 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
     if (get().isInitialized) return
     if (!useEtebaseStore.getState().account) return
 
-    await get().loadFromRemote()
+    await get().loadFromRemote(undefined, epoch)
     assertCurrentAccountEpoch(epoch)
     set({ isInitialized: true })
   },
 
-  loadFromRemote: async (itemsFromRefresh) => {
-    const epoch = getAccountEpoch()
+  loadFromRemote: async (itemsFromRefresh, initiatingEpoch) => {
+    const epoch = initiatingEpoch ?? getAccountEpoch()
+    assertCurrentAccountEpoch(epoch)
     const etebase = useEtebaseStore.getState()
     if (!etebase.account) return
 
-    const items = itemsFromRefresh ?? await readRemotePreferenceItems()
+    const items = itemsFromRefresh ?? await readRemotePreferenceItems(epoch)
     assertCurrentAccountEpoch(epoch)
     const remoteItems = parseRemoteItems(items)
     const canonical = chooseCanonical(remoteItems)
@@ -137,11 +148,11 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
     const etebase = useEtebaseStore.getState()
     if (!etebase.account) return false
 
-    const collectionUid = await ensurePreferencesCollection()
+    const collectionUid = await ensurePreferencesCollection(epoch)
     assertCurrentAccountEpoch(epoch)
     if (!collectionUid) return false
 
-    const remoteItems = parseRemoteItems(await readRemotePreferenceItems())
+    const remoteItems = parseRemoteItems(await readRemotePreferenceItems(epoch))
     assertCurrentAccountEpoch(epoch)
     const mergedRemote = mergeRemoteItems(remoteItems)
     const merged = mergedRemote

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -2,10 +2,28 @@
 
 import { create } from 'zustand'
 import type { SyncStatus } from '@silentsuite/core'
-import { replay, getPendingCount, getFailedCount, onCountChange, getStaleEntries, remove, type QueueEntry } from '@/app/lib/offline-queue'
+import { replay, getPendingCount, getFailedCount, onCountChange, getStaleEntries, remove, type QueueEntry, type OfflineQueueAccountGuard } from '@/app/lib/offline-queue'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
+
+async function captureQueueGuard(): Promise<OfflineQueueAccountGuard> {
+  const accountEpoch = getAccountEpoch()
+  const { useEtebaseStore } = await import('@/app/stores/use-etebase-store')
+  assertCurrentAccountEpoch(accountEpoch)
+  const { account, accountFingerprint } = useEtebaseStore.getState()
+  if (!account || !accountFingerprint) throw new AccountBoundaryChangedError()
+  return { accountEpoch, accountFingerprint }
+}
+
+async function readQueueCounts(guard: OfflineQueueAccountGuard) {
+  const [pendingQueueCount, failedQueueCount] = await Promise.all([
+    getPendingCount(guard), getFailedCount(guard),
+  ])
+  assertCurrentAccountEpoch(guard.accountEpoch)
+  return { pendingQueueCount, failedQueueCount }
+}
 
 interface SyncState {
   syncStatus: SyncStatus
@@ -65,26 +83,33 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
     window.addEventListener('online', handleOnline)
     window.addEventListener('offline', handleOffline)
 
-    // Subscribe to queue count changes (update both pending and failed)
-    const unsubQueue = onCountChange((count) => {
-      set({ pendingQueueCount: count })
-      // Also refresh failed count when queue changes
-      getFailedCount().then((fc) => set({ failedQueueCount: fc }))
-    })
+    // Subscribe to queue changes and refresh counts for the active account only.
+    const refreshCounts = async () => {
+      try {
+        const guard = await captureQueueGuard()
+        const counts = await readQueueCounts(guard)
+        assertCurrentAccountEpoch(guard.accountEpoch)
+        set(counts)
+      } catch (err) {
+        if (!(err instanceof AccountBoundaryChangedError)) logger.warn('[sync-store] Failed to refresh queue counts', getSafeErrorDetails(err))
+      }
+    }
+    const unsubQueue = onCountChange(() => { void refreshCounts() })
 
-    // Load initial queue counts
-    getPendingCount().then((count) => set({ pendingQueueCount: count }))
-    getFailedCount().then((count) => set({ failedQueueCount: count }))
+    void refreshCounts()
 
     // Set initial state
     if (navigator.onLine) {
       set({ isOnline: true })
-      // Cold-start replay: if we load online with pending entries, replay them
-      getPendingCount().then(async (count) => {
+      captureQueueGuard().then(async (guard) => {
+        const count = await getPendingCount(guard)
+        assertCurrentAccountEpoch(guard.accountEpoch)
         if (count > 0) {
           logger.log(`[sync-store] Cold-start: replaying ${count} queued mutations`)
           await get().replayOfflineQueue()
         }
+      }).catch((err) => {
+        if (!(err instanceof AccountBoundaryChangedError)) logger.warn('[sync-store] Cold-start replay check failed', getSafeErrorDetails(err))
       })
     } else {
       set({ syncStatus: 'offline', isOnline: false })
@@ -98,15 +123,19 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
   },
 
   replayOfflineQueue: async () => {
-    const count = await getPendingCount()
+    try {
+    const guard = await captureQueueGuard()
+    const count = await getPendingCount(guard)
+    assertCurrentAccountEpoch(guard.accountEpoch)
     if (count === 0) return
 
     logger.log(`[sync-store] Replaying ${count} queued offline mutations...`)
 
     const executeMutation = async (entry: QueueEntry): Promise<{ itemUid?: string }> => {
       const { useEtebaseStore } = await import('@/app/stores/use-etebase-store')
+      assertCurrentAccountEpoch(guard.accountEpoch)
       const etebase = useEtebaseStore.getState()
-      if (!etebase.account) throw new Error('No Etebase account')
+      if (!etebase.account || etebase.accountFingerprint !== guard.accountFingerprint) throw new AccountBoundaryChangedError()
 
       try {
         switch (entry.type) {
@@ -130,6 +159,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
           }
         }
       } catch (err) {
+        assertCurrentAccountEpoch(guard.accountEpoch)
         // Handle 409 Conflict (ETag mismatch) — server-wins strategy
         const is409 = err instanceof Error && (
           err.message.includes('409') ||
@@ -152,11 +182,13 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       }
     }
 
-    const results = await replay(executeMutation)
+    const results = await replay(executeMutation, guard)
+    assertCurrentAccountEpoch(guard.accountEpoch)
 
     // Replace tempIds in domain stores for successful creates, and old item IDs
     // for successful collection moves that recreate the Etebase item.
     for (const result of results) {
+      assertCurrentAccountEpoch(guard.accountEpoch)
       if (!result.success || !result.itemUid) continue
 
       const { collectionType } = result.entry
@@ -166,6 +198,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
 
       if (collectionType === 'tasks') {
         const { useTaskStore } = await import('@/app/stores/use-task-store')
+        assertCurrentAccountEpoch(guard.accountEpoch)
         useTaskStore.getState().syncFromRemote(
           useTaskStore.getState().tasks.map((t) =>
             t.id === oldId ? { ...t, id: result.itemUid!, listId: targetCollectionUid ?? t.listId } : t,
@@ -173,6 +206,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         )
       } else if (collectionType === 'contacts') {
         const { useContactStore } = await import('@/app/stores/use-contact-store')
+        assertCurrentAccountEpoch(guard.accountEpoch)
         useContactStore.getState().syncFromRemote(
           useContactStore.getState().contacts.map((c) =>
             c.id === oldId ? { ...c, id: result.itemUid!, listId: targetCollectionUid ?? c.listId } : c,
@@ -180,6 +214,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         )
       } else if (collectionType === 'calendar') {
         const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
+        assertCurrentAccountEpoch(guard.accountEpoch)
         useCalendarStore.getState().syncFromRemote(
           useCalendarStore.getState().events.map((e) =>
             e.id === oldId ? { ...e, id: result.itemUid!, calendarId: targetCollectionUid ?? e.calendarId } : e,
@@ -188,12 +223,18 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       }
     }
 
+    assertCurrentAccountEpoch(guard.accountEpoch)
     const succeeded = results.filter((r) => r.success).length
     const failed = results.filter((r) => !r.success).length
     logger.log(`[sync-store] Queue replay done: ${succeeded} succeeded, ${failed} failed`)
+    } catch (err) {
+      if (err instanceof AccountBoundaryChangedError) return
+      throw err
+    }
   },
 
   simulateSyncCycle: () => {
+    const accountEpoch = getAccountEpoch()
     const { isOnline } = get()
     if (!isOnline) return
 
@@ -204,19 +245,27 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       import('@/app/stores/use-etebase-store'),
       import('@silentsuite/core'),
     ]).then(async ([{ useEtebaseStore }, core]) => {
+      assertCurrentAccountEpoch(accountEpoch)
       const etebase = useEtebaseStore.getState()
+      const accountFingerprint = etebase.accountFingerprint
+      if (!etebase.account || !accountFingerprint) throw new AccountBoundaryChangedError()
+      const guard = { accountEpoch, accountFingerprint }
 
       // First reconcile collection membership so manual sync notices calendars,
       // task lists, or address books deleted or created on another device.
       await etebase.reconcileCollections()
+      assertCurrentAccountEpoch(accountEpoch)
       const reconciledEtebase = useEtebaseStore.getState()
+      if (reconciledEtebase.accountFingerprint !== accountFingerprint) throw new AccountBoundaryChangedError()
 
       // Then run the SyncEngine poll to advance stokens for active collections.
       if (reconciledEtebase.syncEngine) {
         try { await reconciledEtebase.syncEngine.syncNow() } catch (err) {
+          assertCurrentAccountEpoch(accountEpoch)
           logger.error('SyncStore', 'SyncEngine.syncNow() failed', err)
           set({ syncStatus: 'error' })
         }
+        assertCurrentAccountEpoch(accountEpoch)
       }
 
       // Then refresh every collection of each type from the server
@@ -225,12 +274,14 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         reconciledEtebase.refreshCollection('contacts'),
         reconciledEtebase.refreshCollection('calendar'),
       ])
+      assertCurrentAccountEpoch(accountEpoch)
 
       // Push fresh data into stores
       const { useTaskStore } = await import('@/app/stores/use-task-store')
       const { useContactStore } = await import('@/app/stores/use-contact-store')
       const { useCalendarStore } = await import('@/app/stores/use-calendar-store')
       const { usePreferencesSyncStore } = await import('@/app/stores/use-preferences-sync-store')
+      assertCurrentAccountEpoch(accountEpoch)
 
       const refreshedEtebase = useEtebaseStore.getState()
       const domainLoadState = refreshedEtebase.domainLoadState
@@ -241,6 +292,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         return { ...task, id: item.uid, listId: item.collectionUid }
       })
       if (domainLoadState.tasks === 'loaded') {
+        assertCurrentAccountEpoch(accountEpoch)
         useTaskStore.getState().syncFromRemote(tasks)
       } else {
         partialDomainCount += 1
@@ -251,6 +303,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         return { ...contact, id: item.uid, listId: item.collectionUid }
       })
       if (domainLoadState.contacts === 'loaded') {
+        assertCurrentAccountEpoch(accountEpoch)
         useContactStore.getState().syncFromRemote(contacts)
       } else {
         partialDomainCount += 1
@@ -261,6 +314,7 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         return { ...event, id: item.uid, calendarId: item.collectionUid }
       })
       if (domainLoadState.calendar === 'loaded') {
+        assertCurrentAccountEpoch(accountEpoch)
         useCalendarStore.getState().syncFromRemote(events)
       } else {
         partialDomainCount += 1
@@ -268,19 +322,23 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
 
       try {
         await usePreferencesSyncStore.getState().loadFromRemote()
+        assertCurrentAccountEpoch(accountEpoch)
       } catch (err) {
+        assertCurrentAccountEpoch(accountEpoch)
         logger.warn('[sync-store] Preferences refresh failed during sync cycle', getSafeErrorDetails(err))
       }
 
       // Purge stale queue entries (older than 24h) that may cause phantom indicators
-      const stale = await getStaleEntries()
+      const stale = await getStaleEntries(guard)
       for (const entry of stale) {
-        await remove(entry.id)
+        assertCurrentAccountEpoch(guard.accountEpoch)
+        await remove(entry.id, guard)
+        assertCurrentAccountEpoch(guard.accountEpoch)
       }
 
       // Refresh counts to ensure UI is accurate after sync
-      const pc = await getPendingCount()
-      const fc = await getFailedCount()
+      const { pendingQueueCount: pc, failedQueueCount: fc } = await readQueueCounts(guard)
+      assertCurrentAccountEpoch(guard.accountEpoch)
       set({
         syncStatus: 'synced',
         lastSyncedAt: new Date(),
@@ -291,6 +349,8 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
         partialLoadDomainCount: partialDomainCount,
       })
     }).catch((err) => {
+      if (err instanceof AccountBoundaryChangedError) return
+      try { assertCurrentAccountEpoch(accountEpoch) } catch { return }
       console.error('[sync-store] Manual sync failed', getSafeErrorDetails(err))
       set({ syncStatus: 'error', error: 'Sync failed' })
       const isOnline = get().isOnline


### PR DESCRIPTION
## Summary

- bind user-initiated Etebase item, collection, sharing, and cleanup operations to the account epoch that started them
- abort stale success and ordinary-error continuations before publishing memory state, encrypted cache data, offline queue changes, domain-store changes, logs, or toasts
- guard single-item and bulk IndexedDB writes/deletes with account fingerprint checks and a final in-transaction epoch sentinel
- add deterministic regressions for stale update, batch, move, sharing, bulk cleanup, reconcile, and queued cache transaction paths

## Verification

- `pnpm --filter @silentsuite/web test` (49 files, 546 tests passed)
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint` (existing unrelated warnings only)
- `git diff --check`

## Context

Follow-up hardening discovered during the `v0.4.1-beta` production-promotion review. This keeps decrypted account data and account-scoped side effects from crossing a login/logout boundary while asynchronous user operations are still in flight.