### PR TITLE
fix(web): preserve retry budget on checkpoint failure

### DIFF
--- a/apps/web/app/lib/__tests__/offline-queue.test.ts
+++ b/apps/web/app/lib/__tests__/offline-queue.test.ts
@@ -335,6 +335,29 @@ describe('offline-queue', () => {
       expect(await getPendingCount(testGuard())).toBe(0)
     })
 
+    it('does not consume remote retries when a target-confirmed checkpoint transaction repeatedly fails', async () => {
+      await enqueue({ type: 'create', collectionType: 'calendar', content: 'PIM', tempId: 'temp-1' })
+      const originalPut = IDBObjectStore.prototype.put
+
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const putSpy = vi.spyOn(IDBObjectStore.prototype, 'put').mockImplementationOnce(function (...args) {
+          const request = originalPut.apply(this, args)
+          this.transaction.abort()
+          return request
+        })
+        try {
+          await replay(async (_entry, checkpoint) => {
+            await checkpoint({ replayPhase: 'target-confirmed', confirmedTargetUid: 'server-1' })
+            return { remoteMutationConfirmed: true, itemUid: 'server-1' }
+          }, testGuard())
+        } finally {
+          putSpy.mockRestore()
+        }
+
+        expect((await getAll(testGuard()))[0]).toMatchObject({ retryCount: 0, status: 'pending' })
+      }
+    })
+
     it('increments retryCount on failure, marks failed after MAX_RETRIES', async () => {
       await enqueue({ type: 'update', collectionType: 'contacts', content: 'x', itemUid: 'u1' })
 

--- a/apps/web/app/lib/offline-queue.ts
+++ b/apps/web/app/lib/offline-queue.ts
@@ -462,9 +462,16 @@ export async function replay(
   for (const entry of pending) {
     let currentEntry = entry
     let remoteMutationConfirmed = false
+    let remoteProgressConfirmed = false
     try {
       assertGuard(guard)
       const checkpoint: ReplayCheckpoint = async (progress) => {
+        // target-confirmed is emitted only after a remote item was found or
+        // created. Record that before the local transaction so an IndexedDB
+        // checkpoint failure cannot consume the remote retry budget.
+        if (progress.replayPhase === 'target-confirmed' && progress.confirmedTargetUid) {
+          remoteProgressConfirmed = true
+        }
         const updated = { ...currentEntry, ...progress }
         await updateEntry(updated, guard)
         currentEntry = updated
@@ -481,7 +488,7 @@ export async function replay(
     } catch (err) {
       if (err instanceof AccountBoundaryChangedError) return []
       assertGuard(guard)
-      if (remoteMutationConfirmed) {
+      if (remoteMutationConfirmed || remoteProgressConfirmed) {
         // The server mutation is complete. A local checkpoint/removal failure
         // must not consume the remote retry budget or mark completed work failed.
         results.push({ entry, success: false, error: err instanceof Error ? err.message : String(err) })


### PR DESCRIPTION
## Summary

- recognize target-confirmed replay progress before its local checkpoint transaction
- preserve pending status and zero remote retries across repeated checkpoint write failures
- add deterministic repeated-IDB-abort coverage

## Verification

- focused replay suite: 96 passed
- type-check: passed
- `git diff --check`: passed

Required follow-up for corrective promotion #526.
