### PR TITLE
fix(web): assert queue owner around Etebase writes

### DIFF
--- a/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
+++ b/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
@@ -65,18 +65,26 @@ export async function clearQueue(): Promise<void> {
   await clearAll()
 }
 
-export function bumpEpochWhenQueuePutRuns(onBoundary: () => void): ReturnType<typeof vi.spyOn> {
+export function changeAccountWhenQueuePutRuns(
+  onBoundary: () => void,
+  options: { putNumber?: number; bumpEpoch?: boolean } = {},
+): ReturnType<typeof vi.spyOn> {
   const originalPut = IDBObjectStore.prototype.put
-  let bumped = false
+  const targetPut = options.putNumber ?? 1
+  let putCount = 0
   return vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementation(function (...args: Parameters<IDBObjectStore['put']>) {
     const request = originalPut.apply(this, args)
-    if (!bumped) {
-      bumped = true
-      bumpAccountEpoch()
+    putCount += 1
+    if (putCount === targetPut) {
+      if (options.bumpEpoch !== false) bumpAccountEpoch()
       onBoundary()
     }
     return request
   })
+}
+
+export function bumpEpochWhenQueuePutRuns(onBoundary: () => void): ReturnType<typeof vi.spyOn> {
+  return changeAccountWhenQueuePutRuns(onBoundary)
 }
 
 export async function expectQuietQueueCommitCancellation(

--- a/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
@@ -1,13 +1,9 @@
 import 'fake-indexeddb/auto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
-import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
+import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, changeAccountWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
 
-const coreMock = vi.hoisted(() => ({
-  createItem: vi.fn(),
-  updateItem: vi.fn(),
-  deleteItem: vi.fn(),
-}))
+const coreMock = vi.hoisted(() => ({ createItem: vi.fn(), updateItem: vi.fn(), deleteItem: vi.fn() }))
 const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
 
 vi.mock('@silentsuite/core', async (importOriginal) => ({
@@ -45,6 +41,22 @@ function setAccount(options: {
   return manager
 }
 
+function switchAccountAtBoundary() {
+  useEtebaseStore.setState({
+    account: {} as any,
+    accountFingerprint: 'new-account',
+    itemCache: new Map([['new-item', cachedItem('new-item')]]),
+    itemTypeMap: new Map([['new-item', 'calendar']]),
+    itemCollectionMap: new Map([['new-item', 'new-col']]),
+  })
+}
+
+function expectNewAccountStateUntouched() {
+  expect([...useEtebaseStore.getState().itemCache.keys()]).toEqual(['new-item'])
+  expect([...useEtebaseStore.getState().itemTypeMap.keys()]).toEqual(['new-item'])
+  expect([...useEtebaseStore.getState().itemCollectionMap.entries()]).toEqual([['new-item', 'new-col']])
+}
+
 async function expectOwned(types: string[]) {
   const entries = await getAll(queueGuard())
   expect(entries.map((entry) => entry.type)).toEqual(types)
@@ -69,9 +81,7 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
   it('real createItem fallback persists the active fingerprint and is visible to guarded count and replay', async () => {
     setAccount()
     coreMock.createItem.mockRejectedValueOnce(offlineError())
-
     await expect(useEtebaseStore.getState().createItem('calendar', 'VEVENT', 'temp-1', 'col-1')).resolves.toBeNull()
-
     await expectOwned(['create'])
   })
 
@@ -79,29 +89,40 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
     setAccount()
     coreMock.createItem.mockRejectedValueOnce(offlineError())
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const putSpy = bumpEpochWhenQueuePutRuns(() => {
-      useEtebaseStore.setState({ account: {} as any, accountFingerprint: 'new-account', itemCache: new Map() })
-    })
-
-    await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'temp-old', 'col-1')).resolves.toBeNull()
-    putSpy.mockRestore()
-
-    expect(await getAll()).toEqual([])
-    expect(errorSpy).not.toHaveBeenCalled()
-    expect(toastMock.showErrorToast).not.toHaveBeenCalled()
-    errorSpy.mockRestore()
+    const putSpy = bumpEpochWhenQueuePutRuns(switchAccountAtBoundary)
+    try {
+      await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'temp-old', 'col-1')).resolves.toBeNull()
+      expect(await getAll()).toEqual([])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally {
+      putSpy.mockRestore()
+      errorSpy.mockRestore()
+    }
   })
 
   it('batch create fallback enqueues each create with the captured owner', async () => {
     const manager = setAccount()
     manager.create.mockRejectedValueOnce(offlineError())
-
-    await useEtebaseStore.getState().createItemsBatch('calendar', [
-      { content: 'A', tempId: 'a' },
-      { content: 'B', tempId: 'b' },
-    ], 'col-1')
-
+    await useEtebaseStore.getState().createItemsBatch('calendar', [{ content: 'A', tempId: 'a' }, { content: 'B', tempId: 'b' }], 'col-1')
     await expectOwned(['create', 'create'])
+  })
+
+  it('batch create stops after a second put boundary and preserves the first committed create', async () => {
+    const manager = setAccount()
+    manager.create.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary, { putNumber: 2 })
+    try {
+      await expect(useEtebaseStore.getState().createItemsBatch('calendar', [
+        { content: 'A', tempId: 'a' }, { content: 'B', tempId: 'b' }, { content: 'C', tempId: 'c' },
+      ], 'col-1')).resolves.toEqual([null, null, null])
+      expect((await getAll()).map((entry) => entry.tempId)).toEqual(['a'])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
   })
 
   it.each([
@@ -111,10 +132,26 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
     setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
     coreMock.updateItem.mockRejectedValueOnce(offlineError())
     coreMock.deleteItem.mockRejectedValueOnce(offlineError())
-
     await mutate()
-
     await expectOwned([expectedType])
+  })
+
+  it.each([
+    ['updateItem', async () => useEtebaseStore.getState().updateItem('calendar', 'item-1', 'NEW')],
+    ['deleteItem', async () => useEtebaseStore.getState().deleteItem('calendar', 'item-1')],
+  ] as const)('%s quietly cancels at its real queue put boundary', async (_name, mutate) => {
+    setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
+    coreMock.updateItem.mockRejectedValueOnce(offlineError())
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary)
+    try {
+      await expect(mutate()).resolves.toBeUndefined()
+      expect(await getAll()).toEqual([])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
   })
 
   it('collection clear fallback enqueues remaining source deletes with the captured owner', async () => {
@@ -123,24 +160,65 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
       { uid: 'item-2', collectionUid: 'col-1', item: cachedItem('item-2') },
     ] })
     manager.batch.mockRejectedValueOnce(offlineError())
-
     await useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')
-
     await expectOwned(['delete', 'delete'])
   })
 
+  it('collection clear stops after a later put abort, preserves prior committed deletes, and skips stale cleanup', async () => {
+    const manager = setAccount({ items: [
+      { uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') },
+      { uid: 'item-2', collectionUid: 'col-1', item: cachedItem('item-2') },
+      { uid: 'item-3', collectionUid: 'col-1', item: cachedItem('item-3') },
+    ] })
+    manager.batch.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary, { putNumber: 2 })
+    try {
+      await expect(useEtebaseStore.getState().deleteItemsInCollection('calendar', 'col-1')).resolves.toBe(0)
+      expect((await getAll()).map((entry) => entry.itemUid)).toEqual(['item-1'])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
+  })
+
   it('move source-delete fallback enqueues against the source collection with the captured owner', async () => {
-    setAccount({
-      collections: [collection('source'), collection('target')],
-      items: [{ uid: 'item-1', collectionUid: 'source', item: cachedItem('item-1') }],
-    })
+    setAccount({ collections: [collection('source'), collection('target')], items: [{ uid: 'item-1', collectionUid: 'source', item: cachedItem('item-1') }] })
     coreMock.createItem.mockResolvedValueOnce(cachedItem('created-target'))
     coreMock.deleteItem.mockRejectedValueOnce(offlineError())
-
     await useEtebaseStore.getState().moveItem('calendar', 'item-1', 'NEW', 'target', 'source')
-
     const [entry] = await getAll(queueGuard())
     expect(entry).toMatchObject({ type: 'delete', collectionUid: 'source', itemUid: 'item-1', accountFingerprint: TEST_FINGERPRINT })
     await expectOwned(['delete'])
+  })
+
+  it('move source-delete quietly cancels at the real queue put boundary without publishing the target', async () => {
+    setAccount({ collections: [collection('source'), collection('target')], items: [{ uid: 'item-1', collectionUid: 'source', item: cachedItem('item-1') }] })
+    coreMock.createItem.mockResolvedValueOnce(cachedItem('created-target'))
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary)
+    try {
+      await expect(useEtebaseStore.getState().moveItem('calendar', 'item-1', 'NEW', 'target', 'source')).resolves.toBeNull()
+      expect(await getAll()).toEqual([])
+      expectNewAccountStateUntouched()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
+  })
+
+  it('missing fingerprint quietly cancels before queue persistence', async () => {
+    setAccount()
+    useEtebaseStore.setState({ accountFingerprint: null })
+    coreMock.createItem.mockRejectedValueOnce(offlineError())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put')
+    try {
+      await expect(useEtebaseStore.getState().createItem('calendar', 'OLD', 'temp-old', 'col-1')).resolves.toBeNull()
+      expect(await getAll()).toEqual([])
+      expect(putSpy).not.toHaveBeenCalled()
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
   })
 })

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -32,6 +32,7 @@ import {
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { RestoreDiagnosticsRecorder, classifySessionPersistence } from '@/app/lib/sync-restore-diagnostics'
 import { AccountBoundaryChangedError, assertCurrentAccountEpoch, bumpAccountEpoch, getAccountEpoch, isCurrentAccountEpoch } from '@/app/lib/account-epoch'
+import { assertOfflineQueueAccountGuard, captureOfflineQueueAccountGuard } from '@/app/lib/offline-queue-account'
 
 /**
  * Holds live Etebase SDK objects (Account, Collections, Items, SyncEngine).
@@ -1311,8 +1312,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   deleteItemsInCollection: async (type: CollectionTypeKey, collectionUid: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, domainLoadState, itemCache, itemCollectionMap, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return 0
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection || !accountFingerprint) {
+    if (!collection) {
       logger.warn(`[etebase-store] Cannot clear ${type} collection ${collectionUid}: missing account or collection`)
       return 0
     }
@@ -1387,15 +1390,14 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       try {
         if (isOfflineError(err)) {
           assertCurrentAccountEpoch(accountEpoch)
-          logger.warn(`[etebase-store] Offline — queuing clear for ${type}/${collection.uid}`)
           await removeQueuedMutationsForCollection(type, collection.uid, false, accountEpoch, accountFingerprint)
           const alreadyDeleted = new Set(successfulUids)
           for (const { uid } of itemEntries) {
             if (alreadyDeleted.has(uid)) continue
             try {
-              assertCurrentAccountEpoch(accountEpoch)
-              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, { accountEpoch, accountFingerprint: accountFingerprint })
-              assertCurrentAccountEpoch(accountEpoch)
+              assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+              await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid: uid }, offlineQueueGuard)
+              assertOfflineQueueAccountGuard(offlineQueueGuard, get())
             } catch (queueErr) {
               if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return 0
               console.error('[etebase-store] Failed to enqueue collection item delete', getSafeErrorDetails(queueErr))
@@ -1431,9 +1433,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   createItem: async (type: CollectionTypeKey, content: string, tempId?: string, collectionUid?: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return null
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot create item: no account or ${type} collection`)
+    if (!collection) {
+      logger.warn(`[etebase-store] Cannot create item: no ${type} collection`)
       return null
     }
 
@@ -1456,10 +1460,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
       if (isOfflineError(err)) {
         const queueTempId = tempId ?? `pending-${Date.now()}`
-        logger.warn(`[etebase-store] Offline — queuing create for ${type} (tempId: ${queueTempId})`)
         try {
-          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, { accountEpoch, accountFingerprint: accountFingerprint })
-          assertCurrentAccountEpoch(accountEpoch)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId: queueTempId }, offlineQueueGuard)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          logger.warn(`[etebase-store] Offline — queued create for ${type} (tempId: ${queueTempId})`)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return null
           console.error('[etebase-store] Failed to enqueue create', getSafeErrorDetails(queueErr))
@@ -1475,9 +1480,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   createItemsBatch: async (type: CollectionTypeKey, contents: { content: string; tempId: string }[], collectionUid?: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return contents.map(() => null)
     const collection = resolveCollection(collections, type, collectionUid)
-    if (!account || !collection || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot create items: no account or ${type} collection`)
+    if (!collection) {
+      logger.warn(`[etebase-store] Cannot create items: no ${type} collection`)
       return contents.map(() => null)
     }
 
@@ -1603,11 +1610,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     } catch (err) {
       if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return contents.map(() => null)
       if (isOfflineError(err)) {
-        logger.warn(`[etebase-store] Offline — queuing ${contents.length} creates for ${type}`)
         for (const { content, tempId } of contents) {
           try {
-            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, { accountEpoch, accountFingerprint: accountFingerprint })
-            assertCurrentAccountEpoch(accountEpoch)
+            assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+            await enqueue({ type: 'create', collectionType: type, collectionUid: collection.uid, content, tempId }, offlineQueueGuard)
+            assertOfflineQueueAccountGuard(offlineQueueGuard, get())
           } catch (queueErr) {
             if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return contents.map(() => null)
             console.error('[etebase-store] Failed to enqueue create', getSafeErrorDetails(queueErr))
@@ -1626,10 +1633,12 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   updateItem: async (type: CollectionTypeKey, itemUid: string, content: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
-    if (!account || !collection || !item || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot update item ${itemUid}: missing account, collection, or item`)
+    if (!collection || !item) {
+      logger.warn(`[etebase-store] Cannot update item ${itemUid}: missing collection or item`)
       return
     }
 
@@ -1645,10 +1654,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     } catch (err) {
       if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return
       if (isOfflineError(err)) {
-        logger.warn(`[etebase-store] Offline — queuing update for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
-          assertCurrentAccountEpoch(accountEpoch)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, offlineQueueGuard)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          logger.warn(`[etebase-store] Offline — queued update for ${type}/${itemUid}`)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
           console.error('[etebase-store] Failed to enqueue update', getSafeErrorDetails(queueErr))
@@ -1663,12 +1673,14 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   moveItem: async (type: CollectionTypeKey, itemUid: string, content: string, targetCollectionUid: string, sourceCollectionUid?: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return null
     const resolvedSourceCollectionUid = itemCollectionMap.get(itemUid) ?? sourceCollectionUid
     const sourceCollection = resolveCollection(collections, type, resolvedSourceCollectionUid)
     const targetCollection = resolveCollection(collections, type, targetCollectionUid)
     const item = itemCache.get(itemUid)
-    if (!account || !sourceCollection || !targetCollection || !item || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot move item ${itemUid}: missing account, source collection, target collection, or item`)
+    if (!sourceCollection || !targetCollection || !item) {
+      logger.warn(`[etebase-store] Cannot move item ${itemUid}: missing source collection, target collection, or item`)
       return null
     }
 
@@ -1691,10 +1703,10 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       } catch (err) {
         if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
         if (isOfflineError(err)) {
-          assertCurrentAccountEpoch(accountEpoch)
-          logger.warn(`[etebase-store] Offline after moving ${type}/${itemUid} - queuing source delete`)
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
-          assertCurrentAccountEpoch(accountEpoch)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: sourceCollection.uid, itemUid }, offlineQueueGuard)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          logger.warn(`[etebase-store] Offline after moving ${type}/${itemUid} - queued source delete`)
           keepSourceUntilQueuedDelete = true
         } else {
           try {
@@ -1741,10 +1753,12 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
   deleteItem: async (type: CollectionTypeKey, itemUid: string) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
+    const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
+    if (!offlineQueueGuard) return
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
-    if (!account || !collection || !item || !accountFingerprint) {
-      logger.warn(`[etebase-store] Cannot delete item ${itemUid}: missing account, collection, or item`)
+    if (!collection || !item) {
+      logger.warn(`[etebase-store] Cannot delete item ${itemUid}: missing collection or item`)
       return
     }
 
@@ -1766,10 +1780,11 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     } catch (err) {
       if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return
       if (isOfflineError(err)) {
-        logger.warn(`[etebase-store] Offline — queuing delete for ${type}/${itemUid}`)
         try {
-          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, { accountEpoch, accountFingerprint: accountFingerprint })
-          assertCurrentAccountEpoch(accountEpoch)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          await enqueue({ type: 'delete', collectionType: type, collectionUid: collection.uid, itemUid }, offlineQueueGuard)
+          assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+          logger.warn(`[etebase-store] Offline — queued delete for ${type}/${itemUid}`)
         } catch (queueErr) {
           if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
           console.error('[etebase-store] Failed to enqueue delete', getSafeErrorDetails(queueErr))


### PR DESCRIPTION
## Summary

- apply the shared account epoch plus fingerprint guard to every Etebase-store offline enqueue path
- defer offline warning logs until guarded persistence succeeds
- add real IndexedDB commit-boundary regressions for batch create, cached update/delete, collection clear, and move source-delete

## Verification

- focused queue/direct-store/Etebase suite: 117 passed
- full web suite: 602 passed
- type-check: passed
- lint: passed with existing warnings only
- `git diff --check`: passed

Follow-up to #525; required before corrective promotion #526 can merge.
