### PR TITLE
feat(contacts): add cross-platform favorite contract and web UI

### DIFF
--- a/apps/docs/user-guide/contacts.md
+++ b/apps/docs/user-guide/contacts.md
@@ -17,6 +17,12 @@ Contacts can be organized into multiple address books. Each address book is a se
 2. Make your changes.
 3. Save. The updated contact is re-encrypted and synced to your other devices.
 
+## Favorites
+
+Select the star beside a contact and use the **Favorites** view to filter starred contacts from visible address books. Favorites use the shared vCard contract; Android synchronization requires a SilentSuite Android version that supports contact favorites. In a shared address book the value is global to all members; writable members can change it and read-only members cannot.
+
+Favorite status remains inside the end-to-end encrypted vCard content, not plaintext collection metadata, indexes, or logs. Offline web changes use encrypted local item content plus a content-free queue record. An online failure rolls the star back. Read-only address books cannot be changed.
+
 ## Delete a Contact
 
 1. Open the contact.
@@ -30,3 +36,5 @@ You can import contacts from vCard (`.vcf`) and CSV files. This makes it straigh
 ## Export
 
 Export your contacts at any time. Your data belongs to you, and you can take it with you.
+
+SilentSuite uses the private `X-SILENTSUITE-FAVORITE` vCard extension. The Bridge preserves received extensions, but favorite is not standardized across CardDAV. Generic CardDAV clients, Thunderbird, DAVx5, Google CardDAV, and Apple Contacts/Phone have no promised compatible favorite UI, and complete-card writers may remove unknown extensions.

--- a/apps/web/app/(app)/contacts/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/contacts/__tests__/page.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ContactsPage from '../page'
 import { renderWithIntl } from '@/src/__tests__/render-with-intl'
@@ -25,6 +25,8 @@ const storeMock = vi.hoisted(() => ({
     createContact: vi.fn(),
     updateContact: vi.fn(),
     deleteContact: vi.fn(),
+    setContactFavorite: vi.fn(),
+    canWriteContact: vi.fn(() => true),
   },
   contactListState: {
     lists: [] as ContactList[],
@@ -63,7 +65,25 @@ describe('ContactsPage mobile reachability', () => {
   beforeEach(() => {
     storeMock.contactState.isLoading = true
     storeMock.contactState.searchQuery = ''
+    storeMock.contactState.contacts = []
+    storeMock.contactListState.lists = []
     storeMock.authState.canWrite.mockReturnValue(true)
+  })
+
+  it('uses separate valid row and star controls and filters favorites', () => {
+    storeMock.contactState.isLoading = false
+    storeMock.contactState.contacts = [
+      { id: '1', uid: '1', displayName: 'Ada', name: { prefix: '', given: 'Ada', family: '', suffix: '' }, phones: [], emails: [], addresses: [], organization: '', title: '', notes: '', birthday: null, photoUrl: null, favorite: true, listId: 'book', created_at: new Date(), updated_at: new Date() },
+      { id: '2', uid: '2', displayName: 'Bob', name: { prefix: '', given: 'Bob', family: '', suffix: '' }, phones: [], emails: [], addresses: [], organization: '', title: '', notes: '', birthday: null, photoUrl: null, favorite: false, listId: 'book', created_at: new Date(), updated_at: new Date() },
+    ]
+    storeMock.contactListState.lists = [{ id: 'book', name: 'Book', color: '#fff', visible: true, accessLevel: 2 }]
+    renderWithIntl(<ContactsPage />)
+
+    expect(screen.getByRole('button', { name: 'Remove Ada from favorites' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add Bob to favorites' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Favorites' }))
+    expect(screen.getByText('Ada')).toBeInTheDocument()
+    expect(screen.queryByText('Bob')).not.toBeInTheDocument()
   })
 
   it('exposes the primary create action on all widths', () => {

--- a/apps/web/app/(app)/contacts/page.tsx
+++ b/apps/web/app/(app)/contacts/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import {
   Search, ArrowLeft, Phone, Mail, MapPin, Building2, Cake,
-  StickyNote, User, WifiOff, Plus, Trash2, X, Pencil, Camera, BookUser, List, Folder, Tag,
+  StickyNote, User, WifiOff, Plus, Trash2, X, Pencil, Camera, BookUser, List, Folder, Tag, Star,
 } from 'lucide-react'
 import { LabelEditor, LabelChips } from '@/app/components/LabelEditor'
 import { useContactStore, getFilteredContacts } from '@/app/stores/use-contact-store'
@@ -172,34 +172,47 @@ function ContactListItem({
   contact,
   isSelected,
   onSelect,
+  onToggleFavorite,
+  canFavorite,
 }: {
   contact: Contact
   isSelected: boolean
   onSelect: () => void
+  onToggleFavorite: () => void
+  canFavorite: boolean
 }) {
   const primaryEmail = contact.emails[0]?.value ?? ''
   const primaryPhone = contact.phones[0]?.value ?? ''
 
   return (
-    <button
-      type="button"
-      onClick={onSelect}
+    <div
       className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors ${
         isSelected
           ? 'bg-emerald-600/15 border border-emerald-500/30'
           : 'border border-transparent hover:bg-[rgb(var(--surface))]'
       }`}
     >
-      <ContactAvatar contact={contact} size="sm" />
-      <div className="min-w-0 flex-1">
+      <button type="button" onClick={onSelect} className="flex min-h-11 min-w-0 flex-1 items-center gap-3 text-left">
+        <ContactAvatar contact={contact} size="sm" />
+        <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium text-[rgb(var(--foreground))]">
           {contact.displayName}
         </div>
         <div className="truncate text-xs text-[rgb(var(--muted))]">
           {primaryEmail || primaryPhone || ''}
         </div>
-      </div>
-    </button>
+        </div>
+      </button>
+      <button
+        type="button"
+        onClick={onToggleFavorite}
+        disabled={!canFavorite}
+        aria-label={`${contact.favorite ? 'Remove' : 'Add'} ${contact.displayName} ${contact.favorite ? 'from' : 'to'} favorites`}
+        className="touch-target shrink-0 rounded-md text-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <Star className={`h-5 w-5 ${contact.favorite ? 'fill-current' : ''}`} />
+      </button>
+    </div>
   )
 }
 
@@ -639,6 +652,8 @@ function ContactDetail({
 }) {
   const updateContact = useContactStore((s) => s.updateContact)
   const deleteContact = useContactStore((s) => s.deleteContact)
+  const setContactFavorite = useContactStore((s) => s.setContactFavorite)
+  const canFavorite = useContactStore((s) => s.canWriteContact(contact))
   const canWrite = useAuthStore((s) => s.canWrite())
   const photoInputRef = useRef<HTMLInputElement>(null)
   const [editing, setEditing] = useState(false)
@@ -765,6 +780,15 @@ function ContactDetail({
             Back
           </button>
           <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setContactFavorite(contact.id, !contact.favorite)}
+              disabled={!canFavorite}
+              aria-label={`${contact.favorite ? 'Remove' : 'Add'} ${contact.displayName} ${contact.favorite ? 'from' : 'to'} favorites`}
+              className="touch-target rounded text-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Star className={`h-5 w-5 ${contact.favorite ? 'fill-current' : ''}`} />
+            </button>
             {canWrite && (
               <>
                 <button
@@ -1082,9 +1106,12 @@ export default function ContactsPage() {
   const searchQuery = useContactStore((s) => s.searchQuery)
   const isOnline = useSyncStore((s) => s.isOnline)
   const contactLists = useContactListStore((s) => s.lists)
+  const setContactFavorite = useContactStore((s) => s.setContactFavorite)
+  const canWriteContact = useContactStore((s) => s.canWriteContact)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [showNewForm, setShowNewForm] = useState(false)
   const [collectionSheetOpen, setCollectionSheetOpen] = useState(false)
+  const [contactView, setContactView] = useState<'all' | 'favorites'>('all')
 
   // Filter contacts by visible lists
   const visibleListIds = useMemo(() => new Set(contactLists.filter(l => l.visible).map(l => l.id)), [contactLists])
@@ -1092,10 +1119,14 @@ export default function ContactsPage() {
     () => contacts.filter((c) => visibleListIds.has(c.listId ?? 'default')),
     [contacts, visibleListIds],
   )
+  const viewFilteredContacts = useMemo(
+    () => contactView === 'favorites' ? listFilteredContacts.filter((contact) => contact.favorite === true) : listFilteredContacts,
+    [contactView, listFilteredContacts],
+  )
 
   const filtered = useMemo(
-    () => sortContacts(getFilteredContacts(listFilteredContacts, searchQuery)),
-    [listFilteredContacts, searchQuery],
+    () => sortContacts(getFilteredContacts(viewFilteredContacts, searchQuery)),
+    [viewFilteredContacts, searchQuery],
   )
 
   const selectedContact = useMemo(
@@ -1103,8 +1134,9 @@ export default function ContactsPage() {
     [contacts, selectedId],
   )
 
-  const isEmpty = listFilteredContacts.length === 0 && !isLoading
+  const isEmpty = contactView === 'all' && listFilteredContacts.length === 0 && !isLoading
   const isEmptySearch = filtered.length === 0 && searchQuery.trim() !== '' && !isLoading
+  const isEmptyFavorites = contactView === 'favorites' && viewFilteredContacts.length === 0 && !searchQuery.trim() && !isLoading
 
   return (
     <div className="flex h-full flex-col gap-3">
@@ -1146,6 +1178,20 @@ export default function ContactsPage() {
       {/* Search */}
       <SearchBar />
 
+      <div className="inline-flex w-fit rounded-lg bg-[rgb(var(--surface))] p-1" role="group" aria-label="Contact view">
+        {(['all', 'favorites'] as const).map((view) => (
+          <button
+            key={view}
+            type="button"
+            aria-pressed={contactView === view}
+            onClick={() => setContactView(view)}
+            className={`min-h-11 rounded-md px-3 text-sm ${contactView === view ? 'bg-emerald-600 text-white' : 'text-[rgb(var(--muted))]'}`}
+          >
+            {view === 'all' ? 'All' : 'Favorites'}
+          </button>
+        ))}
+      </div>
+
       {/* New Contact Form */}
       {showNewForm && (
         <ContactForm
@@ -1162,6 +1208,12 @@ export default function ContactsPage() {
         <ContactSkeleton />
       ) : isEmpty ? (
         <ContactsEmptyState onAddContact={canWrite ? () => setShowNewForm(true) : undefined} />
+      ) : isEmptyFavorites ? (
+        <div className="flex flex-1 flex-col items-center justify-center text-center">
+          <Star className="mb-3 h-10 w-10 text-[rgb(var(--muted))]" />
+          <h3 className="font-medium text-[rgb(var(--foreground))]">No favorite contacts</h3>
+          <p className="mt-1 text-sm text-[rgb(var(--muted))]">Star a contact to see it here.</p>
+        </div>
       ) : isEmptySearch ? (
         <SearchEmptyState query={searchQuery} />
       ) : (
@@ -1178,6 +1230,8 @@ export default function ContactsPage() {
                 contact={contact}
                 isSelected={contact.id === selectedId}
                 onSelect={() => setSelectedId(contact.id)}
+                onToggleFavorite={() => setContactFavorite(contact.id, !contact.favorite)}
+                canFavorite={canWriteContact(contact)}
               />
             ))}
           </div>

--- a/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/export/__tests__/page.test.tsx
@@ -109,11 +109,15 @@ vi.mock('@/app/stores/use-contact-list-store', () => ({
 }))
 
 // Mock @silentsuite/core serializers
-vi.mock('@silentsuite/core', () => ({
-  toVEvent: vi.fn(() => 'BEGIN:VEVENT\r\nSUMMARY:Meeting\r\nEND:VEVENT'),
-  toVTodo: vi.fn(() => 'BEGIN:VTODO\r\nSUMMARY:Test task\r\nEND:VTODO'),
-  toVCard: vi.fn(() => 'BEGIN:VCARD\r\nFN:Alice\r\nEND:VCARD'),
-}))
+vi.mock('@silentsuite/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@silentsuite/core')>()
+  return {
+    ...actual,
+    toVEvent: vi.fn(() => 'BEGIN:VEVENT\r\nSUMMARY:Meeting\r\nEND:VEVENT'),
+    toVTodo: vi.fn(() => 'BEGIN:VTODO\r\nSUMMARY:Test task\r\nEND:VTODO'),
+    toVCard: vi.fn(actual.toVCard),
+  }
+})
 
 // Mock @silentsuite/ui
 vi.mock('@silentsuite/ui', () => ({
@@ -360,6 +364,14 @@ describe('ExportPage', () => {
     const blobCall = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as Blob
     expect(blobCall.type).toBe('text/vcard')
+  })
+
+  it('exports favorite contacts through the canonical contact serializer', () => {
+    mockData.contacts[0]!.favorite = true
+    render(<ExportPage />)
+    fireEvent.click(screen.getByText(/Export Contacts/))
+    expect(toVCard).toHaveBeenCalledWith(expect.objectContaining({ favorite: true }))
+    expect(vi.mocked(toVCard).mock.results[0]!.value).toContain('X-SILENTSUITE-FAVORITE:1')
   })
 
   it('skips events that fail to serialize and shows a warning toast', () => {

--- a/apps/web/app/components/import/ContactImport.tsx
+++ b/apps/web/app/components/import/ContactImport.tsx
@@ -142,6 +142,7 @@ export default function ContactImport({ onImportComplete, heading }: ContactImpo
         birthday: contact.bday ?? null,
         photoUrl: contact.photo ?? null,
         categories: normalizeLabels(contact.categories ?? []),
+        favorite: contact.favorite === true,
         listId: selectedListId,
       }))
       const count = await importContacts(newContacts)

--- a/apps/web/app/components/import/__tests__/ContactImport.test.tsx
+++ b/apps/web/app/components/import/__tests__/ContactImport.test.tsx
@@ -2,23 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import ContactImport from '../ContactImport'
 import { renderWithIntl } from '@/src/__tests__/render-with-intl'
-import type { VCard } from '@silentsuite/core/utils/vcard-parser'
 const mocks = vi.hoisted(() => ({
   importContacts: vi.fn(),
   createCollection: vi.fn(),
   onImportComplete: vi.fn(),
 }))
 
-vi.mock('@silentsuite/core/utils/vcard-parser', () => ({
-  parseVCard: vi.fn((vc: string): VCard => {
-    void vc
-    return {
-      uid: 'vc-1',
-      fn: 'Jane Doe',
-      categories: [' Work ', 'work', 'Home'],
-    }
-  }),
-}))
 
 vi.mock('@/app/stores/use-contact-store', () => ({
   useContactStore: function useContactStore<T>(selector: (state: {
@@ -60,7 +49,7 @@ describe('ContactImport categories normalization', () => {
 
     const input = container.querySelector('input[type="file"]') as HTMLInputElement
     const file = new File(
-      ['BEGIN:VCARD\nVERSION:4.0\nFN:Jane Doe\nEND:VCARD'],
+      ['BEGIN:VCARD\nVERSION:4.0\nUID:vc-1\nFN:Jane Doe\nCATEGORIES: Work ,work,Home\nX-SILENTSUITE-FAVORITE:1\nEND:VCARD'],
       'contacts.vcf',
       { type: 'text/vcard' },
     )
@@ -73,7 +62,8 @@ describe('ContactImport categories normalization', () => {
       expect(mocks.importContacts).toHaveBeenCalledTimes(1)
     })
 
-    const payload = mocks.importContacts.mock.calls[0]![0] as Array<{ categories: string[] }>
+    const payload = mocks.importContacts.mock.calls[0]![0] as Array<{ categories: string[]; favorite: boolean }>
     expect(payload[0]!.categories).toEqual(['Work', 'Home'])
+    expect(payload[0]!.favorite).toBe(true)
   })
 })

--- a/apps/web/app/lib/data-cache.ts
+++ b/apps/web/app/lib/data-cache.ts
@@ -408,8 +408,14 @@ async function commitItemMutations(
 }
 
 /** Insert/update a single item. Failures are logged and swallowed. */
-export async function putItem(item: CachedItem, accountEpoch?: number): Promise<void> {
-  if (!canWriteItemContent('putItem')) return
+export async function putItem(
+  item: CachedItem,
+  accountEpoch?: number,
+  options?: { allowWithoutFeatureFlag?: boolean },
+): Promise<void> {
+  if (options?.allowWithoutFeatureFlag) {
+    if (!hasEncryptedCacheEnvelope()) return
+  } else if (!canWriteItemContent('putItem')) return
   try {
     const stored = await toStoredItem(item)
     if (accountEpoch !== undefined) assertCurrentAccountEpoch(accountEpoch)

--- a/apps/web/app/stores/__tests__/use-contact-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-contact-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useContactStore, getFilteredContacts } from '../use-contact-store'
 import { useEtebaseStore } from '../use-etebase-store'
+import { useContactListStore } from '../use-contact-list-store'
 import type { Contact } from '@silentsuite/core'
 import { getAll } from '@/app/lib/offline-queue'
 import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, enqueueCreateFromStore, expectOwnedQueueEntry, expectQuietQueueCommitCancellation, queueGuard, replayOwnedEntry, resetRealOfflineQueue } from './offline-queue-store-test-utils'
@@ -27,6 +28,7 @@ function resetStore() {
     pendingChanges: [],
   })
   useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+  useContactListStore.setState({ lists: [{ id: 'contacts-1', name: 'Contacts', color: '#fff', visible: true, accessLevel: 2 }], activeListId: 'contacts-1' })
 }
 
 function offlineAccount() {
@@ -257,6 +259,106 @@ describe('useContactStore', () => {
         () => expect(useContactStore.getState().contacts).toEqual([]),
         toastMock,
       )
+    })
+  })
+
+  describe('favorites', () => {
+    beforeEach(() => {
+      toastMock.showErrorToast.mockReset()
+      useContactStore.setState({ contacts: [queuedContact('remote-contact')] })
+    })
+
+    it('persists an authorized favorite as canonical encrypted item content', async () => {
+      const updateItem = vi.fn().mockResolvedValue('remote')
+      useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map([['remote-contact', {}]]), updateItem } as any)
+      await useContactStore.getState().setContactFavorite('remote-contact', true)
+      expect(useContactStore.getState().contacts[0]!.favorite).toBe(true)
+      expect(updateItem.mock.calls[0]![2]).toContain('X-SILENTSUITE-FAVORITE:1')
+      expect(updateItem.mock.calls[0]![3]).toEqual({ suppressErrorToast: true, persistEncryptedOfflineContent: true })
+    })
+
+    it('rolls back an online failure with static feedback', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map([['remote-contact', {}]]), updateItem: vi.fn().mockRejectedValue(new Error('private')) } as any)
+      await useContactStore.getState().setContactFavorite('remote-contact', true)
+      expect(useContactStore.getState().contacts[0]!.favorite).toBe(false)
+      expect(toastMock.showErrorToast).toHaveBeenCalledWith('Failed to update favorite. Please try again.')
+      errorSpy.mockRestore()
+    })
+
+    it('fails closed before mutation when access is read-only or missing', async () => {
+      for (const accessLevel of [0, undefined]) {
+        useContactListStore.setState({ lists: [{ id: 'contacts-1', name: 'Contacts', color: '#fff', visible: true, accessLevel }] })
+        const updateItem = vi.fn()
+        useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map([['remote-contact', {}]]), updateItem } as any)
+        await useContactStore.getState().setContactFavorite('remote-contact', true)
+        expect(useContactStore.getState().contacts[0]!.favorite).not.toBe(true)
+        expect(updateItem).not.toHaveBeenCalled()
+      }
+    })
+
+    it('allows both owner/admin and read-write collection access', () => {
+      const contact = useContactStore.getState().contacts[0]!
+      for (const accessLevel of [1, 2]) {
+        useContactListStore.setState({ lists: [{ id: 'contacts-1', name: 'Contacts', color: '#fff', visible: true, accessLevel }] })
+        expect(useContactStore.getState().canWriteContact(contact)).toBe(true)
+      }
+    })
+
+    it('does not optimistically mutate without an account fingerprint', async () => {
+      const updateItem = vi.fn()
+      useEtebaseStore.setState({ account: {}, accountFingerprint: null, itemCache: new Map([['remote-contact', {}]]), updateItem } as any)
+      await useContactStore.getState().setContactFavorite('remote-contact', true)
+      expect(useContactStore.getState().contacts[0]!.favorite).not.toBe(true)
+      expect(updateItem).not.toHaveBeenCalled()
+    })
+
+    it('rolls back when the authoritative collection is unavailable', async () => {
+      useEtebaseStore.setState({
+        account: {},
+        accountFingerprint: TEST_FINGERPRINT,
+        collections: { calendar: [], tasks: [], contacts: [], preferences: [], labelIndex: [] },
+        itemCache: new Map([['remote-contact', {}]]),
+      } as any)
+      await useContactStore.getState().setContactFavorite('remote-contact', true)
+      expect(useContactStore.getState().contacts[0]!.favorite).toBe(false)
+      expect(toastMock.showErrorToast).toHaveBeenCalledWith('Failed to update favorite. Please try again.')
+    })
+
+    it('does not let an older failed request roll back a newer favorite value', async () => {
+      let rejectFirst!: (reason: Error) => void
+      const first = new Promise<never>((_resolve, reject) => { rejectFirst = reject })
+      const updateItem = vi.fn()
+        .mockReturnValueOnce(first)
+        .mockResolvedValueOnce('remote')
+      useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map([['remote-contact', {}]]), updateItem } as any)
+
+      const older = useContactStore.getState().setContactFavorite('remote-contact', true)
+      const newer = useContactStore.getState().setContactFavorite('remote-contact', false)
+      rejectFirst(new Error('older request failed'))
+      await Promise.all([older, newer])
+
+      expect(useContactStore.getState().contacts[0]!.favorite).toBe(false)
+    })
+
+    it('serializes two successful writes so the latest value reaches the server last', async () => {
+      let resolveFirst!: (value: 'remote') => void
+      let resolveSecond!: (value: 'remote') => void
+      const first = new Promise<'remote'>((resolve) => { resolveFirst = resolve })
+      const second = new Promise<'remote'>((resolve) => { resolveSecond = resolve })
+      const updateItem = vi.fn().mockReturnValueOnce(first).mockReturnValueOnce(second)
+      useEtebaseStore.setState({ account: {}, accountFingerprint: TEST_FINGERPRINT, itemCache: new Map([['remote-contact', {}]]), updateItem } as any)
+
+      const favorite = useContactStore.getState().setContactFavorite('remote-contact', true)
+      const unfavorite = useContactStore.getState().setContactFavorite('remote-contact', false)
+      await vi.waitFor(() => expect(updateItem).toHaveBeenCalledTimes(1))
+      expect(updateItem.mock.calls[0]![2]).toContain('X-SILENTSUITE-FAVORITE:1')
+      resolveFirst('remote')
+      await vi.waitFor(() => expect(updateItem).toHaveBeenCalledTimes(2))
+      expect(updateItem.mock.calls[1]![2]).not.toContain('X-SILENTSUITE-FAVORITE:1')
+      resolveSecond('remote')
+      await Promise.all([favorite, unfavorite])
+      expect(useContactStore.getState().contacts[0]!.favorite).toBe(false)
     })
   })
 })

--- a/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
+++ b/apps/web/app/stores/__tests__/use-etebase-store-offline-queue.integration.test.ts
@@ -1,6 +1,12 @@
 import 'fake-indexeddb/auto'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { enqueue, getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
+import { _setEncryptedQueuePersistenceAvailableForTests, enqueue, getAll, getPendingCount, replay } from '@/app/lib/offline-queue'
+import {
+  _resetForTests as resetDataCache,
+  _setEncryptedCacheAvailableForTests,
+  _setEnvelopeKeyForTests,
+  getItemsByType,
+} from '@/app/lib/data-cache'
 import { bumpAccountEpoch } from '@/app/lib/account-epoch'
 import { TEST_FINGERPRINT, bumpEpochWhenQueuePutRuns, changeAccountWhenQueuePutRuns, queueGuard, resetRealOfflineQueue } from './offline-queue-store-test-utils'
 
@@ -79,12 +85,44 @@ async function expectOwned(types: string[]) {
 describe('useEtebaseStore real guarded offline queue integration', () => {
   beforeEach(async () => {
     await resetRealOfflineQueue()
+    await resetDataCache()
+    _setEnvelopeKeyForTests(await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']))
+    _setEncryptedCacheAvailableForTests(true)
     useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
     coreMock.createItem.mockReset()
     coreMock.updateItem.mockReset()
     coreMock.deleteItem.mockReset()
     coreMock.listItems.mockReset().mockResolvedValue({ items: [], stoken: null, done: true })
     toastMock.showErrorToast.mockReset()
+  })
+
+  it('queues an offline favorite-style update without plaintext queue content', async () => {
+    const sentinel = 'BEGIN:VCARD\r\nFN:PRIVATE FAVORITE\r\nX-SILENTSUITE-FAVORITE:1\r\nEND:VCARD'
+    setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
+    coreMock.updateItem.mockRejectedValueOnce(offlineError())
+    _setEncryptedQueuePersistenceAvailableForTests(false)
+
+    await expect(useEtebaseStore.getState().updateItem('calendar', 'item-1', sentinel, {
+      persistEncryptedOfflineContent: true,
+      suppressErrorToast: true,
+    })).resolves.toBe('queued')
+
+    const entries = await getAll(queueGuard())
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ type: 'update', itemUid: 'item-1', collectionUid: 'col-1' })
+    expect(entries[0]!.content).toBeUndefined()
+    expect(JSON.stringify(entries)).not.toContain('PRIVATE FAVORITE')
+    expect((await getItemsByType('calendar')).find((item) => item.itemUid === 'item-1')?.content).toBe(sentinel)
+
+    coreMock.updateItem.mockResolvedValueOnce(undefined)
+    await useSyncStore.getState().replayOfflineQueue()
+    expect(coreMock.updateItem).toHaveBeenLastCalledWith(
+      useEtebaseStore.getState().account,
+      expect.objectContaining({ uid: 'col-1' }),
+      expect.objectContaining({ uid: 'item-1' }),
+      sentinel,
+    )
+    expect(await getAll(queueGuard())).toEqual([])
   })
 
   it('real createItem fallback persists the active fingerprint and is visible to guarded count and replay', async () => {
@@ -146,16 +184,16 @@ describe('useEtebaseStore real guarded offline queue integration', () => {
   })
 
   it.each([
-    ['updateItem', async () => useEtebaseStore.getState().updateItem('calendar', 'item-1', 'NEW')],
-    ['deleteItem', async () => useEtebaseStore.getState().deleteItem('calendar', 'item-1')],
-  ] as const)('%s quietly cancels at its real queue put boundary', async (_name, mutate) => {
+    ['updateItem', async () => useEtebaseStore.getState().updateItem('calendar', 'item-1', 'NEW'), false],
+    ['deleteItem', async () => useEtebaseStore.getState().deleteItem('calendar', 'item-1'), undefined],
+  ] as const)('%s quietly cancels at its real queue put boundary', async (_name, mutate, expectedResult) => {
     setAccount({ items: [{ uid: 'item-1', collectionUid: 'col-1', item: cachedItem('item-1') }] })
     coreMock.updateItem.mockRejectedValueOnce(offlineError())
     coreMock.deleteItem.mockRejectedValueOnce(offlineError())
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const putSpy = changeAccountWhenQueuePutRuns(switchAccountAtBoundary)
     try {
-      await expect(mutate()).resolves.toBeUndefined()
+      await expect(mutate()).resolves.toBe(expectedResult)
       expect(await getAll()).toEqual([])
       expectNewAccountStateUntouched()
       expect(errorSpy).not.toHaveBeenCalled()

--- a/apps/web/app/stores/use-contact-list-store.ts
+++ b/apps/web/app/stores/use-contact-list-store.ts
@@ -7,6 +7,8 @@ export interface ContactList {
   name: string
   color: string
   visible: boolean
+  /** Etebase access: 0 read-only, 1 admin, 2 read/write. Missing fails closed. */
+  accessLevel?: number
 }
 
 export const DEFAULT_CONTACT_LIST_COLORS = [

--- a/apps/web/app/stores/use-contact-store.ts
+++ b/apps/web/app/stores/use-contact-store.ts
@@ -23,6 +23,7 @@ interface NewContact {
   birthday?: string | null
   photoUrl?: string | null
   categories?: string[]
+  favorite?: boolean
   listId?: string
 }
 
@@ -36,6 +37,8 @@ interface ContactState {
 interface ContactActions {
   createContact: (contact: NewContact) => Promise<Contact>
   updateContact: (id: string, patch: Partial<Contact>) => Promise<void>
+  canWriteContact: (contact: Contact) => boolean
+  setContactFavorite: (id: string, value: boolean) => Promise<void>
   deleteContact: (id: string) => Promise<void>
   setSearchQuery: (query: string) => void
   importContacts: (newContacts: NewContact[]) => Promise<number>
@@ -47,6 +50,8 @@ function defaultContactListId(): string | undefined {
   if (activeListId !== 'all' && lists.some((list) => list.id === activeListId)) return activeListId
   return lists[0]?.id
 }
+
+const favoriteMutationChains = new Map<string, Promise<void>>()
 
 export const useContactStore = create<ContactState & ContactActions>()(
     (set, get) => ({
@@ -78,6 +83,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
           birthday: newContact.birthday ?? null,
           photoUrl: newContact.photoUrl ?? null,
           categories: newContact.categories ?? [],
+          favorite: newContact.favorite ?? false,
           listId: newContact.listId ?? defaultContactListId(),
           created_at: now,
           updated_at: now,
@@ -154,6 +160,88 @@ export const useContactStore = create<ContactState & ContactActions>()(
         }
       },
 
+      canWriteContact: (contact: Contact) => {
+        if (!useAuthStore.getState().canWrite()) return false
+        const list = useContactListStore.getState().lists.find((entry) => entry.id === contact.listId)
+        return list?.accessLevel === 1 || list?.accessLevel === 2
+      },
+
+      setContactFavorite: async (id: string, value: boolean) => {
+        const contact = get().contacts.find((entry) => entry.id === id)
+        if (!contact || !get().canWriteContact(contact)) return
+
+        const etebase = useEtebaseStore.getState()
+        const guard = captureOfflineQueueAccountGuard(etebase)
+        if (!guard) return
+
+        const previous = contact.favorite === true
+        if (previous === value) return
+        const updated = { ...contact, favorite: value, updated_at: new Date() }
+        set((state) => ({ contacts: state.contacts.map((entry) => entry.id === id ? updated : entry) }))
+
+        const rollbackIfCurrent = () => set((state) => ({
+          contacts: state.contacts.map((entry) => (
+            entry.id === id && entry.updated_at === updated.updated_at && entry.favorite === value
+              ? { ...entry, favorite: previous }
+              : entry
+          )),
+        }))
+        const isCurrentFavoriteMutation = () => get().contacts.some((entry) => (
+          entry.id === id && entry.updated_at === updated.updated_at && entry.favorite === value
+        ))
+        let content: string
+        try {
+          assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+          const { serializeContact } = await import('@silentsuite/core')
+          assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+          content = serializeContact(updated)
+        } catch (error) {
+          if (isOfflineQueueBoundaryCancellation(error)) return
+          if (!isCurrentFavoriteMutation()) return
+          console.error('[contact-store] Failed to serialize favorite update', getSafeErrorDetails(error))
+          rollbackIfCurrent()
+          showErrorToast('Failed to update favorite. Please try again.')
+          return
+        }
+
+        const persistFavorite = async () => {
+          if (!etebase.itemCache.has(id)) {
+            // A contact without an authoritative SDK item cannot be replayed from
+            // a content-free queue record. Never fall back to plaintext vCard
+            // persistence; fail closed until the encrypted item cache is ready.
+            if (!isCurrentFavoriteMutation()) return
+            rollbackIfCurrent()
+            showErrorToast('Failed to update favorite. Please try again.')
+            return
+          }
+
+          try {
+            const outcome = await etebase.updateItem('contacts', id, content, {
+              suppressErrorToast: true,
+              persistEncryptedOfflineContent: true,
+            })
+            assertOfflineQueueAccountGuard(guard, useEtebaseStore.getState())
+            if (!outcome) {
+              if (!isCurrentFavoriteMutation()) return
+              rollbackIfCurrent()
+              showErrorToast('Failed to update favorite. Please try again.')
+            }
+          } catch (error) {
+            if (isOfflineQueueBoundaryCancellation(error)) return
+            if (!isCurrentFavoriteMutation()) return
+            console.error('[contact-store] Failed to update favorite', getSafeErrorDetails(error))
+            rollbackIfCurrent()
+            showErrorToast('Failed to update favorite. Please try again.')
+          }
+        }
+
+        const previousMutation = favoriteMutationChains.get(id) ?? Promise.resolve()
+        const mutation = previousMutation.catch(() => undefined).then(persistFavorite)
+        favoriteMutationChains.set(id, mutation)
+        await mutation
+        if (favoriteMutationChains.get(id) === mutation) favoriteMutationChains.delete(id)
+      },
+
       deleteContact: async (id: string) => {
         if (!useAuthStore.getState().canWrite()) throw new Error('Your subscription has ended. Upgrade to make changes.')
         const contactToDelete = get().contacts.find((c) => c.id === id)
@@ -214,6 +302,7 @@ export const useContactStore = create<ContactState & ContactActions>()(
             birthday: nc.birthday ?? null,
             photoUrl: nc.photoUrl ?? null,
             categories: nc.categories ?? [],
+            favorite: nc.favorite ?? false,
             listId: nc.listId ?? defaultContactListId(),
             created_at: now,
             updated_at: now,

--- a/apps/web/app/stores/use-etebase-store.ts
+++ b/apps/web/app/stores/use-etebase-store.ts
@@ -29,6 +29,7 @@ import {
   setStoken as cacheSetStoken,
   putItems as cachePutItems,
   putItem as cachePutItem,
+  getItemsByType as cacheGetItemsByType,
   deleteItem as cacheDeleteItem,
   replaceItemsForCollection as cacheReplaceItemsForCollection,
   isCacheEnabled as isLocalCacheEnabled,
@@ -359,6 +360,10 @@ function getCollectionColor(collection: any): string | undefined {
   }
 }
 
+function getCollectionAccessLevel(collection: any): number | undefined {
+  return typeof collection?.accessLevel === 'number' ? collection.accessLevel : undefined
+}
+
 async function hydrateListStores(
   collections: Record<CollectionTypeKey, any[]>,
   accountEpoch = getAccountEpoch(),
@@ -392,6 +397,7 @@ async function hydrateListStores(
       name: getCollectionName(collection, index === 0 ? 'My Contacts' : `Contacts ${index + 1}`),
       color: getCollectionColor(collection) || contactListStore.DEFAULT_CONTACT_LIST_COLORS[index % contactListStore.DEFAULT_CONTACT_LIST_COLORS.length],
       visible: true,
+      accessLevel: getCollectionAccessLevel(collection),
     })),
   )
 }
@@ -634,7 +640,12 @@ interface EtebaseActions {
   /**
    * Update an existing item by UID.
    */
-  updateItem: (type: CollectionTypeKey, itemUid: string, content: string) => Promise<void>
+  updateItem: (
+    type: CollectionTypeKey,
+    itemUid: string,
+    content: string,
+    options?: { suppressErrorToast?: boolean; persistEncryptedOfflineContent?: boolean },
+  ) => Promise<'remote' | 'queued' | false>
 
   /**
    * Move an existing item to another concrete collection by recreating it there.
@@ -1547,11 +1558,18 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
         return { remoteMutationConfirmed: true, itemUid: createdUid }
       }
       case 'update': {
-        if (typeof entry.content !== 'string') throw new ReplayNotConfirmedError('Replay update content is unavailable')
+        let content = entry.content
+        if (typeof content !== 'string' && entry.itemUid) {
+          assertOfflineQueueAccountGuard(guard, get())
+          const cachedItems = await cacheGetItemsByType(entry.collectionType)
+          assertOfflineQueueAccountGuard(guard, get())
+          content = cachedItems.find((cached) => cached.itemUid === entry.itemUid)?.content
+        }
+        if (typeof content !== 'string') throw new ReplayNotConfirmedError('Replay update content is unavailable')
         const collection = requireCollection(entry.collectionUid, 'owner')
         const item = requireItem()
         assertOfflineQueueAccountGuard(guard, get())
-        await core.updateItem(account, collection, item, entry.content)
+        await core.updateItem(account, collection, item, content)
         assertOfflineQueueAccountGuard(guard, get())
         return { remoteMutationConfirmed: true }
       }
@@ -1801,16 +1819,16 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
     }
   },
 
-  updateItem: async (type: CollectionTypeKey, itemUid: string, content: string) => {
+  updateItem: async (type: CollectionTypeKey, itemUid: string, content: string, options) => {
     const accountEpoch = getAccountEpoch()
     const { account, collections, itemCache, itemCollectionMap, accountFingerprint } = get()
     const offlineQueueGuard = captureOfflineQueueAccountGuard({ account, accountFingerprint })
-    if (!offlineQueueGuard) return
+    if (!offlineQueueGuard) return false
     const collection = resolveCollection(collections, type, itemCollectionMap.get(itemUid))
     const item = itemCache.get(itemUid)
     if (!collection || !item) {
       logger.warn(`[etebase-store] Cannot update item ${itemUid}: missing collection or item`)
-      return
+      return false
     }
 
     try {
@@ -1822,21 +1840,48 @@ export const useEtebaseStore = create<EtebaseState & EtebaseActions>((set, get) 
       newCache.set(itemUid, updated)
       set({ itemCache: newCache })
       await writeItemToCache(type, collection.uid, itemUid, content, accountEpoch)
+      assertCurrentAccountEpoch(accountEpoch)
+      return 'remote'
     } catch (err) {
-      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return
+      if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
       if (isOfflineError(err)) {
         try {
           assertOfflineQueueAccountGuard(offlineQueueGuard, get())
-          await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, offlineQueueGuard)
+          if (options?.persistEncryptedOfflineContent) {
+            if (!await cacheEnsureEncryptedEnvelope(accountEpoch)) return false
+            await cacheEnsureFingerprint(offlineQueueGuard.accountFingerprint, accountEpoch)
+            await cachePutItem({
+              itemUid,
+              collectionType: type,
+              collectionUid: collection.uid,
+              content,
+              lastModified: Date.now(),
+            }, accountEpoch, { allowWithoutFeatureFlag: true })
+            assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+            const cachedItems = await cacheGetItemsByType(type)
+            assertOfflineQueueAccountGuard(offlineQueueGuard, get())
+            const persisted = cachedItems.find((cached) => cached.itemUid === itemUid)
+            if (persisted?.content !== content || persisted.collectionUid !== collection.uid) {
+              return false
+            }
+            await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, itemUid }, offlineQueueGuard)
+          } else {
+            await enqueue({ type: 'update', collectionType: type, collectionUid: collection.uid, content, itemUid }, offlineQueueGuard)
+          }
           assertOfflineQueueAccountGuard(offlineQueueGuard, get())
           logger.warn(`[etebase-store] Offline — queued update for ${type}/${itemUid}`)
+          return 'queued'
         } catch (queueErr) {
-          if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return
+          if (!isCurrentAccountEpoch(accountEpoch) || queueErr instanceof AccountBoundaryChangedError) return false
           console.error('[etebase-store] Failed to enqueue update', getSafeErrorDetails(queueErr))
+          return false
         }
       } else {
         console.error(`[etebase-store] Failed to update ${type} item`, getSafeErrorDetails(err))
-        showErrorToast(`Failed to save ${type === 'calendar' ? 'event' : type === 'tasks' ? 'task' : type === 'contacts' ? 'contact' : 'preferences'}. Please try again.`)
+        if (!options?.suppressErrorToast) {
+          showErrorToast(`Failed to save ${type === 'calendar' ? 'event' : type === 'tasks' ? 'task' : type === 'contacts' ? 'contact' : 'preferences'}. Please try again.`)
+        }
+        return false
       }
     }
   },

--- a/bridge/tests/test_item_format_fixtures.py
+++ b/bridge/tests/test_item_format_fixtures.py
@@ -203,8 +203,40 @@ def _assert_vcard(card, expected: dict, raw: str) -> None:
                 if "cell" in [t.lower() for t in prop.params.get("TYPE", [])]
             ]
             assert value in cells
+        elif key == "favorite":
+            props = [
+                prop
+                for name, values in card.contents.items()
+                if name.split(".")[-1].lower() == "x-silentsuite-favorite"
+                for prop in values
+            ]
+            assert any(prop.value == "1" for prop in props) is value
         else:
             raise AssertionError(f"unhandled expected key {key!r} for a vcard fixture")
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected"),
+    [
+        ([], False),
+        (["X-SILENTSUITE-FAVORITE:0"], False),
+        (["X-SILENTSUITE-FAVORITE:true"], False),
+        (["item1.X-SILENTSUITE-FAVORITE;TYPE=pref:1"], True),
+        (["X-SILENTSUITE-FAVORITE:0", "x-silentsuite-favorite:1"], True),
+        (["X-SILENTSUITE-FAVORITE:", " 1"], True),
+    ],
+)
+def test_favorite_boolean_semantics_survive_vobject(lines, expected):
+    raw = "\r\n".join(["BEGIN:VCARD", "VERSION:4.0", "UID:fav", "FN:Favorite", *lines, "END:VCARD"])
+    serialized = vobject.readOne(raw).serialize()
+    unfolded = serialized.replace("\r\n ", "").replace("\n ", "")
+    values = []
+    for line in unfolded.splitlines():
+        name, separator, value = line.partition(":")
+        normalized = name.split(";", 1)[0].split(".")[-1].upper()
+        if separator and normalized == "X-SILENTSUITE-FAVORITE":
+            values.append(value)
+    assert any(value == "1" for value in values) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/bridge/tests/test_storage.py
+++ b/bridge/tests/test_storage.py
@@ -109,6 +109,108 @@ class TestMetaMapping:
         assert val == "#00FF00"
 
 
+class TestFavoriteStoragePrivacy:
+    def test_cache_schema_has_no_favorite_plaintext_fields_or_indexes(self):
+        forbidden = {"favorite", "starred", "x-silentsuite-favorite"}
+        for model in (CollectionEntity, ItemEntity, HrefMapper):
+            field_names = {name.lower() for name in model._meta.fields}
+            index_text = repr(model._meta.indexes).lower()
+            assert forbidden.isdisjoint(field_names)
+            assert not any(key in index_text for key in forbidden)
+
+    def test_collection_metadata_mapping_has_no_favorite_key(self):
+        keys = {str(key).lower() for key in MetaMappingContacts._mappings}
+        values = {str(value[0]).lower() for value in MetaMappingContacts._mappings.values()}
+        assert not ({"favorite", "starred", "x-silentsuite-favorite"} & (keys | values))
+
+
+class TestFavoriteCardDavRoundTrip:
+    @staticmethod
+    def _collection(mem_db, user, content, *, uid="fav-1", href="favorite.vcf"):
+        cache_col = CollectionEntity.create(
+            local_user=user, uid="contacts", eb_col=b"encrypted-collection"
+        )
+        cache_item = ItemEntity.create(
+            collection=cache_col, uid=uid, eb_item=b"encrypted-item"
+        )
+        HrefMapper.create(content=cache_item, href=href)
+
+        item = MagicMock()
+        item.cache_item = cache_item
+        item.content = content
+        item.etag = "etag-favorite"
+        item.meta = {"mtime": 1700000000000}
+
+        cached_collection = MagicMock()
+        cached_collection.col_type = "etebase.vcard"
+        cached_collection.cache_col = cache_col
+        cached_collection.stoken = "stoken-favorite"
+        cached_collection.get.side_effect = lambda requested_uid: item if requested_uid == uid else None
+        cached_collection.list.return_value = [item]
+
+        storage = MagicMock()
+        storage.etesync.get.return_value = cached_collection
+        collection = Collection(storage, "/test@example.com/contacts")
+        return collection, cached_collection, item
+
+    def test_get_update_and_removal_preserve_favorite_href_and_etag(self, mem_db, user):
+        content = "\r\n".join([
+            "BEGIN:VCARD", "VERSION:4.0", "UID:fav-1", "FN:Favorite",
+            "X-SILENTSUITE-FAVORITE:1", "END:VCARD",
+        ])
+        collection, _, item = self._collection(mem_db, user, content)
+
+        fetched = collection._get("favorite.vcf")
+        assert fetched.href == "favorite.vcf"
+        assert fetched.etag == '"etag-favorite"'
+        assert "X-SILENTSUITE-FAVORITE:1" in fetched.serialize()
+
+        replacement = MagicMock()
+        replacement.vobject_item = vobject.readOne(content.replace("X-SILENTSUITE-FAVORITE:1\r\n", ""))
+        updated = collection.upload("favorite.vcf", replacement)
+        assert "X-SILENTSUITE-FAVORITE" not in item.content
+        assert updated.href == "favorite.vcf"
+        item.save.assert_called_once()
+
+        collection.delete("favorite.vcf")
+        item.delete.assert_called_once()
+
+    def test_get_preserves_grouped_folded_duplicate_semantics_through_v4_to_v3(self, mem_db, user):
+        content = "\r\n".join([
+            "BEGIN:VCARD", "VERSION:4.0", "UID:fav-1", "FN:Favorite",
+            "item1.X-SILENTSUITE-FAVORITE;TYPE=pref:0",
+            "X-SILENTSUITE-FAVORITE:", " 1", "END:VCARD",
+        ])
+        collection, _, _ = self._collection(mem_db, user, content)
+        serialized = collection._get("favorite.vcf").serialize()
+        assert "VERSION:3.0" in serialized
+        assert "X-SILENTSUITE-FAVORITE" in serialized
+        assert ":1" in serialized
+
+    def test_create_persists_favorite_and_href(self, mem_db, user):
+        collection, cached_collection, _ = self._collection(mem_db, user, "BEGIN:VCARD\r\nVERSION:3.0\r\nUID:fav-1\r\nFN:Existing\r\nEND:VCARD")
+        new_cache_item = ItemEntity.create(
+            collection=cached_collection.cache_col, uid="fav-new", eb_item=b"encrypted-new-item"
+        )
+        new_item = MagicMock()
+        new_item.cache_item = new_cache_item
+        new_item.content = "BEGIN:VCARD\r\nVERSION:4.0\r\nUID:fav-new\r\nFN:New\r\nX-SILENTSUITE-FAVORITE:1\r\nEND:VCARD"
+        new_item.etag = "etag-new"
+        new_item.meta = {"mtime": 1700000000000}
+        cached_collection.create.return_value = new_item
+        original_get = cached_collection.get.side_effect
+        cached_collection.get.side_effect = lambda uid: new_item if uid == "fav-new" else original_get(uid)
+
+        incoming = MagicMock()
+        incoming.vobject_item = vobject.readOne(new_item.content)
+        created = collection.upload("new-name.vcf", incoming)
+
+        assert created.href == "new-name.vcf"
+        assert created.etag == '"etag-new"'
+        assert "X-SILENTSUITE-FAVORITE:1" in created.serialize()
+        assert HrefMapper.get_by_id(new_cache_item.id).href == "new-name.vcf"
+
+
 # ---------------------------------------------------------------------------
 # acquire_lock — sync is forced on every client request
 # ---------------------------------------------------------------------------

--- a/docs/user-guide/contacts.md
+++ b/docs/user-guide/contacts.md
@@ -16,6 +16,12 @@ Open a contact, edit its fields, save. Or open and delete. Changes are re-encryp
 
 The search box at the top of the contacts list filters by name, email, phone, or organisation. Search runs against your locally decrypted data, so it's fast and works offline.
 
+## Favorites
+
+Use the star beside a contact, then choose **Favorites** to show starred contacts from your visible address books. Favorites use the shared vCard contract; Android synchronization requires a SilentSuite Android version that supports contact favorites. A favorite is global contact data, so members of a shared writable address book see and can change the same value.
+
+The favorite flag stays inside the end-to-end encrypted vCard content; it is not placed in collection metadata, indexes, or logs. Offline web changes are stored in the encrypted local item cache and queued without plaintext contact content, then sync after reconnecting. Failed online changes return the star to its previous state. Read-only address books cannot be changed.
+
 ## Import
 
 **Settings → Import** accepts `.vcf` files (vCard 3.0 and 4.0). Parsing is local-only — the file content never leaves your browser unencrypted. Multi-contact files are supported (one big `.vcf` with many `BEGIN:VCARD` blocks).
@@ -37,9 +43,13 @@ With the [desktop bridge](./getting-started.md#desktop-caldav--carddav-via-the-b
 
 Multiple address books are supported. Each address book is a separate encrypted collection and appears as its own CardDAV collection in compatible clients.
 
+The Bridge preserves `X-SILENTSUITE-FAVORITE` when a client sends it, but favorite is not a standard CardDAV field. Generic CardDAV clients, Thunderbird, DAVx5, Google CardDAV, and Apple Contacts/Phone do not have a promised compatible favorite UI. Clients that rewrite a complete card may strip unknown extensions.
+
 ## Sharing
 
-Shared address books between accounts are not supported in v0.1.0-beta. Your contacts are visible only to you, across your own devices.
+Favorites in a shared address book are shared contact state, not a private per-member preference. Writable members can change them; read-only members cannot.
+
+On Android, starring an aggregate contact may also affect constituent raw contacts owned by other accounts because the native Contacts provider controls aggregation. SilentSuite reads and writes only its own account row.
 
 ## Limits in this beta
 

--- a/packages/core/fixtures/item-format/manifest.json
+++ b/packages/core/fixtures/item-format/manifest.json
@@ -77,6 +77,19 @@
         "telNumber": "+1-555-0100",
         "cellNumber": "+1-555-0199"
       }
+    },
+    {
+      "path": "vcf/contact-favorite.vcf",
+      "kind": "vcard",
+      "covers": ["favorite", "categories"],
+      "expected": {
+        "uid": "golden-vcf-favorite-001",
+        "fn": "Star Favorite",
+        "n": { "family": "Favorite", "given": "Star" },
+        "categories": ["VIP"],
+        "email": [{ "type": "home", "value": "star@example.com" }],
+        "favorite": true
+      }
     }
   ]
 }

--- a/packages/core/fixtures/item-format/vcf/contact-favorite.vcf
+++ b/packages/core/fixtures/item-format/vcf/contact-favorite.vcf
@@ -1,0 +1,10 @@
+BEGIN:VCARD
+VERSION:3.0
+UID:golden-vcf-favorite-001
+FN:Star Favorite
+N:Favorite;Star;;;
+EMAIL;TYPE=home:star@example.com
+CATEGORIES:VIP
+X-SILENTSUITE-FAVORITE:0
+X-SILENTSUITE-FAVORITE:1
+END:VCARD

--- a/packages/core/src/models/contact.test.ts
+++ b/packages/core/src/models/contact.test.ts
@@ -120,6 +120,56 @@ describe('categories roundtrip (#291)', () => {
   });
 });
 
+// ── favorite roundtrip (X-SILENTSUITE-FAVORITE) ──
+
+describe('favorite roundtrip', () => {
+  it('emits exactly one X-SILENTSUITE-FAVORITE:1 line when favorite is true', () => {
+    const original = makeFullContact({ favorite: true });
+    const vcardStr = toVCard(original);
+
+    const matches = vcardStr.split('\r\n').filter((l) => l.startsWith('X-SILENTSUITE-FAVORITE'));
+    expect(matches).toEqual(['X-SILENTSUITE-FAVORITE:1']);
+
+    expect(fromVCard(vcardStr).favorite).toBe(true);
+  });
+
+  it('omits the favorite property when favorite is false', () => {
+    const vcardStr = toVCard(makeFullContact({ favorite: false }));
+    expect(vcardStr).not.toContain('X-SILENTSUITE-FAVORITE');
+    expect(fromVCard(vcardStr).favorite).toBe(false);
+  });
+
+  it('omits the favorite property when favorite is undefined', () => {
+    const contact = makeFullContact();
+    delete contact.favorite;
+    const vcardStr = toVCard(contact);
+    expect(vcardStr).not.toContain('X-SILENTSUITE-FAVORITE');
+    expect(fromVCard(vcardStr).favorite).toBe(false);
+  });
+
+  it('defaults favorite to false when deserializing a legacy vCard', () => {
+    const legacy = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:legacy-nofav',
+      'FN:Legacy Contact',
+      'END:VCARD',
+    ].join('\r\n');
+    expect(deserializeContact(legacy).favorite).toBe(false);
+  });
+
+  it('removes stale favorite state on a true→false serialize', () => {
+    const original = makeFullContact({ favorite: true });
+    const asFavorite = toVCard(original);
+    expect(asFavorite).toContain('X-SILENTSUITE-FAVORITE:1');
+
+    const restored = fromVCard(asFavorite);
+    restored.favorite = false;
+    const unfavorited = toVCard(restored);
+    expect(unfavorited).not.toContain('X-SILENTSUITE-FAVORITE');
+  });
+});
+
 // ── toVCard / fromVCard roundtrip ──
 
 describe('toVCard / fromVCard roundtrip', () => {

--- a/packages/core/src/models/contact.ts
+++ b/packages/core/src/models/contact.ts
@@ -30,6 +30,10 @@ export interface Contact {
    *  Round-tripped via the vCard CATEGORIES property (comma-separated).
    *  Optional so existing callers keep compiling; deserialize paths default to []. */
   categories?: string[];
+  /** Favorite/starred state, round-tripped via the SilentSuite-owned
+   *  `X-SILENTSUITE-FAVORITE:1` vCard extension. Optional so existing callers
+   *  keep compiling; deserialize paths default to false. */
+  favorite?: boolean;
   listId?: string;
   created_at: Date;
   updated_at: Date;
@@ -54,6 +58,7 @@ export function toVCard(contact: Contact): string {
     note: contact.notes || undefined,
     bday: contact.birthday ?? undefined,
     photo: contact.photoUrl ?? undefined,
+    favorite: contact.favorite === true ? true : undefined,
     rev: formatRevTimestamp(contact.updated_at),
   };
 
@@ -97,6 +102,8 @@ export function fromVCard(vcardStr: string): Contact {
     photoUrl: vcard.photo ?? null,
     // Preserve CATEGORIES for round-trip; default to [] for legacy records
     categories: vcard.categories ?? [],
+    // Preserve favorite state; legacy/absent cards deserialize to false
+    favorite: vcard.favorite ?? false,
     created_at: now,
     updated_at: vcard.rev ? parseRevTimestamp(vcard.rev) : now,
   };

--- a/packages/core/src/utils/item-format-fixtures.test.ts
+++ b/packages/core/src/utils/item-format-fixtures.test.ts
@@ -175,6 +175,11 @@ function assertVCardExpectations(vcard: VCard, expected: Record<string, unknown>
       case 'cellNumber':
         expect(vcard.tel).toContainEqual({ type: 'cell', value: value as string });
         break;
+      case 'favorite':
+        // Canonical `X-SILENTSUITE-FAVORITE:1` resolves to true; the parser
+        // leaves the field undefined when the resolved value is false.
+        expect(vcard.favorite ?? false).toBe(value);
+        break;
       default:
         throw new Error(`unhandled expected key "${key}" for a vcard fixture`);
     }

--- a/packages/core/src/utils/vcard-parser.test.ts
+++ b/packages/core/src/utils/vcard-parser.test.ts
@@ -404,3 +404,121 @@ describe('CATEGORIES', () => {
     expect(generateVCard(empty)).not.toContain('CATEGORIES');
   });
 });
+
+// ── X-SILENTSUITE-FAVORITE (favorite flag) ──
+
+describe('X-SILENTSUITE-FAVORITE parsing', () => {
+  function rawWith(...propLines: string[]): string {
+    return [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:vcf-fav',
+      'FN:Jane Doe',
+      ...propLines,
+      'END:VCARD',
+    ].join('\r\n');
+  }
+
+  it('defaults favorite to undefined when the property is absent', () => {
+    expect(parseVCard(rawWith()).favorite).toBeUndefined();
+  });
+
+  it('parses the canonical X-SILENTSUITE-FAVORITE:1 as true', () => {
+    expect(parseVCard(rawWith('X-SILENTSUITE-FAVORITE:1')).favorite).toBe(true);
+  });
+
+  it('treats value 0 as not favorite', () => {
+    expect(parseVCard(rawWith('X-SILENTSUITE-FAVORITE:0')).favorite).toBeUndefined();
+  });
+
+  it('treats malformed values as not favorite without unescaping/trimming', () => {
+    expect(parseVCard(rawWith('X-SILENTSUITE-FAVORITE:true')).favorite).toBeUndefined();
+    expect(parseVCard(rawWith('X-SILENTSUITE-FAVORITE: 1')).favorite).toBeUndefined();
+    expect(parseVCard(rawWith('X-SILENTSUITE-FAVORITE:1 ')).favorite).toBeUndefined();
+    expect(parseVCard(rawWith('X-SILENTSUITE-FAVORITE:01')).favorite).toBeUndefined();
+    expect(parseVCard(rawWith('X-SILENTSUITE-FAVORITE:')).favorite).toBeUndefined();
+  });
+
+  it('normalizes property name case-insensitively', () => {
+    expect(parseVCard(rawWith('x-silentsuite-favorite:1')).favorite).toBe(true);
+    expect(parseVCard(rawWith('X-SilentSuite-Favorite:1')).favorite).toBe(true);
+  });
+
+  it('accepts a grouped canonical property', () => {
+    expect(parseVCard(rawWith('item3.X-SILENTSUITE-FAVORITE:1')).favorite).toBe(true);
+  });
+
+  it('accepts a parameterized canonical property', () => {
+    expect(parseVCard(rawWith('X-SILENTSUITE-FAVORITE;TYPE=pref:1')).favorite).toBe(true);
+  });
+
+  it('resolves duplicates with "any exact 1 wins" regardless of order', () => {
+    expect(
+      parseVCard(rawWith('X-SILENTSUITE-FAVORITE:0', 'X-SILENTSUITE-FAVORITE:1')).favorite,
+    ).toBe(true);
+    expect(
+      parseVCard(rawWith('X-SILENTSUITE-FAVORITE:1', 'X-SILENTSUITE-FAVORITE:0')).favorite,
+    ).toBe(true);
+  });
+
+  it('resolves a duplicate false-only set to not favorite', () => {
+    expect(
+      parseVCard(rawWith('X-SILENTSUITE-FAVORITE:0', 'X-SILENTSUITE-FAVORITE:no')).favorite,
+    ).toBeUndefined();
+  });
+
+  it('parses a folded canonical property', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:vcf-fav-fold',
+      'FN:Jane Doe',
+      'X-SILENTSUITE-FAVORITE:',
+      ' 1',
+      'END:VCARD',
+    ].join('\r\n');
+    expect(parseVCard(raw).favorite).toBe(true);
+  });
+});
+
+describe('X-SILENTSUITE-FAVORITE generation', () => {
+  it('emits exactly one ungrouped, parameterless canonical line when true', () => {
+    const generated = generateVCard({ uid: 'g-fav', fn: 'Jane Doe', favorite: true });
+    const matches = generated.split('\r\n').filter((l) => l.startsWith('X-SILENTSUITE-FAVORITE'));
+    expect(matches).toEqual(['X-SILENTSUITE-FAVORITE:1']);
+  });
+
+  it('omits the property when favorite is false or undefined', () => {
+    expect(generateVCard({ uid: 'g-fav-0', fn: 'Jane Doe', favorite: false })).not.toContain(
+      'X-SILENTSUITE-FAVORITE',
+    );
+    expect(generateVCard({ uid: 'g-fav-u', fn: 'Jane Doe' })).not.toContain(
+      'X-SILENTSUITE-FAVORITE',
+    );
+  });
+
+  it('removes stale/duplicate favorite properties on true→false regeneration', () => {
+    const raw = [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'UID:vcf-fav-stale',
+      'FN:Jane Doe',
+      'X-SILENTSUITE-FAVORITE:1',
+      'item1.X-SILENTSUITE-FAVORITE:1',
+      'END:VCARD',
+    ].join('\r\n');
+    const parsed = parseVCard(raw);
+    expect(parsed.favorite).toBe(true);
+    parsed.favorite = false;
+    const regenerated = generateVCard(parsed);
+    expect(regenerated).not.toContain('X-SILENTSUITE-FAVORITE');
+  });
+
+  it('roundtrips a favorite through generate/parse producing one canonical line', () => {
+    const generated = generateVCard({ uid: 'g-fav-rt', fn: 'Jane Doe', favorite: true });
+    expect(parseVCard(generated).favorite).toBe(true);
+    expect(generated.split('\r\n').filter((l) => l.includes('X-SILENTSUITE-FAVORITE'))).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/core/src/utils/vcard-parser.ts
+++ b/packages/core/src/utils/vcard-parser.ts
@@ -44,7 +44,14 @@ export interface VCard {
   bday?: string;
   photo?: string;
   rev?: string;
+  /** SilentSuite-owned favorite flag, wire form `X-SILENTSUITE-FAVORITE:1`.
+   *  `true` means favorite; absence means not favorite. Only `true` is ever
+   *  emitted, so a false/absent value is represented as `undefined`. */
+  favorite?: boolean;
 }
+
+/** Canonical SilentSuite favorite extension property name (uppercased). */
+export const FAVORITE_PROPERTY = 'X-SILENTSUITE-FAVORITE';
 
 // ── Escaping ──
 
@@ -322,6 +329,15 @@ export function parseVCard(vcardStr: string): VCard {
       case 'REV':
         vcard.rev = prop.value;
         break;
+      case FAVORITE_PROPERTY:
+        // Canonical favorite is exactly `1`. Do not trim or unescape the
+        // scalar; group prefix and parameters are already normalized away by
+        // parseProperty(). Duplicates reduce with "any exact `1` wins", so we
+        // only ever set true and never clear it here.
+        if (prop.value === '1') {
+          vcard.favorite = true;
+        }
+        break;
     }
   }
 
@@ -397,6 +413,11 @@ export function generateVCard(vcard: VCard): string {
     lines.push(foldLine(`CATEGORIES:${vcard.categories.map(escapeText).join(',')}`));
   }
   if (vcard.note) lines.push(foldLine(`NOTE:${escapeText(vcard.note)}`));
+  // Emit exactly one ungrouped, parameterless canonical favorite property, and
+  // only when true. False/absent favorite produces no line at all.
+  if (vcard.favorite === true) {
+    lines.push(`${FAVORITE_PROPERTY}:1`);
+  }
   if (vcard.bday) lines.push(foldLine(`BDAY:${vcard.bday}`));
   if (vcard.photo) {
     if (vcard.photo.startsWith('data:') || vcard.photo.startsWith('http://') || vcard.photo.startsWith('https://')) {


### PR DESCRIPTION
## Summary
- add the canonical `X-SILENTSUITE-FAVORITE:1` vCard contract and shared fixtures
- add accessible Favorites controls and filtering to the web contacts UI
- preserve favorite state through import, export, and Bridge storage paths
- queue offline favorite updates using encrypted local item content and content-free queue records

## Validation
- `pnpm --filter @silentsuite/core test`
- `pnpm --filter @silentsuite/core type-check`
- `pnpm --filter @silentsuite/web test`
- `pnpm --filter @silentsuite/web type-check`
- `git diff --check`

## Follow-up
Android provider synchronization is isolated on `feat/contact-favorites-android` and will be proposed after this contract slice merges.

## Remaining gates
- Bridge pytest in CI
- Cloudflare desktop/mobile Favorites QA
- real import/export round-trip QA