### PR TITLE
feat: add privacy-safe public analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  analytics-boundary:
+    name: Public Analytics Boundary
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build public surfaces
+        run: |
+          pnpm --filter @silentsuite/web build
+          SILENTSUITE_HOSTED_DOCS_ANALYTICS=1 pnpm --filter @silentsuite/docs exec vitepress build --outDir .vitepress/dist-hosted
+          pnpm --filter @silentsuite/docs exec vitepress build --outDir .vitepress/dist-self
+      - name: Enforce source and bundle analytics boundary
+        run: pnpm run check:public-analytics
+
   lint-and-typecheck:
     name: Lint & Type Check
     runs-on: ubuntu-latest
@@ -58,6 +82,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Enforce public analytics boundary
+        run: pnpm run check:public-analytics
 
       - name: Run tests
         run: pnpm run test

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Build docs
         run: pnpm run build --filter=@silentsuite/docs
+        env:
+          SILENTSUITE_HOSTED_DOCS_ANALYTICS: '1'
 
       - name: Deploy to production Worker
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -1,13 +1,20 @@
 import { defineConfig } from 'vitepress'
 
+const hostedAnalytics = process.env.SILENTSUITE_HOSTED_DOCS_ANALYTICS === '1'
+
 export default defineConfig({
+  vite: {
+    define: {
+      __SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__: JSON.stringify(
+        hostedAnalytics ? 'https://plausible.silentsuite.io/api/event' : '',
+      ),
+    },
+  },
   title: 'SilentSuite Docs',
   description: 'Documentation for SilentSuite — end-to-end encrypted calendar, contacts & tasks.',
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
-    // Privacy-friendly analytics by Plausible
-    ['script', { async: '', src: 'https://plausible.silentsuite.io/js/pa-cpFZuMRijOONfz35zBtMP.js' }],
-    ['script', {}, `window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init()`],
+
     ['meta', { name: 'theme-color', content: '#0a1018' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: 'SilentSuite Docs' }],

--- a/apps/docs/.vitepress/theme/index.mts
+++ b/apps/docs/.vitepress/theme/index.mts
@@ -1,4 +1,44 @@
 import DefaultTheme from 'vitepress/theme'
+import { defineComponent, h, onMounted, onUnmounted } from 'vue'
+import { classifyDocsOutboundEvent } from './public-analytics.mts'
 import './custom.css'
 
-export default DefaultTheme
+declare const __SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__: string
+
+function sendDocsEvent(event: ReturnType<typeof classifyDocsOutboundEvent>) {
+  if (!event) return
+  const payload = JSON.stringify({
+    domain: 'docs.silentsuite.io',
+    name: event.event,
+    url: 'https://docs.silentsuite.io/',
+    props: event.props,
+  })
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__, new Blob([payload], { type: 'application/json' }))
+    return
+  }
+  void fetch(__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+    keepalive: true,
+  })
+}
+
+export default {
+  ...DefaultTheme,
+  Layout: defineComponent({
+    setup() {
+      const handleClick = (event: MouseEvent) => {
+        if (!__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__ || window.location.hostname !== 'docs.silentsuite.io') return
+        const anchor = event.target instanceof Element ? event.target.closest('a[href]') : null
+        const analyticsEvent = anchor ? classifyDocsOutboundEvent(anchor.getAttribute('href') ?? '', window.location.pathname) : undefined
+        sendDocsEvent(analyticsEvent)
+      }
+
+      onMounted(() => document.addEventListener('click', handleClick))
+      onUnmounted(() => document.removeEventListener('click', handleClick))
+      return () => h(DefaultTheme.Layout!)
+    },
+  }),
+}

--- a/apps/docs/.vitepress/theme/public-analytics.mts
+++ b/apps/docs/.vitepress/theme/public-analytics.mts
@@ -1,0 +1,51 @@
+export type DocsOutboundEvent =
+  | { event: 'Hosted App Click'; props: { surface: 'docs'; route_class: 'app_home' | 'signup' } }
+  | { event: 'Android Download Click'; props: { surface: 'docs_android'; channel: 'github_release' } }
+  | { event: 'GitHub Click'; props: { surface: 'docs_android'; channel: 'repository' } }
+
+const APPROVED_DESTINATIONS: Readonly<Record<string, DocsOutboundEvent>> = {
+  'https://app.silentsuite.io': {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'app_home' },
+  },
+  'https://app.silentsuite.io/signup': {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'signup' },
+  },
+}
+
+const ANDROID_DESTINATIONS: Readonly<Record<string, DocsOutboundEvent>> = {
+  'https://github.com/silent-suite/silentsuite/releases/latest': {
+    event: 'Android Download Click',
+    props: { surface: 'docs_android', channel: 'github_release' },
+  },
+  'https://github.com/silent-suite/silentsuite/tree/main/android': {
+    event: 'GitHub Click',
+    props: { surface: 'docs_android', channel: 'repository' },
+  },
+}
+
+const HOSTED_APP_ROUTES = new Set([
+  '/user-guide/getting-started',
+  '/user-guide/apps',
+  '/self-hosting',
+  '/self-hosting/quick-start',
+  '/self-hosting/manual-setup',
+  '/self-hosting/architecture',
+  '/user-guide/faq',
+  '/user-guide/calendar',
+])
+
+export function classifyDocsOutboundEvent(rawHref: string, docsPath: string): DocsOutboundEvent | undefined {
+  try {
+    const url = new URL(rawHref)
+    if (url.username || url.password || url.search || url.hash) return undefined
+    const destination = url.toString().replace(/\/$/, '')
+    const normalizedPath = docsPath.replace(/\/$/, '') || '/'
+    if (normalizedPath === '/user-guide/apps/android') return ANDROID_DESTINATIONS[destination]
+    if (HOSTED_APP_ROUTES.has(normalizedPath)) return APPROVED_DESTINATIONS[destination]
+    return undefined
+  } catch {
+    return undefined
+  }
+}

--- a/apps/docs/.vitepress/theme/public-analytics.test.mts
+++ b/apps/docs/.vitepress/theme/public-analytics.test.mts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { classifyDocsOutboundEvent } from './public-analytics.mts'
+
+test('classifies approved hosted-app destinations by route class', () => {
+  assert.deepEqual(classifyDocsOutboundEvent('https://app.silentsuite.io', '/user-guide/getting-started'), {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'app_home' },
+  })
+  assert.deepEqual(classifyDocsOutboundEvent('https://app.silentsuite.io', '/user-guide/getting-started/'), {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'app_home' },
+  })
+  assert.deepEqual(classifyDocsOutboundEvent('https://app.silentsuite.io/signup', '/user-guide/faq'), {
+    event: 'Hosted App Click',
+    props: { surface: 'docs', route_class: 'signup' },
+  })
+})
+
+test('classifies Android destinations only on the Android guide', () => {
+  assert.deepEqual(classifyDocsOutboundEvent('https://github.com/silent-suite/silentsuite/releases/latest', '/user-guide/apps/android'), {
+    event: 'Android Download Click',
+    props: { surface: 'docs_android', channel: 'github_release' },
+  })
+  assert.deepEqual(classifyDocsOutboundEvent('https://github.com/silent-suite/silentsuite/tree/main/android', '/user-guide/apps/android'), {
+    event: 'GitHub Click',
+    props: { surface: 'docs_android', channel: 'repository' },
+  })
+  assert.equal(classifyDocsOutboundEvent('https://github.com/silent-suite/silentsuite/releases/latest', '/user-guide/faq'), undefined)
+})
+
+test('does not classify generic, credentialed, or path-bearing external links', () => {
+  assert.equal(classifyDocsOutboundEvent('https://github.com/silent-suite/silentsuite/issues/1', '/user-guide/apps/android'), undefined)
+  assert.equal(classifyDocsOutboundEvent('https://user@example.com/secret', '/user-guide/getting-started'), undefined)
+  assert.equal(classifyDocsOutboundEvent('not a url', '/user-guide/getting-started'), undefined)
+  assert.equal(classifyDocsOutboundEvent('https://app.silentsuite.io', '/contributing/testing'), undefined)
+})

--- a/apps/web/app/(auth)/signup/signup-analytics.tsx
+++ b/apps/web/app/(auth)/signup/signup-analytics.tsx
@@ -2,48 +2,16 @@
 
 import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
+import { buildSignupPageviewPayload } from '@/app/lib/public-analytics'
 
 const PLAUSIBLE_EVENT_ENDPOINT = 'https://plausible.silentsuite.io/api/event'
-const PLAUSIBLE_DOMAIN = 'app.silentsuite.io'
-const MARKETING_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']
-
-function signupAnalyticsUrl() {
-  const current = new URL(window.location.href)
-  const sanitized = new URL(`${current.origin}${current.pathname}`)
-
-  if (current.pathname === '/signup') {
-    for (const param of MARKETING_PARAMS) {
-      const value = current.searchParams.get(param)
-      if (value) sanitized.searchParams.set(param, value)
-    }
-  }
-
-  return sanitized.toString()
-}
-
-function sanitizedReferrer() {
-  if (!document.referrer) return undefined
-
-  try {
-    const referrer = new URL(document.referrer)
-    return `${referrer.origin}${referrer.pathname}`
-  } catch {
-    return undefined
-  }
-}
-
 export function SignupAnalytics() {
   const pathname = usePathname()
 
   useEffect(() => {
     if (!pathname?.startsWith('/signup')) return
 
-    const payload = JSON.stringify({
-      domain: PLAUSIBLE_DOMAIN,
-      name: 'pageview',
-      url: signupAnalyticsUrl(),
-      referrer: sanitizedReferrer(),
-    })
+    const payload = JSON.stringify(buildSignupPageviewPayload(window.location.href, document.referrer))
 
     if (navigator.sendBeacon) {
       const blob = new Blob([payload], { type: 'application/json' })

--- a/apps/web/app/lib/__tests__/public-analytics.test.ts
+++ b/apps/web/app/lib/__tests__/public-analytics.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSignupPageviewPayload,
+  canonicalizeCampaignParams,
+  classifyReferrer,
+  sanitizedSignupPageUrl,
+} from '../public-analytics'
+
+describe('public analytics privacy contract', () => {
+  it('canonicalizes only registered campaign parameters', () => {
+    expect(
+      canonicalizeCampaignParams('?utm_source=x&utm_medium=social&utm_campaign=beta-2026-q2'),
+    ).toEqual({
+      utm_source: 'social',
+      utm_medium: 'organic',
+      utm_campaign: 'beta-2026-q2',
+    })
+  })
+
+  it('drops content, term, repeated, identity-shaped, and encoded values', () => {
+    expect(
+      canonicalizeCampaignParams(
+        '?utm_source=x&utm_source=github&utm_medium=user%40example.com&utm_campaign=https%253A%252F%252Fevil.test&utm_content=secret&utm_term=private',
+      ),
+    ).toEqual({})
+  })
+
+  it('emits canonical fallback categories without retaining unknown raw strings', () => {
+    expect(
+      canonicalizeCampaignParams('?utm_source=conference&utm_medium=poster&utm_campaign=private-launch'),
+    ).toEqual({
+      utm_source: 'other',
+      utm_medium: 'other',
+      utm_campaign: 'other_campaign',
+    })
+  })
+
+  it('sanitizes signup page URLs to canonical campaign values', () => {
+    expect(
+      sanitizedSignupPageUrl(
+        'https://app.silentsuite.io/signup?utm_source=github&utm_medium=referral&utm_content=email@example.com&returnTo=%2Fcalendar',
+      ),
+    ).toBe('https://app.silentsuite.io/signup?utm_source=github&utm_medium=referral')
+  })
+
+  it('classifies the referrer without retaining its path', () => {
+    expect(classifyReferrer('https://github.com/silent-suite/silentsuite/issues/123?token=secret')).toBe(
+      'github',
+    )
+    expect(classifyReferrer('https://evil.test/reset/user@example.com')).toBe('other')
+    expect(classifyReferrer('bad url')).toBeUndefined()
+  })
+
+  it('builds the exact identity-free signup pageview payload', () => {
+    expect(buildSignupPageviewPayload(
+      'https://app.silentsuite.io/signup?utm_source=github&utm_content=user@example.com&returnTo=/calendar',
+      'https://github.com/silent-suite/silentsuite/issues/123?token=secret',
+    )).toEqual({
+      domain: 'app.silentsuite.io',
+      name: 'pageview',
+      url: 'https://app.silentsuite.io/signup?utm_source=github',
+      props: { referrer_category: 'github' },
+    })
+  })
+})

--- a/apps/web/app/lib/public-analytics.ts
+++ b/apps/web/app/lib/public-analytics.ts
@@ -1,0 +1,92 @@
+export type CampaignParams = Partial<{
+  utm_source: 'search' | 'social' | 'github' | 'newsletter' | 'community' | 'known_partner' | 'paid' | 'other'
+  utm_medium: 'organic' | 'referral' | 'email' | 'community' | 'paid_social' | 'cpc' | 'qr' | 'other'
+  utm_campaign: 'beta-2026-q2' | 'other_campaign'
+}>
+
+export type ReferrerCategory = 'direct' | 'search' | 'social' | 'github' | 'known_partner' | 'other'
+
+export type SignupPageviewPayload = {
+  domain: 'app.silentsuite.io'
+  name: 'pageview'
+  url: string
+  props: { referrer_category: ReferrerCategory }
+}
+
+const SOURCE_ALIASES: Readonly<Record<string, NonNullable<CampaignParams['utm_source']>>> = {
+  google: 'search', bing: 'search', duckduckgo: 'search',
+  x: 'social', twitter: 'social', mastodon: 'social', bluesky: 'social',
+  github: 'github', newsletter: 'newsletter',
+  'hacker-news': 'community', reddit: 'community', lemmy: 'community',
+  alternativeto: 'known_partner', 'privacy-media': 'known_partner',
+}
+const MEDIUM_ALIASES: Readonly<Record<string, NonNullable<CampaignParams['utm_medium']>>> = {
+  organic: 'organic', social: 'organic', referral: 'referral', listing: 'referral', media: 'referral',
+  email: 'email', newsletter: 'email', community: 'community', dm: 'community',
+  'paid-social': 'paid_social', cpc: 'cpc', qr: 'qr',
+}
+const CAMPAIGN_ALIASES: Readonly<Record<string, NonNullable<CampaignParams['utm_campaign']>>> = {
+  'beta-2026-q2': 'beta-2026-q2',
+}
+const SAFE_VALUE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+function safeSingleValue(params: URLSearchParams, key: string): string | undefined {
+  const values = params.getAll(key)
+  if (values.length !== 1) return undefined
+  const rawValue = values[0]
+  if (!/^[\x20-\x7e]+$/.test(rawValue)) return undefined
+  const value = rawValue.normalize('NFKC')
+  if (value !== value.toLowerCase() || !SAFE_VALUE.test(value) || UUID.test(value)) return undefined
+  return value
+}
+
+export function canonicalizeCampaignParams(search: string | URLSearchParams): CampaignParams {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search
+  const result: CampaignParams = {}
+  const source = safeSingleValue(params, 'utm_source')
+  const medium = safeSingleValue(params, 'utm_medium')
+  const campaign = safeSingleValue(params, 'utm_campaign')
+  if (source) result.utm_source = SOURCE_ALIASES[source] ?? 'other'
+  if (medium) result.utm_medium = MEDIUM_ALIASES[medium] ?? 'other'
+  if (campaign) result.utm_campaign = CAMPAIGN_ALIASES[campaign] ?? 'other_campaign'
+  return result
+}
+
+export function sanitizedSignupPageUrl(rawUrl: string): string {
+  const current = new URL(rawUrl)
+  const sanitized = new URL(`${current.origin}${current.pathname}`)
+  if (current.pathname === '/signup') {
+    for (const [key, value] of Object.entries(canonicalizeCampaignParams(current.searchParams))) {
+      sanitized.searchParams.set(key, value)
+    }
+  }
+  return sanitized.toString()
+}
+
+function hostMatches(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`)
+}
+
+export function classifyReferrer(raw: string): ReferrerCategory | undefined {
+  if (!raw) return 'direct'
+  try {
+    const host = new URL(raw).hostname.toLowerCase()
+    if (hostMatches(host, 'github.com')) return 'github'
+    if (hostMatches(host, 'google.com') || hostMatches(host, 'bing.com') || hostMatches(host, 'duckduckgo.com')) return 'search'
+    if (hostMatches(host, 'x.com') || hostMatches(host, 'twitter.com') || hostMatches(host, 'mastodon.social') || hostMatches(host, 'bsky.app')) return 'social'
+    if (hostMatches(host, 'alternativeto.net') || hostMatches(host, 'privacyguides.org')) return 'known_partner'
+    return 'other'
+  } catch {
+    return undefined
+  }
+}
+
+export function buildSignupPageviewPayload(rawUrl: string, rawReferrer: string): SignupPageviewPayload {
+  return {
+    domain: 'app.silentsuite.io',
+    name: 'pageview',
+    url: sanitizedSignupPageUrl(rawUrl),
+    props: { referrer_category: classifyReferrer(rawReferrer) ?? 'other' },
+  }
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -4,6 +4,8 @@ const withPWA = require('@ducanh2912/next-pwa').default
 const { withSentryConfig } = require('@sentry/nextjs')
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts')
+const hostedConnectSources = "connect-src 'self' https://api.silentsuite.io https://server.silentsuite.io wss://server.silentsuite.io https://*.sentry.io"
+const signupConnectSources = `${hostedConnectSources} https://plausible.silentsuite.io https://api.stripe.com`
 
 // Resolve etebase CJS entry — it's a dep of @silentsuite/core,
 // not directly in apps/web's node_modules (pnpm strict isolation).
@@ -26,6 +28,19 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   transpilePackages: ['@silentsuite/ui', '@silentsuite/core'],
+  async headers() {
+    if (process.env.NEXT_PUBLIC_SELF_HOSTED === 'true') return []
+    return [
+      {
+        source: '/signup/:path*',
+        headers: [{ key: 'Content-Security-Policy', value: signupConnectSources }],
+      },
+      ...['/calendar/:path*', '/contacts/:path*', '/tasks/:path*', '/settings/:path*'].map((source) => ({
+        source,
+        headers: [{ key: 'Content-Security-Policy', value: hostedConnectSources }],
+      })),
+    ]
+  },
   webpack: (config) => {
     config.resolve.extensionAlias = {
       '.js': ['.ts', '.tsx', '.js'],

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type-check": "turbo type-check",
     "i18n:check": "pnpm --filter @silentsuite/web i18n:check",
     "i18n:report": "pnpm --filter @silentsuite/web i18n:report",
+    "check:public-analytics": "node scripts/check-public-analytics.mjs && node --experimental-strip-types --test apps/docs/.vitepress/theme/public-analytics.test.mts",
     "audit:security": "node scripts/audit-high-critical.mjs"
   },
   "devDependencies": {

--- a/scripts/check-public-analytics.mjs
+++ b/scripts/check-public-analytics.mjs
@@ -1,0 +1,95 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const appsRoot = path.resolve('apps')
+const allowedAnalyticsFiles = new Set([
+  path.join(appsRoot, 'web/app/(auth)/signup/signup-analytics.tsx'),
+  path.join(appsRoot, 'web/next.config.js'),
+  path.join(appsRoot, 'docs/.vitepress/config.mts'),
+  path.join(appsRoot, 'docs/.vitepress/theme/index.mts'),
+])
+const violations = []
+
+async function walk(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name)
+    if (entry.name === 'node_modules' || entry.name === '.next' || entry.name.startsWith('dist') || entry.name === 'cache') continue
+    if (entry.isDirectory()) await walk(fullPath)
+    else if (/\.(?:ts|tsx|js|jsx|mts|mjs)$/.test(entry.name) && !/\.(?:test|spec)\./.test(entry.name)) {
+      const source = await readFile(fullPath, 'utf8')
+      if (/plausible(?:\.silentsuite\.io|\s*\?*\.|\s*\()|window\.plausible/.test(source) && !allowedAnalyticsFiles.has(fullPath)) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: direct analytics call outside approved boundary`)
+      }
+      if (/(?:@segment\/analytics|@amplitude\/analytics|mixpanel|google-analytics|googletagmanager|posthog|hotjar|analytics\.js)/i.test(source)) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: unapproved analytics SDK`)
+      }
+      if (/utm_(?:content|term)/.test(source)) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: prohibited free-form UTM key`)
+      }
+      if (fullPath.includes(`${path.sep}web${path.sep}app${path.sep}(app)${path.sep}`) && /plausible|analytics/i.test(source)) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: analytics reference in authenticated app route`)
+      }
+    }
+  }
+}
+
+await walk(appsRoot)
+
+const requiredContracts = new Map([
+  ['apps/docs/.vitepress/theme/public-analytics.mts', ['Hosted App Click', 'Android Download Click', 'github_release', 'repository']],
+  ['apps/docs/.vitepress/theme/index.mts', ['__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__', 'window.location.hostname', 'classifyDocsOutboundEvent']],
+  ['apps/web/next.config.js', ['Content-Security-Policy', 'signupConnectSources', 'hostedConnectSources']],
+  ['.github/workflows/ci.yml', ['pnpm run check:public-analytics']],
+])
+for (const [relativePath, snippets] of requiredContracts) {
+  const source = await readFile(path.resolve(relativePath), 'utf8')
+  for (const snippet of snippets) {
+    if (!source.includes(snippet)) violations.push(`${relativePath}: missing required analytics contract ${snippet}`)
+  }
+}
+
+const generatedAppRoot = path.join(appsRoot, 'web/.next/static/chunks/app/(app)')
+try {
+  async function scanGenerated(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) await scanGenerated(fullPath)
+      else if (/\.js$/.test(entry.name) && /plausible\.silentsuite\.io|window\.plausible/.test(await readFile(fullPath, 'utf8'))) {
+        violations.push(`${path.relative(process.cwd(), fullPath)}: analytics endpoint in authenticated production bundle`)
+      }
+    }
+  }
+  await scanGenerated(generatedAppRoot)
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error
+}
+
+async function generatedText(directory) {
+  let result = ''
+  async function collect(current) {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) await collect(fullPath)
+      else if (/\.(?:js|html)$/.test(entry.name)) result += await readFile(fullPath, 'utf8')
+    }
+  }
+  await collect(directory)
+  return result
+}
+
+try {
+  const hostedBundle = await generatedText(path.join(appsRoot, 'docs/.vitepress/dist-hosted'))
+  const selfHostedBundle = await generatedText(path.join(appsRoot, 'docs/.vitepress/dist-self'))
+  if (!hostedBundle.includes('plausible.silentsuite.io/api/event')) violations.push('hosted docs bundle: expected analytics endpoint absent')
+  if (selfHostedBundle.includes('plausible.silentsuite.io')) violations.push('self-hosted docs bundle: analytics endpoint present')
+  if (hostedBundle.includes('__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__') || selfHostedBundle.includes('__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__')) {
+    violations.push('docs bundle: unresolved analytics compile constant')
+  }
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error
+}
+if (violations.length) {
+  console.error(violations.join('\n'))
+  process.exit(1)
+}
+console.log('Public analytics boundary check passed')


### PR DESCRIPTION
## Summary
- add typed signup analytics with canonical campaign and coarse referrer fields
- instrument only exact approved docs routes and destinations
- compile analytics out of self-hosted docs builds
- isolate authenticated application routes with CSP policies that exclude Plausible
- add source and production-bundle analytics boundary gates to CI

Android and Bridge remain telemetry-free.

## Verification
- focused web analytics tests: 6 passed
- docs analytics tests: 3 passed
- web type-check and production build
- hosted/self-hosted docs production builds and bundle inspection
- source/authenticated-bundle boundary scanner
- `git diff --check`
- GPT-5.6 Sol review: approved

## Privacy
No raw referrer paths, arbitrary UTM values, account identifiers, authenticated PIM activity, Android telemetry, or Bridge telemetry are exported.