### PR TITLE
fix(web): require confirmed remote replay

### DIFF
--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -298,7 +298,7 @@ describe('offline-queue', () => {
       const order: string[] = []
       const results = await replay(async (entry) => {
         order.push(entry.type)
-        return { itemUid: entry.type === 'create' ? 'real-uid' : undefined }
+        return { remoteMutationConfirmed: true, itemUid: entry.type === 'create' ? 'real-uid' : undefined }
       })
 
       expect(order).toEqual(['create', 'update'])
@@ -744,7 +744,7 @@ describe('offline-queue', () => {
       expect(count).toBe(2)
 
       // Replay all pending entries (simulates cold-start replay)
-      const executeFn = vi.fn().mockResolvedValue({ itemUid: 'new-uid' })
+      const executeFn = vi.fn().mockResolvedValue({ remoteMutationConfirmed: true, itemUid: 'new-uid' })
       const results = await replay(executeFn)
 
       expect(executeFn).toHaveBeenCalledTimes(2)
@@ -774,7 +774,7 @@ describe('offline-queue', () => {
       const unsubscribe = onCountChange(listener)
       const results = await replay(async () => {
         bumpAccountEpoch()
-        return { itemUid: 'must-not-publish' }
+        return { remoteMutationConfirmed: true, itemUid: 'must-not-publish' }
       }, guard)
       unsubscribe()
 

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -22,6 +22,9 @@ export interface QueueEntry {
   retryCount: number
   status: 'pending' | 'failed'
   accountFingerprint?: string
+  /** Durable, non-plaintext replay progress. Older records omit these fields. */
+  replayPhase?: 'target-confirmed'
+  confirmedTargetUid?: string
 }
 
 export interface OfflineQueueAccountGuard {
@@ -35,6 +38,22 @@ export interface ReplayResult {
   /** For create replays, the real UID returned by Etebase */
   itemUid?: string
   error?: string
+}
+
+/** A replay executor may acknowledge an entry only after the remote mutation succeeded. */
+export interface ConfirmedRemoteMutation {
+  remoteMutationConfirmed: true
+  itemUid?: string
+}
+
+export type ReplayCheckpoint = (progress: Pick<QueueEntry, 'replayPhase' | 'confirmedTargetUid'>) => Promise<void>
+
+/** The remote mutation was not attempted or could not be affirmatively confirmed. */
+export class ReplayNotConfirmedError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ReplayNotConfirmedError'
+  }
 }
 
 const DB_NAME = 'silentsuite-offline-queue'
@@ -427,7 +446,7 @@ export async function retryFailed(guard: OfflineQueueAccountGuard): Promise<void
  * after MAX_RETRIES, marks as 'failed'.
  */
 export async function replay(
-  executeMutation: (entry: QueueEntry) => Promise<{ itemUid?: string }>,
+  executeMutation: (entry: QueueEntry, checkpoint: ReplayCheckpoint) => Promise<ConfirmedRemoteMutation>,
   guard: OfflineQueueAccountGuard,
 ): Promise<ReplayResult[]> {
   try {
@@ -438,19 +457,45 @@ export async function replay(
   const results: ReplayResult[] = []
 
   for (const entry of pending) {
+    let currentEntry = entry
+    let remoteMutationConfirmed = false
     try {
       assertGuard(guard)
-      const result = await executeMutation(entry)
+      const checkpoint: ReplayCheckpoint = async (progress) => {
+        const updated = { ...currentEntry, ...progress }
+        await updateEntry(updated, guard)
+        currentEntry = updated
+      }
+      const result = await executeMutation(currentEntry, checkpoint)
       assertGuard(guard)
+      if (!result || result.remoteMutationConfirmed !== true) {
+        throw new ReplayNotConfirmedError('Replay mutation did not receive affirmative remote confirmation')
+      }
+      remoteMutationConfirmed = true
       await remove(entry.id, guard)
       assertGuard(guard)
       results.push({ entry, success: true, itemUid: result.itemUid })
     } catch (err) {
       if (err instanceof AccountBoundaryChangedError) return []
       assertGuard(guard)
-      const retryCount = entry.retryCount + 1
+      if (remoteMutationConfirmed) {
+        // The server mutation is complete. A local checkpoint/removal failure
+        // must not consume the remote retry budget or mark completed work failed.
+        results.push({ entry, success: false, error: err instanceof Error ? err.message : String(err) })
+        continue
+      }
+      if (err instanceof ReplayNotConfirmedError || isOfflineError(err)) {
+        results.push({
+          entry,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        if (isOfflineError(err)) break
+        continue
+      }
+      const retryCount = currentEntry.retryCount + 1
       const status = retryCount >= MAX_RETRIES ? 'failed' : 'pending'
-      await updateEntry({ ...entry, retryCount, status }, guard)
+      await updateEntry({ ...currentEntry, retryCount, status }, guard)
       assertGuard(guard)
       results.push({
         entry,

--- a/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
+++ b/apps/web/app/stores/__tests__/offline-queue-store-test-utils.ts
@@ -54,7 +54,7 @@ export async function expectOwnedQueueEntry(type: QueueEntry['type'], collection
 }
 
 export async function replayOwnedEntry(entry: QueueEntry): Promise<void> {
-  const execute = vi.fn(async () => ({}))
+  const execute = vi.fn(async () => ({ remoteMutationConfirmed: true }))
   const results = await replay(execute, queueGuard())
   if (results.length !== 1 || !results[0]!.success) throw new Error('Guarded replay did not execute entry')
   if (execute.mock.calls[0]?.[0].id !== entry.id) throw new Error('Replay executed a different entry')

--- a/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
@@ -1,9 +1,10 @@
 import 'fake-indexeddb/auto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
+import { enqueue, getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
+import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, changeAccountWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
 
-const coreMock = vi.hoisted(() => ({ createItem: vi.fn(), updateItem: vi.fn(), deleteItem: vi.fn() }))
+const coreMock = vi.hoisted(() => ({ createItem: vi.fn(), updateItem: vi.fn(), deleteItem: vi.fn(), listItems: vi.fn() }))
 const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
 
 vi.mock('@silentsuite/core', async (importOriginal) => ({
@@ -14,10 +15,17 @@ vi.mock('@/app/stores/use-toast-store', () => toastMock)
 vi.mock('@/app/stores/use-label-suggestions-store', () => ({ useLabelSuggestionsStore: { getState: () => ({ recordUsage: vi.fn() }) } }))
 
 import { useEtebaseStore } from '../use-etebase-store'
+import { useSyncStore } from '../use-sync-store'
+
+// These tests exercise real fake-IndexedDB transactions and remote-replay
+// reconciliation. Leave headroom for heavily loaded CI/review workers so a
+// single timeout cannot cascade into later singleton-state assertions.
+vi.setConfig({ testTimeout: 15_000 })
 
 const offlineError = () => new TypeError('Failed to fetch')
 const collection = (uid: string) => ({ uid, getMeta: vi.fn(() => ({})) })
-const cachedItem = (uid: string) => ({ uid, delete: vi.fn(), getContent: vi.fn(async () => 'OLD') })
+const cachedItem = (uid: string) => ({ uid, isDeleted: false, delete: vi.fn(), getContent: vi.fn(async () => 'OLD') })
+const remoteItem = (uid: string, content: string) => ({ uid, isDeleted: false, delete: vi.fn(), getContent: vi.fn(async () => content) })
 
 function setAccount(options: {
   collections?: { uid: string }[]
@@ -62,7 +70,7 @@ async function expectOwned(types: string[]) {
   expect(entries.map((entry) => entry.type)).toEqual(types)
   expect(entries.every((entry) => entry.accountFingerprint === TEST_FINGERPRINT)).toBe(true)
   expect(await getPendingCount(queueGuard())).toBe(entries.length)
-  const execute = vi.fn(async () => ({}))
+  const execute = vi.fn(async () => ({ remoteMutationConfirmed: true }))
   await replay(execute, queueGuard())
   expect(execute).toHaveBeenCalledTimes(entries.length)
   expect(await getAll(queueGuard())).toEqual([])
@@ -75,6 +83,7 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
     coreMock.createItem.mockReset()
     coreMock.updateItem.mockReset()
     coreMock.deleteItem.mockReset()
+    coreMock.listItems.mockReset().mockResolvedValue({ items: [], stoken: null, done: true })
     toastMock.showErrorToast.mockReset()
   })
 
@@ -220,5 +229,284 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
       expect(errorSpy).not.toHaveBeenCalled()
       expect(toastMock.showErrorToast).not.toHaveBeenCalled()
     } finally { putSpy.mockRestore(); errorSpy.mockRestore() }
+  })
+
+  it.each([
+    ['create', { type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', tempId: 'temp-1' }],
+    ['update', { type: 'update', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', itemUid: 'item-1' }],
+    ['delete', { type: 'delete', collectionType: 'calendar', collectionUid: 'col-1', itemUid: 'item-1' }],
+    ['move', { type: 'move', collectionType: 'calendar', collectionUid: 'col-1', targetCollectionUid: 'col-2', content: 'NEW', itemUid: 'item-1' }],
+  ] as const)('real sync replay retains exactly one owned %s entry when the remote path is offline', async (_name, queued) => {
+    setAccount({
+      collections: [collection('col-1'), collection('col-2')],
+      items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }],
+    })
+    await enqueue(queued, queueGuard())
+    coreMock.createItem.mockRejectedValue(offlineError())
+    coreMock.updateItem.mockRejectedValue(offlineError())
+    coreMock.deleteItem.mockRejectedValue(offlineError())
+
+    await useSyncStore.getState().replayOfflineQueue()
+
+    const entries = await getAll(queueGuard())
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ id: expect.any(String), type: queued.type, accountFingerprint: TEST_FINGERPRINT, status: 'pending', retryCount: 0 })
+  })
+
+  it.each([
+    ['create collection', { type: 'create', collectionType: 'calendar', collectionUid: 'missing', content: 'NEW', tempId: 'temp-1' }],
+    ['update item', { type: 'update', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', itemUid: 'missing' }],
+    ['delete item', { type: 'delete', collectionType: 'calendar', collectionUid: 'col-1', itemUid: 'missing' }],
+    ['move target collection', { type: 'move', collectionType: 'calendar', collectionUid: 'col-1', targetCollectionUid: 'missing', content: 'NEW', itemUid: 'item-1' }],
+  ] as const)('real sync replay retains the original entry when the %s prerequisite is unavailable', async (_name, queued) => {
+    setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
+    await enqueue(queued, queueGuard())
+    const [original] = await getAll(queueGuard())
+
+    await useSyncStore.getState().replayOfflineQueue()
+
+    expect(await getAll(queueGuard())).toEqual([original!])
+    expect(coreMock.createItem).not.toHaveBeenCalled()
+    expect(coreMock.updateItem).not.toHaveBeenCalled()
+    expect(coreMock.deleteItem).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['create', { type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', tempId: 'temp-1' }],
+    ['update', { type: 'update', collectionType: 'calendar', collectionUid: 'col-1', content: 'NEW', itemUid: 'item-1' }],
+    ['delete', { type: 'delete', collectionType: 'calendar', collectionUid: 'col-1', itemUid: 'item-1' }],
+    ['move', { type: 'move', collectionType: 'calendar', collectionUid: 'col-1', targetCollectionUid: 'col-2', content: 'NEW', itemUid: 'item-1' }],
+  ] as const)('real sync replay removes %s only after confirmed remote success', async (name, queued) => {
+    setAccount({
+      collections: [collection('col-1'), collection('col-2')],
+      items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }],
+    })
+    await enqueue(queued, queueGuard())
+    coreMock.createItem.mockResolvedValue({ uid: name === 'create' ? 'server-created' : 'server-moved' })
+    coreMock.updateItem.mockResolvedValue({ uid: 'item-1' })
+    coreMock.deleteItem.mockResolvedValue(undefined)
+
+    await useSyncStore.getState().replayOfflineQueue()
+
+    expect(await getAll(queueGuard())).toEqual([])
+    if (name === 'create') expect(coreMock.createItem).toHaveReturnedWith(Promise.resolve({ uid: 'server-created' }))
+  })
+
+  it('fresh create publishes the returned item atomically, removes temp maps, and supports immediate update', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:fresh-create\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const temp = cachedItem('temp-1')
+    const created = remoteItem('server-fresh', content)
+    setAccount({ items: [{ uid: 'temp-1', collectionUid: 'col-1', item: temp }] })
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-1' }, queueGuard())
+    coreMock.createItem.mockResolvedValueOnce(created)
+
+    await useSyncStore.getState().replayOfflineQueue()
+
+    const state = useEtebaseStore.getState()
+    expect(state.itemCache.get('server-fresh')).toBe(created)
+    expect(state.itemTypeMap.get('server-fresh')).toBe('calendar')
+    expect(state.itemCollectionMap.get('server-fresh')).toBe('col-1')
+    expect(state.itemCache.has('temp-1')).toBe(false)
+    expect(state.itemTypeMap.has('temp-1')).toBe(false)
+    expect(state.itemCollectionMap.has('temp-1')).toBe(false)
+    expect(await getAll(queueGuard())).toEqual([])
+
+    coreMock.updateItem.mockResolvedValueOnce(created)
+    await useEtebaseStore.getState().updateItem('calendar', 'server-fresh', 'UPDATED')
+    expect(coreMock.updateItem).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ uid: 'col-1' }), created, 'UPDATED')
+  })
+
+  it('account boundary inside create cache publication publishes nothing and leaves a reconciliable checkpoint', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:publish-boundary\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const created = remoteItem('server-boundary', content)
+    const remote = [created]
+    setAccount()
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-boundary' }, queueGuard())
+    coreMock.listItems.mockResolvedValue({ items: [], stoken: null, done: true })
+    coreMock.createItem.mockResolvedValueOnce(created)
+    const originalMapSet = Map.prototype.set
+    let switched = false
+    const mapSetSpy = vi.spyOn(Map.prototype, 'set').mockImplementation(function (key, value) {
+      const result = originalMapSet.call(this, key, value)
+      if (!switched && key === 'server-boundary') {
+        switched = true
+        bumpAccountEpoch()
+        switchAccountAtBoundary()
+      }
+      return result
+    })
+
+    try {
+      await useSyncStore.getState().replayOfflineQueue()
+    } finally {
+      mapSetSpy.mockRestore()
+    }
+
+    expectNewAccountStateUntouched()
+    expect((await getAll())[0]).toMatchObject({ replayPhase: 'target-confirmed', confirmedTargetUid: 'server-boundary' })
+
+    bumpAccountEpoch()
+    setAccount()
+    coreMock.listItems.mockResolvedValue({ items: remote, stoken: null, done: true })
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(coreMock.createItem).toHaveBeenCalledTimes(1)
+    expect(useEtebaseStore.getState().itemCache.get('server-boundary')).toBe(created)
+    expect(await getAll(queueGuard())).toEqual([])
+  })
+
+  it('cold-start replay publishes a fresh target before queue success is exposed', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:cold-start\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const created = remoteItem('server-cold', content)
+    setAccount()
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-cold' }, queueGuard())
+    coreMock.createItem.mockResolvedValueOnce(created)
+
+    const cleanup = useSyncStore.getState().initializeSync()
+    try {
+      await vi.waitFor(() => expect(useEtebaseStore.getState().itemCache.get('server-cold')).toBe(created))
+      expect(useEtebaseStore.getState().itemTypeMap.get('server-cold')).toBe('calendar')
+      expect(useEtebaseStore.getState().itemCollectionMap.get('server-cold')).toBe('col-1')
+      expect(await getAll(queueGuard())).toEqual([])
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('account boundary after create commit retains recoverable old work and retry reconciles exactly one remote object', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:logical-1\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const remote: any[] = []
+    setAccount()
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-1' }, queueGuard())
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    coreMock.listItems.mockImplementation(async () => ({ items: remote, stoken: null, done: true }))
+    coreMock.createItem.mockImplementationOnce(async () => {
+      const created = remoteItem('server-1', content)
+      remote.push(created)
+      bumpAccountEpoch()
+      switchAccountAtBoundary()
+      return created
+    })
+    try {
+      await useSyncStore.getState().replayOfflineQueue()
+      expect(remote).toHaveLength(1)
+      expect(await getAll()).toHaveLength(1)
+      expectNewAccountStateUntouched()
+
+      bumpAccountEpoch()
+      setAccount()
+      await useSyncStore.getState().replayOfflineQueue()
+      expect(remote).toHaveLength(1)
+      expect(coreMock.createItem).toHaveBeenCalledTimes(1)
+      expect(await getAll(queueGuard())).toEqual([])
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    } finally { errorSpy.mockRestore() }
+  })
+
+  it('response loss after server commit is reconciled by PIM UID without a second create', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:response-loss-logical\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const created = remoteItem('server-contact', content)
+    const remote: any[] = []
+    setAccount({ collections: [collection('col-1')] })
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-1' }, queueGuard())
+    coreMock.listItems.mockImplementation(async () => ({ items: remote, stoken: null, done: true }))
+    coreMock.createItem.mockImplementationOnce(async () => { remote.push(created); throw offlineError() })
+
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(remote).toHaveLength(1)
+    await useSyncStore.getState().replayOfflineQueue()
+
+    expect(coreMock.createItem).toHaveBeenCalledTimes(1)
+    expect(await getAll(queueGuard())).toEqual([])
+    expect(useEtebaseStore.getState().itemCache.get('server-contact')).toBe(created)
+    expect(useEtebaseStore.getState().itemTypeMap.get('server-contact')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('server-contact')).toBe('col-1')
+
+    const updated = remoteItem('server-contact', 'UPDATED')
+    coreMock.updateItem.mockResolvedValueOnce(updated)
+    await useEtebaseStore.getState().updateItem('calendar', 'server-contact', 'UPDATED')
+    expect(coreMock.updateItem).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ uid: 'col-1' }), created, 'UPDATED')
+
+    coreMock.deleteItem.mockResolvedValueOnce(undefined)
+    await useEtebaseStore.getState().deleteItem('calendar', 'server-contact')
+    expect(coreMock.deleteItem).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ uid: 'col-1' }), updated)
+  })
+
+  it('local queue removal abort after create checkpoint retains progress and retry does not duplicate', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:idb-failure-logical\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const created = remoteItem('server-idb', content)
+    const remote = [created]
+    setAccount()
+    await enqueue({ type: 'create', collectionType: 'calendar', collectionUid: 'col-1', content, tempId: 'temp-idb' }, queueGuard())
+    coreMock.listItems.mockResolvedValue({ items: remote, stoken: null, done: true })
+    const originalDelete = IDBObjectStore.prototype.delete
+    const deleteSpy = vi.spyOn(IDBObjectStore.prototype, 'delete').mockImplementationOnce(function (...args) {
+      const request = originalDelete.apply(this, args)
+      this.transaction.abort()
+      return request
+    })
+    try {
+      await useSyncStore.getState().replayOfflineQueue()
+    } finally {
+      deleteSpy.mockRestore()
+    }
+    expect((await getAll(queueGuard()))[0]).toMatchObject({
+      replayPhase: 'target-confirmed', confirmedTargetUid: 'server-idb',
+      retryCount: 0, status: 'pending',
+    })
+    expect(useEtebaseStore.getState().itemCache.get('server-idb')).toBe(created)
+    expect(useEtebaseStore.getState().itemTypeMap.get('server-idb')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('server-idb')).toBe('col-1')
+
+    const secondDeleteSpy = vi.spyOn(IDBObjectStore.prototype, 'delete').mockImplementationOnce(function (...args) {
+      const request = originalDelete.apply(this, args)
+      this.transaction.abort()
+      return request
+    })
+    try {
+      await useSyncStore.getState().replayOfflineQueue()
+    } finally {
+      secondDeleteSpy.mockRestore()
+    }
+    expect((await getAll(queueGuard()))[0]).toMatchObject({ retryCount: 0, status: 'pending' })
+
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(coreMock.createItem).not.toHaveBeenCalled()
+    expect(await getAll(queueGuard())).toEqual([])
+  })
+
+  it('move checkpoints one target and retries only source deletion after an ambiguous failure', async () => {
+    const content = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:move-logical\r\nEND:VEVENT\r\nEND:VCALENDAR'
+    const source = remoteItem('source-item', content)
+    const target: any[] = []
+    const sourceItems: any[] = [source]
+    setAccount({ collections: [collection('source'), collection('target')], items: [{ uid: 'source-item', collectionUid: 'source', item: source }] })
+    await enqueue({ type: 'move', collectionType: 'calendar', collectionUid: 'source', targetCollectionUid: 'target', content, itemUid: 'source-item' }, queueGuard())
+    coreMock.listItems.mockImplementation(async (_account, col) => ({ items: col.uid === 'target' ? target : sourceItems, stoken: null, done: true }))
+    coreMock.createItem.mockImplementationOnce(async () => { const item = remoteItem('target-item', content); target.push(item); return item })
+    coreMock.deleteItem.mockRejectedValueOnce(offlineError()).mockImplementationOnce(async () => { sourceItems.splice(0) })
+
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(target).toHaveLength(1)
+    expect((await getAll(queueGuard()))[0]).toMatchObject({ replayPhase: 'target-confirmed', confirmedTargetUid: 'target-item' })
+    expect(useEtebaseStore.getState().itemCache.get('source-item')).toBe(source)
+    expect(useEtebaseStore.getState().itemTypeMap.get('source-item')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('source-item')).toBe('source')
+    await useSyncStore.getState().replayOfflineQueue()
+
+    expect(coreMock.createItem).toHaveBeenCalledTimes(1)
+    expect(target).toHaveLength(1)
+    expect(sourceItems).toEqual([])
+    expect(await getAll(queueGuard())).toEqual([])
+    expect(useEtebaseStore.getState().itemCache.get('target-item')).toBe(target[0])
+    expect(useEtebaseStore.getState().itemTypeMap.get('target-item')).toBe('calendar')
+    expect(useEtebaseStore.getState().itemCollectionMap.get('target-item')).toBe('target')
+    expect(useEtebaseStore.getState().itemCache.has('source-item')).toBe(false)
+    expect(useEtebaseStore.getState().itemTypeMap.has('source-item')).toBe(false)
+    expect(useEtebaseStore.getState().itemCollectionMap.has('source-item')).toBe(false)
+
+    coreMock.deleteItem.mockResolvedValueOnce(undefined)
+    await useEtebaseStore.getState().deleteItem('calendar', 'target-item')
+    expect(coreMock.deleteItem).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({ uid: 'target' }), target[0])
   })
 })

--- a/apps/web/app/stores/__tests__/use-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-sync-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useSyncStore } from '../use-sync-store'
-import { getPendingCount, replay } from '@/app/lib/offline-queue'
+import { getPendingCount, getStaleEntries, remove, replay } from '@/app/lib/offline-queue'
 import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 const etebaseMock = vi.hoisted(() => ({
@@ -11,6 +11,7 @@ const etebaseMock = vi.hoisted(() => ({
     domainLoadState: { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' },
     reconcileCollections: vi.fn().mockResolvedValue(undefined),
     refreshCollection: vi.fn().mockResolvedValue([]),
+    replayQueuedMutation: vi.fn(),
     moveItem: vi.fn(),
   },
 }))
@@ -85,6 +86,7 @@ function resetStore() {
   etebaseMock.state.domainLoadState = { tasks: 'loaded', contacts: 'loaded', calendar: 'loaded', preferences: 'unknown' }
   etebaseMock.state.reconcileCollections.mockReset().mockResolvedValue(undefined)
   etebaseMock.state.refreshCollection.mockReset().mockResolvedValue([])
+  etebaseMock.state.replayQueuedMutation.mockReset()
   etebaseMock.state.moveItem.mockReset()
   calendarStoreMock.events = []
   calendarStoreMock.syncFromRemote.mockReset()
@@ -143,6 +145,22 @@ describe('useSyncStore', () => {
     expect(useSyncStore.getState().lastSyncedAt).toBeInstanceOf(Date)
     expect(preferencesSyncMock.loadFromRemote).toHaveBeenCalledTimes(1)
     expect(preferencesSyncMock.pushNow).not.toHaveBeenCalled()
+  })
+
+  it('never age-purges unconfirmed or checkpointed queue entries during sync', async () => {
+    vi.mocked(getStaleEntries).mockResolvedValueOnce([{
+      id: 'old-unconfirmed', type: 'move', collectionType: 'calendar',
+      collectionUid: 'source', targetCollectionUid: 'target', itemUid: 'item-1',
+      content: 'encrypted-at-rest-content', createdAt: 0, retryCount: 0,
+      status: 'pending', accountFingerprint: 'test-account',
+      replayPhase: 'target-confirmed', confirmedTargetUid: 'target-item',
+    }])
+
+    useSyncStore.getState().simulateSyncCycle()
+    await vi.waitFor(() => expect(useSyncStore.getState().syncStatus).toBe('synced'))
+
+    expect(getStaleEntries).not.toHaveBeenCalled()
+    expect(remove).not.toHaveBeenCalled()
   })
 
   it('simulateSyncCycle does nothing when offline', () => {
@@ -229,7 +247,7 @@ describe('useSyncStore', () => {
 
   it('replays queued collection moves and remaps the calendar event id', async () => {
     etebaseMock.state.account = {}
-    etebaseMock.state.moveItem.mockResolvedValue('item-new')
+    etebaseMock.state.replayQueuedMutation.mockResolvedValue({ remoteMutationConfirmed: true, itemUid: 'item-new' })
     calendarStoreMock.events = [{ id: 'item-old', calendarId: 'cal-a' }]
     vi.mocked(getPendingCount).mockResolvedValueOnce(1)
     vi.mocked(replay).mockImplementationOnce(async (executeMutation) => {
@@ -251,7 +269,7 @@ describe('useSyncStore', () => {
 
     await useSyncStore.getState().replayOfflineQueue()
 
-    expect(etebaseMock.state.moveItem).toHaveBeenCalledWith('calendar', 'item-old', 'VEVENT content', 'cal-b', 'cal-a')
+    expect(etebaseMock.state.replayQueuedMutation).toHaveBeenCalledWith(expect.objectContaining({ type: 'move', itemUid: 'item-old' }), expect.objectContaining({ accountFingerprint: 'test-account' }), undefined)
     expect(calendarStoreMock.syncFromRemote).toHaveBeenCalledWith([{ id: 'item-new', calendarId: 'cal-b' }])
   })
 })

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -12,6 +12,11 @@ import {
   getAll as getQueuedMutations,
   isOfflineError,
   remove as removeQueuedMutation,
+  type ConfirmedRemoteMutation,
+  type OfflineQueueAccountGuard,
+  type QueueEntry,
+  type ReplayCheckpoint,
+  ReplayNotConfirmedError,
 } from '@/app/lib/offline-queue'
 import { secureGet } from '@/app/lib/secure-storage'
 import { showErrorToast } from '@/app/stores/use-toast-store'
@@ -541,6 +546,9 @@ interface EtebaseActions {
    * @param tempId - optional temp ID from the domain store, used for offline queue mapping
    */
   createItem: (type: CollectionTypeKey, content: string, tempId?: string, collectionUid?: string) => Promise<string | null>
+
+  /** Execute a queued mutation remotely without ordinary offline fallback/requeue behavior. */
+  replayQueuedMutation: (entry: QueueEntry, guard: OfflineQueueAccountGuard, checkpoint?: ReplayCheckpoint) => Promise<ConfirmedRemoteMutation>
 
   /**
    * Create a new Etebase collection for the given type.
@@ -1426,6 +1434,169 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       } catch (cleanupErr) {
         if (!isCurrentAccountEpoch(accountEpoch) || cleanupErr instanceof AccountBoundaryChangedError) return 0
         throw cleanupErr
+      }
+    }
+  },
+
+  replayQueuedMutation: async (entry, guard, checkpoint = async () => {}) => {
+    assertOfflineQueueAccountGuard(guard, get())
+    const { account, collections, itemCache, itemCollectionMap } = get()
+    if (!account) throw new ReplayNotConfirmedError('Replay requires an active Etebase account')
+
+    const requireCollection = (uid: string | undefined, role: string) => {
+      if (!uid) throw new ReplayNotConfirmedError(`Replay requires a ${role} collection UID`)
+      const resolved = resolveCollection(collections, entry.collectionType, uid)
+      if (!resolved || resolved.uid !== uid) throw new ReplayNotConfirmedError(`Replay ${role} collection is unavailable`)
+      return resolved
+    }
+    const requireItem = () => {
+      if (!entry.itemUid) throw new ReplayNotConfirmedError('Replay requires an item UID')
+      const item = itemCache.get(entry.itemUid)
+      if (!item) throw new ReplayNotConfirmedError('Replay item is unavailable')
+      if (!entry.collectionUid || itemCollectionMap.get(entry.itemUid) !== entry.collectionUid) {
+        throw new ReplayNotConfirmedError('Replay item collection ownership is unavailable')
+      }
+      return item
+    }
+
+    const core = await import('@silentsuite/core')
+    assertOfflineQueueAccountGuard(guard, get())
+
+    const logicalUid = (content: string): string | null => {
+      if (entry.collectionType !== 'calendar' && entry.collectionType !== 'tasks' && entry.collectionType !== 'contacts') return null
+      const unfolded = content.replace(/\r?\n[ \t]/g, '')
+      const match = unfolded.match(/^UID(?:;[^:]*)?:(.*)$/im)
+      return match?.[1]?.trim() || null
+    }
+    const findRemoteItem = async (collection: any, wantedContent: string, confirmedUid?: string) => {
+      const wantedLogicalUid = logicalUid(wantedContent)
+      if (!wantedLogicalUid && !confirmedUid && !wantedContent) {
+        throw new ReplayNotConfirmedError('Replay create cannot be reconciled without content identity')
+      }
+      let stoken: string | null | undefined
+      do {
+        assertOfflineQueueAccountGuard(guard, get())
+        const response = await core.listItems(account, collection, stoken)
+        assertOfflineQueueAccountGuard(guard, get())
+        for (const candidate of response.items) {
+          if (candidate.isDeleted) continue
+          if (confirmedUid && candidate.uid === confirmedUid) return candidate
+          const rawCandidateContent = await candidate.getContent()
+          assertOfflineQueueAccountGuard(guard, get())
+          const candidateContent = typeof rawCandidateContent === 'string' ? rawCandidateContent : new TextDecoder().decode(rawCandidateContent)
+          if (wantedLogicalUid ? logicalUid(candidateContent) === wantedLogicalUid : candidateContent === wantedContent) return candidate
+        }
+        if (response.done) return null
+        stoken = response.stoken
+      } while (true)
+    }
+    const findRemoteItemByUid = async (collection: any, uid: string) => {
+      let stoken: string | null | undefined
+      do {
+        assertOfflineQueueAccountGuard(guard, get())
+        const response = await core.listItems(account, collection, stoken)
+        assertOfflineQueueAccountGuard(guard, get())
+        const found = response.items.find((candidate: any) => !candidate.isDeleted && candidate.uid === uid)
+        if (found) return found
+        if (response.done) return null
+        stoken = response.stoken
+      } while (true)
+    }
+
+    const publishConfirmedReplayItem = (
+      item: any,
+      itemUid: string,
+      collectionUid: string,
+      removeUid?: string,
+    ) => {
+      assertOfflineQueueAccountGuard(guard, get())
+      const current = get()
+      const nextItemCache = new Map(current.itemCache)
+      const nextItemTypeMap = new Map(current.itemTypeMap)
+      const nextItemCollectionMap = new Map(current.itemCollectionMap)
+      if (removeUid && removeUid !== itemUid) {
+        nextItemCache.delete(removeUid)
+        nextItemTypeMap.delete(removeUid)
+        nextItemCollectionMap.delete(removeUid)
+      }
+      nextItemCache.set(itemUid, item)
+      nextItemTypeMap.set(itemUid, entry.collectionType)
+      nextItemCollectionMap.set(itemUid, collectionUid)
+      assertOfflineQueueAccountGuard(guard, get())
+      set({
+        itemCache: nextItemCache,
+        itemTypeMap: nextItemTypeMap,
+        itemCollectionMap: nextItemCollectionMap,
+      })
+    }
+
+    switch (entry.type) {
+      case 'create': {
+        if (typeof entry.content !== 'string') throw new ReplayNotConfirmedError('Replay create content is unavailable')
+        const collection = requireCollection(entry.collectionUid, 'target')
+        let created = await findRemoteItem(collection, entry.content, entry.confirmedTargetUid)
+        if (!created) {
+          assertOfflineQueueAccountGuard(guard, get())
+          created = await core.createItem(account, collection, entry.content)
+        }
+        const createdUid = created?.uid
+        if (!createdUid) throw new ReplayNotConfirmedError('Replay create did not return a server UID')
+        await checkpoint({ replayPhase: 'target-confirmed', confirmedTargetUid: createdUid })
+        assertOfflineQueueAccountGuard(guard, get())
+        publishConfirmedReplayItem(created, createdUid, collection.uid, entry.tempId)
+        return { remoteMutationConfirmed: true, itemUid: createdUid }
+      }
+      case 'update': {
+        if (typeof entry.content !== 'string') throw new ReplayNotConfirmedError('Replay update content is unavailable')
+        const collection = requireCollection(entry.collectionUid, 'owner')
+        const item = requireItem()
+        assertOfflineQueueAccountGuard(guard, get())
+        await core.updateItem(account, collection, item, entry.content)
+        assertOfflineQueueAccountGuard(guard, get())
+        return { remoteMutationConfirmed: true }
+      }
+      case 'delete': {
+        const collection = requireCollection(entry.collectionUid, 'owner')
+        const item = requireItem()
+        assertOfflineQueueAccountGuard(guard, get())
+        await core.deleteItem(account, collection, item)
+        assertOfflineQueueAccountGuard(guard, get())
+        return { remoteMutationConfirmed: true }
+      }
+      case 'move': {
+        if (typeof entry.content !== 'string') throw new ReplayNotConfirmedError('Replay move content is unavailable')
+        const sourceCollection = requireCollection(entry.collectionUid, 'source')
+        const targetCollection = requireCollection(entry.targetCollectionUid, 'target')
+        if (!entry.itemUid) throw new ReplayNotConfirmedError('Replay move requires a source item UID')
+        if (sourceCollection.uid === targetCollection.uid) {
+          const item = requireItem()
+          assertOfflineQueueAccountGuard(guard, get())
+          await core.updateItem(account, sourceCollection, item, entry.content)
+          assertOfflineQueueAccountGuard(guard, get())
+          return { remoteMutationConfirmed: true, itemUid: entry.itemUid }
+        }
+
+        // Copy first, checkpoint its opaque Etebase UID, then monotonically retry
+        // source deletion. We intentionally never roll the target back: an
+        // ambiguous rollback recreates the duplicate window this state machine
+        // is designed to close.
+        let targetItem = await findRemoteItem(targetCollection, entry.content, entry.confirmedTargetUid)
+        if (!targetItem) {
+          assertOfflineQueueAccountGuard(guard, get())
+          targetItem = await core.createItem(account, targetCollection, entry.content)
+        }
+        const targetItemUid = targetItem?.uid
+        if (!targetItemUid) throw new ReplayNotConfirmedError('Replay move create did not return a server UID')
+        await checkpoint({ replayPhase: 'target-confirmed', confirmedTargetUid: targetItemUid })
+        assertOfflineQueueAccountGuard(guard, get())
+
+        const sourceItem = await findRemoteItemByUid(sourceCollection, entry.itemUid)
+        if (sourceItem) {
+          await core.deleteItem(account, sourceCollection, sourceItem)
+          assertOfflineQueueAccountGuard(guard, get())
+        }
+        publishConfirmedReplayItem(targetItem, targetItemUid, targetCollection.uid, entry.itemUid)
+        return { remoteMutationConfirmed: true, itemUid: targetItemUid }
       }
     }
   },

--- a/apps/web/app/stores/use-sync-store.ts
+++ b/apps/web/app/stores/use-sync-store.ts
@@ -2,7 +2,7 @@
 
 import { create } from 'zustand'
 import type { SyncStatus } from '@silentsuite/core'
-import { replay, getPendingCount, getFailedCount, onCountChange, getStaleEntries, remove, type QueueEntry, type OfflineQueueAccountGuard } from '@/app/lib/offline-queue'
+import { replay, getPendingCount, getFailedCount, onCountChange, type ConfirmedRemoteMutation, type QueueEntry, type OfflineQueueAccountGuard, type ReplayCheckpoint } from '@/app/lib/offline-queue'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { logger } from '@/app/lib/logger'
@@ -131,55 +131,12 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
 
     logger.log(`[sync-store] Replaying ${count} queued offline mutations...`)
 
-    const executeMutation = async (entry: QueueEntry): Promise<{ itemUid?: string }> => {
+    const executeMutation = async (entry: QueueEntry, checkpoint: ReplayCheckpoint): Promise<ConfirmedRemoteMutation> => {
       const { useEtebaseStore } = await import('@/app/stores/use-etebase-store')
       assertCurrentAccountEpoch(guard.accountEpoch)
       const etebase = useEtebaseStore.getState()
       if (!etebase.account || etebase.accountFingerprint !== guard.accountFingerprint) throw new AccountBoundaryChangedError()
-
-      try {
-        switch (entry.type) {
-          case 'create': {
-            const uid = await etebase.createItem(entry.collectionType, entry.content!, entry.tempId, entry.collectionUid)
-            return { itemUid: uid ?? undefined }
-          }
-          case 'update': {
-            await etebase.updateItem(entry.collectionType, entry.itemUid!, entry.content!)
-            return {}
-          }
-          case 'delete': {
-            await etebase.deleteItem(entry.collectionType, entry.itemUid!)
-            return {}
-          }
-          case 'move': {
-            if (!entry.targetCollectionUid) throw new Error('Missing move target collection')
-            const uid = await etebase.moveItem(entry.collectionType, entry.itemUid!, entry.content!, entry.targetCollectionUid, entry.collectionUid)
-            if (!uid) throw new Error('Move did not return item UID')
-            return { itemUid: uid }
-          }
-        }
-      } catch (err) {
-        assertCurrentAccountEpoch(guard.accountEpoch)
-        // Handle 409 Conflict (ETag mismatch) — server-wins strategy
-        const is409 = err instanceof Error && (
-          err.message.includes('409') ||
-          err.message.includes('conflict') ||
-          err.message.includes('Conflict')
-        )
-        if (is409 && entry.type !== 'create') {
-          logger.warn(
-            `[sync-store] Conflict on ${entry.type} ${entry.collectionType}/${entry.itemUid} — discarding local change (server wins)`,
-          )
-          // Refresh the collection to get server's version
-          await etebase.refreshCollection(entry.collectionType, entry.collectionUid)
-          if (entry.type === 'move' && entry.targetCollectionUid && entry.targetCollectionUid !== entry.collectionUid) {
-            await etebase.refreshCollection(entry.collectionType, entry.targetCollectionUid)
-          }
-          // Return success so the entry is removed from queue
-          return {}
-        }
-        throw err
-      }
+      return etebase.replayQueuedMutation(entry, guard, checkpoint)
     }
 
     const results = await replay(executeMutation, guard)
@@ -326,14 +283,6 @@ export const useSyncStore = create<SyncState & SyncActions>((set, get) => ({
       } catch (err) {
         assertCurrentAccountEpoch(accountEpoch)
         logger.warn('[sync-store] Preferences refresh failed during sync cycle', getSafeErrorDetails(err))
-      }
-
-      // Purge stale queue entries (older than 24h) that may cause phantom indicators
-      const stale = await getStaleEntries(guard)
-      for (const entry of stale) {
-        assertCurrentAccountEpoch(guard.accountEpoch)
-        await remove(entry.id, guard)
-        assertCurrentAccountEpoch(guard.accountEpoch)
       }
 
       // Refresh counts to ensure UI is accurate after sync


### PR DESCRIPTION
## Summary

- require affirmative remote confirmation before offline replay removes a mutation
- add a dedicated remote-only Etebase replay path that never requeues through ordinary user mutation fallbacks
- retain original entries when offline, account ownership changes, or collection/item prerequisites are unavailable
- preserve server-created item identifiers for successful create/move replay

## Regression coverage

- offline create/update/delete/move each retain exactly one owned original entry
- missing collection/item prerequisites retain pending entries
- confirmed remote success removes entries
- account switching during replay retains the old scoped mutation without stale state, error, or toast publication

## Verification

- focused replay suite: 87 passed
- full web suite: 615 passed
- type-check: passed
- lint: passed with existing warnings only
- `git diff --check`: passed

Required follow-up for corrective promotion #526.
