### PR TITLE
fix(web): scope production offline queue writes

### DIFF
--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import 'fake-indexeddb/auto'
 import { AccountBoundaryChangedError, bumpAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 import {
-  enqueue,
+  enqueue as guardedEnqueue,
   getAll,
   getPendingCount,
   getFailedCount,
@@ -21,6 +21,17 @@ import {
   _resetForTests,
   _setEncryptedQueuePersistenceAvailableForTests,
 } from '../offline-queue'
+
+const TEST_FINGERPRINT = 'offline-queue-unit-test-account'
+function testGuard(accountFingerprint = TEST_FINGERPRINT) {
+  return { accountEpoch: getAccountEpoch(), accountFingerprint }
+}
+function enqueue(
+  entry: Parameters<typeof guardedEnqueue>[0],
+  guard = testGuard(),
+) {
+  return guardedEnqueue(entry, guard)
+}
 
 beforeEach(async () => {
   process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'
@@ -60,11 +71,11 @@ describe('offline-queue', () => {
     })
 
     it('increments pending count', async () => {
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
       await enqueue({ type: 'update', collectionType: 'contacts', content: 'vcard', itemUid: 'uid-1' })
-      expect(await getPendingCount()).toBe(1)
+      expect(await getPendingCount(testGuard())).toBe(1)
       await enqueue({ type: 'delete', collectionType: 'calendar', itemUid: 'uid-2' })
-      expect(await getPendingCount()).toBe(2)
+      expect(await getPendingCount(testGuard())).toBe(2)
     })
   })
 
@@ -154,12 +165,12 @@ describe('offline-queue', () => {
 
     it('clearAll removes queued mutations for logout/account switch cleanup', async () => {
       await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: 'tasks', itemUid: 'task-1' })
-      expect(await getPendingCount()).toBe(1)
+      expect(await getPendingCount(testGuard())).toBe(1)
 
       await clearAll()
 
       expect(await getAll()).toHaveLength(0)
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
   })
 
@@ -251,6 +262,26 @@ describe('offline-queue', () => {
       await vi.waitFor(() => expect(counts).toEqual([1]))
     })
 
+    it('fails closed before IndexedDB work when the exported enqueue guard is undefined', async () => {
+      const counts: number[] = []
+      const enqueues: number[] = []
+      const openSpy = vi.spyOn(indexedDB, 'open')
+      onCountChange((count) => counts.push(count))
+      onEnqueue(() => enqueues.push(1))
+
+      await expect(guardedEnqueue(
+        { type: 'delete', collectionType: 'tasks', itemUid: 'x' },
+        undefined as any,
+      )).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(await getAll()).toEqual([])
+      expect(counts).toEqual([])
+      expect(enqueues).toEqual([])
+      openSpy.mockRestore()
+    })
+
     it('fails closed when a guarded operation has no fingerprint', async () => {
       await expect(enqueue({ type: 'delete', collectionType: 'tasks', itemUid: 'x' }, {
         accountEpoch: getAccountEpoch(),
@@ -275,7 +306,7 @@ describe('offline-queue', () => {
       expect(results[0].success).toBe(true)
       expect(results[0].itemUid).toBe('real-uid')
       expect(results[1].success).toBe(true)
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
 
     it('increments retryCount on failure, marks failed after MAX_RETRIES', async () => {
@@ -292,7 +323,7 @@ describe('offline-queue', () => {
       expect(all[0].status).toBe('failed')
 
       // Failed entries don't count as pending
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
 
     it('retries pending entries but skips failed ones', async () => {
@@ -433,7 +464,7 @@ describe('offline-queue', () => {
 
       const all = await getAll()
       expect(all).toHaveLength(0)
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
 
     it('update + update with same itemUid → merges to latest content', async () => {
@@ -573,12 +604,12 @@ describe('offline-queue', () => {
         await replay(async () => { throw new Error('fail') })
       }
 
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
       expect(await getFailedCount()).toBe(1)
 
       await retryFailed()
 
-      expect(await getPendingCount()).toBe(1)
+      expect(await getPendingCount(testGuard())).toBe(1)
       expect(await getFailedCount()).toBe(0)
 
       const all = await getAll()
@@ -709,7 +740,7 @@ describe('offline-queue', () => {
       _setEncryptedQueuePersistenceAvailableForTests(true)
 
       // Verify entries persist across resets
-      const count = await getPendingCount()
+      const count = await getPendingCount(testGuard())
       expect(count).toBe(2)
 
       // Replay all pending entries (simulates cold-start replay)
@@ -719,7 +750,7 @@ describe('offline-queue', () => {
       expect(executeFn).toHaveBeenCalledTimes(2)
       expect(results).toHaveLength(2)
       expect(results.every((r) => r.success)).toBe(true)
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
   })
 

--- a/apps/web/app/lib/offline-queue-account.ts
+++ b/apps/web/app/lib/offline-queue-account.ts
@@ -1,0 +1,33 @@
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
+import type { OfflineQueueAccountGuard } from '@/app/lib/offline-queue'
+
+interface ActiveAccountState {
+  account: unknown | null
+  accountFingerprint: string | null
+}
+
+/** Capture queue ownership synchronously. Missing identity fails closed. */
+export function captureOfflineQueueAccountGuard(
+  state: ActiveAccountState,
+): OfflineQueueAccountGuard | null {
+  if (!state.account || !state.accountFingerprint) return null
+  return {
+    accountEpoch: getAccountEpoch(),
+    accountFingerprint: state.accountFingerprint,
+  }
+}
+
+/** Assert both the epoch and stable account identity at a publication boundary. */
+export function assertOfflineQueueAccountGuard(
+  guard: OfflineQueueAccountGuard,
+  state: ActiveAccountState,
+): void {
+  assertCurrentAccountEpoch(guard.accountEpoch)
+  if (!state.account || state.accountFingerprint !== guard.accountFingerprint) {
+    throw new AccountBoundaryChangedError()
+  }
+}
+
+export function isOfflineQueueBoundaryCancellation(error: unknown): boolean {
+  return error instanceof AccountBoundaryChangedError
+}

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -236,9 +236,9 @@ async function compact(
   return null
 }
 
-export async function enqueue(
+async function enqueueInternal(
   entry: Omit<QueueEntry, 'id' | 'createdAt' | 'retryCount' | 'status'>,
-  guard?: OfflineQueueAccountGuard,
+  guard: OfflineQueueAccountGuard,
 ): Promise<string> {
   assertGuard(guard)
   // Try compaction first
@@ -260,7 +260,7 @@ export async function enqueue(
     createdAt: Date.now(),
     retryCount: 0,
     status: 'pending',
-    ...(guard ? { accountFingerprint: guard.accountFingerprint } : {}),
+    accountFingerprint: guard.accountFingerprint,
   }
   assertCanPersistEntry(record)
   return new Promise<string>((resolve, reject) => {
@@ -276,6 +276,17 @@ export async function enqueue(
     tx.onerror = () => reject(tx.error)
     tx.onabort = () => reject(guard ? new AccountBoundaryChangedError() : tx.error)
   })
+}
+
+/** Account-scoped production enqueue. A valid owner is mandatory by type. */
+export function enqueue(
+  entry: Omit<QueueEntry, 'id' | 'createdAt' | 'retryCount' | 'status'>,
+  guard: OfflineQueueAccountGuard,
+): Promise<string> {
+  // TypeScript cannot protect this runtime boundary from JavaScript callers,
+  // `any`, or stale bundles. Reject before compact/openDB can touch IndexedDB.
+  if (!guard) return Promise.reject(new AccountBoundaryChangedError())
+  return enqueueInternal(entry, guard)
 }
 
 export async function getAll(guard?: OfflineQueueAccountGuard): Promise<QueueEntry[]> {

--- a/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
+++ b/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
@@ -1,0 +1,101 @@
+import 'fake-indexeddb/auto'
+import { expect, vi } from 'vitest'
+import { bumpAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
+import {
+  _resetForTests,
+  _setEncryptedQueuePersistenceAvailableForTests,
+  clearAll,
+  enqueue,
+  getAll,
+  getPendingCount,
+  replay,
+  type OfflineQueueAccountGuard,
+  type QueueEntry,
+} from '@/app/lib/offline-queue'
+
+export const TEST_FINGERPRINT = 'store-regression-account'
+
+export function queueGuard(fingerprint = TEST_FINGERPRINT): OfflineQueueAccountGuard {
+  return { accountEpoch: getAccountEpoch(), accountFingerprint: fingerprint }
+}
+
+export async function resetRealOfflineQueue(): Promise<void> {
+  await _resetForTests()
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase('silentsuite-offline-queue')
+    request.onsuccess = () => resolve()
+    request.onerror = () => resolve()
+    request.onblocked = () => resolve()
+  })
+  _setEncryptedQueuePersistenceAvailableForTests(true)
+}
+
+export async function enqueueCreateFromStore(
+  collectionType: QueueEntry['collectionType'],
+  collectionUid: string | undefined,
+  content: string,
+  tempId: string,
+): Promise<null> {
+  await enqueue({ type: 'create', collectionType, collectionUid, content, tempId }, queueGuard())
+  return null
+}
+
+export async function expectOwnedQueueEntry(type: QueueEntry['type'], collectionType: QueueEntry['collectionType']): Promise<QueueEntry> {
+  const guard = queueGuard()
+  const entries = await getAll(guard)
+  if (entries.length !== 1) throw new Error(`Expected one guarded queue entry, got ${entries.length}`)
+  const entry = entries[0]!
+  if (!entry.accountFingerprint) throw new Error('Queue entry has no account fingerprint')
+  if (entry.accountFingerprint !== TEST_FINGERPRINT || entry.type !== type || entry.collectionType !== collectionType) {
+    throw new Error(`Unexpected queue entry: ${JSON.stringify(entry)}`)
+  }
+  if (await getPendingCount(guard) !== 1) throw new Error('Guarded pending count did not include entry')
+  return entry
+}
+
+export async function replayOwnedEntry(entry: QueueEntry): Promise<void> {
+  const execute = vi.fn(async () => ({}))
+  const results = await replay(execute, queueGuard())
+  if (results.length !== 1 || !results[0]!.success) throw new Error('Guarded replay did not execute entry')
+  if (execute.mock.calls[0]?.[0].id !== entry.id) throw new Error('Replay executed a different entry')
+  if ((await getAll(queueGuard())).length !== 0) throw new Error('Replay did not remove guarded entry')
+}
+
+export async function clearQueue(): Promise<void> {
+  await clearAll()
+}
+
+export function bumpEpochWhenQueuePutRuns(onBoundary: () => void): ReturnType<typeof vi.spyOn> {
+  const originalPut = IDBObjectStore.prototype.put
+  let bumped = false
+  return vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (...args: Parameters<IDBObjectStore['put']>) {
+    const request = originalPut.apply(this, args)
+    if (!bumped) {
+      bumped = true
+      bumpAccountEpoch()
+      onBoundary()
+    }
+    return request
+  })
+}
+
+export async function expectQuietQueueCommitCancellation(
+  mutate: () => Promise<unknown>,
+  onBoundary: () => void,
+  assertNoStaleState: () => void,
+  toast: { showErrorToast: ReturnType<typeof vi.fn> },
+): Promise<void> {
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const putSpy = bumpEpochWhenQueuePutRuns(onBoundary)
+  try {
+    await expect(mutate()).resolves.not.toThrow()
+    assertNoStaleState()
+    expect(await getAll()).toEqual([])
+    expect(await getAll(queueGuard('new-account'))).toEqual([])
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toast.showErrorToast).not.toHaveBeenCalled()
+  } finally {
+    putSpy.mockRestore()
+    errorSpy.mockRestore()
+  }
+}

--- a/apps/web/app/stores/__tests__/use-calendar-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-calendar-store.test.ts
@@ -3,14 +3,20 @@ import { useCalendarStore } from '../use-calendar-store'
 import { serializeCalendarEvent, deserializeCalendarEvent } from '@silentsuite/core'
 import type { CalendarEvent } from '@silentsuite/core'
 import { expandEventsForRange } from '@/app/(app)/calendar/lib/calendar-grid-events'
+import { getAll } from '@/app/lib/offline-queue'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, enqueueCreateFromStore, expectOwnedQueueEntry, expectQuietQueueCommitCancellation, queueGuard, replayOwnedEntry, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+
+const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
 
 const etebaseMock = vi.hoisted(() => ({
   state: {
     account: null as unknown,
+    accountFingerprint: null as string | null,
     createItem: vi.fn(),
     createItemsBatch: vi.fn(),
     updateItem: vi.fn(),
     moveItem: vi.fn(),
+    deleteItem: vi.fn(),
     itemCache: new Map<string, unknown>(),
     itemCollectionMap: new Map<string, string>(),
   },
@@ -28,16 +34,16 @@ vi.mock('@/app/stores/use-etebase-store', () => ({
   },
 }))
 
-vi.mock('@/app/stores/use-toast-store', () => ({
-  showErrorToast: vi.fn(),
-}))
+vi.mock('@/app/stores/use-toast-store', () => toastMock)
 
 function resetStore() {
   etebaseMock.state.account = null
+  etebaseMock.state.accountFingerprint = 'calendar-test-account'
   etebaseMock.state.createItem.mockReset()
   etebaseMock.state.createItemsBatch.mockReset()
   etebaseMock.state.updateItem.mockReset()
   etebaseMock.state.moveItem.mockReset()
+  etebaseMock.state.deleteItem.mockReset()
   etebaseMock.state.itemCache = new Map()
   etebaseMock.state.itemCollectionMap = new Map()
   useCalendarStore.setState({
@@ -48,6 +54,13 @@ function resetStore() {
     currentDate: new Date('2026-06-01T12:00:00Z'),
     selectedEventId: null,
   })
+}
+
+function offlineAccount() {
+  etebaseMock.state.account = {}
+  etebaseMock.state.accountFingerprint = TEST_FINGERPRINT
+  etebaseMock.state.itemCache = new Map()
+  etebaseMock.state.createItem.mockImplementation((type, content, tempId, collectionUid) => enqueueCreateFromStore(type, collectionUid, content, tempId))
 }
 
 function makeRecurringEvent(overrides?: Partial<CalendarEvent>): CalendarEvent {
@@ -398,5 +411,90 @@ describe('useCalendarStore.getFilteredEvents', () => {
     // Empty query returns everything
     useCalendarStore.getState().setSearchQuery('')
     expect(useCalendarStore.getState().getFilteredEvents()).toHaveLength(2)
+  })
+})
+
+describe('useCalendarStore guarded offline queue integration', () => {
+  // Enqueue surface map: create -> Etebase createItem; update + recurring updates ->
+  // syncEventToEtebase update; offline calendar moves -> that helper's move fallback;
+  // deleteEvent + recurring/all each have cached-item and temp-item delete branches.
+  const queuedEvent = (id = 'temp-event') => makeRecurringEvent({ id, uid: id, recurrenceRule: null, calendarId: 'cal-1' })
+  beforeEach(async () => { await resetRealOfflineQueue(); resetStore(); offlineAccount(); toastMock.showErrorToast.mockReset() })
+
+  it.each([
+    ['create', async () => { await useCalendarStore.getState().createEvent({ title: 'Create', startDate: new Date('2026-06-01T09:00:00Z'), endDate: new Date('2026-06-01T10:00:00Z'), calendarId: 'cal-1' }) }],
+    ['update', async () => { useCalendarStore.setState({ events: [queuedEvent()] }); await useCalendarStore.getState().updateEvent('temp-event', { title: 'Update' }) }],
+    ['delete', async () => { useCalendarStore.setState({ events: [queuedEvent()] }); await useCalendarStore.getState().deleteEvent('temp-event') }],
+  ] as const)('persists, exposes, and replays an owned offline %s', async (type, mutate) => {
+    await mutate()
+    await replayOwnedEntry(await expectOwnedQueueEntry(type, 'calendar'))
+  })
+
+  it('isolates equal calendar IDs across account fingerprints', async () => {
+    useCalendarStore.setState({ events: [queuedEvent()] })
+    await useCalendarStore.getState().updateEvent('temp-event', { title: 'Owned' })
+    expect(await getAll(queueGuard('other-account'))).toEqual([])
+    expect(await getAll(queueGuard(TEST_FINGERPRINT))).toHaveLength(1)
+  })
+
+  it('quietly cancels at the actual IndexedDB commit boundary', async () => {
+    useCalendarStore.setState({ events: [queuedEvent()] })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = bumpEpochWhenQueuePutRuns(() => {
+      etebaseMock.state.account = {}; etebaseMock.state.accountFingerprint = 'new-account'
+      useCalendarStore.setState({ events: [], selectedEventId: null })
+    })
+    await expect(useCalendarStore.getState().updateEvent('temp-event', { title: 'Stale' })).resolves.toBeUndefined()
+    putSpy.mockRestore()
+    expect(useCalendarStore.getState().events).toEqual([])
+    expect(await getAll()).toEqual([])
+    expect(await getAll(queueGuard('new-account'))).toEqual([])
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it.each([
+    ['cached move fallback', () => {
+      const event = queuedEvent('cached-move')
+      useCalendarStore.setState({ events: [event] })
+      etebaseMock.state.itemCache = new Map([[event.id, {}]])
+      etebaseMock.state.itemCollectionMap = new Map([[event.id, 'cal-1']])
+      etebaseMock.state.moveItem.mockRejectedValue(new TypeError('offline'))
+      return useCalendarStore.getState().updateEvent(event.id, { calendarId: 'cal-2' })
+    }],
+    ['cached delete fallback', () => {
+      const event = queuedEvent('cached-delete')
+      useCalendarStore.setState({ events: [event] })
+      etebaseMock.state.itemCache = new Map([[event.id, {}]])
+      etebaseMock.state.itemCollectionMap = new Map([[event.id, 'cal-1']])
+      etebaseMock.state.deleteItem.mockRejectedValue(new TypeError('offline'))
+      return useCalendarStore.getState().deleteEvent(event.id)
+    }],
+    ['uncached delete', () => {
+      const event = queuedEvent('uncached-delete')
+      useCalendarStore.setState({ events: [event] })
+      return useCalendarStore.getState().deleteEvent(event.id)
+    }],
+    ['cached recurring delete fallback', () => {
+      const event = makeRecurringEvent({ id: 'cached-recurring-delete' })
+      useCalendarStore.setState({ events: [event] })
+      etebaseMock.state.itemCache = new Map([[event.id, {}]])
+      etebaseMock.state.itemCollectionMap = new Map([[event.id, 'cal-1']])
+      etebaseMock.state.deleteItem.mockRejectedValue(new TypeError('offline'))
+      return useCalendarStore.getState().deleteRecurringEvent(event.id, 'all', new Date('2026-06-03T09:00:00Z'))
+    }],
+    ['uncached recurring delete', () => {
+      const event = makeRecurringEvent({ id: 'uncached-recurring-delete' })
+      useCalendarStore.setState({ events: [event] })
+      return useCalendarStore.getState().deleteRecurringEvent(event.id, 'all', new Date('2026-06-03T09:00:00Z'))
+    }],
+  ] as const)('quietly cancels the %s direct branch at the actual IndexedDB commit boundary', async (_branch, mutate) => {
+    await expectQuietQueueCommitCancellation(
+      mutate,
+      () => { etebaseMock.state.account = {}; etebaseMock.state.accountFingerprint = 'new-account'; useCalendarStore.setState({ events: [], selectedEventId: null }) },
+      () => { expect(useCalendarStore.getState().events).toEqual([]); expect(useCalendarStore.getState().selectedEventId).toBeNull() },
+      toastMock,
+    )
   })
 })

--- a/apps/web/app/stores/__tests__/use-contact-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-contact-store.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useContactStore, getFilteredContacts } from '../use-contact-store'
 import { useEtebaseStore } from '../use-etebase-store'
 import type { Contact } from '@silentsuite/core'
+import { getAll } from '@/app/lib/offline-queue'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, enqueueCreateFromStore, expectOwnedQueueEntry, expectQuietQueueCommitCancellation, queueGuard, replayOwnedEntry, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+
+const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
+vi.mock('@/app/stores/use-toast-store', () => toastMock)
 
 // Mock the sync store to prevent side effects
 vi.mock('@/app/stores/use-sync-store', () => ({
@@ -22,6 +27,14 @@ function resetStore() {
     pendingChanges: [],
   })
   useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+}
+
+function offlineAccount() {
+  useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map(), createItem: vi.fn((type, content, tempId, collectionUid) => enqueueCreateFromStore(type, collectionUid, content, tempId!)) } as any)
+}
+
+function queuedContact(id = 'temp-contact'): Contact {
+  return { id, uid: id, displayName: 'Contact', name: { prefix: '', given: '', family: '', suffix: '' }, phones: [], emails: [], addresses: [], organization: '', title: '', notes: '', birthday: null, photoUrl: null, categories: [], listId: 'contacts-1', created_at: new Date(), updated_at: new Date() }
 }
 
 describe('useContactStore', () => {
@@ -195,6 +208,55 @@ describe('useContactStore', () => {
       const vip = getFilteredContacts(tagged, 'vip')
       expect(vip).toHaveLength(1)
       expect(vip[0]!.displayName).toBe('Carol King')
+    })
+  })
+
+  describe('guarded offline queue integration', () => {
+    // Enqueue surface map: create -> Etebase createItem; uncached update/delete ->
+    // the direct guarded branches below; cached update/delete enqueue in Etebase store.
+    beforeEach(async () => { await resetRealOfflineQueue(); resetStore(); offlineAccount(); toastMock.showErrorToast.mockReset() })
+
+    it.each([
+      ['create', async () => { await useContactStore.getState().createContact({ displayName: 'Create', listId: 'contacts-1' }) }],
+      ['update', async () => { useContactStore.setState({ contacts: [queuedContact()] }); await useContactStore.getState().updateContact('temp-contact', { displayName: 'Update' }) }],
+      ['delete', async () => { useContactStore.setState({ contacts: [queuedContact()] }); await useContactStore.getState().deleteContact('temp-contact') }],
+    ] as const)('persists, exposes, and replays an owned offline %s', async (type, mutate) => {
+      await mutate()
+      await replayOwnedEntry(await expectOwnedQueueEntry(type, 'contacts'))
+    })
+
+    it('isolates equal contact IDs across account fingerprints', async () => {
+      useContactStore.setState({ contacts: [queuedContact()] })
+      await useContactStore.getState().updateContact('temp-contact', { displayName: 'Owned' })
+      expect(await getAll(queueGuard('other-account'))).toEqual([])
+      expect(await getAll(queueGuard(TEST_FINGERPRINT))).toHaveLength(1)
+    })
+
+    it('quietly cancels at the actual IndexedDB commit boundary', async () => {
+      useContactStore.setState({ contacts: [queuedContact()] })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const putSpy = bumpEpochWhenQueuePutRuns(() => {
+        useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any)
+        useContactStore.setState({ contacts: [] })
+      })
+      await expect(useContactStore.getState().updateContact('temp-contact', { displayName: 'Stale' })).resolves.toBeUndefined()
+      putSpy.mockRestore()
+      expect(useContactStore.getState().contacts).toEqual([])
+      expect(await getAll()).toEqual([])
+      expect(await getAll(queueGuard('new-account'))).toEqual([])
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it('quietly cancels its distinct uncached delete branch at the actual IndexedDB commit boundary', async () => {
+      useContactStore.setState({ contacts: [queuedContact()] })
+      await expectQuietQueueCommitCancellation(
+        () => useContactStore.getState().deleteContact('temp-contact'),
+        () => { useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any); useContactStore.setState({ contacts: [] }) },
+        () => expect(useContactStore.getState().contacts).toEqual([]),
+        toastMock,
+      )
     })
   })
 })

--- a/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
@@ -1,0 +1,146 @@
+import 'fake-indexeddb/auto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+
+const coreMock = vi.hoisted(() => ({
+  createItem: vi.fn(),
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+}))
+const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
+
+vi.mock('@silentsuite/core', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@silentsuite/core')>(),
+  ...coreMock,
+}))
+vi.mock('@/app/stores/use-toast-store', () => toastMock)
+vi.mock('@/app/stores/use-label-suggestions-store', () => ({ useLabelSuggestionsStore: { getState: () => ({ recordUsage: vi.fn() }) } }))
+
+import { useEtebaseStore } from '../use-etebase-store'
+
+const offlineError = () => new TypeError('Failed to fetch')
+const collection = (uid: string) => ({ uid, getMeta: vi.fn(() => ({})) })
+const cachedItem = (uid: string) => ({ uid, delete: vi.fn(), getContent: vi.fn(async () => 'OLD') })
+
+function setAccount(options: {
+  collections?: { uid: string }[]
+  items?: { uid: string; collectionUid: string; item: any }[]
+  manager?: { create: ReturnType<typeof vi.fn>; batch: ReturnType<typeof vi.fn> }
+} = {}) {
+  const collections = options.collections ?? [collection('col-1')]
+  const manager = options.manager ?? { create: vi.fn(), batch: vi.fn() }
+  const items = options.items ?? []
+  useEtebaseStore.setState({
+    account: { getCollectionManager: () => ({ getItemManager: () => manager }) } as any,
+    accountFingerprint: TEST_FINGERPRINT,
+    collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [] },
+    itemCache: new Map(items.map(({ uid, item }) => [uid, item])),
+    itemTypeMap: new Map(items.map(({ uid }) => [uid, 'calendar' as const])),
+    itemCollectionMap: new Map(items.map(({ uid, collectionUid }) => [uid, collectionUid])),
+    domainLoadState: { calendar: 'loaded', tasks: 'loaded', contacts: 'loaded', preferences: 'unknown' },
+    isInitialized: true,
+    syncEngine: null,
+  } as any)
+  return manager
+}
+
+async function expectOwned(types: string[]) {
+  const entries = await getAll(queueGuard())
+  expect(entries.map((entry) => entry.type)).toEqual(types)
+  expect(entries.every((entry) => entry.accountFingerprint === TEST_FINGERPRINT)).toBe(true)
+  expect(await getPendingCount(queueGuard())).toBe(entries.length)
+  const execute = vi.fn(async () => ({}))
+  await replay(execute, queueGuard())
+  expect(execute).toHaveBeenCalledTimes(entries.length)
+  expect(await getAll(queueGuard())).toEqual([])
+}
+
+describe('useEtebaseStore real guarded offline queue integration', () => {
+  beforeEach(async () => {
+    await resetRealOfflineQueue()
+    useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+    coreMock.createItem.mockReset()
+    coreMock.updateItem.mockReset()
+    coreMock.deleteItem.mockReset()
+    toastMock.showErrorToast.mockReset()
+  })
+
+  it('real createItem fallback persists the active fingerprint and is visible to guarded count and replay', async () => {
+    setAccount()
+    coreMock.createItem.mockRejectedValueOnce(offlineError())
+
+    await expect(useEtebaseStore.getState().createItem('calendar', 'VEVENT', 'temp-1', 'col-1')).resolves.toBeNull()
+
+    await expectOwned(['create'])
+  })
+
+  it('real createItem fallback quietly cancels at the IndexedDB commit boundary', async () => {
+    setAccount()
+    coreMock.createItem.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = bumpEpochWhenQueuePutRuns(() => {
+      useEtebaseStore.setState({ account: {} as any, accountFingerprint: 'new-account', itemCache: new Map() })
+    })
+
+    await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'temp-old', 'col-1')).resolves.toBeNull()
+    putSpy.mockRestore()
+
+    expect(await getAll()).toEqual([])
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('batch create fallback enqueues each create with the captured owner', async () => {
+    const manager = setAccount()
+    manager.create.mockRejectedValueOnce(offlineError())
+
+    await useEtebaseStore.getState().createItemsBatch('calendar', [
+      { content: 'A', tempId: 'a' },
+      { content: 'B', tempId: 'b' },
+    ], 'col-1')
+
+    await expectOwned(['create', 'create'])
+  })
+
+  it.each([
+    ['updateItem', async () => useEtebaseStore.getState().updateItem('calendar', 'item-1', 'NEW'), 'update'],
+    ['deleteItem', async () => useEtebaseStore.getState().deleteItem('calendar', 'item-1'), 'delete'],
+  ] as const)('%s cached offline fallback enqueues with the captured owner', async (_name, mutate, expectedType) => {
+    setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
+    coreMock.updateItem.mockRejectedValueOnce(offlineError())
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError())
+
+    await mutate()
+
+    await expectOwned([expectedType])
+  })
+
+  it('collection clear fallback enqueues remaining source deletes with the captured owner', async () => {
+    const manager = setAccount({ items: [
+      { uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') },
+      { uid: 'item-2', collectionUid: 'col-1', item: cachedItem('item-2') },
+    ] })
+    manager.batch.mockRejectedValueOnce(offlineError())
+
+    await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
+
+    await expectOwned(['delete', 'delete'])
+  })
+
+  it('move source-delete fallback enqueues against the source collection with the captured owner', async () => {
+    setAccount({
+      collections: [collection('source'), collection('target')],
+      items: [{ uid: 'item-1', collectionUid: 'source', item: cachedItem('item-1') }],
+    })
+    coreMock.createItem.mockResolvedValueOnce(cachedItem('created-target'))
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError())
+
+    await useEtebaseStore.getState().moveItem('calendar', 'item-1', 'NEW', 'target', 'source')
+
+    const [entry] = await getAll(queueGuard())
+    expect(entry).toMatchObject({ type: 'delete', collectionUid: 'source', itemUid: 'item-1', accountFingerprint: TEST_FINGERPRINT })
+    await expectOwned(['delete'])
+  })
+})

--- a/apps/web/app/stores/__tests__/use-task-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-task-store.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useTaskStore } from '../use-task-store'
 import { useEtebaseStore } from '../use-etebase-store'
+import { getAll } from '@/app/lib/offline-queue'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, enqueueCreateFromStore, expectOwnedQueueEntry, expectQuietQueueCommitCancellation, queueGuard, replayOwnedEntry, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+
+const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
+vi.mock('@/app/stores/use-toast-store', () => toastMock)
 
 // Mock the sync store to prevent side effects
 vi.mock('@/app/stores/use-sync-store', () => ({
@@ -19,6 +24,14 @@ function resetStore() {
     syncStatus: 'synced',
   })
   useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+}
+
+function offlineAccount() {
+  useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map(), createItem: vi.fn((type, content, tempId, collectionUid) => enqueueCreateFromStore(type, collectionUid, content, tempId!)) } as any)
+}
+
+function queuedTask(id = 'temp-task') {
+  return { id, uid: id, title: 'Task', description: '', start_date: null, due_date: null, priority: 'medium' as const, completed: false, status: 'needs-action' as const, percent_complete: 0, location: '', url: '', categories: [], listId: 'tasks-1', created_at: new Date(), updated_at: new Date() }
 }
 
 describe('useTaskStore', () => {
@@ -125,5 +138,54 @@ describe('useTaskStore', () => {
     expect(tasks).toHaveLength(2)
     expect(tasks[0]!.completed).toBe(true)
     expect(tasks[1]!.completed).toBe(false)
+  })
+
+  describe('guarded offline queue integration', () => {
+    beforeEach(async () => { await resetRealOfflineQueue(); resetStore(); offlineAccount(); toastMock.showErrorToast.mockReset() })
+
+    it.each([
+      ['create', 'create', async () => { await useTaskStore.getState().createTask({ title: 'Create', listId: 'tasks-1' }) }],
+      ['update', 'update', async () => { useTaskStore.setState({ tasks: [queuedTask()] }); await useTaskStore.getState().updateTask('temp-task', { title: 'Update' }) }],
+      ['delete', 'delete', async () => { useTaskStore.setState({ tasks: [queuedTask()] }); await useTaskStore.getState().deleteTask('temp-task') }],
+      ['toggleComplete', 'update', async () => { useTaskStore.setState({ tasks: [queuedTask()] }); await useTaskStore.getState().toggleComplete('temp-task') }],
+    ] as const)('%s persists and replays an owned offline mutation', async (_operation, type, mutate) => {
+      await mutate()
+      const entry = await expectOwnedQueueEntry(type, 'tasks')
+      await replayOwnedEntry(entry)
+    })
+
+    it('quietly cancels at the real enqueue boundary', async () => {
+      useTaskStore.setState({ tasks: [queuedTask()] })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const putSpy = bumpEpochWhenQueuePutRuns(() => { useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any); useTaskStore.setState({ tasks: [] }) })
+      await expect(useTaskStore.getState().updateTask('temp-task', { title: 'Stale' })).resolves.toBeUndefined()
+      putSpy.mockRestore()
+      await vi.waitFor(() => expect(useTaskStore.getState().tasks).toEqual([]))
+      expect(await getAll(queueGuard('new-account'))).toEqual([])
+      expect(await getAll()).toEqual([])
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it('quietly cancels an uncached delete at the actual IndexedDB commit boundary', async () => {
+      useTaskStore.setState({ tasks: [queuedTask()] })
+      await expectQuietQueueCommitCancellation(
+        () => useTaskStore.getState().deleteTask('temp-task'),
+        () => { useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any); useTaskStore.setState({ tasks: [] }) },
+        () => expect(useTaskStore.getState().tasks).toEqual([]),
+        toastMock,
+      )
+    })
+
+    it('quietly cancels an uncached toggle at the actual IndexedDB commit boundary', async () => {
+      useTaskStore.setState({ tasks: [queuedTask()] })
+      await expectQuietQueueCommitCancellation(
+        () => useTaskStore.getState().toggleComplete('temp-task'),
+        () => { useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any); useTaskStore.setState({ tasks: [] }) },
+        () => expect(useTaskStore.getState().tasks).toEqual([]),
+        toastMock,
+      )
+    })
   })
 })

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -10,6 +10,7 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
+import { assertOfflineQueueAccountGuard, captureOfflineQueueAccountGuard, isOfflineQueueBoundaryCancellation } from '@/app/lib/offline-queue-account'
 
 type CalendarView = 'week' | 'month'
 
@@ -98,10 +99,13 @@ function addUntilToRRule(rrule: string, untilDate: Date): string {
 async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update', tempId?: string, sourceCalendarId?: string): Promise<string | null> {
   const etebase = useEtebaseStore.getState()
   if (!etebase.account) return null
+  const guard = captureOfflineQueueAccountGuard(etebase)
+  if (!guard) return null
 
   let content: string | undefined
   try {
     const { serializeCalendarEvent } = await import('@silentsuite/core')
+    assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
     content = serializeCalendarEvent(event)
     if (mode === 'create') {
       return await etebase.createItem('calendar', content, tempId, event.calendarId)
@@ -120,12 +124,14 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
         return event.id
       } else {
         const { enqueue } = await import('@/app/lib/offline-queue')
-        await enqueue({ type: 'update', collectionType: 'calendar', collectionUid: event.calendarId, content, tempId: event.id })
+        assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+        await enqueue({ type: 'update', collectionType: 'calendar', collectionUid: event.calendarId, content, tempId: event.id }, guard)
+        assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
         return event.id
       }
     }
   } catch (err) {
-    console.error(`[calendar-store] Failed to ${mode} event in Etebase`, getSafeErrorDetails(err))
+    try { assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState()) } catch { return null }
     const { enqueue, isOfflineError } = await import('@/app/lib/offline-queue')
     if (!isOfflineError(err)) {
       showErrorToast('Failed to save event. Please try again.')
@@ -138,16 +144,25 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
         && event.calendarId
         && event.calendarId !== sourceCollectionUid
       ) {
-        await enqueue({
-          type: 'move',
-          collectionType: 'calendar',
-          collectionUid: sourceCollectionUid,
-          targetCollectionUid: event.calendarId,
-          content,
-          itemUid: event.id,
-        })
+        try {
+          assertOfflineQueueAccountGuard(guard, latestEtebase)
+          await enqueue({
+            type: 'move',
+            collectionType: 'calendar',
+            collectionUid: sourceCollectionUid,
+            targetCollectionUid: event.calendarId,
+            content,
+            itemUid: event.id,
+          }, guard)
+          assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+        } catch (queueError) {
+          if (isOfflineQueueBoundaryCancellation(queueError)) return null
+          throw queueError
+        }
       }
     }
+    try { assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState()) } catch { return null }
+    console.error(`[calendar-store] Failed to ${mode} event in Etebase`, getSafeErrorDetails(err))
     return null
   }
 }
@@ -241,6 +256,8 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
     // Sync to Etebase
     const etebase = useEtebaseStore.getState()
     if (etebase.account) {
+      const guard = captureOfflineQueueAccountGuard(etebase)
+      if (!guard) return
       const itemInCache = etebase.itemCache.has(id)
       if (itemInCache) {
         try {
@@ -249,8 +266,15 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
           // If the error is a network/offline error, enqueue for later replay.
           // Non-offline errors are logged and the optimistic removal stands.
           const { isOfflineError, enqueue } = await import('@/app/lib/offline-queue')
+          try { assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState()) } catch { return }
           if (isOfflineError(err)) {
-            await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id })
+            try {
+              await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (queueError) {
+              if (isOfflineQueueBoundaryCancellation(queueError)) return
+              throw queueError
+            }
           } else {
             showErrorToast('Failed to delete event. Please try again.')
           }
@@ -259,7 +283,14 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
       } else {
         // Item was created offline — enqueue delete with tempId for compaction
         const { enqueue } = await import('@/app/lib/offline-queue')
-        await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: eventToDelete?.calendarId, tempId: id })
+        try {
+          assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+          await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: eventToDelete?.calendarId, tempId: id }, guard)
+          assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+        } catch (queueError) {
+          if (isOfflineQueueBoundaryCancellation(queueError)) return
+          throw queueError
+        }
       }
     }
   },
@@ -439,14 +470,23 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
         // Sync to Etebase
         const etebase = useEtebaseStore.getState()
         if (etebase.account) {
+          const guard = captureOfflineQueueAccountGuard(etebase)
+          if (!guard) break
           const itemInCache = etebase.itemCache.has(id)
           if (itemInCache) {
             try {
               await etebase.deleteItem('calendar', id)
             } catch (err) {
               const { isOfflineError, enqueue } = await import('@/app/lib/offline-queue')
+              try { assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState()) } catch { break }
               if (isOfflineError(err)) {
-                await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id })
+                try {
+                  await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id }, guard)
+                  assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+                } catch (queueError) {
+                  if (isOfflineQueueBoundaryCancellation(queueError)) break
+                  throw queueError
+                }
               } else {
                 showErrorToast('Failed to delete event. Please try again.')
               }
@@ -454,7 +494,14 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
             }
           } else {
             const { enqueue } = await import('@/app/lib/offline-queue')
-            await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: master.calendarId, tempId: id })
+            try {
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: master.calendarId, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (queueError) {
+              if (isOfflineQueueBoundaryCancellation(queueError)) break
+              throw queueError
+            }
           }
         }
         break

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -5,6 +5,7 @@ import type { Contact, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
+import { assertOfflineQueueAccountGuard, captureOfflineQueueAccountGuard, isOfflineQueueBoundaryCancellation } from '@/app/lib/offline-queue-account'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
@@ -136,9 +137,19 @@ export const useContactStore = create<ContactState & ContactActions>()(
               showErrorToast('Failed to save contact. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             const { serializeContact } = await import('@silentsuite/core')
-            const content = serializeContact(updated)
-            await enqueue({ type: 'update', collectionType: 'contacts', collectionUid: updated.listId, content, tempId: id })
+            try {
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              const content = serializeContact(updated)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              await enqueue({ type: 'update', collectionType: 'contacts', collectionUid: updated.listId, content, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },
@@ -160,8 +171,17 @@ export const useContactStore = create<ContactState & ContactActions>()(
               showErrorToast('Failed to delete contact. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             // Item was created offline and not yet synced — enqueue delete with tempId for compaction
-            await enqueue({ type: 'delete', collectionType: 'contacts', collectionUid: contactToDelete?.listId, tempId: id })
+            try {
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              await enqueue({ type: 'delete', collectionType: 'contacts', collectionUid: contactToDelete?.listId, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -454,8 +454,9 @@ async function removeQueuedMutationsForCollection(
   accountEpoch: number,
   accountFingerprint: string | null,
 ): Promise<number> {
+  if (!accountFingerprint) return 0
   try {
-    const guard = { accountEpoch, accountFingerprint: accountFingerprint ?? '' }
+    const guard = { accountEpoch, accountFingerprint: accountFingerprint }
     assertCurrentAccountEpoch(accountEpoch)
     const entries = await getQueuedMutations(guard)
     assertCurrentAccountEpoch(accountEpoch)
@@ -1311,7 +1312,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const accountEpoch = getAccountEpoch()
     const { account, collections, domainLoadState, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection) {
+    if (!account || !collection || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot clear ${type} collection ${collectionUid}: missing account or collection`)
       return 0
     }
@@ -1393,7 +1394,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
             if (alreadyDeleted.has(uid)) continue
             try {
               assertCurrentAccountEpoch(accountEpoch)
-              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, { accountEpoch, accountFingerprint: accountFingerprint })
               assertCurrentAccountEpoch(accountEpoch)
             } catch (queueErr) {
               if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return 0
@@ -1431,7 +1432,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const accountEpoch = getAccountEpoch()
     const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection) {
+    if (!account || !collection || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot create item: no account or ${type} collection`)
       return null
     }
@@ -1457,7 +1458,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const queueTempId = tempId ?? `pending-${Date.now()}`
         logger.warn(`[etebase-store] Offline — queuing create for ${type} (tempId: ${queueTempId})`)
         try {
-          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, { accountEpoch, accountFingerprint: accountFingerprint })
           assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return null
@@ -1475,7 +1476,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const accountEpoch = getAccountEpoch()
     const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection) {
+    if (!account || !collection || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot create items: no account or ${type} collection`)
       return contents.map(() => null)
     }
@@ -1605,7 +1606,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         logger.warn(`[etebase-store] Offline — queuing ${contents.length} creates for ${type}`)
         for (const { content, tempId } of contents) {
           try {
-            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, { accountEpoch, accountFingerprint: accountFingerprint })
             assertCurrentAccountEpoch(accountEpoch)
           } catch (queueErr) {
             if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return contents.map(() => null)
@@ -1627,7 +1628,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
-    if (!account || !collection || !item) {
+    if (!account || !collection || !item || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot update item ${itemUid}: missing account, collection, or item`)
       return
     }
@@ -1646,7 +1647,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
           assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
@@ -1666,7 +1667,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const sourceCollection = resolveCollection(collections, type, resolvedSourceCollectionUid)
     const targetCollection = resolveCollection(collections, type, targetCollectionUid)
     const item = itemCache.get(itemUid)
-    if (!account || !sourceCollection || !targetCollection || !item) {
+    if (!account || !sourceCollection || !targetCollection || !item || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot move item ${itemUid}: missing account, source collection, target collection, or item`)
       return null
     }
@@ -1692,7 +1693,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         if (isOfflineError(err)) {
           assertCurrentAccountEpoch(accountEpoch)
           logger.warn(`[etebase-store] Offline after moving ${type}/${itemUid} - queuing source delete`)
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
           assertCurrentAccountEpoch(accountEpoch)
           keepSourceUntilQueuedDelete = true
         } else {
@@ -1742,7 +1743,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
-    if (!account || !collection || !item) {
+    if (!account || !collection || !item || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot delete item ${itemUid}: missing account, collection, or item`)
       return
     }
@@ -1767,7 +1768,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing delete for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
           assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -5,6 +5,7 @@ import type { Task, TaskStatus, Priority, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
+import { assertOfflineQueueAccountGuard, captureOfflineQueueAccountGuard, isOfflineQueueBoundaryCancellation } from '@/app/lib/offline-queue-account'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
@@ -130,10 +131,20 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               showErrorToast('Failed to save task. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             // Item was created offline — enqueue update with tempId so compaction merges into create
             const { serializeTask } = await import('@silentsuite/core')
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
             const content = serializeTask(updated)
-            await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id })
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            try {
+              await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },
@@ -156,8 +167,17 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               showErrorToast('Failed to delete task. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             // Item was created offline and not yet synced — enqueue delete with tempId for compaction
-            await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: taskToDelete?.listId, tempId: id })
+            try {
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: taskToDelete?.listId, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },
@@ -196,9 +216,19 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               showErrorToast('Failed to save task. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             const { serializeTask } = await import('@silentsuite/core')
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
             const content = serializeTask(updated)
-            await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id })
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            try {
+              await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary

- require account epoch and fingerprint ownership for every production offline mutation enqueue
- add fail-closed guard capture/assertion shared by calendar, task, and contact stores
- quietly cancel stale account-boundary enqueue continuations
- retain unscoped persistence only through an explicitly named test/legacy API
- add real IndexedDB calendar/task/contact CRUD, guarded replay, cross-account isolation, and commit-boundary regressions

## Why

The promotion review found that several domain-store offline paths wrote fingerprint-less queue records. Guarded replay intentionally filters by the active fingerprint, so those records could become invisible and never sync.

## Verification

- focused queue/calendar/task/contact tests: 94 passed
- full web suite: 579 passed
- web type-check: passed
- web lint: passed with existing warnings only
- `git diff --check`: passed
