### PR TITLE
fix: promote offline queue ownership correction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  analytics-boundary:
+    name: Public Analytics Boundary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build public surfaces
+        run: |
+          pnpm --filter @silentsuite/web build
+          SILENTSUITE_HOSTED_DOCS_ANALYTICS=1 pnpm --filter @silentsuite/docs exec vitepress build --outDir .vitepress/dist-hosted
+          pnpm --filter @silentsuite/docs exec vitepress build --outDir .vitepress/dist-self
+      - name: Enforce source and bundle analytics boundary
+        run: pnpm run check:public-analytics
+
   lint-and-typecheck:
     name: Lint & Type Check
     runs-on: ubuntu-latest
@@ -58,6 +82,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Enforce public analytics boundary
+        run: pnpm run check:public-analytics
 
       - name: Run tests
         run: pnpm run test

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build docs
         run: pnpm run build --filter=@silentsuite/docs
+        env:
+          SILENTSUITE_HOSTED_DOCS_ANALYTICS: '1'
 
       - name: Deploy to production Worker
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -1,13 +1,20 @@
 import { defineConfig } from 'vitepress'
 
+const hostedAnalytics = process.env.SILENTSUITE_HOSTED_DOCS_ANALYTICS === '1'
+
 export default defineConfig({
+  vite: {
+    define: {
+      __SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__: JSON.stringify(
+        hostedAnalytics ? 'https://plausible.silentsuite.io/api/event' : '',
+      ),
+    },
+  },
   title: 'SilentSuite Docs',
   description: 'Documentation for SilentSuite — end-to-end encrypted calendar, contacts & tasks.',
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
-    // Privacy-friendly analytics by Plausible
-    ['script', { async: '', src: 'https://plausible.silentsuite.io/js/pa-cpFZuMRijOONfz35zBtMP.js' }],
-    ['script', {}, `window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()`],
+
     ['meta', { name: 'theme-color', content: '#0a1018' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: 'SilentSuite Docs' }],

--- a/apps/docs/.vitepress/theme/index.mts
+++ b/apps/docs/.vitepress/theme/index.mts
@@ -1,4 +1,44 @@
 import DefaultTheme from 'vitepress/theme'
+import { defineComponent, h, onMounted, onUnmounted } from 'vue'
+import { classifyDocsOutboundEvent } from './public-analytics.mts'
 import './custom.css'
 
-export default DefaultTheme
+declare const __SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__: string
+
+function sendDocsEvent(event: ReturnType<typeof classifyDocsOutboundEvent>) {
+  if (!event) return
+  const payload = JSON.stringify({
+    domain: 'docs.silentsuite.io',
+    name: event.event,
+    url: 'https://docs.silentsuite.io/',
+    props: event.props,
+  })
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__, new Blob([payload], { type: 'application/json' }))
+    return
+  }
+  void fetch(__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+    keepalive: true,
+  })
+}
+
+export default {
+  ...DefaultTheme,
+  Layout: defineComponent({
+    setup() {
+      const handleClick = (event: MouseEvent) => {
+        if (!__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__ || window.location.hostname !== 'docs.silentsuite.io') return
+        const anchor = event.target instanceof Element ? event.target.closest('a[href]') : null
+        const analyticsEvent = anchor ? classifyDocsOutboundEvent(anchor.getAttribute('href') ?? '', window.location.pathname) : undefined
+        sendDocsEvent(analyticsEvent)
+      }
+
+      onMounted(() => document.addEventListener('click', handleClick))
+      onUnmounted(() => document.removeEventListener('click', handleClick))
+      return () => h(DefaultTheme.Layout!)
+    },
+  }),
+}

--- a/apps/docs/.vitepress/theme/public-analytics.mts
+++ b/apps/docs/.vitepress/theme/public-analytics.mts
@@ -1,0 +1,51 @@
+export type DocsOutboundEvent =
+  | { event: 'Hosted App Click'; props: { surface: 'docs'; route_class: 'app_home' | 'signup' } }
+  | { event: 'Android Download Click'; props: { surface: 'docs_android'; channel: 'github_release' } }
+  | { event: 'GitHub Click'; props: { surface: 'docs_android'; channel: 'repository' } }
+
+const APPROVED_DESTINATIONS: Readonly<Record<string, DocsOutboundEvent>> = {
+  'https://app.silentsuite.io': {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'app_home' },
+  },
+  'https://app.silentsuite.io/signup': {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'signup' },
+  },
+}
+
+const ANDROID_DESTINATIONS: Readonly<Record<string, DocsOutboundEvent>> = {
+  'https://github.com/silent-suite/silentsuite/releases/latest': {
+    event: 'Android Download Click',
+    props: { surface: 'docs_android', channel: 'github_release' },
+  },
+  'https://github.com/silent-suite/silentsuite/tree/main/android': {
+    event: 'GitHub Click',
+    props: { surface: 'docs_android', channel: 'repository' },
+  },
+}
+
+const HOSTED_APP_ROUTES = new Set([
+  '/user-guide/getting-started',
+  '/user-guide/apps',
+  '/self-hosting',
+  '/self-hosting/quick-start',
+  '/self-hosting/manual-setup',
+  '/self-hosting/architecture',
+  '/user-guide/faq',
+  '/user-guide/calendar',
+])
+
+export function classifyDocsOutboundEvent(rawHref: string, docsPath: string): DocsOutboundEvent | undefined {
+  try {
+    const url = new URL(rawHref)
+    if (url.username || url.password || url.search || url.hash) return undefined
+    const destination = url.toString().replace(/\/$/, '')
+    const normalizedPath = docsPath.replace(/\/$/, '') || '/'
+    if (normalizedPath === '/user-guide/apps/android') return ANDROID_DESTINATIONS[destination]
+    if (HOSTED_APP_ROUTES.has(normalizedPath)) return APPROVED_DESTINATIONS[destination]
+    return undefined
+  } catch {
+    return undefined
+  }
+}

--- a/apps/docs/.vitepress/theme/public-analytics.test.mts
+++ b/apps/docs/.vitepress/theme/public-analytics.test.mts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { classifyDocsOutboundEvent } from './public-analytics.mts'
+
+test('classifies approved hosted-app destinations by route class', () => {
+  assert.deepEqual(classifyDocsOutboundEvent('https://app.silentsuite.io', '/user-guide/getting-started'), {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'app_home' },
+  })
+  assert.deepEqual(classifyDocsOutboundEvent('https://app.silentsuite.io', '/user-guide/getting-started/'), {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'app_home' },
+  })
+  assert.deepEqual(classifyDocsOutboundEvent('https://app.silentsuite.io/signup', '/user-guide/faq'), {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'signup' },
+  })
+})
+
+test('classifies Android destinations only on the Android guide', () => {
+  assert.deepEqual(classifyDocsOutboundEvent('https://github.com/silent-suite/silentsuite/releases/latest', '/user-guide/apps/android'), {
+    event: 'Android Download Click',
+    props: { surface: 'docs_android', channel: 'github_release' },
+  })
+  assert.deepEqual(classifyDocsOutboundEvent('https://github.com/silent-suite/silentsuite/tree/main/android', '/user-guide/apps/android'), {
+    event: 'GitHub Click',
+    props: { surface: 'docs_android', channel: 'repository' },
+  })
+  assert.equal(classifyDocsOutboundEvent('https://github.com/silent-suite/silentsuite/releases/latest', '/user-guide/faq'), undefined)
+})
+
+test('does not classify generic, credentialed, or path-bearing external links', () => {
+  assert.equal(classifyDocsOutboundEvent('https://github.com/silent-suite/silentsuite/issues/1', '/user-guide/apps/android'), undefined)
+  assert.equal(classifyDocsOutboundEvent('https://user@example.com/secret', '/user-guide/getting-started'), undefined)
+  assert.equal(classifyDocsOutboundEvent('not a url', '/user-guide/getting-started'), undefined)
+  assert.equal(classifyDocsOutboundEvent('https://app.silentsuite.io', '/contributing/testing'), undefined)
+})

--- a/apps/web/app/(auth)/signup/signup-analytics.tsx
+++ b/apps/web/app/(auth)/signup/signup-analytics.tsx
@@ -2,48 +2,16 @@
 
 import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
+import { buildSignupPageviewPayload } from '@/app/lib/public-analytics'
 
 const PLAUSIBLE_EVENT_ENDPOINT = 'https://plausible.silentsuite.io/api/event'
-const PLAUSIBLE_DOMAIN = 'app.silentsuite.io'
-const MARKETING_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']
-
-function signupAnalyticsUrl() {
-  const current = new URL(window.location.href)
-  const sanitized = new URL(`${current.origin}${current.pathname}`)
-
-  if (current.pathname === '/signup') {
-    for (const param of MARKETING_PARAMS) {
-      const value = current.searchParams.get(param)
-      if (value) sanitized.searchParams.set(param, value)
-    }
-  }
-
-  return sanitized.toString()
-}
-
-function sanitizedReferrer() {
-  if (!document.referrer) return undefined
-
-  try {
-    const referrer = new URL(document.referrer)
-    return `${referrer.origin}${referrer.pathname}`
-  } catch {
-    return undefined
-  }
-}
-
 export function SignupAnalytics() {
   const pathname = usePathname()
 
   useEffect(() => {
     if (!pathname?.startsWith('/signup')) return
 
-    const payload = JSON.stringify({
-      domain: PLAUSIBLE_DOMAIN,
-      name: 'pageview',
-      url: signupAnalyticsUrl(),
-      referrer: sanitizedReferrer(),
-    })
+    const payload = JSON.stringify(buildSignupPageviewPayload(window.location.href, document.referrer))
 
     if (navigator.sendBeacon) {
       const blob = new Blob([payload], { type: 'application/json' })

--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -298,7 +298,7 @@ describe('offline-queue', () => {
       const order: string[] = []
       const results = await replay(async (entry) => {
         order.push(entry.type)
-        return { itemUid: entry.type === 'create' ? 'real-uid' : undefined }
+        return { remoteMutationConfirmed: true, itemUid: entry.type === 'create' ? 'real-uid' : undefined }
       })
 
       expect(order).toEqual(['create', 'update'])
@@ -744,7 +744,7 @@ describe('offline-queue', () => {
       expect(count).toBe(2)
 
       // Replay all pending entries (simulates cold-start replay)
-      const executeFn = vi.fn().mockResolvedValue({ itemUid: 'new-uid' })
+      const executeFn = vi.fn().mockResolvedValue({ remoteMutationConfirmed: true, itemUid: 'new-uid' })
       const results = await replay(executeFn)
 
       expect(executeFn).toHaveBeenCalledTimes(2)
@@ -774,7 +774,7 @@ describe('offline-queue', () => {
       const unsubscribe = onCountChange(listener)
       const results = await replay(async () => {
         bumpAccountEpoch()
-        return { itemUid: 'must-not-publish' }
+        return { remoteMutationConfirmed: true, itemUid: 'must-not-publish' }
       }, guard)
       unsubscribe()
 

--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import 'fake-indexeddb/auto'
 import { AccountBoundaryChangedError, bumpAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 import {
-  enqueue,
+  enqueue as guardedEnqueue,
   getAll,
   getPendingCount,
   getFailedCount,
@@ -21,6 +21,17 @@ import {
   _resetForTests,
   _setEncryptedQueuePersistenceAvailableForTests,
 } from '../offline-queue'
+
+const TEST_FINGERPRINT = 'offline-queue-unit-test-account'
+function testGuard(accountFingerprint = TEST_FINGERPRINT) {
+  return { accountEpoch: getAccountEpoch(), accountFingerprint }
+}
+function enqueue(
+  entry: Parameters<typeof guardedEnqueue>[0],
+  guard = testGuard(),
+) {
+  return guardedEnqueue(entry, guard)
+}
 
 beforeEach(async () => {
   process.env.NEXT_PUBLIC_LOCAL_CACHE_ENABLED = 'true'
@@ -60,11 +71,11 @@ describe('offline-queue', () => {
     })
 
     it('increments pending count', async () => {
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
       await enqueue({ type: 'update', collectionType: 'contacts', content: 'vcard', itemUid: 'uid-1' })
-      expect(await getPendingCount()).toBe(1)
+      expect(await getPendingCount(testGuard())).toBe(1)
       await enqueue({ type: 'delete', collectionType: 'calendar', itemUid: 'uid-2' })
-      expect(await getPendingCount()).toBe(2)
+      expect(await getPendingCount(testGuard())).toBe(2)
     })
   })
 
@@ -154,12 +165,12 @@ describe('offline-queue', () => {
 
     it('clearAll removes queued mutations for logout/account switch cleanup', async () => {
       await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: 'tasks', itemUid: 'task-1' })
-      expect(await getPendingCount()).toBe(1)
+      expect(await getPendingCount(testGuard())).toBe(1)
 
       await clearAll()
 
       expect(await getAll()).toHaveLength(0)
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
   })
 
@@ -251,6 +262,26 @@ describe('offline-queue', () => {
       await vi.waitFor(() => expect(counts).toEqual([1]))
     })
 
+    it('fails closed before IndexedDB work when the exported enqueue guard is undefined', async () => {
+      const counts: number[] = []
+      const enqueues: number[] = []
+      const openSpy = vi.spyOn(indexedDB, 'open')
+      onCountChange((count) => counts.push(count))
+      onEnqueue(() => enqueues.push(1))
+
+      await expect(guardedEnqueue(
+        { type: 'delete', collectionType: 'tasks', itemUid: 'x' },
+        undefined as any,
+      )).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(await getAll()).toEqual([])
+      expect(counts).toEqual([])
+      expect(enqueues).toEqual([])
+      openSpy.mockRestore()
+    })
+
     it('fails closed when a guarded operation has no fingerprint', async () => {
       await expect(enqueue({ type: 'delete', collectionType: 'tasks', itemUid: 'x' }, {
         accountEpoch: getAccountEpoch(),
@@ -275,7 +306,7 @@ describe('offline-queue', () => {
       expect(results[0].success).toBe(true)
       expect(results[0].itemUid).toBe('real-uid')
       expect(results[1].success).toBe(true)
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
 
     it('increments retryCount on failure, marks failed after MAX_RETRIES', async () => {
@@ -292,7 +323,7 @@ describe('offline-queue', () => {
       expect(all[0].status).toBe('failed')
 
       // Failed entries don't count as pending
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
 
     it('retries pending entries but skips failed ones', async () => {
@@ -433,7 +464,7 @@ describe('offline-queue', () => {
 
       const all = await getAll()
       expect(all).toHaveLength(0)
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
 
     it('update + update with same itemUid → merges to latest content', async () => {
@@ -573,12 +604,12 @@ describe('offline-queue', () => {
         await replay(async () => { throw new Error('fail') })
       }
 
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
       expect(await getFailedCount()).toBe(1)
 
       await retryFailed()
 
-      expect(await getPendingCount()).toBe(1)
+      expect(await getPendingCount(testGuard())).toBe(1)
       expect(await getFailedCount()).toBe(0)
 
       const all = await getAll()
@@ -709,7 +740,7 @@ describe('offline-queue', () => {
       _setEncryptedQueuePersistenceAvailableForTests(true)
 
       // Verify entries persist across resets
-      const count = await getPendingCount()
+      const count = await getPendingCount(testGuard())
       expect(count).toBe(2)
 
       // Replay all pending entries (simulates cold-start replay)
@@ -719,7 +750,7 @@ describe('offline-queue', () => {
       expect(executeFn).toHaveBeenCalledTimes(2)
       expect(results).toHaveLength(2)
       expect(results.every((r) => r.success)).toBe(true)
-      expect(await getPendingCount()).toBe(0)
+      expect(await getPendingCount(testGuard())).toBe(0)
     })
   })
 

--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -335,6 +335,29 @@ describe('offline-queue', () => {
       expect(await getPendingCount(testGuard())).toBe(0)
     })
 
+    it('does not consume remote retries when a target-confirmed checkpoint transaction repeatedly fails', async () => {
+      await enqueue({ type: 'create', collectionType: 'calendar', content: 'PIM', tempId: 'temp-1' })
+      const originalPut = IDBObjectStore.prototype.put
+
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementationOnce(function (...args) {
+          const request = originalPut.apply(this, args)
+          this.transaction.abort()
+          return request
+        })
+        try {
+          await replay(async (_entry, checkpoint) => {
+            await checkpoint({ replayPhase: 'target-confirmed', confirmedTargetUid: 'server-1' })
+            return { remoteMutationConfirmed: true, itemUid: 'server-1' }
+          }, testGuard())
+        } finally {
+          putSpy.mockRestore()
+        }
+
+        expect((await getAll(testGuard()))[0]).toMatchObject({ retryCount: 0, status: 'pending' })
+      }
+    })
+
     it('increments retryCount on failure, marks failed after MAX_RETRIES', async () => {
       await enqueue({ type: 'update', collectionType: 'contacts', content: 'x', itemUid: 'u1' })
 

--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -291,6 +291,32 @@ describe('offline-queue', () => {
   })
 
   describe('replay', () => {
+    it('fails closed before IndexedDB or remote work when the exported replay guard is undefined', async () => {
+      const id = await enqueue({ type: 'delete', collectionType: 'tasks', itemUid: 'guard-required' })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      const counts: number[] = []
+      const enqueues: number[] = []
+      const execute = vi.fn(async () => ({ remoteMutationConfirmed: true as const }))
+      // Force the next queue access to open IndexedDB while preserving the record.
+      await _resetForTests()
+      _setEncryptedQueuePersistenceAvailableForTests(true)
+      const openSpy = vi.spyOn(indexedDB, 'open')
+      const unsubscribeCount = onCountChange((count) => counts.push(count))
+      const unsubscribeEnqueue = onEnqueue(() => enqueues.push(1))
+
+      await expect(replay(execute, undefined as any)).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(execute).not.toHaveBeenCalled()
+      expect((await getAll()).map((entry) => entry.id)).toEqual([id])
+      expect(counts).toEqual([])
+      expect(enqueues).toEqual([])
+      unsubscribeCount()
+      unsubscribeEnqueue()
+      openSpy.mockRestore()
+    })
+
     it('processes entries in FIFO order and removes on success', async () => {
       await enqueue({ type: 'create', collectionType: 'tasks', content: 'a', tempId: 't1' })
       await enqueue({ type: 'update', collectionType: 'tasks', content: 'b', itemUid: 'u1' })
@@ -299,7 +325,7 @@ describe('offline-queue', () => {
       const results = await replay(async (entry) => {
         order.push(entry.type)
         return { remoteMutationConfirmed: true, itemUid: entry.type === 'create' ? 'real-uid' : undefined }
-      })
+      }, testGuard())
 
       expect(order).toEqual(['create', 'update'])
       expect(results).toHaveLength(2)
@@ -314,7 +340,7 @@ describe('offline-queue', () => {
 
       // Fail 3 times (MAX_RETRIES = 3)
       for (let i = 0; i < 3; i++) {
-        await replay(async () => { throw new Error('server error') })
+        await replay(async () => { throw new Error('server error') }, testGuard())
       }
 
       const all = await getAll()
@@ -331,14 +357,14 @@ describe('offline-queue', () => {
 
       // Fail it 3 times to mark as failed
       for (let i = 0; i < 3; i++) {
-        await replay(async () => { throw new Error('fail') })
+        await replay(async () => { throw new Error('fail') }, testGuard())
       }
 
       // Add a new pending entry
       await enqueue({ type: 'delete', collectionType: 'tasks', itemUid: 'u2' })
 
       const executeFn = vi.fn().mockResolvedValue({})
-      await replay(executeFn)
+      await replay(executeFn, testGuard())
 
       // Only the new pending entry should be replayed
       expect(executeFn).toHaveBeenCalledTimes(1)
@@ -360,7 +386,7 @@ describe('offline-queue', () => {
           // First entry (create) always fails; second (update) succeeds
           if (callCount % 2 === 1) throw new Error('fail')
           return {}
-        })
+        }, testGuard())
       }
 
       // After 3 rounds: create should be failed (3 retries), update should be gone (succeeded)
@@ -572,7 +598,7 @@ describe('offline-queue', () => {
       // Enqueue and fail an update 3 times to mark it as failed
       await enqueue({ type: 'update', collectionType: 'tasks', content: 'v1', itemUid: 'uid-3' })
       for (let i = 0; i < 3; i++) {
-        await replay(async () => { throw new Error('fail') })
+        await replay(async () => { throw new Error('fail') }, testGuard())
       }
       // Now enqueue another update for the same uid — should NOT compact with failed entry
       await enqueue({ type: 'update', collectionType: 'tasks', content: 'v2', itemUid: 'uid-3' })
@@ -591,7 +617,7 @@ describe('offline-queue', () => {
       expect(await getFailedCount()).toBe(0)
 
       for (let i = 0; i < 3; i++) {
-        await replay(async () => { throw new Error('fail') })
+        await replay(async () => { throw new Error('fail') }, testGuard())
       }
       expect(await getFailedCount()).toBe(1)
     })
@@ -601,7 +627,7 @@ describe('offline-queue', () => {
     it('resets failed entries back to pending with retryCount 0', async () => {
       await enqueue({ type: 'update', collectionType: 'tasks', content: 'x', itemUid: 'u1' })
       for (let i = 0; i < 3; i++) {
-        await replay(async () => { throw new Error('fail') })
+        await replay(async () => { throw new Error('fail') }, testGuard())
       }
 
       expect(await getPendingCount(testGuard())).toBe(0)
@@ -684,7 +710,7 @@ describe('offline-queue', () => {
 
       // Fail it to mark as failed
       for (let i = 0; i < 3; i++) {
-        await replay(async () => { throw new Error('fail') })
+        await replay(async () => { throw new Error('fail') }, testGuard())
       }
 
       // Backdate createdAt
@@ -745,7 +771,7 @@ describe('offline-queue', () => {
 
       // Replay all pending entries (simulates cold-start replay)
       const executeFn = vi.fn().mockResolvedValue({ remoteMutationConfirmed: true, itemUid: 'new-uid' })
-      const results = await replay(executeFn)
+      const results = await replay(executeFn, testGuard())
 
       expect(executeFn).toHaveBeenCalledTimes(2)
       expect(results).toHaveLength(2)

--- a/apps/web/app/lib/__tests__/public-analytics.test.ts
+++ b/apps/web/app/lib/__tests__/public-analytics.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSignupPageviewPayload,
+  canonicalizeCampaignParams,
+  classifyReferrer,
+  sanitizedSignupPageUrl,
+} from '../public-analytics'
+
+describe('public analytics privacy contract', () => {
+  it('canonicalizes only registered campaign parameters', () => {
+    expect(
+      canonicalizeCampaignParams('?utm_source=x&utm_medium=social&utm_campaign=beta-2026-q2'),
+    ).toEqual({
+      utm_source: 'social',
+      utm_medium: 'organic',
+      utm_campaign: 'beta-2026-q2',
+    })
+  })
+
+  it('drops content, term, repeated, identity-shaped, and encoded values', () => {
+    expect(
+      canonicalizeCampaignParams(
+        '?utm_source=x&utm_source=github&utm_medium=user%40example.com&utm_campaign=https%253A%252F%252Fevil.test&utm_content=secret&utm_term=private',
+      ),
+    ).toEqual({})
+  })
+
+  it('emits canonical fallback categories without retaining unknown raw strings', () => {
+    expect(
+      canonicalizeCampaignParams('?utm_source=conference&utm_medium=poster&utm_campaign=private-launch'),
+    ).toEqual({
+      utm_source: 'other',
+      utm_medium: 'other',
+      utm_campaign: 'other_campaign',
+    })
+  })
+
+  it('sanitizes signup page URLs to canonical campaign values', () => {
+    expect(
+      sanitizedSignupPageUrl(
+        'https://app.silentsuite.io/signup?utm_source=github&utm_medium=referral&utm_content=email@example.com&returnTo=%2Fcalendar',
+      ),
+    ).toBe('https://app.silentsuite.io/signup?utm_source=github&utm_medium=referral')
+  })
+
+  it('classifies the referrer without retaining its path', () => {
+    expect(classifyReferrer('https://github.com/silent-suite/silentsuite/issues/123?token=secret')).toBe(
+      'github',
+    )
+    expect(classifyReferrer('https://evil.test/reset/user@example.com')).toBe('other')
+    expect(classifyReferrer('bad url')).toBeUndefined()
+  })
+
+  it('builds the exact identity-free signup pageview payload', () => {
+    expect(buildSignupPageviewPayload(
+      'https://app.silentsuite.io/signup?utm_source=github&utm_content=user@example.com&returnTo=/calendar',
+      'https://github.com/silent-suite/silentsuite/issues/123?token=secret',
+    )).toEqual({
+      domain: 'app.silentsuite.io',
+      name: 'pageview',
+      url: 'https://app.silentsuite.io/signup?utm_source=github',
+      props: { referrer_category: 'github' },
+    })
+  })
+})

--- a/apps/web/app/lib/offline-queue-account.ts
+++ b/apps/web/app/lib/offline-queue-account.ts
@@ -1,0 +1,33 @@
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
+import type { OfflineQueueAccountGuard } from '@/app/lib/offline-queue'
+
+interface ActiveAccountState {
+  account: unknown | null
+  accountFingerprint: string | null
+}
+
+/** Capture queue ownership synchronously. Missing identity fails closed. */
+export function captureOfflineQueueAccountGuard(
+  state: ActiveAccountState,
+): OfflineQueueAccountGuard | null {
+  if (!state.account || !state.accountFingerprint) return null
+  return {
+    accountEpoch: getAccountEpoch(),
+    accountFingerprint: state.accountFingerprint,
+  }
+}
+
+/** Assert both the epoch and stable account identity at a publication boundary. */
+export function assertOfflineQueueAccountGuard(
+  guard: OfflineQueueAccountGuard,
+  state: ActiveAccountState,
+): void {
+  assertCurrentAccountEpoch(guard.accountEpoch)
+  if (!state.account || state.accountFingerprint !== guard.accountFingerprint) {
+    throw new AccountBoundaryChangedError()
+  }
+}
+
+export function isOfflineQueueBoundaryCancellation(error: unknown): boolean {
+  return error instanceof AccountBoundaryChangedError
+}

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -462,9 +462,16 @@ export async function replay(
   for (const entry of pending) {
     let currentEntry = entry
     let remoteMutationConfirmed = false
+    let remoteProgressConfirmed = false
     try {
       assertGuard(guard)
       const checkpoint: ReplayCheckpoint = async (progress) => {
+        // target-confirmed is emitted only after a remote item was found or
+        // created. Record that before the local transaction so an IndexedDB
+        // checkpoint failure cannot consume the remote retry budget.
+        if (progress.replayPhase === 'target-confirmed' && progress.confirmedTargetUid) {
+          remoteProgressConfirmed = true
+        }
         const updated = { ...currentEntry, ...progress }
         await updateEntry(updated, guard)
         currentEntry = updated
@@ -481,7 +488,7 @@ export async function replay(
     } catch (err) {
       if (err instanceof AccountBoundaryChangedError) return []
       assertGuard(guard)
-      if (remoteMutationConfirmed) {
+      if (remoteMutationConfirmed || remoteProgressConfirmed) {
         // The server mutation is complete. A local checkpoint/removal failure
         // must not consume the remote retry budget or mark completed work failed.
         results.push({ entry, success: false, error: err instanceof Error ? err.message : String(err) })

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -449,6 +449,9 @@ export async function replay(
   executeMutation: (entry: QueueEntry, checkpoint: ReplayCheckpoint) => Promise<ConfirmedRemoteMutation>,
   guard: OfflineQueueAccountGuard,
 ): Promise<ReplayResult[]> {
+  // Match enqueue's runtime boundary: JavaScript callers, `any`, and stale
+  // bundles must fail before getAll/openDB or any remote executor can run.
+  if (!guard) throw new AccountBoundaryChangedError()
   try {
   assertGuard(guard)
   const entries = await getAll(guard)

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -236,9 +236,9 @@ async function compact(
   return null
 }
 
-export async function enqueue(
+async function enqueueInternal(
   entry: Omit<QueueEntry, 'id' | 'createdAt' | 'retryCount' | 'status'>,
-  guard?: OfflineQueueAccountGuard,
+  guard: OfflineQueueAccountGuard,
 ): Promise<string> {
   assertGuard(guard)
   // Try compaction first
@@ -260,7 +260,7 @@ export async function enqueue(
     createdAt: Date.now(),
     retryCount: 0,
     status: 'pending',
-    ...(guard ? { accountFingerprint: guard.accountFingerprint } : {}),
+    accountFingerprint: guard.accountFingerprint,
   }
   assertCanPersistEntry(record)
   return new Promise<string>((resolve, reject) => {
@@ -276,6 +276,17 @@ export async function enqueue(
     tx.onerror = () => reject(tx.error)
     tx.onabort = () => reject(guard ? new AccountBoundaryChangedError() : tx.error)
   })
+}
+
+/** Account-scoped production enqueue. A valid owner is mandatory by type. */
+export function enqueue(
+  entry: Omit<QueueEntry, 'id' | 'createdAt' | 'retryCount' | 'status'>,
+  guard: OfflineQueueAccountGuard,
+): Promise<string> {
+  // TypeScript cannot protect this runtime boundary from JavaScript callers,
+  // `any`, or stale bundles. Reject before compact/openDB can touch IndexedDB.
+  if (!guard) return Promise.reject(new AccountBoundaryChangedError())
+  return enqueueInternal(entry, guard)
 }
 
 export async function getAll(guard?: OfflineQueueAccountGuard): Promise<QueueEntry[]> {

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -22,6 +22,9 @@ export interface QueueEntry {
   retryCount: number
   status: 'pending' | 'failed'
   accountFingerprint?: string
+  /** Durable, non-plaintext replay progress. Older records omit these fields. */
+  replayPhase?: 'target-confirmed'
+  confirmedTargetUid?: string
 }
 
 export interface OfflineQueueAccountGuard {
@@ -35,6 +38,22 @@ export interface ReplayResult {
   /** For create replays, the real UID returned by Etebase */
   itemUid?: string
   error?: string
+}
+
+/** A replay executor may acknowledge an entry only after the remote mutation succeeded. */
+export interface ConfirmedRemoteMutation {
+  remoteMutationConfirmed: true
+  itemUid?: string
+}
+
+export type ReplayCheckpoint = (progress: Pick<QueueEntry, 'replayPhase' | 'confirmedTargetUid'>) => Promise<void>
+
+/** The remote mutation was not attempted or could not be affirmatively confirmed. */
+export class ReplayNotConfirmedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ReplayNotConfirmedError'
+  }
 }
 
 const DB_NAME = 'silentsuite-offline-queue'
@@ -427,7 +446,7 @@ export async function retryFailed(guard: OfflineQueueAccountGuard): Promise<void
  * after MAX_RETRIES, marks as 'failed'.
  */
 export async function replay(
-  executeMutation: (entry: QueueEntry) => Promise<{ itemUid?: string }>,
+  executeMutation: (entry: QueueEntry, checkpoint: ReplayCheckpoint) => Promise<ConfirmedRemoteMutation>,
   guard: OfflineQueueAccountGuard,
 ): Promise<ReplayResult[]> {
   try {
@@ -438,19 +457,45 @@ export async function replay(
   const results: ReplayResult[] = []
 
   for (const entry of pending) {
+    let currentEntry = entry
+    let remoteMutationConfirmed = false
     try {
       assertGuard(guard)
-      const result = await executeMutation(entry)
+      const checkpoint: ReplayCheckpoint = async (progress) => {
+        const updated = { ...currentEntry, ...progress }
+        await updateEntry(updated, guard)
+        currentEntry = updated
+      }
+      const result = await executeMutation(currentEntry, checkpoint)
       assertGuard(guard)
+      if (!result || result.remoteMutationConfirmed !== true) {
+        throw new ReplayNotConfirmedError('Replay mutation did not receive affirmative remote confirmation')
+      }
+      remoteMutationConfirmed = true
       await remove(entry.id, guard)
       assertGuard(guard)
       results.push({ entry, success: true, itemUid: result.itemUid })
     } catch (err) {
       if (err instanceof AccountBoundaryChangedError) return []
       assertGuard(guard)
-      const retryCount = entry.retryCount + 1
+      if (remoteMutationConfirmed) {
+        // The server mutation is complete. A local checkpoint/removal failure
+        // must not consume the remote retry budget or mark completed work failed.
+        results.push({ entry, success: false, error: err instanceof Error ? err.message : String(err) })
+        continue
+      }
+      if (err instanceof ReplayNotConfirmedError || isOfflineError(err)) {
+        results.push({
+          entry,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        if (isOfflineError(err)) break
+        continue
+      }
+      const retryCount = currentEntry.retryCount + 1
       const status = retryCount >= MAX_RETRIES ? 'failed' : 'pending'
-      await updateEntry({ ...entry, retryCount, status }, guard)
+      await updateEntry({ ...currentEntry, retryCount, status }, guard)
       assertGuard(guard)
       results.push({
         entry,

--- a/apps/web/app/lib/public-analytics.ts
+++ b/apps/web/app/lib/public-analytics.ts
@@ -1,0 +1,92 @@
+export type CampaignParams = Partial<{
+  utm_source: 'search' | 'social' | 'github' | 'newsletter' | 'community' | 'known_partner' | 'paid' | 'other'
+  utm_medium: 'organic' | 'referral' | 'email' | 'community' | 'paid_social' | 'cpc' | 'qr' | 'other'
+  utm_campaign: 'beta-2026-q2' | 'other_campaign'
+}>
+
+export type ReferrerCategory = 'direct' | 'search' | 'social' | 'github' | 'known_partner' | 'other'
+
+export type SignupPageviewPayload = {
+  domain: 'app.silentsuite.io'
+  name: 'pageview'
+  url: string
+  props: { referrer_category: ReferrerCategory }
+}
+
+const SOURCE_ALIASES: Readonly<Record<string, NonNullable<CampaignParams['utm_source']>>> = {
+  google: 'search', bing: 'search', duckduckgo: 'search',
+  x: 'social', twitter: 'social', mastodon: 'social', bluesky: 'social',
+  github: 'github', newsletter: 'newsletter',
+  'hacker-news': 'community', reddit: 'community', lemmy: 'community',
+  alternativeto: 'known_partner', 'privacy-media': 'known_partner',
+}
+const MEDIUM_ALIASES: Readonly<Record<string, NonNullable<CampaignParams['utm_medium']>>> = {
+  organic: 'organic', social: 'organic', referral: 'referral', listing: 'referral', media: 'referral',
+  email: 'email', newsletter: 'email', community: 'community', dm: 'community',
+  'paid-social': 'paid_social', cpc: 'cpc', qr: 'qr',
+}
+const CAMPAIGN_ALIASES: Readonly<Record<string, NonNullable<CampaignParams['utm_campaign']>>> = {
+  'beta-2026-q2': 'beta-2026-q2',
+}
+const SAFE_VALUE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+function safeSingleValue(params: URLSearchParams, key: string): string | undefined {
+  const values = params.getAll(key)
+  if (values.length !== 1) return undefined
+  const rawValue = values[0]
+  if (!/^[\x20-\x7e]+$/.test(rawValue)) return undefined
+  const value = rawValue.normalize('NFKC')
+  if (value !== value.toLowerCase() || !SAFE_VALUE.test(value) || UUID.test(value)) return undefined
+  return value
+}
+
+export function canonicalizeCampaignParams(search: string | URLSearchParams): CampaignParams {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search
+  const result: CampaignParams = {}
+  const source = safeSingleValue(params, 'utm_source')
+  const medium = safeSingleValue(params, 'utm_medium')
+  const campaign = safeSingleValue(params, 'utm_campaign')
+  if (source) result.utm_source = SOURCE_ALIASES[source] ?? 'other'
+  if (medium) result.utm_medium = MEDIUM_ALIASES[medium] ?? 'other'
+  if (campaign) result.utm_campaign = CAMPAIGN_ALIASES[campaign] ?? 'other_campaign'
+  return result
+}
+
+export function sanitizedSignupPageUrl(rawUrl: string): string {
+  const current = new URL(rawUrl)
+  const sanitized = new URL(`${current.origin}${current.pathname}`)
+  if (current.pathname === '/signup') {
+    for (const [key, value] of Object.entries(canonicalizeCampaignParams(current.searchParams))) {
+      sanitized.searchParams.set(key, value)
+    }
+  }
+  return sanitized.toString()
+}
+
+function hostMatches(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`)
+}
+
+export function classifyReferrer(raw: string): ReferrerCategory | undefined {
+  if (!raw) return 'direct'
+  try {
+    const host = new URL(raw).hostname.toLowerCase()
+    if (hostMatches(host, 'github.com')) return 'github'
+    if (hostMatches(host, 'google.com') || hostMatches(host, 'bing.com') || hostMatches(host, 'duckduckgo.com')) return 'search'
+    if (hostMatches(host, 'x.com') || hostMatches(host, 'twitter.com') || hostMatches(host, 'mastodon.social') || hostMatches(host, 'bsky.app')) return 'social'
+    if (hostMatches(host, 'alternativeto.net') || hostMatches(host, 'privacyguides.org')) return 'known_partner'
+    return 'other'
+  } catch {
+    return undefined
+  }
+}
+
+export function buildSignupPageviewPayload(rawUrl: string, rawReferrer: string): SignupPageviewPayload {
+  return {
+    domain: 'app.silentsuite.io',
+    name: 'pageview',
+    url: sanitizedSignupPageUrl(rawUrl),
+    props: { referrer_category: classifyReferrer(rawReferrer) ?? 'other' },
+  }
+}

--- a/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
+++ b/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
@@ -1,0 +1,101 @@
+import 'fake-indexeddb/auto'
+import { expect, vi } from 'vitest'
+import { bumpAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
+import {
+  _resetForTests,
+  _setEncryptedQueuePersistenceAvailableForTests,
+  clearAll,
+  enqueue,
+  getAll,
+  getPendingCount,
+  replay,
+  type OfflineQueueAccountGuard,
+  type QueueEntry,
+} from '@/app/lib/offline-queue'
+
+export const TEST_FINGERPRINT = 'store-regression-account'
+
+export function queueGuard(fingerprint = TEST_FINGERPRINT): OfflineQueueAccountGuard {
+  return { accountEpoch: getAccountEpoch(), accountFingerprint: fingerprint }
+}
+
+export async function resetRealOfflineQueue(): Promise<void> {
+  await _resetForTests()
+  await new Promise<void>((resolve) => {
+    const request = indexedDB.deleteDatabase('silentsuite-offline-queue')
+    request.onsuccess = () => resolve()
+    request.onerror = () => resolve()
+    request.onblocked = () => resolve()
+  })
+  _setEncryptedQueuePersistenceAvailableForTests(true)
+}
+
+export async function enqueueCreateFromStore(
+  collectionType: QueueEntry['collectionType'],
+  collectionUid: string | undefined,
+  content: string,
+  tempId: string,
+): Promise<null> {
+  await enqueue({ type: 'create', collectionType, collectionUid, content, tempId }, queueGuard())
+  return null
+}
+
+export async function expectOwnedQueueEntry(type: QueueEntry['type'], collectionType: QueueEntry['collectionType']): Promise<QueueEntry> {
+  const guard = queueGuard()
+  const entries = await getAll(guard)
+  if (entries.length !== 1) throw new Error(`Expected one guarded queue entry, got ${entries.length}`)
+  const entry = entries[0]!
+  if (!entry.accountFingerprint) throw new Error('Queue entry has no account fingerprint')
+  if (entry.accountFingerprint !== TEST_FINGERPRINT || entry.type !== type || entry.collectionType !== collectionType) {
+    throw new Error(`Unexpected queue entry: ${JSON.stringify(entry)}`)
+  }
+  if (await getPendingCount(guard) !== 1) throw new Error('Guarded pending count did not include entry')
+  return entry
+}
+
+export async function replayOwnedEntry(entry: QueueEntry): Promise<void> {
+  const execute = vi.fn(async () => ({}))
+  const results = await replay(execute, queueGuard())
+  if (results.length !== 1 || !results[0]!.success) throw new Error('Guarded replay did not execute entry')
+  if (execute.mock.calls[0]?.[0].id !== entry.id) throw new Error('Replay executed a different entry')
+  if ((await getAll(queueGuard())).length !== 0) throw new Error('Replay did not remove guarded entry')
+}
+
+export async function clearQueue(): Promise<void> {
+  await clearAll()
+}
+
+export function bumpEpochWhenQueuePutRuns(onBoundary: () => void): ReturnType<typeof vi.spyOn> {
+  const originalPut = IDBObjectStore.prototype.put
+  let bumped = false
+  return vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (...args: Parameters<IDBObjectStore['put']>) {
+    const request = originalPut.apply(this, args)
+    if (!bumped) {
+      bumped = true
+      bumpAccountEpoch()
+      onBoundary()
+    }
+    return request
+  })
+}
+
+export async function expectQuietQueueCommitCancellation(
+  mutate: () => Promise<unknown>,
+  onBoundary: () => void,
+  assertNoStaleState: () => void,
+  toast: { showErrorToast: ReturnType<typeof vi.fn> },
+): Promise<void> {
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const putSpy = bumpEpochWhenQueuePutRuns(onBoundary)
+  try {
+    await expect(mutate()).resolves.not.toThrow()
+    assertNoStaleState()
+    expect(await getAll()).toEqual([])
+    expect(await getAll(queueGuard('new-account'))).toEqual([])
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toast.showErrorToast).not.toHaveBeenCalled()
+  } finally {
+    putSpy.mockRestore()
+    errorSpy.mockRestore()
+  }
+}

--- a/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
+++ b/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
@@ -65,18 +65,26 @@ export async function clearQueue(): Promise<void> {
   await clearAll()
 }
 
-export function bumpEpochWhenQueuePutRuns(onBoundary: () => void): ReturnType<typeof vi.spyOn> {
+export function changeAccountWhenQueuePutRuns(
+  onBoundary: () => void,
+  options: { putNumber?: number; bumpEpoch?: boolean } = {},
+): ReturnType<typeof vi.spyOn> {
   const originalPut = IDBObjectStore.prototype.put
-  let bumped = false
+  const targetPut = options.putNumber ?? 1
+  let putCount = 0
   return vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (...args: Parameters<IDBObjectStore['put']>) {
     const request = originalPut.apply(this, args)
-    if (!bumped) {
-      bumped = true
-      bumpAccountEpoch()
+    putCount += 1
+    if (putCount === targetPut) {
+      if (options.bumpEpoch !== false) bumpAccountEpoch()
       onBoundary()
     }
     return request
   })
+}
+
+export function bumpEpochWhenQueuePutRuns(onBoundary: () => void): ReturnType<typeof vi.spyOn> {
+  return changeAccountWhenQueuePutRuns(onBoundary)
 }
 
 export async function expectQuietQueueCommitCancellation(

--- a/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
+++ b/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
@@ -54,7 +54,7 @@ export async function expectOwnedQueueEntry(type: QueueEntry['type'], collection
 }
 
 export async function replayOwnedEntry(entry: QueueEntry): Promise<void> {
-  const execute = vi.fn(async () => ({}))
+  const execute = vi.fn(async () => ({ remoteMutationConfirmed: true }))
   const results = await replay(execute, queueGuard())
   if (results.length !== 1 || !results[0]!.success) throw new Error('Guarded replay did not execute entry')
   if (execute.mock.calls[0]?.[0].id !== entry.id) throw new Error('Replay executed a different entry')

--- a/apps/web/app/stores/__tests__/use-calendar-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-calendar-store.test.ts
@@ -3,14 +3,20 @@ import { useCalendarStore } from '../use-calendar-store'
 import { serializeCalendarEvent, deserializeCalendarEvent } from '@silentsuite/core'
 import type { CalendarEvent } from '@silentsuite/core'
 import { expandEventsForRange } from '@/app/(app)/calendar/lib/calendar-grid-events'
+import { getAll } from '@/app/lib/offline-queue'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, enqueueCreateFromStore, expectOwnedQueueEntry, expectQuietQueueCommitCancellation, queueGuard, replayOwnedEntry, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+
+const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
 
 const etebaseMock = vi.hoisted(() => ({
   state: {
     account: null as unknown,
+    accountFingerprint: null as string | null,
     createItem: vi.fn(),
     createItemsBatch: vi.fn(),
     updateItem: vi.fn(),
     moveItem: vi.fn(),
+    deleteItem: vi.fn(),
     itemCache: new Map<string, unknown>(),
     itemCollectionMap: new Map<string, string>(),
   },
@@ -28,16 +34,16 @@ vi.mock('@/app/stores/use-etebase-store', () => ({
   },
 }))
 
-vi.mock('@/app/stores/use-toast-store', () => ({
-  showErrorToast: vi.fn(),
-}))
+vi.mock('@/app/stores/use-toast-store', () => toastMock)
 
 function resetStore() {
   etebaseMock.state.account = null
+  etebaseMock.state.accountFingerprint = 'calendar-test-account'
   etebaseMock.state.createItem.mockReset()
   etebaseMock.state.createItemsBatch.mockReset()
   etebaseMock.state.updateItem.mockReset()
   etebaseMock.state.moveItem.mockReset()
+  etebaseMock.state.deleteItem.mockReset()
   etebaseMock.state.itemCache = new Map()
   etebaseMock.state.itemCollectionMap = new Map()
   useCalendarStore.setState({
@@ -48,6 +54,13 @@ function resetStore() {
     currentDate: new Date('2026-06-01T12:00:00Z'),
     selectedEventId: null,
   })
+}
+
+function offlineAccount() {
+  etebaseMock.state.account = {}
+  etebaseMock.state.accountFingerprint = TEST_FINGERPRINT
+  etebaseMock.state.itemCache = new Map()
+  etebaseMock.state.createItem.mockImplementation((type, content, tempId, collectionUid) => enqueueCreateFromStore(type, collectionUid, content, tempId))
 }
 
 function makeRecurringEvent(overrides?: Partial<CalendarEvent>): CalendarEvent {
@@ -398,5 +411,90 @@ describe('useCalendarStore.getFilteredEvents', () => {
     // Empty query returns everything
     useCalendarStore.getState().setSearchQuery('')
     expect(useCalendarStore.getState().getFilteredEvents()).toHaveLength(2)
+  })
+})
+
+describe('useCalendarStore guarded offline queue integration', () => {
+  // Enqueue surface map: create -> Etebase createItem; update + recurring updates ->
+  // syncEventToEtebase update; offline calendar moves -> that helper's move fallback;
+  // deleteEvent + recurring/all each have cached-item and temp-item delete branches.
+  const queuedEvent = (id = 'temp-event') => makeRecurringEvent({ id, uid: id, recurrenceRule: null, calendarId: 'cal-1' })
+  beforeEach(async () => { await resetRealOfflineQueue(); resetStore(); offlineAccount(); toastMock.showErrorToast.mockReset() })
+
+  it.each([
+    ['create', async () => { await useCalendarStore.getState().createEvent({ title: 'Create', startDate: new Date('2026-06-01T09:00:00Z'), endDate: new Date('2026-06-01T10:00:00Z'), calendarId: 'cal-1' }) }],
+    ['update', async () => { useCalendarStore.setState({ events: [queuedEvent()] }); await useCalendarStore.getState().updateEvent('temp-event', { title: 'Update' }) }],
+    ['delete', async () => { useCalendarStore.setState({ events: [queuedEvent()] }); await useCalendarStore.getState().deleteEvent('temp-event') }],
+  ] as const)('persists, exposes, and replays an owned offline %s', async (type, mutate) => {
+    await mutate()
+    await replayOwnedEntry(await expectOwnedQueueEntry(type, 'calendar'))
+  })
+
+  it('isolates equal calendar IDs across account fingerprints', async () => {
+    useCalendarStore.setState({ events: [queuedEvent()] })
+    await useCalendarStore.getState().updateEvent('temp-event', { title: 'Owned' })
+    expect(await getAll(queueGuard('other-account'))).toEqual([])
+    expect(await getAll(queueGuard(TEST_FINGERPRINT))).toHaveLength(1)
+  })
+
+  it('quietly cancels at the actual IndexedDB commit boundary', async () => {
+    useCalendarStore.setState({ events: [queuedEvent()] })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = bumpEpochWhenQueuePutRuns(() => {
+      etebaseMock.state.account = {}; etebaseMock.state.accountFingerprint = 'new-account'
+      useCalendarStore.setState({ events: [], selectedEventId: null })
+    })
+    await expect(useCalendarStore.getState().updateEvent('temp-event', { title: 'Stale' })).resolves.toBeUndefined()
+    putSpy.mockRestore()
+    expect(useCalendarStore.getState().events).toEqual([])
+    expect(await getAll()).toEqual([])
+    expect(await getAll(queueGuard('new-account'))).toEqual([])
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it.each([
+    ['cached move fallback', () => {
+      const event = queuedEvent('cached-move')
+      useCalendarStore.setState({ events: [event] })
+      etebaseMock.state.itemCache = new Map([[event.id, {}]])
+      etebaseMock.state.itemCollectionMap = new Map([[event.id, 'cal-1']])
+      etebaseMock.state.moveItem.mockRejectedValue(new TypeError('offline'))
+      return useCalendarStore.getState().updateEvent(event.id, { calendarId: 'cal-2' })
+    }],
+    ['cached delete fallback', () => {
+      const event = queuedEvent('cached-delete')
+      useCalendarStore.setState({ events: [event] })
+      etebaseMock.state.itemCache = new Map([[event.id, {}]])
+      etebaseMock.state.itemCollectionMap = new Map([[event.id, 'cal-1']])
+      etebaseMock.state.deleteItem.mockRejectedValue(new TypeError('offline'))
+      return useCalendarStore.getState().deleteEvent(event.id)
+    }],
+    ['uncached delete', () => {
+      const event = queuedEvent('uncached-delete')
+      useCalendarStore.setState({ events: [event] })
+      return useCalendarStore.getState().deleteEvent(event.id)
+    }],
+    ['cached recurring delete fallback', () => {
+      const event = makeRecurringEvent({ id: 'cached-recurring-delete' })
+      useCalendarStore.setState({ events: [event] })
+      etebaseMock.state.itemCache = new Map([[event.id, {}]])
+      etebaseMock.state.itemCollectionMap = new Map([[event.id, 'cal-1']])
+      etebaseMock.state.deleteItem.mockRejectedValue(new TypeError('offline'))
+      return useCalendarStore.getState().deleteRecurringEvent(event.id, 'all', new Date('2026-06-03T09:00:00Z'))
+    }],
+    ['uncached recurring delete', () => {
+      const event = makeRecurringEvent({ id: 'uncached-recurring-delete' })
+      useCalendarStore.setState({ events: [event] })
+      return useCalendarStore.getState().deleteRecurringEvent(event.id, 'all', new Date('2026-06-03T09:00:00Z'))
+    }],
+  ] as const)('quietly cancels the %s direct branch at the actual IndexedDB commit boundary', async (_branch, mutate) => {
+    await expectQuietQueueCommitCancellation(
+      mutate,
+      () => { etebaseMock.state.account = {}; etebaseMock.state.accountFingerprint = 'new-account'; useCalendarStore.setState({ events: [], selectedEventId: null }) },
+      () => { expect(useCalendarStore.getState().events).toEqual([]); expect(useCalendarStore.getState().selectedEventId).toBeNull() },
+      toastMock,
+    )
   })
 })

--- a/apps/web/app/stores/__tests__/use-contact-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-contact-store.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useContactStore, getFilteredContacts } from '../use-contact-store'
 import { useEtebaseStore } from '../use-etebase-store'
 import type { Contact } from '@silentsuite/core'
+import { getAll } from '@/app/lib/offline-queue'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, enqueueCreateFromStore, expectOwnedQueueEntry, expectQuietQueueCommitCancellation, queueGuard, replayOwnedEntry, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+
+const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
+vi.mock('@/app/stores/use-toast-store', () => toastMock)
 
 // Mock the sync store to prevent side effects
 vi.mock('@/app/stores/use-sync-store', () => ({
@@ -22,6 +27,14 @@ function resetStore() {
     pendingChanges: [],
   })
   useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+}
+
+function offlineAccount() {
+  useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map(), createItem: vi.fn((type, content, tempId, collectionUid) => enqueueCreateFromStore(type, collectionUid, content, tempId!)) } as any)
+}
+
+function queuedContact(id = 'temp-contact'): Contact {
+  return { id, uid: id, displayName: 'Contact', name: { prefix: '', given: '', family: '', suffix: '' }, phones: [], emails: [], addresses: [], organization: '', title: '', notes: '', birthday: null, photoUrl: null, categories: [], listId: 'contacts-1', created_at: new Date(), updated_at: new Date() }
 }
 
 describe('useContactStore', () => {
@@ -195,6 +208,55 @@ describe('useContactStore', () => {
       const vip = getFilteredContacts(tagged, 'vip')
       expect(vip).toHaveLength(1)
       expect(vip[0]!.displayName).toBe('Carol King')
+    })
+  })
+
+  describe('guarded offline queue integration', () => {
+    // Enqueue surface map: create -> Etebase createItem; uncached update/delete ->
+    // the direct guarded branches below; cached update/delete enqueue in Etebase store.
+    beforeEach(async () => { await resetRealOfflineQueue(); resetStore(); offlineAccount(); toastMock.showErrorToast.mockReset() })
+
+    it.each([
+      ['create', async () => { await useContactStore.getState().createContact({ displayName: 'Create', listId: 'contacts-1' }) }],
+      ['update', async () => { useContactStore.setState({ contacts: [queuedContact()] }); await useContactStore.getState().updateContact('temp-contact', { displayName: 'Update' }) }],
+      ['delete', async () => { useContactStore.setState({ contacts: [queuedContact()] }); await useContactStore.getState().deleteContact('temp-contact') }],
+    ] as const)('persists, exposes, and replays an owned offline %s', async (type, mutate) => {
+      await mutate()
+      await replayOwnedEntry(await expectOwnedQueueEntry(type, 'contacts'))
+    })
+
+    it('isolates equal contact IDs across account fingerprints', async () => {
+      useContactStore.setState({ contacts: [queuedContact()] })
+      await useContactStore.getState().updateContact('temp-contact', { displayName: 'Owned' })
+      expect(await getAll(queueGuard('other-account'))).toEqual([])
+      expect(await getAll(queueGuard(TEST_FINGERPRINT))).toHaveLength(1)
+    })
+
+    it('quietly cancels at the actual IndexedDB commit boundary', async () => {
+      useContactStore.setState({ contacts: [queuedContact()] })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const putSpy = bumpEpochWhenQueuePutRuns(() => {
+        useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any)
+        useContactStore.setState({ contacts: [] })
+      })
+      await expect(useContactStore.getState().updateContact('temp-contact', { displayName: 'Stale' })).resolves.toBeUndefined()
+      putSpy.mockRestore()
+      expect(useContactStore.getState().contacts).toEqual([])
+      expect(await getAll()).toEqual([])
+      expect(await getAll(queueGuard('new-account'))).toEqual([])
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it('quietly cancels its distinct uncached delete branch at the actual IndexedDB commit boundary', async () => {
+      useContactStore.setState({ contacts: [queuedContact()] })
+      await expectQuietQueueCommitCancellation(
+        () => useContactStore.getState().deleteContact('temp-contact'),
+        () => { useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any); useContactStore.setState({ contacts: [] }) },
+        () => expect(useContactStore.getState().contacts).toEqual([]),
+        toastMock,
+      )
     })
   })
 })

--- a/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
@@ -1,13 +1,9 @@
 import 'fake-indexeddb/auto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
-import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, changeAccountWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
 
-const coreMock = vi.hoisted(() => ({
-  createItem: vi.fn(),
-  updateItem: vi.fn(),
-  deleteItem: vi.fn(),
-}))
+const coreMock = vi.hoisted(() => ({ createItem: vi.fn(), updateItem: vi.fn(), deleteItem: vi.fn() }))
 const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
 
 vi.mock('@silentsuite/core', async (importOriginal) => ({
@@ -45,6 +41,22 @@ function setAccount(options: {
   return manager
 }
 
+function switchAccountAtBoundary() {
+  useEtebaseStore.setState({
+    account: {} as any,
+    accountFingerprint: 'new-account',
+    itemCache: new Map([['new-item', cachedItem('new-item')]]),
+    itemTypeMap: new Map([['new-item', 'calendar']]),
+    itemCollectionMap: new Map([['new-item', 'new-col']]),
+  })
+}
+
+function expectNewAccountStateUntouched() {
+  expect([...useEtebaseStore.getState().itemCache.keys()]).toEqual(['new-item'])
+  expect([...useEtebaseStore.getState().itemTypeMap.keys()]).toEqual(['new-item'])
+  expect([...useEtebaseStore.getState().itemCollectionMap.entries()]).toEqual([['new-item', 'new-col']])
+}
+
 async function expectOwned(types: string[]) {
   const entries = await getAll(queueGuard())
   expect(entries.map((entry) => entry.type)).toEqual(types)
@@ -69,9 +81,7 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
   it('real createItem fallback persists the active fingerprint and is visible to guarded count and replay', async () => {
     setAccount()
     coreMock.createItem.mockRejectedValueOnce(offlineError())
-
     await expect(useEtebaseStore.getState().createItem('calendar', 'VEVENT', 'temp-1', 'col-1')).resolves.toBeNull()
-
     await expectOwned(['create'])
   })
 
@@ -79,29 +89,40 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
     setAccount()
     coreMock.createItem.mockRejectedValueOnce(offlineError())
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const putSpy = bumpEpochWhenQueuePutRuns(() => {
-      useEtebaseStore.setState({ account: {} as any, accountFingerprint: 'new-account', itemCache: new Map() })
-    })
-
-    await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'temp-old', 'col-1')).resolves.toBeNull()
-    putSpy.mockRestore()
-
-    expect(await getAll()).toEqual([])
-    expect(errorSpy).not.toHaveBeenCalled()
-    expect(toastMock.showErrorToast).not.toHaveBeenCalled()
-    errorSpy.mockRestore()
+    const putSpy = bumpEpochWhenQueuePutRuns(switchAccountAtBoundary)
+    try {
+      await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'temp-old', 'col-1')).resolves.toBeNull()
+      expect(await getAll()).toEqual([])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally {
+      putSpy.mockRestore()
+      errorSpy.mockRestore()
+    }
   })
 
   it('batch create fallback enqueues each create with the captured owner', async () => {
     const manager = setAccount()
     manager.create.mockRejectedValueOnce(offlineError())
-
-    await useEtebaseStore.getState().createItemsBatch('calendar', [
-      { content: 'A', tempId: 'a' },
-      { content: 'B', tempId: 'b' },
-    ], 'col-1')
-
+    await useEtebaseStore.getState().createItemsBatch('calendar', [{ content: 'A', tempId: 'a' }, { content: 'B', tempId: 'b' }], 'col-1')
     await expectOwned(['create', 'create'])
+  })
+
+  it('batch create stops after a second put boundary and preserves the first committed create', async () => {
+    const manager = setAccount()
+    manager.create.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary, { putNumber: 2 })
+    try {
+      await expect(useEtebaseStore.getState().createItemsBatch('calendar', [
+        { content: 'A', tempId: 'a' }, { content: 'B', tempId: 'b' }, { content: 'C', tempId: 'c' },
+      ], 'col-1')).resolves.toEqual([null, null, null])
+      expect((await getAll()).map((entry) => entry.tempId)).toEqual(['a'])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
   })
 
   it.each([
@@ -111,10 +132,26 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
     setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
     coreMock.updateItem.mockRejectedValueOnce(offlineError())
     coreMock.deleteItem.mockRejectedValueOnce(offlineError())
-
     await mutate()
-
     await expectOwned([expectedType])
+  })
+
+  it.each([
+    ['updateItem', async () => useEtebaseStore.getState().updateItem('calendar', 'item-1', 'NEW')],
+    ['deleteItem', async () => useEtebaseStore.getState().deleteItem('calendar', 'item-1')],
+  ] as const)('%s quietly cancels at its real queue put boundary', async (_name, mutate) => {
+    setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
+    coreMock.updateItem.mockRejectedValueOnce(offlineError())
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary)
+    try {
+      await expect(mutate()).resolves.toBeUndefined()
+      expect(await getAll()).toEqual([])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
   })
 
   it('collection clear fallback enqueues remaining source deletes with the captured owner', async () => {
@@ -123,24 +160,65 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
       { uid: 'item-2', collectionUid: 'col-1', item: cachedItem('item-2') },
     ] })
     manager.batch.mockRejectedValueOnce(offlineError())
-
     await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
-
     await expectOwned(['delete', 'delete'])
   })
 
+  it('collection clear stops after a later put abort, preserves prior committed deletes, and skips stale cleanup', async () => {
+    const manager = setAccount({ items: [
+      { uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') },
+      { uid: 'item-2', collectionUid: 'col-1', item: cachedItem('item-2') },
+      { uid: 'item-3', collectionUid: 'col-1', item: cachedItem('item-3') },
+    ] })
+    manager.batch.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary, { putNumber: 2 })
+    try {
+      await expect(useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')).resolves.toBe(0)
+      expect((await getAll()).map((entry) => entry.itemUid)).toEqual(['item-1'])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
+  })
+
   it('move source-delete fallback enqueues against the source collection with the captured owner', async () => {
-    setAccount({
-      collections: [collection('source'), collection('target')],
-      items: [{ uid: 'item-1', collectionUid: 'source', item: cachedItem('item-1') }],
-    })
+    setAccount({ collections: [collection('source'), collection('target')], items: [{ uid: 'item-1', collectionUid: 'source', item: cachedItem('item-1') }] })
     coreMock.createItem.mockResolvedValueOnce(cachedItem('created-target'))
     coreMock.deleteItem.mockRejectedValueOnce(offlineError())
-
     await useEtebaseStore.getState().moveItem('calendar', 'item-1', 'NEW', 'target', 'source')
-
     const [entry] = await getAll(queueGuard())
     expect(entry).toMatchObject({ type: 'delete', collectionUid: 'source', itemUid: 'item-1', accountFingerprint: TEST_FINGERPRINT })
     await expectOwned(['delete'])
+  })
+
+  it('move source-delete quietly cancels at the real queue put boundary without publishing the target', async () => {
+    setAccount({ collections: [collection('source'), collection('target')], items: [{ uid: 'item-1', collectionUid: 'source', item: cachedItem('item-1') }] })
+    coreMock.createItem.mockResolvedValueOnce(cachedItem('created-target'))
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary)
+    try {
+      await expect(useEtebaseStore.getState().moveItem('calendar', 'item-1', 'NEW', 'target', 'source')).resolves.toBeNull()
+      expect(await getAll()).toEqual([])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
+  })
+
+  it('missing fingerprint quietly cancels before queue persistence', async () => {
+    setAccount()
+    useEtebaseStore.setState({ accountFingerprint: null })
+    coreMock.createItem.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put')
+    try {
+      await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'temp-old', 'col-1')).resolves.toBeNull()
+      expect(await getAll()).toEqual([])
+      expect(putSpy).not.toHaveBeenCalled()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
   })
 })

--- a/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
@@ -1,0 +1,146 @@
+import 'fake-indexeddb/auto'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+
+const coreMock = vi.hoisted(() => ({
+  createItem: vi.fn(),
+  updateItem: vi.fn(),
+  deleteItem: vi.fn(),
+}))
+const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
+
+vi.mock('@silentsuite/core', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@silentsuite/core')>(),
+  ...coreMock,
+}))
+vi.mock('@/app/stores/use-toast-store', () => toastMock)
+vi.mock('@/app/stores/use-label-suggestions-store', () => ({ useLabelSuggestionsStore: { getState: () => ({ recordUsage: vi.fn() }) } }))
+
+import { useEtebaseStore } from '../use-etebase-store'
+
+const offlineError = () => new TypeError('Failed to fetch')
+const collection = (uid: string) => ({ uid, getMeta: vi.fn(() => ({})) })
+const cachedItem = (uid: string) => ({ uid, delete: vi.fn(), getContent: vi.fn(async () => 'OLD') })
+
+function setAccount(options: {
+  collections?: { uid: string }[]
+  items?: { uid: string; collectionUid: string; item: any }[]
+  manager?: { create: ReturnType<typeof vi.fn>; batch: ReturnType<typeof vi.fn> }
+} = {}) {
+  const collections = options.collections ?? [collection('col-1')]
+  const manager = options.manager ?? { create: vi.fn(), batch: vi.fn() }
+  const items = options.items ?? []
+  useEtebaseStore.setState({
+    account: { getCollectionManager: () => ({ getItemManager: () => manager }) } as any,
+    accountFingerprint: TEST_FINGERPRINT,
+    collections: { calendar: collections as any[], tasks: [], contacts: [], preferences: [] },
+    itemCache: new Map(items.map(({ uid, item }) => [uid, item])),
+    itemTypeMap: new Map(items.map(({ uid }) => [uid, 'calendar' as const])),
+    itemCollectionMap: new Map(items.map(({ uid, collectionUid }) => [uid, collectionUid])),
+    domainLoadState: { calendar: 'loaded', tasks: 'loaded', contacts: 'loaded', preferences: 'unknown' },
+    isInitialized: true,
+    syncEngine: null,
+  } as any)
+  return manager
+}
+
+async function expectOwned(types: string[]) {
+  const entries = await getAll(queueGuard())
+  expect(entries.map((entry) => entry.type)).toEqual(types)
+  expect(entries.every((entry) => entry.accountFingerprint === TEST_FINGERPRINT)).toBe(true)
+  expect(await getPendingCount(queueGuard())).toBe(entries.length)
+  const execute = vi.fn(async () => ({}))
+  await replay(execute, queueGuard())
+  expect(execute).toHaveBeenCalledTimes(entries.length)
+  expect(await getAll(queueGuard())).toEqual([])
+}
+
+describe('useEtebaseStore real guarded offline queue integration', () => {
+  beforeEach(async () => {
+    await resetRealOfflineQueue()
+    useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+    coreMock.createItem.mockReset()
+    coreMock.updateItem.mockReset()
+    coreMock.deleteItem.mockReset()
+    toastMock.showErrorToast.mockReset()
+  })
+
+  it('real createItem fallback persists the active fingerprint and is visible to guarded count and replay', async () => {
+    setAccount()
+    coreMock.createItem.mockRejectedValueOnce(offlineError())
+
+    await expect(useEtebaseStore.getState().createItem('calendar', 'VEVENT', 'temp-1', 'col-1')).resolves.toBeNull()
+
+    await expectOwned(['create'])
+  })
+
+  it('real createItem fallback quietly cancels at the IndexedDB commit boundary', async () => {
+    setAccount()
+    coreMock.createItem.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = bumpEpochWhenQueuePutRuns(() => {
+      useEtebaseStore.setState({ account: {} as any, accountFingerprint: 'new-account', itemCache: new Map() })
+    })
+
+    await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'temp-old', 'col-1')).resolves.toBeNull()
+    putSpy.mockRestore()
+
+    expect(await getAll()).toEqual([])
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it('batch create fallback enqueues each create with the captured owner', async () => {
+    const manager = setAccount()
+    manager.create.mockRejectedValueOnce(offlineError())
+
+    await useEtebaseStore.getState().createItemsBatch('calendar', [
+      { content: 'A', tempId: 'a' },
+      { content: 'B', tempId: 'b' },
+    ], 'col-1')
+
+    await expectOwned(['create', 'create'])
+  })
+
+  it.each([
+    ['updateItem', async () => useEtebaseStore.getState().updateItem('calendar', 'item-1', 'NEW'), 'update'],
+    ['deleteItem', async () => useEtebaseStore.getState().deleteItem('calendar', 'item-1'), 'delete'],
+  ] as const)('%s cached offline fallback enqueues with the captured owner', async (_name, mutate, expectedType) => {
+    setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
+    coreMock.updateItem.mockRejectedValueOnce(offlineError())
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError())
+
+    await mutate()
+
+    await expectOwned([expectedType])
+  })
+
+  it('collection clear fallback enqueues remaining source deletes with the captured owner', async () => {
+    const manager = setAccount({ items: [
+      { uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') },
+      { uid: 'item-2', collectionUid: 'col-1', item: cachedItem('item-2') },
+    ] })
+    manager.batch.mockRejectedValueOnce(offlineError())
+
+    await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
+
+    await expectOwned(['delete', 'delete'])
+  })
+
+  it('move source-delete fallback enqueues against the source collection with the captured owner', async () => {
+    setAccount({
+      collections: [collection('source'), collection('target')],
+      items: [{ uid: 'item-1', collectionUid: 'source', item: cachedItem('item-1') }],
+    })
+    coreMock.createItem.mockResolvedValueOnce(cachedItem('created-target'))
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError())
+
+    await useEtebaseStore.getState().moveItem('calendar', 'item-1', 'NEW', 'target', 'source')
+
+    const [entry] = await getAll(queueGuard())
+    expect(entry).toMatchObject({ type: 'delete', collectionUid: 'source', itemUid: 'item-1', accountFingerprint: TEST_FINGERPRINT })
+    await expectOwned(['delete'])
+  })
+})

--- a/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
@@ -1,9 +1,10 @@
 import 'fake-indexeddb/auto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
+import { enqueue, getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
+import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, changeAccountWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
 
-const coreMock = vi.hoisted(() => ({ createItem: vi.fn(), updateItem: vi.fn(), deleteItem: vi.fn() }))
+const coreMock = vi.hoisted(() => ({ createItem: vi.fn(), updateItem: vi.fn(), deleteItem: vi.fn(), listItems: vi.fn() }))
 const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
 
 vi.mock('@silentsuite/core', async (importOriginal) => ({
@@ -14,10 +15,17 @@ vi.mock('@/app/stores/use-toast-store', () => toastMock)
 vi.mock('@/app/stores/use-label-suggestions-store', () => ({ useLabelSuggestionsStore: { getState: () => ({ recordUsage: vi.fn() }) } }))
 
 import { useEtebaseStore } from '../use-etebase-store'
+import { useSyncStore } from '../use-sync-store'
+
+// These tests exercise real fake-IndexedDB transactions and remote-replay
+// reconciliation. Leave headroom for heavily loaded CI/review workers so a
+// single timeout cannot cascade into later singleton-state assertions.
+vi.setConfig({ testTimeout: 15_000 })
 
 const offlineError = () => new TypeError('Failed to fetch')
 const collection = (uid: string) => ({ uid, getMeta: vi.fn(() => ({})) })
-const cachedItem = (uid: string) => ({ uid, delete: vi.fn(), getContent: vi.fn(async () => 'OLD') })
+const cachedItem = (uid: string) => ({ uid, isDeleted: false, delete: vi.fn(), getContent: vi.fn(async () => 'OLD') })
+const remoteItem = (uid: string, content: string) => ({ uid, isDeleted: false, delete: vi.fn(), getContent: vi.fn(async () => content) })
 
 function setAccount(options: {
   collections?: { uid: string }[]
@@ -62,7 +70,7 @@ async function expectOwned(types: string[]) {
   expect(entries.map((entry) => entry.type)).toEqual(types)
   expect(entries.every((entry) => entry.accountFingerprint === TEST_FINGERPRINT)).toBe(true)
   expect(await getPendingCount(queueGuard())).toBe(entries.length)
-  const execute = vi.fn(async () => ({}))
+  const execute = vi.fn(async () => ({ remoteMutationConfirmed: true }))
   await replay(execute, queueGuard())
   expect(execute).toHaveBeenCalledTimes(entries.length)
   expect(await getAll(queueGuard())).toEqual([])
@@ -75,6 +83,7 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
     coreMock.createItem.mockReset()
     coreMock.updateItem.mockReset()
     coreMock.deleteItem.mockReset()
+    coreMock.listItems.mockReset().mockResolvedValue({ items: [], stoken: null, done: true })
     toastMock.showErrorToast.mockReset()
   })
 
@@ -220,5 +229,284 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
       expect(errorSpy).not.toHaveBeenCalled()
       expect(toastMock.showErrorToast).not.toHaveBeenCalled()
     } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
+  })
+
+  it.each([
+    ['create', { type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', tempId: 'temp-1' }],
+    ['update', { type: 'update', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', itemUid: 'item-1' }],
+    ['delete', { type: 'delete', collectionType: 'calendar', collectionUid: 'col-1', itemUid: 'item-1' }],
+    ['move', { type: 'move', collectionType: 'calendar', collectionUid: 'col-1', targetCollectionUid: 'col-2', content: 'NEW', itemUid: 'item-1' }],
+  ] as const)('real sync replay retains exactly one owned %s entry when the remote path is offline', async (_name, queued) => {
+    setAccount({
+      collections: [collection('col-1'), collection('col-2')],
+      items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }],
+    })
+    await enqueue(queued, queueGuard())
+    coreMock.createItem.mockRejectedValue(offlineError())
+    coreMock.updateItem.mockRejectedValue(offlineError())
+    coreMock.deleteItem.mockRejectedValue(offlineError())
+
+    await useSyncStore.getState().replayOfflineQueue()
+
+    const entries = await getAll(queueGuard())
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ id: expect.any(String), type: queued.type, accountFingerprint: TEST_FINGERPRINT, status: 'pending', retryCount: 0 })
+  })
+
+  it.each([
+    ['create collection', { type: 'create', collectionType: 'calendar', collectionUid: 'missing', content: 'NEW', tempId: 'temp-1' }],
+    ['update item', { type: 'update', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', itemUid: 'missing' }],
+    ['delete item', { type: 'delete', collectionType: 'calendar', collectionUid: 'col-1', itemUid: 'missing' }],
+    ['move target collection', { type: 'move', collectionType: 'calendar', collectionUid: 'col-1', targetCollectionUid: 'missing', content: 'NEW', itemUid: 'item-1' }],
+  ] as const)('real sync replay retains the original entry when the %s prerequisite is unavailable', async (_name, queued) => {
+    setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
+    await enqueue(queued, queueGuard())
+    const [original] = await getAll(queueGuard())
+
+    await useSyncStore.getState().replayOfflineQueue()
+
+    expect(await getAll(queueGuard())).toEqual([original!])
+    expect(coreMock.createItem).not.toHaveBeenCalled()
+    expect(coreMock.updateItem).not.toHaveBeenCalled()
+    expect(coreMock.deleteItem).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['create', { type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', tempId: 'temp-1' }],
+    ['update', { type: 'update', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', itemUid: 'item-1' }],
+    ['delete', { type: 'delete', collectionType: 'calendar', collectionUid: 'col-1', itemUid: 'item-1' }],
+    ['move', { type: 'move', collectionType: 'calendar', collectionUid: 'col-1', targetCollectionUid: 'col-2', content: 'NEW', itemUid: 'item-1' }],
+  ] as const)('real sync replay removes %s only after confirmed remote success', async (name, queued) => {
+    setAccount({
+      collections: [collection('col-1'), collection('col-2')],
+      items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }],
+    })
+    await enqueue(queued, queueGuard())
+    coreMock.createItem.mockResolvedValue({ uid: name === 'create' ? 'server-created' : 'server-moved' })
+    coreMock.updateItem.mockResolvedValue({ uid: 'item-1' })
+    coreMock.deleteItem.mockResolvedValue(undefined)
+
+    await useSyncStore.getState().replayOfflineQueue()
+
+    expect(await getAll(queueGuard())).toEqual([])
+    if (name === 'create') expect(coreMock.createItem).toHaveReturnedWith(Promise.resolve({ uid: 'server-created' }))
+  })
+
+  it('fresh create publishes the returned item atomically, removes temp maps, and supports immediate update', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:fresh-create\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const temp = cachedItem('temp-1')
+    const created = remoteItem('server-fresh', content)
+    setAccount({ items: [{ uid: 'temp-1', collectionUid: 'col-1', item: temp }] })
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-1' }, queueGuard())
+    coreMock.createItem.mockResolvedValueOnce(created)
+
+    await useSyncStore.getState().replayOfflineQueue()
+
+    const state = useEtebaseStore.getState()
+    expect(state.itemCache.get('server-fresh')).toBe(created)
+    expect(state.itemTypeMap.get('server-fresh')).toBe('calendar')
+    expect(state.itemCollectionMap.get('server-fresh')).toBe('col-1')
+    expect(state.itemCache.has('temp-1')).toBe(false)
+    expect(state.itemTypeMap.has('temp-1')).toBe(false)
+    expect(state.itemCollectionMap.has('temp-1')).toBe(false)
+    expect(await getAll(queueGuard())).toEqual([])
+
+    coreMock.updateItem.mockResolvedValueOnce(created)
+    await useEtebaseStore.getState().updateItem('calendar', 'server-fresh', 'UPDATED')
+    expect(coreMock.updateItem).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ uid: 'col-1' }), created, 'UPDATED')
+  })
+
+  it('account boundary inside create cache publication publishes nothing and leaves a reconciliable checkpoint', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:publish-boundary\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const created = remoteItem('server-boundary', content)
+    const remote = [created]
+    setAccount()
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-boundary' }, queueGuard())
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+    coreMock.createItem.mockResolvedValueOnce(created)
+    const originalMapSet = Map.prototype.set
+    let switched = false
+    const mapSetSpy = vi.spyOn(Map.prototype, 'set').mockImplementation(function (key, value) {
+      const result = originalMapSet.call(this, key, value)
+      if (!switched && key === 'server-boundary') {
+        switched = true
+        bumpAccountEpoch()
+        switchAccountAtBoundary()
+      }
+      return result
+    })
+
+    try {
+      await useSyncStore.getState().replayOfflineQueue()
+    } finally {
+      mapSetSpy.mockRestore()
+    }
+
+    expectNewAccountStateUntouched()
+    expect((await getAll())[0]).toMatchObject({ replayPhase: 'target-confirmed', confirmedTargetUid: 'server-boundary' })
+
+    bumpAccountEpoch()
+    setAccount()
+    coreMock.listItems.mockResolvedValue({ items: remote, stoken: null, done: true })
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(coreMock.createItem).toHaveBeenCalledTimes(1)
+    expect(useEtebaseStore.getState().itemCache.get('server-boundary')).toBe(created)
+    expect(await getAll(queueGuard())).toEqual([])
+  })
+
+  it('cold-start replay publishes a fresh target before queue success is exposed', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:cold-start\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const created = remoteItem('server-cold', content)
+    setAccount()
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-cold' }, queueGuard())
+    coreMock.createItem.mockResolvedValueOnce(created)
+
+    const cleanup = useSyncStore.getState().initializeSync()
+    try {
+      await vi.waitFor(() => expect(useEtebaseStore.getState().itemCache.get('server-cold')).toBe(created))
+      expect(useEtebaseStore.getState().itemTypeMap.get('server-cold')).toBe('calendar')
+      expect(useEtebaseStore.getState().itemCollectionMap.get('server-cold')).toBe('col-1')
+      expect(await getAll(queueGuard())).toEqual([])
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('account boundary after create commit retains recoverable old work and retry reconciles exactly one remote object', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:logical-1\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const remote: any[] = []
+    setAccount()
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-1' }, queueGuard())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    coreMock.listItems.mockImplementation(async () => ({ items: remote, stoken: null, done: true }))
+    coreMock.createItem.mockImplementationOnce(async () => {
+      const created = remoteItem('server-1', content)
+      remote.push(created)
+      bumpAccountEpoch()
+      switchAccountAtBoundary()
+      return created
+    })
+    try {
+      await useSyncStore.getState().replayOfflineQueue()
+      expect(remote).toHaveLength(1)
+      expect(await getAll()).toHaveLength(1)
+      expectNewAccountStateUntouched()
+
+      bumpAccountEpoch()
+      setAccount()
+      await useSyncStore.getState().replayOfflineQueue()
+      expect(remote).toHaveLength(1)
+      expect(coreMock.createItem).toHaveBeenCalledTimes(1)
+      expect(await getAll(queueGuard())).toEqual([])
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { errorSpy.mockRestore() }
+  })
+
+  it('response loss after server commit is reconciled by PIM UID without a second create', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:response-loss-logical\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const created = remoteItem('server-contact', content)
+    const remote: any[] = []
+    setAccount({ collections: [collection('col-1')] })
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-1' }, queueGuard())
+    coreMock.listItems.mockImplementation(async () => ({ items: remote, stoken: null, done: true }))
+    coreMock.createItem.mockImplementationOnce(async () => { remote.push(created); throw offlineError() })
+
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(remote).toHaveLength(1)
+    await useSyncStore.getState().replayOfflineQueue()
+
+    expect(coreMock.createItem).toHaveBeenCalledTimes(1)
+    expect(await getAll(queueGuard())).toEqual([])
+    expect(useEtebaseStore.getState().itemCache.get('server-contact')).toBe(created)
+    expect(useEtebaseStore.getState().itemTypeMap.get('server-contact')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('server-contact')).toBe('col-1')
+
+    const updated = remoteItem('server-contact', 'UPDATED')
+    coreMock.updateItem.mockResolvedValueOnce(updated)
+    await useEtebaseStore.getState().updateItem('calendar', 'server-contact', 'UPDATED')
+    expect(coreMock.updateItem).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ uid: 'col-1' }), created, 'UPDATED')
+
+    coreMock.deleteItem.mockResolvedValueOnce(undefined)
+    await useEtebaseStore.getState().deleteItem('calendar', 'server-contact')
+    expect(coreMock.deleteItem).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ uid: 'col-1' }), updated)
+  })
+
+  it('local queue removal abort after create checkpoint retains progress and retry does not duplicate', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:idb-failure-logical\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const created = remoteItem('server-idb', content)
+    const remote = [created]
+    setAccount()
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-idb' }, queueGuard())
+    coreMock.listItems.mockResolvedValue({ items: remote, stoken: null, done: true })
+    const originalDelete = IDBObjectStore.prototype.delete
+    const deleteSpy = vi.spyOn(IDBObjectStore.prototype, 'delete').mockImplementationOnce(function (...args) {
+      const request = originalDelete.apply(this, args)
+      this.transaction.abort()
+      return request
+    })
+    try {
+      await useSyncStore.getState().replayOfflineQueue()
+    } finally {
+      deleteSpy.mockRestore()
+    }
+    expect((await getAll(queueGuard()))[0]).toMatchObject({
+      replayPhase: 'target-confirmed', confirmedTargetUid: 'server-idb',
+      retryCount: 0, status: 'pending',
+    })
+    expect(useEtebaseStore.getState().itemCache.get('server-idb')).toBe(created)
+    expect(useEtebaseStore.getState().itemTypeMap.get('server-idb')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('server-idb')).toBe('col-1')
+
+    const secondDeleteSpy = vi.spyOn(IDBObjectStore.prototype, 'delete').mockImplementationOnce(function (...args) {
+      const request = originalDelete.apply(this, args)
+      this.transaction.abort()
+      return request
+    })
+    try {
+      await useSyncStore.getState().replayOfflineQueue()
+    } finally {
+      secondDeleteSpy.mockRestore()
+    }
+    expect((await getAll(queueGuard()))[0]).toMatchObject({ retryCount: 0, status: 'pending' })
+
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(coreMock.createItem).not.toHaveBeenCalled()
+    expect(await getAll(queueGuard())).toEqual([])
+  })
+
+  it('move checkpoints one target and retries only source deletion after an ambiguous failure', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:move-logical\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const source = remoteItem('source-item', content)
+    const target: any[] = []
+    const sourceItems: any[] = [source]
+    setAccount({ collections: [collection('source'), collection('target')], items: [{ uid: 'source-item', collectionUid: 'source', item: source }] })
+    await enqueue({ type: 'move', collectionType: 'calendar', collectionUid: 'source', targetCollectionUid: 'target', content, itemUid: 'source-item' }, queueGuard())
+    coreMock.listItems.mockImplementation(async (_account, col) => ({ items: col.uid === 'target' ? target : sourceItems, stoken: null, done: true }))
+    coreMock.createItem.mockImplementationOnce(async () => { const item = remoteItem('target-item', content); target.push(item); return item })
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError()).mockImplementationOnce(async () => { sourceItems.splice(0) })
+
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(target).toHaveLength(1)
+    expect((await getAll(queueGuard()))[0]).toMatchObject({ replayPhase: 'target-confirmed', confirmedTargetUid: 'target-item' })
+    expect(useEtebaseStore.getState().itemCache.get('source-item')).toBe(source)
+    expect(useEtebaseStore.getState().itemTypeMap.get('source-item')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('source-item')).toBe('source')
+    await useSyncStore.getState().replayOfflineQueue()
+
+    expect(coreMock.createItem).toHaveBeenCalledTimes(1)
+    expect(target).toHaveLength(1)
+    expect(sourceItems).toEqual([])
+    expect(await getAll(queueGuard())).toEqual([])
+    expect(useEtebaseStore.getState().itemCache.get('target-item')).toBe(target[0])
+    expect(useEtebaseStore.getState().itemTypeMap.get('target-item')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('target-item')).toBe('target')
+    expect(useEtebaseStore.getState().itemCache.has('source-item')).toBe(false)
+    expect(useEtebaseStore.getState().itemTypeMap.has('source-item')).toBe(false)
+    expect(useEtebaseStore.getState().itemCollectionMap.has('source-item')).toBe(false)
+
+    coreMock.deleteItem.mockResolvedValueOnce(undefined)
+    await useEtebaseStore.getState().deleteItem('calendar', 'target-item')
+    expect(coreMock.deleteItem).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({ uid: 'target' }), target[0])
   })
 })

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useSyncStore } from '../use-sync-store'
-import { getPendingCount, replay } from '@/app/lib/offline-queue'
+import { getPendingCount, getStaleEntries, remove, replay } from '@/app/lib/offline-queue'
 import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 const etebaseMock = vi.hoisted(() => ({
@@ -11,6 +11,7 @@ const etebaseMock = vi.hoisted(() => ({
     domainLoadState: { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' },
     reconcileCollections: vi.fn().mockResolvedValue(undefined),
     refreshCollection: vi.fn().mockResolvedValue([]),
+    replayQueuedMutation: vi.fn(),
     moveItem: vi.fn(),
   },
 }))
@@ -85,6 +86,7 @@ function resetStore() {
   etebaseMock.state.domainLoadState = { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' }
   etebaseMock.state.reconcileCollections.mockReset().mockResolvedValue(undefined)
   etebaseMock.state.refreshCollection.mockReset().mockResolvedValue([])
+  etebaseMock.state.replayQueuedMutation.mockReset()
   etebaseMock.state.moveItem.mockReset()
   calendarStoreMock.events = []
   calendarStoreMock.syncFromRemote.mockReset()
@@ -143,6 +145,22 @@ describe('useSyncStore', () => {
     expect(useSyncStore.getState().lastSyncedAt).toBeInstanceOf(Date)
     expect(preferencesSyncMock.loadFromRemote).toHaveBeenCalledTimes(1)
     expect(preferencesSyncMock.pushNow).not.toHaveBeenCalled()
+  })
+
+  it('never age-purges unconfirmed or checkpointed queue entries during sync', async () => {
+    vi.mocked(getStaleEntries).mockResolvedValueOnce([{
+      id: 'old-unconfirmed', type: 'move', collectionType: 'calendar',
+      collectionUid: 'source', targetCollectionUid: 'target', itemUid: 'item-1',
+      content: 'encrypted-at-rest-content', createdAt: 0, retryCount: 0,
+      status: 'pending', accountFingerprint: 'test-account',
+      replayPhase: 'target-confirmed', confirmedTargetUid: 'target-item',
+    }])
+
+    useSyncStore.getState().simulateSyncCycle()
+    await vi.waitFor(() => expect(useSyncStore.getState().syncStatus).toBe('synced'))
+
+    expect(getStaleEntries).not.toHaveBeenCalled()
+    expect(remove).not.toHaveBeenCalled()
   })
 
   it('simulateSyncCycle does nothing when offline', () => {
@@ -229,7 +247,7 @@ describe('useSyncStore', () => {
 
   it('replays queued collection moves and remaps the calendar event id', async () => {
     etebaseMock.state.account = {}
-    etebaseMock.state.moveItem.mockResolvedValue('item-new')
+    etebaseMock.state.replayQueuedMutation.mockResolvedValue({ remoteMutationConfirmed: true, itemUid: 'item-new' })
     calendarStoreMock.events = [{ id: 'item-old', calendarId: 'cal-a' }]
     vi.mocked(getPendingCount).mockResolvedValueOnce(1)
     vi.mocked(replay).mockImplementationOnce(async (executeMutation) => {
@@ -251,7 +269,7 @@ describe('useSyncStore', () => {
 
     await useSyncStore.getState().replayOfflineQueue()
 
-    expect(etebaseMock.state.moveItem).toHaveBeenCalledWith('calendar', 'item-old', 'VEVENT content', 'cal-b', 'cal-a')
+    expect(etebaseMock.state.replayQueuedMutation).toHaveBeenCalledWith(expect.objectContaining({ type: 'move', itemUid: 'item-old' }), expect.objectContaining({ accountFingerprint: 'test-account' }), undefined)
     expect(calendarStoreMock.syncFromRemote).toHaveBeenCalledWith([{ id: 'item-new', calendarId: 'cal-b' }])
   })
 })

--- a/apps/web/app/stores/__tests__/use-task-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-task-store.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useTaskStore } from '../use-task-store'
 import { useEtebaseStore } from '../use-etebase-store'
+import { getAll } from '@/app/lib/offline-queue'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, enqueueCreateFromStore, expectOwnedQueueEntry, expectQuietQueueCommitCancellation, queueGuard, replayOwnedEntry, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+
+const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
+vi.mock('@/app/stores/use-toast-store', () => toastMock)
 
 // Mock the sync store to prevent side effects
 vi.mock('@/app/stores/use-sync-store', () => ({
@@ -19,6 +24,14 @@ function resetStore() {
     syncStatus: 'synced',
   })
   useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+}
+
+function offlineAccount() {
+  useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map(), createItem: vi.fn((type, content, tempId, collectionUid) => enqueueCreateFromStore(type, collectionUid, content, tempId!)) } as any)
+}
+
+function queuedTask(id = 'temp-task') {
+  return { id, uid: id, title: 'Task', description: '', start_date: null, due_date: null, priority: 'medium' as const, completed: false, status: 'needs-action' as const, percent_complete: 0, location: '', url: '', categories: [], listId: 'tasks-1', created_at: new Date(), updated_at: new Date() }
 }
 
 describe('useTaskStore', () => {
@@ -125,5 +138,54 @@ describe('useTaskStore', () => {
     expect(tasks).toHaveLength(2)
     expect(tasks[0]!.completed).toBe(true)
     expect(tasks[1]!.completed).toBe(false)
+  })
+
+  describe('guarded offline queue integration', () => {
+    beforeEach(async () => { await resetRealOfflineQueue(); resetStore(); offlineAccount(); toastMock.showErrorToast.mockReset() })
+
+    it.each([
+      ['create', 'create', async () => { await useTaskStore.getState().createTask({ title: 'Create', listId: 'tasks-1' }) }],
+      ['update', 'update', async () => { useTaskStore.setState({ tasks: [queuedTask()] }); await useTaskStore.getState().updateTask('temp-task', { title: 'Update' }) }],
+      ['delete', 'delete', async () => { useTaskStore.setState({ tasks: [queuedTask()] }); await useTaskStore.getState().deleteTask('temp-task') }],
+      ['toggleComplete', 'update', async () => { useTaskStore.setState({ tasks: [queuedTask()] }); await useTaskStore.getState().toggleComplete('temp-task') }],
+    ] as const)('%s persists and replays an owned offline mutation', async (_operation, type, mutate) => {
+      await mutate()
+      const entry = await expectOwnedQueueEntry(type, 'tasks')
+      await replayOwnedEntry(entry)
+    })
+
+    it('quietly cancels at the real enqueue boundary', async () => {
+      useTaskStore.setState({ tasks: [queuedTask()] })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const putSpy = bumpEpochWhenQueuePutRuns(() => { useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any); useTaskStore.setState({ tasks: [] }) })
+      await expect(useTaskStore.getState().updateTask('temp-task', { title: 'Stale' })).resolves.toBeUndefined()
+      putSpy.mockRestore()
+      await vi.waitFor(() => expect(useTaskStore.getState().tasks).toEqual([]))
+      expect(await getAll(queueGuard('new-account'))).toEqual([])
+      expect(await getAll()).toEqual([])
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it('quietly cancels an uncached delete at the actual IndexedDB commit boundary', async () => {
+      useTaskStore.setState({ tasks: [queuedTask()] })
+      await expectQuietQueueCommitCancellation(
+        () => useTaskStore.getState().deleteTask('temp-task'),
+        () => { useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any); useTaskStore.setState({ tasks: [] }) },
+        () => expect(useTaskStore.getState().tasks).toEqual([]),
+        toastMock,
+      )
+    })
+
+    it('quietly cancels an uncached toggle at the actual IndexedDB commit boundary', async () => {
+      useTaskStore.setState({ tasks: [queuedTask()] })
+      await expectQuietQueueCommitCancellation(
+        () => useTaskStore.getState().toggleComplete('temp-task'),
+        () => { useEtebaseStore.setState({ account: {}, accountFingerprint: 'new-account' } as any); useTaskStore.setState({ tasks: [] }) },
+        () => expect(useTaskStore.getState().tasks).toEqual([]),
+        toastMock,
+      )
+    })
   })
 })

--- a/apps/web/app/stores/use-calendar-store.ts
+++ b/apps/web/app/stores/use-calendar-store.ts
@@ -10,6 +10,7 @@ import { useAuthStore } from '@/app/stores/use-auth-store'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useCalendarListStore } from '@/app/stores/use-calendar-list-store'
 import { useLabelSuggestionsStore } from '@/app/stores/use-label-suggestions-store'
+import { assertOfflineQueueAccountGuard, captureOfflineQueueAccountGuard, isOfflineQueueBoundaryCancellation } from '@/app/lib/offline-queue-account'
 
 type CalendarView = 'week' | 'month'
 
@@ -98,10 +99,13 @@ function addUntilToRRule(rrule: string, untilDate: Date): string {
 async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update', tempId?: string, sourceCalendarId?: string): Promise<string | null> {
   const etebase = useEtebaseStore.getState()
   if (!etebase.account) return null
+  const guard = captureOfflineQueueAccountGuard(etebase)
+  if (!guard) return null
 
   let content: string | undefined
   try {
     const { serializeCalendarEvent } = await import('@silentsuite/core')
+    assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
     content = serializeCalendarEvent(event)
     if (mode === 'create') {
       return await etebase.createItem('calendar', content, tempId, event.calendarId)
@@ -120,12 +124,14 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
         return event.id
       } else {
         const { enqueue } = await import('@/app/lib/offline-queue')
-        await enqueue({ type: 'update', collectionType: 'calendar', collectionUid: event.calendarId, content, tempId: event.id })
+        assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+        await enqueue({ type: 'update', collectionType: 'calendar', collectionUid: event.calendarId, content, tempId: event.id }, guard)
+        assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
         return event.id
       }
     }
   } catch (err) {
-    console.error(`[calendar-store] Failed to ${mode} event in Etebase`, getSafeErrorDetails(err))
+    try { assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState()) } catch { return null }
     const { enqueue, isOfflineError } = await import('@/app/lib/offline-queue')
     if (!isOfflineError(err)) {
       showErrorToast('Failed to save event. Please try again.')
@@ -138,16 +144,25 @@ async function syncEventToEtebase(event: CalendarEvent, mode: 'create' | 'update
         && event.calendarId
         && event.calendarId !== sourceCollectionUid
       ) {
-        await enqueue({
-          type: 'move',
-          collectionType: 'calendar',
-          collectionUid: sourceCollectionUid,
-          targetCollectionUid: event.calendarId,
-          content,
-          itemUid: event.id,
-        })
+        try {
+          assertOfflineQueueAccountGuard(guard, latestEtebase)
+          await enqueue({
+            type: 'move',
+            collectionType: 'calendar',
+            collectionUid: sourceCollectionUid,
+            targetCollectionUid: event.calendarId,
+            content,
+            itemUid: event.id,
+          }, guard)
+          assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+        } catch (queueError) {
+          if (isOfflineQueueBoundaryCancellation(queueError)) return null
+          throw queueError
+        }
       }
     }
+    try { assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState()) } catch { return null }
+    console.error(`[calendar-store] Failed to ${mode} event in Etebase`, getSafeErrorDetails(err))
     return null
   }
 }
@@ -241,6 +256,8 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
     // Sync to Etebase
     const etebase = useEtebaseStore.getState()
     if (etebase.account) {
+      const guard = captureOfflineQueueAccountGuard(etebase)
+      if (!guard) return
       const itemInCache = etebase.itemCache.has(id)
       if (itemInCache) {
         try {
@@ -249,8 +266,15 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
           // If the error is a network/offline error, enqueue for later replay.
           // Non-offline errors are logged and the optimistic removal stands.
           const { isOfflineError, enqueue } = await import('@/app/lib/offline-queue')
+          try { assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState()) } catch { return }
           if (isOfflineError(err)) {
-            await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id })
+            try {
+              await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (queueError) {
+              if (isOfflineQueueBoundaryCancellation(queueError)) return
+              throw queueError
+            }
           } else {
             showErrorToast('Failed to delete event. Please try again.')
           }
@@ -259,7 +283,14 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
       } else {
         // Item was created offline — enqueue delete with tempId for compaction
         const { enqueue } = await import('@/app/lib/offline-queue')
-        await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: eventToDelete?.calendarId, tempId: id })
+        try {
+          assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+          await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: eventToDelete?.calendarId, tempId: id }, guard)
+          assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+        } catch (queueError) {
+          if (isOfflineQueueBoundaryCancellation(queueError)) return
+          throw queueError
+        }
       }
     }
   },
@@ -439,14 +470,23 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
         // Sync to Etebase
         const etebase = useEtebaseStore.getState()
         if (etebase.account) {
+          const guard = captureOfflineQueueAccountGuard(etebase)
+          if (!guard) break
           const itemInCache = etebase.itemCache.has(id)
           if (itemInCache) {
             try {
               await etebase.deleteItem('calendar', id)
             } catch (err) {
               const { isOfflineError, enqueue } = await import('@/app/lib/offline-queue')
+              try { assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState()) } catch { break }
               if (isOfflineError(err)) {
-                await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id })
+                try {
+                  await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: etebase.itemCollectionMap.get(id), itemUid: id }, guard)
+                  assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+                } catch (queueError) {
+                  if (isOfflineQueueBoundaryCancellation(queueError)) break
+                  throw queueError
+                }
               } else {
                 showErrorToast('Failed to delete event. Please try again.')
               }
@@ -454,7 +494,14 @@ export const useCalendarStore = create<CalendarState & CalendarActions>()((set, 
             }
           } else {
             const { enqueue } = await import('@/app/lib/offline-queue')
-            await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: master.calendarId, tempId: id })
+            try {
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              await enqueue({ type: 'delete', collectionType: 'calendar', collectionUid: master.calendarId, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (queueError) {
+              if (isOfflineQueueBoundaryCancellation(queueError)) break
+              throw queueError
+            }
           }
         }
         break

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -5,6 +5,7 @@ import type { Contact, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
+import { assertOfflineQueueAccountGuard, captureOfflineQueueAccountGuard, isOfflineQueueBoundaryCancellation } from '@/app/lib/offline-queue-account'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useContactListStore } from '@/app/stores/use-contact-list-store'
@@ -136,9 +137,19 @@ export const useContactStore = create<ContactState & ContactActions>()(
               showErrorToast('Failed to save contact. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             const { serializeContact } = await import('@silentsuite/core')
-            const content = serializeContact(updated)
-            await enqueue({ type: 'update', collectionType: 'contacts', collectionUid: updated.listId, content, tempId: id })
+            try {
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              const content = serializeContact(updated)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              await enqueue({ type: 'update', collectionType: 'contacts', collectionUid: updated.listId, content, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },
@@ -160,8 +171,17 @@ export const useContactStore = create<ContactState & ContactActions>()(
               showErrorToast('Failed to delete contact. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             // Item was created offline and not yet synced — enqueue delete with tempId for compaction
-            await enqueue({ type: 'delete', collectionType: 'contacts', collectionUid: contactToDelete?.listId, tempId: id })
+            try {
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              await enqueue({ type: 'delete', collectionType: 'contacts', collectionUid: contactToDelete?.listId, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -12,6 +12,11 @@ import {
   getAll as getQueuedMutations,
   isOfflineError,
   remove as removeQueuedMutation,
+  type ConfirmedRemoteMutation,
+  type OfflineQueueAccountGuard,
+  type QueueEntry,
+  type ReplayCheckpoint,
+  ReplayNotConfirmedError,
 } from '@/app/lib/offline-queue'
 import { secureGet } from '@/app/lib/secure-storage'
 import { showErrorToast } from '@/app/stores/use-toast-store'
@@ -541,6 +546,9 @@ interface EtebaseActions {
    * @param tempId - optional temp ID from the domain store, used for offline queue mapping
    */
   createItem: (type: CollectionTypeKey, content: string, tempId?: string, collectionUid?: string) => Promise<string | null>
+
+  /** Execute a queued mutation remotely without ordinary offline fallback/requeue behavior. */
+  replayQueuedMutation: (entry: QueueEntry, guard: OfflineQueueAccountGuard, checkpoint?: ReplayCheckpoint) => Promise<ConfirmedRemoteMutation>
 
   /**
    * Create a new Etebase collection for the given type.
@@ -1426,6 +1434,169 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       } catch (cleanupErr) {
         if (!isCurrentAccountEpoch(accountEpoch) || cleanupErr instanceof AccountBoundaryChangedError) return 0
         throw cleanupErr
+      }
+    }
+  },
+
+  replayQueuedMutation: async (entry, guard, checkpoint = async () => {}) => {
+    assertOfflineQueueAccountGuard(guard, get())
+    const { account, collections, itemCache, itemCollectionMap } = get()
+    if (!account) throw new ReplayNotConfirmedError('Replay requires an active Etebase account')
+
+    const requireCollection = (uid: string | undefined, role: string) => {
+      if (!uid) throw new ReplayNotConfirmedError(`Replay requires a ${role} collection UID`)
+      const resolved = resolveCollection(collections, entry.collectionType, uid)
+      if (!resolved || resolved.uid !== uid) throw new ReplayNotConfirmedError(`Replay ${role} collection is unavailable`)
+      return resolved
+    }
+    const requireItem = () => {
+      if (!entry.itemUid) throw new ReplayNotConfirmedError('Replay requires an item UID')
+      const item = itemCache.get(entry.itemUid)
+      if (!item) throw new ReplayNotConfirmedError('Replay item is unavailable')
+      if (!entry.collectionUid || itemCollectionMap.get(entry.itemUid) !== entry.collectionUid) {
+        throw new ReplayNotConfirmedError('Replay item collection ownership is unavailable')
+      }
+      return item
+    }
+
+    const core = await import('@silentsuite/core')
+    assertOfflineQueueAccountGuard(guard, get())
+
+    const logicalUid = (content: string): string | null => {
+      if (entry.collectionType !== 'calendar' && entry.collectionType !== 'tasks' && entry.collectionType !== 'contacts') return null
+      const unfolded = content.replace(/\r?\n[ \t]/g, '')
+      const match = unfolded.match(/^UID(?:;[^:]*)?:(.*)$/im)
+      return match?.[1]?.trim() || null
+    }
+    const findRemoteItem = async (collection: any, wantedContent: string, confirmedUid?: string) => {
+      const wantedLogicalUid = logicalUid(wantedContent)
+      if (!wantedLogicalUid && !confirmedUid && !wantedContent) {
+        throw new ReplayNotConfirmedError('Replay create cannot be reconciled without content identity')
+      }
+      let stoken: string | null | undefined
+      do {
+        assertOfflineQueueAccountGuard(guard, get())
+        const response = await core.listItems(account, collection, stoken)
+        assertOfflineQueueAccountGuard(guard, get())
+        for (const candidate of response.items) {
+          if (candidate.isDeleted) continue
+          if (confirmedUid && candidate.uid === confirmedUid) return candidate
+          const rawCandidateContent = await candidate.getContent()
+          assertOfflineQueueAccountGuard(guard, get())
+          const candidateContent = typeof rawCandidateContent === 'string' ? rawCandidateContent : new TextDecoder().decode(rawCandidateContent)
+          if (wantedLogicalUid ? logicalUid(candidateContent) === wantedLogicalUid : candidateContent === wantedContent) return candidate
+        }
+        if (response.done) return null
+        stoken = response.stoken
+      } while (true)
+    }
+    const findRemoteItemByUid = async (collection: any, uid: string) => {
+      let stoken: string | null | undefined
+      do {
+        assertOfflineQueueAccountGuard(guard, get())
+        const response = await core.listItems(account, collection, stoken)
+        assertOfflineQueueAccountGuard(guard, get())
+        const found = response.items.find((candidate: any) => !candidate.isDeleted && candidate.uid === uid)
+        if (found) return found
+        if (response.done) return null
+        stoken = response.stoken
+      } while (true)
+    }
+
+    const publishConfirmedReplayItem = (
+      item: any,
+      itemUid: string,
+      collectionUid: string,
+      removeUid?: string,
+    ) => {
+      assertOfflineQueueAccountGuard(guard, get())
+      const current = get()
+      const nextItemCache = new Map(current.itemCache)
+      const nextItemTypeMap = new Map(current.itemTypeMap)
+      const nextItemCollectionMap = new Map(current.itemCollectionMap)
+      if (removeUid && removeUid !== itemUid) {
+        nextItemCache.delete(removeUid)
+        nextItemTypeMap.delete(removeUid)
+        nextItemCollectionMap.delete(removeUid)
+      }
+      nextItemCache.set(itemUid, item)
+      nextItemTypeMap.set(itemUid, entry.collectionType)
+      nextItemCollectionMap.set(itemUid, collectionUid)
+      assertOfflineQueueAccountGuard(guard, get())
+      set({
+        itemCache: nextItemCache,
+        itemTypeMap: nextItemTypeMap,
+        itemCollectionMap: nextItemCollectionMap,
+      })
+    }
+
+    switch (entry.type) {
+      case 'create': {
+        if (typeof entry.content !== 'string') throw new ReplayNotConfirmedError('Replay create content is unavailable')
+        const collection = requireCollection(entry.collectionUid, 'target')
+        let created = await findRemoteItem(collection, entry.content, entry.confirmedTargetUid)
+        if (!created) {
+          assertOfflineQueueAccountGuard(guard, get())
+          created = await core.createItem(account, collection, entry.content)
+        }
+        const createdUid = created?.uid
+        if (!createdUid) throw new ReplayNotConfirmedError('Replay create did not return a server UID')
+        await checkpoint({ replayPhase: 'target-confirmed', confirmedTargetUid: createdUid })
+        assertOfflineQueueAccountGuard(guard, get())
+        publishConfirmedReplayItem(created, createdUid, collection.uid, entry.tempId)
+        return { remoteMutationConfirmed: true, itemUid: createdUid }
+      }
+      case 'update': {
+        if (typeof entry.content !== 'string') throw new ReplayNotConfirmedError('Replay update content is unavailable')
+        const collection = requireCollection(entry.collectionUid, 'owner')
+        const item = requireItem()
+        assertOfflineQueueAccountGuard(guard, get())
+        await core.updateItem(account, collection, item, entry.content)
+        assertOfflineQueueAccountGuard(guard, get())
+        return { remoteMutationConfirmed: true }
+      }
+      case 'delete': {
+        const collection = requireCollection(entry.collectionUid, 'owner')
+        const item = requireItem()
+        assertOfflineQueueAccountGuard(guard, get())
+        await core.deleteItem(account, collection, item)
+        assertOfflineQueueAccountGuard(guard, get())
+        return { remoteMutationConfirmed: true }
+      }
+      case 'move': {
+        if (typeof entry.content !== 'string') throw new ReplayNotConfirmedError('Replay move content is unavailable')
+        const sourceCollection = requireCollection(entry.collectionUid, 'source')
+        const targetCollection = requireCollection(entry.targetCollectionUid, 'target')
+        if (!entry.itemUid) throw new ReplayNotConfirmedError('Replay move requires a source item UID')
+        if (sourceCollection.uid === targetCollection.uid) {
+          const item = requireItem()
+          assertOfflineQueueAccountGuard(guard, get())
+          await core.updateItem(account, sourceCollection, item, entry.content)
+          assertOfflineQueueAccountGuard(guard, get())
+          return { remoteMutationConfirmed: true, itemUid: entry.itemUid }
+        }
+
+        // Copy first, checkpoint its opaque Etebase UID, then monotonically retry
+        // source deletion. We intentionally never roll the target back: an
+        // ambiguous rollback recreates the duplicate window this state machine
+        // is designed to close.
+        let targetItem = await findRemoteItem(targetCollection, entry.content, entry.confirmedTargetUid)
+        if (!targetItem) {
+          assertOfflineQueueAccountGuard(guard, get())
+          targetItem = await core.createItem(account, targetCollection, entry.content)
+        }
+        const targetItemUid = targetItem?.uid
+        if (!targetItemUid) throw new ReplayNotConfirmedError('Replay move create did not return a server UID')
+        await checkpoint({ replayPhase: 'target-confirmed', confirmedTargetUid: targetItemUid })
+        assertOfflineQueueAccountGuard(guard, get())
+
+        const sourceItem = await findRemoteItemByUid(sourceCollection, entry.itemUid)
+        if (sourceItem) {
+          await core.deleteItem(account, sourceCollection, sourceItem)
+          assertOfflineQueueAccountGuard(guard, get())
+        }
+        publishConfirmedReplayItem(targetItem, targetItemUid, targetCollection.uid, entry.itemUid)
+        return { remoteMutationConfirmed: true, itemUid: targetItemUid }
       }
     }
   },

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -454,8 +454,9 @@ async function removeQueuedMutationsForCollection(
   accountEpoch: number,
   accountFingerprint: string | null,
 ): Promise<number> {
+  if (!accountFingerprint) return 0
   try {
-    const guard = { accountEpoch, accountFingerprint: accountFingerprint ?? '' }
+    const guard = { accountEpoch, accountFingerprint: accountFingerprint }
     assertCurrentAccountEpoch(accountEpoch)
     const entries = await getQueuedMutations(guard)
     assertCurrentAccountEpoch(accountEpoch)
@@ -1311,7 +1312,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const accountEpoch = getAccountEpoch()
     const { account, collections, domainLoadState, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection) {
+    if (!account || !collection || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot clear ${type} collection ${collectionUid}: missing account or collection`)
       return 0
     }
@@ -1393,7 +1394,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
             if (alreadyDeleted.has(uid)) continue
             try {
               assertCurrentAccountEpoch(accountEpoch)
-              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, { accountEpoch, accountFingerprint: accountFingerprint })
               assertCurrentAccountEpoch(accountEpoch)
             } catch (queueErr) {
               if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return 0
@@ -1431,7 +1432,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const accountEpoch = getAccountEpoch()
     const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection) {
+    if (!account || !collection || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot create item: no account or ${type} collection`)
       return null
     }
@@ -1457,7 +1458,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         const queueTempId = tempId ?? `pending-${Date.now()}`
         logger.warn(`[etebase-store] Offline — queuing create for ${type} (tempId: ${queueTempId})`)
         try {
-          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, { accountEpoch, accountFingerprint: accountFingerprint })
           assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return null
@@ -1475,7 +1476,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const accountEpoch = getAccountEpoch()
     const { account, collections, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection) {
+    if (!account || !collection || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot create items: no account or ${type} collection`)
       return contents.map(() => null)
     }
@@ -1605,7 +1606,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         logger.warn(`[etebase-store] Offline — queuing ${contents.length} creates for ${type}`)
         for (const { content, tempId } of contents) {
           try {
-            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, { accountEpoch, accountFingerprint: accountFingerprint })
             assertCurrentAccountEpoch(accountEpoch)
           } catch (queueErr) {
             if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return contents.map(() => null)
@@ -1627,7 +1628,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
-    if (!account || !collection || !item) {
+    if (!account || !collection || !item || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot update item ${itemUid}: missing account, collection, or item`)
       return
     }
@@ -1646,7 +1647,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
           assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
@@ -1666,7 +1667,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const sourceCollection = resolveCollection(collections, type, resolvedSourceCollectionUid)
     const targetCollection = resolveCollection(collections, type, targetCollectionUid)
     const item = itemCache.get(itemUid)
-    if (!account || !sourceCollection || !targetCollection || !item) {
+    if (!account || !sourceCollection || !targetCollection || !item || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot move item ${itemUid}: missing account, source collection, target collection, or item`)
       return null
     }
@@ -1692,7 +1693,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         if (isOfflineError(err)) {
           assertCurrentAccountEpoch(accountEpoch)
           logger.warn(`[etebase-store] Offline after moving ${type}/${itemUid} - queuing source delete`)
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
           assertCurrentAccountEpoch(accountEpoch)
           keepSourceUntilQueuedDelete = true
         } else {
@@ -1742,7 +1743,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
-    if (!account || !collection || !item) {
+    if (!account || !collection || !item || !accountFingerprint) {
       logger.warn(`[etebase-store] Cannot delete item ${itemUid}: missing account, collection, or item`)
       return
     }
@@ -1767,7 +1768,7 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (isOfflineError(err)) {
         logger.warn(`[etebase-store] Offline — queuing delete for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint ?? '' })
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
           assertCurrentAccountEpoch(accountEpoch)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -32,6 +32,7 @@ import {
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { RestoreDiagnosticsRecorder, classifySessionPersistence } from '@/app/lib/sync-restore-diagnostics'
 import { AccountBoundaryChangedError, assertCurrentAccountEpoch, bumpAccountEpoch, getAccountEpoch, isCurrentAccountEpoch } from '@/app/lib/account-epoch'
+import { assertOfflineQueueAccountGuard, captureOfflineQueueAccountGuard } from '@/app/lib/offline-queue-account'
 
 /**
  * Holds live Etebase SDK objects (Account, Collections, Items, SyncEngine).
@@ -1311,8 +1312,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   deleteItemsInCollection: async (type: CollectionTypeKey, collectionUid: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, domainLoadState, itemCache, itemCollectionMap, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return 0
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection || !accountFingerprint) {
+    if (!collection) {
       logger.warn(`[etebase-store] Cannot clear ${type} collection ${collectionUid}: missing account or collection`)
       return 0
     }
@@ -1387,15 +1390,14 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       try {
         if (isOfflineError(err)) {
           assertCurrentAccountEpoch(accountEpoch)
-          logger.warn(`[etebase-store] Offline — queuing clear for ${type}/${collection.uid}`)
           await removeQueuedMutationsForCollection(type, collection.uid, false, accountEpoch, accountFingerprint)
           const alreadyDeleted = new Set(successfulUids)
           for (const { uid } of itemEntries) {
             if (alreadyDeleted.has(uid)) continue
             try {
-              assertCurrentAccountEpoch(accountEpoch)
-              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, { accountEpoch, accountFingerprint: accountFingerprint })
-              assertCurrentAccountEpoch(accountEpoch)
+              assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, offlineQueueGuard)
+              assertOfflineQueueAccountGuard(offlineQueueGuard, get())
             } catch (queueErr) {
               if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return 0
               console.error('[etebase-store] Failed to enqueue collection item delete', getSafeErrorDetails(queueErr))
@@ -1431,9 +1433,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   createItem: async (type: CollectionTypeKey, content: string, tempId?: string, collectionUid?: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return null
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot create item: no account or ${type} collection`)
+    if (!collection) {
+      logger.warn(`[etebase-store] Cannot create item: no ${type} collection`)
       return null
     }
 
@@ -1456,10 +1460,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
       if (isOfflineError(err)) {
         const queueTempId = tempId ?? `pending-${Date.now()}`
-        logger.warn(`[etebase-store] Offline — queuing create for ${type} (tempId: ${queueTempId})`)
         try {
-          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, { accountEpoch, accountFingerprint: accountFingerprint })
-          assertCurrentAccountEpoch(accountEpoch)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, offlineQueueGuard)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          logger.warn(`[etebase-store] Offline — queued create for ${type} (tempId: ${queueTempId})`)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return null
           console.error('[etebase-store] Failed to enqueue create', getSafeErrorDetails(queueErr))
@@ -1475,9 +1480,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   createItemsBatch: async (type: CollectionTypeKey, contents: { content: string; tempId: string }[], collectionUid?: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return contents.map(() => null)
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot create items: no account or ${type} collection`)
+    if (!collection) {
+      logger.warn(`[etebase-store] Cannot create items: no ${type} collection`)
       return contents.map(() => null)
     }
 
@@ -1603,11 +1610,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     } catch (err) {
       if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return contents.map(() => null)
       if (isOfflineError(err)) {
-        logger.warn(`[etebase-store] Offline — queuing ${contents.length} creates for ${type}`)
         for (const { content, tempId } of contents) {
           try {
-            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, { accountEpoch, accountFingerprint: accountFingerprint })
-            assertCurrentAccountEpoch(accountEpoch)
+            assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, offlineQueueGuard)
+            assertOfflineQueueAccountGuard(offlineQueueGuard, get())
           } catch (queueErr) {
             if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return contents.map(() => null)
             console.error('[etebase-store] Failed to enqueue create', getSafeErrorDetails(queueErr))
@@ -1626,10 +1633,12 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   updateItem: async (type: CollectionTypeKey, itemUid: string, content: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
-    if (!account || !collection || !item || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot update item ${itemUid}: missing account, collection, or item`)
+    if (!collection || !item) {
+      logger.warn(`[etebase-store] Cannot update item ${itemUid}: missing collection or item`)
       return
     }
 
@@ -1645,10 +1654,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     } catch (err) {
       if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return
       if (isOfflineError(err)) {
-        logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
-          assertCurrentAccountEpoch(accountEpoch)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, offlineQueueGuard)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          logger.warn(`[etebase-store] Offline — queued update for ${type}/${itemUid}`)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
           console.error('[etebase-store] Failed to enqueue update', getSafeErrorDetails(queueErr))
@@ -1663,12 +1673,14 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   moveItem: async (type: CollectionTypeKey, itemUid: string, content: string, targetCollectionUid: string, sourceCollectionUid?: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return null
     const resolvedSourceCollectionUid = itemCollectionMap.get(itemUid) ?? sourceCollectionUid
     const sourceCollection = resolveCollection(collections, type, resolvedSourceCollectionUid)
     const targetCollection = resolveCollection(collections, type, targetCollectionUid)
     const item = itemCache.get(itemUid)
-    if (!account || !sourceCollection || !targetCollection || !item || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot move item ${itemUid}: missing account, source collection, target collection, or item`)
+    if (!sourceCollection || !targetCollection || !item) {
+      logger.warn(`[etebase-store] Cannot move item ${itemUid}: missing source collection, target collection, or item`)
       return null
     }
 
@@ -1691,10 +1703,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       } catch (err) {
         if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
         if (isOfflineError(err)) {
-          assertCurrentAccountEpoch(accountEpoch)
-          logger.warn(`[etebase-store] Offline after moving ${type}/${itemUid} - queuing source delete`)
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
-          assertCurrentAccountEpoch(accountEpoch)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, offlineQueueGuard)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          logger.warn(`[etebase-store] Offline after moving ${type}/${itemUid} - queued source delete`)
           keepSourceUntilQueuedDelete = true
         } else {
           try {
@@ -1741,10 +1753,12 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   deleteItem: async (type: CollectionTypeKey, itemUid: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
-    if (!account || !collection || !item || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot delete item ${itemUid}: missing account, collection, or item`)
+    if (!collection || !item) {
+      logger.warn(`[etebase-store] Cannot delete item ${itemUid}: missing collection or item`)
       return
     }
 
@@ -1766,10 +1780,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     } catch (err) {
       if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return
       if (isOfflineError(err)) {
-        logger.warn(`[etebase-store] Offline — queuing delete for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
-          assertCurrentAccountEpoch(accountEpoch)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, offlineQueueGuard)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          logger.warn(`[etebase-store] Offline — queued delete for ${type}/${itemUid}`)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
           console.error('[etebase-store] Failed to enqueue delete', getSafeErrorDetails(queueErr))

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -2,7 +2,7 @@
 
 import { create } from 'zustand'
 import type { SyncStatus } from '@silentsuite/core'
-import { replay, getPendingCount, getFailedCount, onCountChange, getStaleEntries, remove, type QueueEntry, type OfflineQueueAccountGuard } from '@/app/lib/offline-queue'
+import { replay, getPendingCount, getFailedCount, onCountChange, type ConfirmedRemoteMutation, type QueueEntry, type OfflineQueueAccountGuard, type ReplayCheckpoint } from '@/app/lib/offline-queue'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
@@ -131,55 +131,12 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
 
     logger.log(`[sync-store] Replaying ${count} queued offline mutations...`)
 
-    const executeMutation = async (entry: QueueEntry): Promise<{ itemUid?: string }> => {
+    const executeMutation = async (entry: QueueEntry, checkpoint: ReplayCheckpoint): Promise<ConfirmedRemoteMutation> => {
       const { useEtebaseStore } = await import('@/app/stores/use-etebase-store')
       assertCurrentAccountEpoch(guard.accountEpoch)
       const etebase = useEtebaseStore.getState()
       if (!etebase.account || etebase.accountFingerprint !== guard.accountFingerprint) throw new AccountBoundaryChangedError()
-
-      try {
-        switch (entry.type) {
-          case 'create': {
-            const uid = await etebase.createItem(entry.collectionType, entry.content!, entry.tempId, entry.collectionUid)
-            return { itemUid: uid ?? undefined }
-          }
-          case 'update': {
-            await etebase.updateItem(entry.collectionType, entry.itemUid!, entry.content!)
-            return {}
-          }
-          case 'delete': {
-            await etebase.deleteItem(entry.collectionType, entry.itemUid!)
-            return {}
-          }
-          case 'move': {
-            if (!entry.targetCollectionUid) throw new Error('Missing move target collection')
-            const uid = await etebase.moveItem(entry.collectionType, entry.itemUid!, entry.content!, entry.targetCollectionUid, entry.collectionUid)
-            if (!uid) throw new Error('Move did not return item UID')
-            return { itemUid: uid }
-          }
-        }
-      } catch (err) {
-        assertCurrentAccountEpoch(guard.accountEpoch)
-        // Handle 409 Conflict (ETag mismatch) — server-wins strategy
-        const is409 = err instanceof Error && (
-          err.message.includes('409') ||
-          err.message.includes('conflict') ||
-          err.message.includes('Conflict')
-        )
-        if (is409 && entry.type !== 'create') {
-          logger.warn(
-            `[sync-store] Conflict on ${entry.type} ${entry.collectionType}/${entry.itemUid} — discarding local change (server wins)`,
-          )
-          // Refresh the collection to get server's version
-          await etebase.refreshCollection(entry.collectionType, entry.collectionUid)
-          if (entry.type === 'move' && entry.targetCollectionUid && entry.targetCollectionUid !== entry.collectionUid) {
-            await etebase.refreshCollection(entry.collectionType, entry.targetCollectionUid)
-          }
-          // Return success so the entry is removed from queue
-          return {}
-        }
-        throw err
-      }
+      return etebase.replayQueuedMutation(entry, guard, checkpoint)
     }
 
     const results = await replay(executeMutation, guard)
@@ -326,14 +283,6 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       } catch (err) {
         assertCurrentAccountEpoch(accountEpoch)
         logger.warn('[sync-store] Preferences refresh failed during sync cycle', getSafeErrorDetails(err))
-      }
-
-      // Purge stale queue entries (older than 24h) that may cause phantom indicators
-      const stale = await getStaleEntries(guard)
-      for (const entry of stale) {
-        assertCurrentAccountEpoch(guard.accountEpoch)
-        await remove(entry.id, guard)
-        assertCurrentAccountEpoch(guard.accountEpoch)
       }
 
       // Refresh counts to ensure UI is accurate after sync

--- a/apps/web/app/stores/use-task-store.ts
+++ b/apps/web/app/stores/use-task-store.ts
@@ -5,6 +5,7 @@ import type { Task, TaskStatus, Priority, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { enqueue } from '@/app/lib/offline-queue'
+import { assertOfflineQueueAccountGuard, captureOfflineQueueAccountGuard, isOfflineQueueBoundaryCancellation } from '@/app/lib/offline-queue-account'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { useTaskListStore } from '@/app/stores/use-task-list-store'
@@ -130,10 +131,20 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               showErrorToast('Failed to save task. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             // Item was created offline — enqueue update with tempId so compaction merges into create
             const { serializeTask } = await import('@silentsuite/core')
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
             const content = serializeTask(updated)
-            await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id })
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            try {
+              await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },
@@ -156,8 +167,17 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               showErrorToast('Failed to delete task. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             // Item was created offline and not yet synced — enqueue delete with tempId for compaction
-            await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: taskToDelete?.listId, tempId: id })
+            try {
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+              await enqueue({ type: 'delete', collectionType: 'tasks', collectionUid: taskToDelete?.listId, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },
@@ -196,9 +216,19 @@ export const useTaskStore = create<TaskState & TaskActions>()(
               showErrorToast('Failed to save task. Please try again.')
             }
           } else {
+            const guard = captureOfflineQueueAccountGuard(etebase)
+            if (!guard) return
             const { serializeTask } = await import('@silentsuite/core')
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
             const content = serializeTask(updated)
-            await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id })
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            try {
+              await enqueue({ type: 'update', collectionType: 'tasks', collectionUid: updated.listId, content, tempId: id }, guard)
+              assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            } catch (error) {
+              if (isOfflineQueueBoundaryCancellation(error)) return
+              throw error
+            }
           }
         }
       },

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -4,6 +4,8 @@ const withPWA = require('@ducanh2912/next-pwa').default
 const { withSentryConfig } = require('@sentry/nextjs')
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts')
+const hostedConnectSources = "connect-src 'self' https://api.silentsuite.io https://server.silentsuite.io wss://server.silentsuite.io https://*.sentry.io"
+const signupConnectSources = `${hostedConnectSources} https://plausible.silentsuite.io https://api.stripe.com`
 
 // Resolve etebase CJS entry — it's a dep of @silentsuite/core,
 // not directly in apps/web's node_modules (pnpm strict isolation).
@@ -26,6 +28,19 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   transpilePackages: ['@silentsuite/ui', '@silentsuite/core'],
+  async headers() {
+    if (process.env.NEXT_PUBLIC_SELF_HOSTED === 'true') return []
+    return [
+      {
+        source: '/signup/:path*',
+        headers: [{ key: 'Content-Security-Policy', value: signupConnectSources }],
+      },
+      ...['/calendar/:path*', '/contacts/:path*', '/tasks/:path*', '/settings/:path*'].map((source) => ({
+        source,
+        headers: [{ key: 'Content-Security-Policy', value: hostedConnectSources }],
+      })),
+    ]
+  },
   webpack: (config) => {
     config.resolve.extensionAlias = {
       '.js': ['.ts', '.tsx', '.js'],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type-check": "turbo type-check",
     "i18n:check": "pnpm --filter @silentsuite/web i18n:check",
     "i18n:report": "pnpm --filter @silentsuite/web i18n:report",
+    "check:public-analytics": "node scripts/check-public-analytics.mjs && node --experimental-strip-types --test apps/docs/.vitepress/theme/public-analytics.test.mts",
     "audit:security": "node scripts/audit-high-critical.mjs"
   },
   "devDependencies": {

--- a/scripts/check-public-analytics.mjs
+++ b/scripts/check-public-analytics.mjs
@@ -1,0 +1,95 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const appsRoot = path.resolve('apps')
+const allowedAnalyticsFiles = new Set([
+  path.join(appsRoot, 'web/app/(auth)/signup/signup-analytics.tsx'),
+  path.join(appsRoot, 'web/next.config.js'),
+  path.join(appsRoot, 'docs/.vitepress/config.mts'),
+  path.join(appsRoot, 'docs/.vitepress/theme/index.mts'),
+])
+const violations = []
+
+async function walk(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name)
+    if (entry.name === 'node_modules' || entry.name === '.next' || entry.name.startsWith('dist') || entry.name === 'cache') continue
+    if (entry.isDirectory()) await walk(fullPath)
+    else if (/\.(?:ts|tsx|js|jsx|mts|mjs)$/.test(entry.name) && !/\.(?:test|spec)\./.test(entry.name)) {
+      const source = await readFile(fullPath, 'utf8')
+      if (/plausible(?:\.silentsuite\.io|\s*\?*\.|\s*\()|window\.plausible/.test(source) && !allowedAnalyticsFiles.has(fullPath)) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: direct analytics call outside approved boundary`)
+      }
+      if (/(?:@segment\/analytics|@amplitude\/analytics|mixpanel|google-analytics|googletagmanager|posthog|hotjar|analytics\.js)/i.test(source)) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: unapproved analytics SDK`)
+      }
+      if (/utm_(?:content|term)/.test(source)) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: prohibited free-form UTM key`)
+      }
+      if (fullPath.includes(`${path.sep}web${path.sep}app${path.sep}(app)${path.sep}`) && /plausible|analytics/i.test(source)) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: analytics reference in authenticated app route`)
+      }
+    }
+  }
+}
+
+await walk(appsRoot)
+
+const requiredContracts = new Map([
+  ['apps/docs/.vitepress/theme/public-analytics.mts', ['Hosted App Click', 'Android Download Click', 'github_release', 'repository']],
+  ['apps/docs/.vitepress/theme/index.mts', ['__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__', 'window.location.hostname', 'classifyDocsOutboundEvent']],
+  ['apps/web/next.config.js', ['Content-Security-Policy', 'signupConnectSources', 'hostedConnectSources']],
+  ['.github/workflows/ci.yml', ['pnpm run check:public-analytics']],
+])
+for (const [relativePath, snippets] of requiredContracts) {
+  const source = await readFile(path.resolve(relativePath), 'utf8')
+  for (const snippet of snippets) {
+    if (!source.includes(snippet)) violations.push(`${relativePath}: missing required analytics contract ${snippet}`)
+  }
+}
+
+const generatedAppRoot = path.join(appsRoot, 'web/.next/static/chunks/app/(app)')
+try {
+  async function scanGenerated(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) await scanGenerated(fullPath)
+      else if (/\.js$/.test(entry.name) && /plausible\.silentsuite\.io|window\.plausible/.test(await readFile(fullPath, 'utf8'))) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: analytics endpoint in authenticated production bundle`)
+      }
+    }
+  }
+  await scanGenerated(generatedAppRoot)
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error
+}
+
+async function generatedText(directory) {
+  let result = ''
+  async function collect(current) {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) await collect(fullPath)
+      else if (/\.(?:js|html)$/.test(entry.name)) result += await readFile(fullPath, 'utf8')
+    }
+  }
+  await collect(directory)
+  return result
+}
+
+try {
+  const hostedBundle = await generatedText(path.join(appsRoot, 'docs/.vitepress/dist-hosted'))
+  const selfHostedBundle = await generatedText(path.join(appsRoot, 'docs/.vitepress/dist-self'))
+  if (!hostedBundle.includes('plausible.silentsuite.io/api/event')) violations.push('hosted docs bundle: expected analytics endpoint absent')
+  if (selfHostedBundle.includes('plausible.silentsuite.io')) violations.push('self-hosted docs bundle: analytics endpoint present')
+  if (hostedBundle.includes('__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__') || selfHostedBundle.includes('__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__')) {
+    violations.push('docs bundle: unresolved analytics compile constant')
+  }
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error
+}
+if (violations.length) {
+  console.error(violations.join('\n'))
+  process.exit(1)
+}
+console.log('Public analytics boundary check passed')


### PR DESCRIPTION
## Summary

Promotes the reviewed offline-queue ownership correction from `dev` to `main`.

## Why

Post-merge GPT-5.6 Sol review found that several production calendar/task/contact offline paths could persist fingerprint-less queue records. Guarded replay intentionally filters by account fingerprint, making those records invisible and potentially causing optimistic mutations to disappear without syncing.

## Correction

- production enqueue now requires epoch and fingerprint at TypeScript and runtime boundaries
- all production callers capture and assert active account ownership
- stale account-boundary writes cancel quietly
- calendar/task/contact and real Etebase integration tests cover persistence, replay, isolation, and actual IndexedDB commit-boundary aborts

## Verification

- feature PR #525 exact-head Sol review: GREEN
- feature PR #525 CI: green
- full web suite: 596 passed
- type-check and lint: passed

The `v0.4.1-beta` release remains blocked until this corrective promotion is merged.
