### PR TITLE
fix(release): use basename in Bridge checksums

### DIFF
--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -223,7 +223,7 @@ jobs:
             esac
             echo "=== Rename + checksum (inside container to avoid permission issues) ==="
             mv dist/silentsuite-bridge dist/${{ matrix.asset-name }}
-            sha256sum dist/${{ matrix.asset-name }} > dist/${{ matrix.asset-name }}.sha256
+            (cd dist && sha256sum "${{ matrix.asset-name }}" > "${{ matrix.asset-name }}.sha256")
             cat dist/${{ matrix.asset-name }}.sha256
             echo "Smoke test passed."
 

--- a/tests/test_release_versions_static.py
+++ b/tests/test_release_versions_static.py
@@ -86,3 +86,10 @@ def test_bridge_release_workflow_validates_frozen_version_without_runtime_env_ov
     assert "Removed stale generated version stamp" in spec
     assert "target.unlink()" in spec
     assert "VERSION = {version!r}" in spec
+
+
+def test_bridge_release_checksums_use_downloadable_asset_basenames():
+    workflow = read(".github/workflows/build-bridge.yml")
+
+    assert '(cd dist && sha256sum "${{ matrix.asset-name }}"' in workflow
+    assert "sha256sum dist/${{ matrix.asset-name }}" not in workflow


### PR DESCRIPTION
## Summary

- generate Linux ARM64 Bridge checksums from inside the artifact directory
- ensure checksum records use downloadable asset basenames
- add a static regression against path-prefixed checksum records

## Verification

- release-version static tests: 7 passed
- workflow YAML parse: passed
- `git diff --check`: passed

Discovered and manually corrected while verifying the `v0.4.1-beta` draft release.
