### PR TITLE
ci: enforce Android telemetry guardrails

### DIFF
--- a/.github/workflows/android-network-evidence.yml
+++ b/.github/workflows/android-network-evidence.yml
@@ -1,0 +1,95 @@
+name: Validate Android UID network evidence
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact_sha256:
+        description: SHA-256 of the exact tested APK
+        required: true
+        type: string
+      app_uid:
+        description: Single Android app UID used for every captured scenario
+        required: true
+        type: string
+      raw_capture_sha256:
+        description: SHA-256 of the raw capture retained outside public GitHub artifacts
+        required: true
+        type: string
+      restricted_evidence_reference:
+        description: Opaque owner record ID for access-controlled raw evidence (never a public URL)
+        required: true
+        type: string
+      manual_owner:
+        description: Named human owner accountable for restricted evidence and correlation checklist
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-evidence:
+    runs-on: ubuntu-latest
+    environment: android-network-evidence
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Materialize sanitized evidence only
+        env:
+          NETWORK_EVIDENCE_JSONL: ${{ secrets.ANDROID_NETWORK_EVIDENCE_JSONL }}
+        run: |
+          set -euo pipefail
+          test -n "$NETWORK_EVIDENCE_JSONL"
+          mkdir -p network-evidence/summary
+          printf '%s\n' "$NETWORK_EVIDENCE_JSONL" > network-evidence/summary/endpoints.jsonl
+      - name: Enforce provenance, one app UID, scenarios, and endpoint allowlist
+        env:
+          APP_UID: ${{ inputs.app_uid }}
+          ARTIFACT_SHA256: ${{ inputs.artifact_sha256 }}
+          RAW_CAPTURE_SHA256: ${{ inputs.raw_capture_sha256 }}
+        run: |
+          set -euo pipefail
+          python3 android/scripts/check-network-evidence.py \
+            --allowlist android/security/android-network-endpoints.txt \
+            --evidence network-evidence/summary/endpoints.jsonl \
+            --app-uid "$APP_UID" \
+            --artifact-sha256 "$ARTIFACT_SHA256" \
+            --raw-capture-sha256 "$RAW_CAPTURE_SHA256" \
+            --provenance-output network-evidence/summary/provenance.json \
+            --require-complete
+      - name: Record accountable restricted/manual review
+        env:
+          RESTRICTED_REFERENCE: ${{ inputs.restricted_evidence_reference }}
+          MANUAL_OWNER: ${{ inputs.manual_owner }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          python3 - <<'PY'
+          import json, os, re
+          from pathlib import Path
+          reference = os.environ['RESTRICTED_REFERENCE'].strip()
+          owner = os.environ['MANUAL_OWNER'].strip()
+          if not re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9._/-]{2,127}', reference):
+              raise SystemExit('restricted evidence reference must be an opaque record ID')
+          if len(owner) < 3 or len(owner) > 100:
+              raise SystemExit('manual owner must be a named accountable owner')
+          record = {
+              'schema_version': 1,
+              'restricted_evidence_reference': reference,
+              'manual_owner': owner,
+              'commit': os.environ['COMMIT_SHA'],
+              'owner_attestations': [
+                  'raw capture remains in access-controlled storage and is not a GitHub artifact',
+                  'raw capture digest matches provenance',
+                  'installed APK digest matches provenance',
+                  'dumpsys package UID matches the one UID in every JSONL row',
+                  'raw capture was filtered to that UID and destinations were transcribed without hiding unexpected hosts',
+                  'capture excludes bodies, credentials, tokens, PIM data, and TLS key material'
+              ]
+          }
+          Path('network-evidence/summary/manual-review.json').write_text(json.dumps(record, indent=2) + '\n')
+          PY
+      - name: Upload sanitized summary
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: android-network-summary-${{ github.sha }}
+          path: network-evidence/summary/
+          retention-days: 30

--- a/.github/workflows/android-tracker-quarterly-review.yml
+++ b/.github/workflows/android-tracker-quarterly-review.yml
@@ -1,0 +1,59 @@
+name: Android tracker policy quarterly review
+
+on:
+  schedule:
+    # Weekly enforcement prevents a due date from remaining overdue for a quarter.
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Run positive fixtures and policy checks
+        run: |
+          python3 -m unittest tests.test_android_tracker_scan -v
+          python3 - <<'PY'
+          import datetime as dt, json
+          from pathlib import Path
+          policy = json.loads(Path('android/security/tracker-signatures.json').read_text())
+          due = dt.date.fromisoformat(policy['review_due'])
+          baseline = policy.get('catalog_baseline', {})
+          required = {'sources', 'manual_owner', 'review_record'}
+          if not required.issubset(baseline) or not baseline['sources']:
+              raise SystemExit('catalog baseline review_record and manual owner are required')
+          if due <= dt.date.today():
+              raise SystemExit(f'tracker signature review overdue: {due}')
+          print(f"tracker manifest review due {due}; signatures={len(policy['signatures'])}")
+          PY
+      - name: Preserve quarterly review result
+        run: |
+          mkdir -p android-quarterly-review
+          python3 android/scripts/scan-tracker-signatures.py \
+            --manifest android/security/tracker-signatures.json \
+            --summary android-quarterly-review/tracker-scan-summary.json \
+            android/security/fixtures/tracker-scan/clean
+          cp android/security/tracker-signatures.json android/security/android-network-endpoints.txt android-quarterly-review/
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          policy = json.loads(Path('android/security/tracker-signatures.json').read_text())
+          baseline = policy['catalog_baseline']
+          Path('android-quarterly-review/review_record.json').write_text(json.dumps({
+              'schema_version': 1,
+              'reviewed_on': policy['reviewed_on'],
+              'review_due': policy['review_due'],
+              'manual_owner': baseline['manual_owner'],
+              'catalog_sources': baseline['sources'],
+              'review_record': baseline['review_record'],
+          }, indent=2) + '\n')
+          PY
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: android-tracker-quarterly-review-${{ github.sha }}
+          path: android-quarterly-review/
+          retention-days: 30

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -70,8 +70,59 @@ jobs:
       - name: Build 16 KB-aligned Etebase client AAR
         run: scripts/build-etebase-client-16kb.sh
 
-      - name: Build debug APK
-        run: ./gradlew assembleDebug --no-daemon -PrequireEtebase16Kb=true
+      - name: Capture debug and release runtime dependency graphs
+        run: |
+          mkdir -p build/privacy-evidence/dependencies
+          ./gradlew app:dependencies --configuration debugRuntimeClasspath --no-daemon \
+            > build/privacy-evidence/dependencies/debug-runtime.txt
+          ./gradlew app:dependencies --configuration releaseRuntimeClasspath --no-daemon \
+            > build/privacy-evidence/dependencies/release-runtime.txt
+
+      - name: Build debug APK and unsigned release APK/AAB
+        run: ./gradlew assembleDebug assembleRelease bundleRelease --no-daemon -PrequireEtebase16Kb=true
+
+      - name: Generate universal split set from unsigned AAB
+        env:
+          BUNDLETOOL_VERSION: '1.18.1'
+          BUNDLETOOL_SHA256: '675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c'
+        run: |
+          curl --fail --location --silent --show-error \
+            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar" \
+            --output "$RUNNER_TEMP/bundletool.jar"
+          echo "$BUNDLETOOL_SHA256  $RUNNER_TEMP/bundletool.jar" | sha256sum --check --strict
+          java -jar "$RUNNER_TEMP/bundletool.jar" build-apks \
+            --bundle app/build/outputs/bundle/release/app-release.aab \
+            --output build/privacy-evidence/unsigned-release.apks \
+            --mode universal
+          unzip -q build/privacy-evidence/unsigned-release.apks \
+            -d build/privacy-evidence/unsigned-release-splits
+
+      - name: Scan dependency, manifest, mapping, resources, APK, AAB, splits, DEX, and native payloads
+        run: |
+          set -euo pipefail
+          mkdir -p build/privacy-evidence/build-metadata
+          test -s app/build/outputs/mapping/release/mapping.txt
+          mkdir -p build/privacy-evidence/build-metadata/app/build/outputs/mapping/release
+          cp app/build/outputs/mapping/release/mapping.txt \
+            build/privacy-evidence/build-metadata/app/build/outputs/mapping/release/mapping.txt
+          find app/build/intermediates -type f \
+            \( -iname '*manifest*.xml' -o -iname '*mapping*.txt' -o -iname 'resources*.txt' -o -iname 'resources*.arsc' \) \
+            -exec cp --parents {} build/privacy-evidence/build-metadata/ \;
+          sha256sum app/build/outputs/apk/debug/*.apk \
+            app/build/outputs/apk/release/*.apk \
+            app/build/outputs/bundle/release/*.aab \
+            build/privacy-evidence/unsigned-release.apks \
+            > build/privacy-evidence/artifact-sha256.txt
+          python3 scripts/scan-tracker-signatures.py \
+            --manifest security/tracker-signatures.json \
+            --summary build/privacy-evidence/tracker-scan-summary.json \
+            build/privacy-evidence/dependencies \
+            build/privacy-evidence/build-metadata \
+            app/build/outputs/apk/debug \
+            app/build/outputs/apk/release \
+            app/build/outputs/bundle/release \
+            build/privacy-evidence/unsigned-release.apks \
+            build/privacy-evidence/unsigned-release-splits
 
       - name: Verify debug native library alignment
         run: |
@@ -79,6 +130,13 @@ jobs:
             --require-lib libetebase_android.so \
             --require-lib libconscrypt_jni.so \
             app/build/outputs/apk/debug/*.apk
+
+      - name: Upload tracker verification evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: android-tracker-scan-${{ github.sha }}
+          path: android/build/privacy-evidence/
+          retention-days: 14
 
       - name: Upload debug APK artifact
         uses: actions/upload-artifact@v4
@@ -161,6 +219,57 @@ jobs:
             -PrequireEtebase16Kb=true \
             -PsigningStoreLocation="$KEYSTORE_PATH" \
             -PsigningKeyAlias="$KEY_ALIAS"
+
+      - name: Capture release dependency graph and generate signed-release splits
+        env:
+          BUNDLETOOL_VERSION: '1.18.1'
+          BUNDLETOOL_SHA256: '675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c'
+          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          mkdir -p build/privacy-evidence/dependencies build/privacy-evidence/build-metadata
+          ./gradlew app:dependencies --configuration releaseRuntimeClasspath --no-daemon \
+            > build/privacy-evidence/dependencies/release-runtime.txt
+          curl --fail --location --silent --show-error \
+            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar" \
+            --output "$RUNNER_TEMP/bundletool.jar"
+          echo "$BUNDLETOOL_SHA256  $RUNNER_TEMP/bundletool.jar" | sha256sum --check --strict
+          java -jar "$RUNNER_TEMP/bundletool.jar" build-apks \
+            --bundle app/build/outputs/bundle/release/app-release.aab \
+            --output build/privacy-evidence/signed-release.apks \
+            --mode universal \
+            --ks="$KEYSTORE_PATH" --ks-key-alias="$KEY_ALIAS" \
+            --ks-pass=env:KSTOREPWD --key-pass=env:KSTOREPWD
+          unzip -q build/privacy-evidence/signed-release.apks \
+            -d build/privacy-evidence/signed-release-splits
+          test -s app/build/outputs/mapping/release/mapping.txt
+          mkdir -p build/privacy-evidence/build-metadata/app/build/outputs/mapping/release
+          cp app/build/outputs/mapping/release/mapping.txt \
+            build/privacy-evidence/build-metadata/app/build/outputs/mapping/release/mapping.txt
+          find app/build/intermediates -type f \
+            \( -iname '*manifest*.xml' -o -iname '*mapping*.txt' -o -iname 'resources*.txt' -o -iname 'resources*.arsc' \) \
+            -exec cp --parents {} build/privacy-evidence/build-metadata/ \;
+          sha256sum app/build/outputs/apk/release/*.apk \
+            app/build/outputs/bundle/release/*.aab \
+            build/privacy-evidence/signed-release.apks \
+            > build/privacy-evidence/artifact-sha256.txt
+          python3 scripts/scan-tracker-signatures.py \
+            --manifest security/tracker-signatures.json \
+            --summary build/privacy-evidence/tracker-scan-summary.json \
+            build/privacy-evidence/dependencies \
+            build/privacy-evidence/build-metadata \
+            app/build/outputs/apk/release \
+            app/build/outputs/bundle/release \
+            build/privacy-evidence/signed-release.apks \
+            build/privacy-evidence/signed-release-splits
+
+      - name: Upload signed tracker verification evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: android-tracker-scan-${{ github.sha }}
+          path: android/build/privacy-evidence/
+          retention-days: 30
 
       - name: Verify release native library alignment
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  android-privacy-guardrails:
+    name: Android Privacy Guardrail Fixtures
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Run tracker scanner and UID network evidence fixtures
+        run: python3 -m unittest tests.test_android_tracker_scan -v
+
   analytics-boundary:
     name: Public Analytics Boundary
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+*.py[cod]
+__pycache__/
+.pytest_cache/
 .vercel
 package-lock.json
 tsconfig.tsbuildinfo

--- a/android/scripts/check-network-evidence.py
+++ b/android/scripts/check-network-evidence.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Validate sanitized, app-UID-scoped Android network evidence."""
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+REQUIRED_SCENARIOS = {
+    "clean_launch", "idle_5m", "account_setup", "login", "foreground_sync",
+    "background_sync", "network_failure", "logout",
+}
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--allowlist", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--require-complete", action="store_true")
+    parser.add_argument("--app-uid", type=int)
+    parser.add_argument("--artifact-sha256")
+    parser.add_argument("--raw-capture-sha256")
+    parser.add_argument("--provenance-output", type=Path)
+    args = parser.parse_args()
+    allowed = {line.strip().lower() for line in args.allowlist.read_text(encoding="utf-8").splitlines()
+               if line.strip() and not line.lstrip().startswith("#")}
+    seen = set()
+    seen_uids = set()
+    failures = []
+    try:
+        provenance_values = (args.app_uid, args.artifact_sha256, args.raw_capture_sha256, args.provenance_output)
+        if any(value is not None for value in provenance_values) and not all(value is not None for value in provenance_values):
+            raise ValueError("app UID, artifact SHA-256, raw capture SHA-256, and provenance output are required together")
+        for label, digest in (("artifact", args.artifact_sha256), ("raw capture", args.raw_capture_sha256)):
+            if digest is not None and not SHA256_RE.fullmatch(digest):
+                raise ValueError(f"{label} SHA-256 must be 64 lowercase hexadecimal characters")
+        if args.app_uid is not None and args.app_uid < 10_000:
+            raise ValueError("app UID must be an Android application UID")
+
+        raw_evidence = args.evidence.read_bytes()
+        lines = raw_evidence.decode("utf-8").splitlines()
+        if not lines:
+            raise ValueError("empty evidence")
+        for number, line in enumerate(lines, 1):
+            row = json.loads(line)
+            scenario, uid, host, requests = row["scenario"], row["uid"], row["host"], row["requests"]
+            if scenario not in REQUIRED_SCENARIOS or not isinstance(uid, int) or uid < 10_000:
+                raise ValueError(f"line {number}: invalid scenario or app UID")
+            seen_uids.add(uid)
+            if not isinstance(requests, int) or requests < 0 or (requests == 0) != (host is None):
+                raise ValueError(f"line {number}: inconsistent request count/host")
+            seen.add(scenario)
+            if host is not None and str(host).lower() not in allowed:
+                failures.append(f"line {number}: host is not allowlisted: {host}")
+            if scenario == "clean_launch" and requests != 0:
+                failures.append("clean_launch must have zero outbound requests")
+        if len(seen_uids) != 1 or (args.app_uid is not None and seen_uids != {args.app_uid}):
+            raise ValueError("evidence must contain one app UID matching the recorded app UID")
+    except (OSError, KeyError, TypeError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"invalid network evidence: {exc}", file=sys.stderr)
+        return 3
+    if args.require_complete and seen != REQUIRED_SCENARIOS:
+        failures.append("missing scenarios: " + ", ".join(sorted(REQUIRED_SCENARIOS - seen)))
+    if failures:
+        print("\n".join(failures), file=sys.stderr)
+        return 2
+    if args.provenance_output:
+        record = {
+            "schema_version": 1,
+            "app_uid": args.app_uid,
+            "artifact_sha256": args.artifact_sha256,
+            "raw_capture_sha256": args.raw_capture_sha256,
+            "evidence_jsonl_sha256": hashlib.sha256(raw_evidence).hexdigest(),
+        }
+        args.provenance_output.parent.mkdir(parents=True, exist_ok=True)
+        args.provenance_output.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    print(f"network evidence passed: {len(lines)} UID-scoped endpoint row(s), {len(seen)} scenario(s), app UID {next(iter(seen_uids))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/android/scripts/scan-tracker-signatures.py
+++ b/android/scripts/scan-tracker-signatures.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Fail-closed tracker signature scanner for Android build evidence."""
+
+import argparse
+import datetime as dt
+import json
+import re
+import sys
+import zipfile
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+
+MAX_MEMBER_BYTES = 128 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 100_000
+ARCHIVE_SUFFIXES = {".apk", ".aab", ".apks", ".zip", ".jar", ".aar"}
+
+
+class ManifestError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Finding:
+    signature_id: str
+    category: str
+    description: str
+    location: str
+    excerpt: str
+    excepted: bool = False
+
+
+def load_manifest(path: Path) -> tuple[dict, list[tuple[dict, re.Pattern[bytes]]]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ManifestError(f"invalid signature manifest: {exc}") from exc
+    if data.get("schema_version") != 1 or not isinstance(data.get("signatures"), list) or not data["signatures"]:
+        raise ManifestError("invalid signature manifest: schema_version=1 and non-empty signatures are required")
+    required = {"id", "category", "description", "pattern"}
+    seen = set()
+    compiled = []
+    for entry in data["signatures"]:
+        if not isinstance(entry, dict) or not required.issubset(entry) or not all(entry[key] for key in required):
+            raise ManifestError("invalid signature manifest: incomplete signature")
+        if entry["id"] in seen:
+            raise ManifestError(f"invalid signature manifest: duplicate id {entry['id']}")
+        seen.add(entry["id"])
+        try:
+            compiled.append((entry, re.compile(entry["pattern"].encode("ascii"), re.IGNORECASE)))
+        except (UnicodeEncodeError, re.error) as exc:
+            raise ManifestError(f"invalid signature manifest: bad pattern for {entry['id']}: {exc}") from exc
+    exceptions = data.get("exceptions", [])
+    if not isinstance(exceptions, list):
+        raise ManifestError("invalid signature manifest: exceptions must be a list")
+    today = dt.date.today()
+    for exception in exceptions:
+        fields = {"signature_id", "path_regex", "rationale", "owner", "reviewed_on", "expires_on"}
+        if not isinstance(exception, dict) or not fields.issubset(exception) or not all(exception[key] for key in fields):
+            raise ManifestError("invalid signature manifest: incomplete exception review record")
+        if exception["signature_id"] not in seen:
+            raise ManifestError(f"invalid signature manifest: exception references unknown signature {exception['signature_id']}")
+        try:
+            re.compile(exception["path_regex"])
+            reviewed = dt.date.fromisoformat(exception["reviewed_on"])
+            expiry = dt.date.fromisoformat(exception["expires_on"])
+        except (re.error, ValueError) as exc:
+            raise ManifestError(f"invalid signature manifest: malformed exception: {exc}") from exc
+        path_regex = exception["path_regex"].strip()
+        broad_patterns = {".*", "^.*$", ".+", "^.+$", ".*?", "^.*?$"}
+        if path_regex in broad_patterns or not any(char.isalnum() for char in path_regex):
+            raise ManifestError(f"invalid signature manifest: broad path wildcard for {exception['signature_id']}")
+        if reviewed > today:
+            raise ManifestError(f"invalid signature manifest: future review date for {exception['signature_id']}")
+        if expiry < today:
+            raise ManifestError(f"invalid signature manifest: expired exception for {exception['signature_id']}")
+        if expiry <= reviewed:
+            raise ManifestError(f"invalid signature manifest: expiry must follow review for {exception['signature_id']}")
+        if (expiry - reviewed).days > 90:
+            raise ManifestError(f"invalid signature manifest: exception review window exceeds 90 days for {exception['signature_id']}")
+    return data, compiled
+
+
+def iter_payloads(path: Path, location: str | None = None, depth: int = 0):
+    if depth > 4:
+        raise ManifestError(f"archive nesting limit exceeded: {location or path}")
+    if path.is_dir():
+        for child in sorted(path.rglob("*")):
+            if child.is_file():
+                yield from iter_payloads(child, str(child), depth)
+        return
+    location = location or str(path)
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise ManifestError(f"cannot read scan target {path}: {exc}") from exc
+    yield location, raw
+    if path.suffix.lower() in ARCHIVE_SUFFIXES or zipfile.is_zipfile(BytesIO(raw)):
+        try:
+            with zipfile.ZipFile(BytesIO(raw)) as archive:
+                members = archive.infolist()
+                if len(members) > MAX_ARCHIVE_MEMBERS:
+                    raise ManifestError(f"archive member limit exceeded: {location}")
+                for member in members:
+                    if member.is_dir():
+                        continue
+                    if member.file_size > MAX_MEMBER_BYTES:
+                        raise ManifestError(f"archive member size limit exceeded: {location}!{member.filename}")
+                    payload = archive.read(member)
+                    nested_location = f"{location}!{member.filename}"
+                    yield nested_location, payload
+                    if Path(member.filename).suffix.lower() in ARCHIVE_SUFFIXES or zipfile.is_zipfile(BytesIO(payload)):
+                        with tempfile_payload(payload) as nested:
+                            yield from iter_payloads(nested, nested_location, depth + 1)
+        except (zipfile.BadZipFile, RuntimeError) as exc:
+            raise ManifestError(f"cannot inspect archive {location}: {exc}") from exc
+
+
+class tempfile_payload:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+        self.path = None
+
+    def __enter__(self):
+        import tempfile
+        handle = tempfile.NamedTemporaryFile(delete=False)
+        handle.write(self.payload)
+        handle.close()
+        self.path = Path(handle.name)
+        return self.path
+
+    def __exit__(self, *_):
+        if self.path:
+            self.path.unlink(missing_ok=True)
+
+
+def is_excepted(manifest: dict, signature_id: str, location: str) -> bool:
+    return any(
+        item["signature_id"] == signature_id and re.search(item["path_regex"], location)
+        for item in manifest.get("exceptions", [])
+    )
+
+
+def scan(manifest: dict, signatures, targets: list[Path]) -> list[Finding]:
+    findings = []
+    for target in targets:
+        if not target.exists():
+            raise ManifestError(f"scan target does not exist: {target}")
+        for location, payload in iter_payloads(target):
+            for entry, pattern in signatures:
+                match = pattern.search(payload)
+                if match:
+                    excerpt = match.group(0).decode("ascii", errors="replace")[:160]
+                    findings.append(Finding(entry["id"], entry["category"], entry["description"], location, excerpt,
+                                            is_excepted(manifest, entry["id"], location)))
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--summary", type=Path)
+    parser.add_argument("targets", type=Path, nargs="+")
+    args = parser.parse_args()
+    try:
+        manifest, signatures = load_manifest(args.manifest)
+        findings = scan(manifest, signatures, args.targets)
+    except ManifestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 3
+    active = [finding for finding in findings if not finding.excepted]
+    for finding in findings:
+        status = "EXCEPTED" if finding.excepted else "PROHIBITED"
+        print(f"{status} [{finding.category}] {finding.signature_id} {finding.location}: {finding.excerpt}")
+    summary = {
+        "schema_version": 1,
+        "manifest_reviewed_on": manifest["reviewed_on"],
+        "targets_scanned": len(args.targets),
+        "prohibited_findings": len(active),
+        "reviewed_exceptions": len(findings) - len(active),
+        "result": "fail" if active else "pass",
+    }
+    if args.summary:
+        args.summary.parent.mkdir(parents=True, exist_ok=True)
+        args.summary.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    if active:
+        print(f"tracker scan failed: {len(active)} prohibited finding(s)")
+        return 2
+    print(f"tracker scan passed: {len(findings)} finding(s), {len(findings) - len(active)} reviewed exception(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/android/security/README.md
+++ b/android/security/README.md
@@ -1,0 +1,65 @@
+# Android tracker and network verification
+
+SilentSuite's Android policy prohibits analytics, advertising, attribution, install-referrer, device-identifier, and crash-reporting runtime integrations. These checks are release guardrails, not telemetry.
+
+## Static artifact gate
+
+`security/tracker-signatures.json` is the reviewed, versioned policy. It covers dependency coordinates, Java/Kotlin packages, collection domains, manifest components/metadata, advertising and identifier APIs, DEX signatures, and native strings/symbols. Every category has a positive fixture under `security/fixtures/tracker-scan/positive`; the clean fixture must pass.
+
+`scan-tracker-signatures.py` uses only Python's standard library. It scans ordinary files and recursively scans ZIP-compatible APK, AAB, APKS/split APK, AAR, JAR, DEX, resource, manifest, mapping, dependency-report, and native-library payloads. A match is blocking even if code is dormant, disabled, obfuscated, or believed unreachable.
+
+The Android build workflow gates:
+
+- debug APK, unsigned release APK, and unsigned release AAB on PR/dev/main;
+- signed release APK and AAB before tag artifacts are attached;
+- bundletool 1.18.1, verified by its pinned SHA-256, to generate local split/universal APK evidence;
+- debug/release runtime dependency graphs, merged/intermediate manifests, mapping/resource outputs, packaged archives, DEX bytes, and native strings;
+- the existing 16 KiB ELF alignment check.
+
+Evidence is uploaded as `android-tracker-scan-<sha>` with bounded retention. It includes dependency/build metadata, archive/split inventory, SHA-256 hashes, and a sanitized scanner summary. It must never include signing files, credentials, or app data.
+
+### Exceptions and review
+
+An exception must be a narrow `exceptions` record in the manifest with an exact signature ID, path regex, rationale, owner, review date, and expiry date. Unknown, incomplete, malformed, or expired exceptions fail closed. Exceptions are not wildcard policy waivers. Changes require security/privacy review and new or updated fixtures.
+
+The scheduled quarterly workflow reruns fixtures and fails when `review_due` has passed. Reviewers must compare the registry against current dependency graphs, Exodus/TrackerControl tracker catalogs, Android advertising/identifier APIs, and newly adopted native libraries, then update `reviewed_on` and `review_due` in the same reviewed change.
+
+## UID-scoped network evidence
+
+Network evidence is a protected manual release/privacy-claim gate because authenticated scenarios require a dedicated test account and interactive emulator actions. Use an isolated emulator restored from a clean snapshot, controlled DNS, no unrelated apps, and an app-UID-aware VPN/proxy or packet-capture facility. Record the installed APK SHA-256 and discover the app UID with `adb shell dumpsys package io.silentsuite.sync` (the `userId=` value). Filter by that UID; a machine-wide capture is not acceptable evidence.
+
+Exercise all scenarios separately:
+
+1. `clean_launch` after clean install (must make zero outbound requests)
+2. `idle_5m`
+3. `account_setup`
+4. `login`
+5. `foreground_sync`
+6. `background_sync`
+7. `network_failure` using a deliberate DNS/auth/network failure
+8. `logout`
+
+The sanitized JSONL has one row per UID/destination/scenario:
+
+```json
+{"scenario":"foreground_sync","uid":10123,"host":"<user-selected-server>","requests":2}
+```
+
+Use `host:null` and `requests:0` when no request occurred. Normalize the dedicated configured auth/sync host to `<user-selected-server>` after confirming the raw destination. Compare every destination to `security/android-network-endpoints.txt`. Plausible, Telegram, advertising, crash, and analytics destinations are prohibited. Never normalize an unexpected destination into the placeholder.
+
+Before dispatching `.github/workflows/android-network-evidence.yml`, place **only** the sanitized JSONL in the protected `android-network-evidence` environment secret `ANDROID_NETWORK_EVIDENCE_JSONL`. Supply the exact tested APK SHA-256, the one app UID, the raw-capture SHA-256, an opaque restricted evidence record ID, and a named accountable human owner. The checker rejects malformed digests and mixed/mismatched UIDs, hashes the JSONL, and binds those values in sanitized provenance.
+
+**Raw PCAP must never be placed in a public-repository secret or GitHub artifact.** The named owner stores it outside GitHub in access-controlled storage whose ACL limits access to approved security/privacy reviewers and whose retention/deletion policy is enforceable. The public artifact contains only the opaque record ID and digest, never a storage URL, credential, packet bytes, or account data. Before approval, that owner must attest that the raw digest matches provenance, the installed APK digest matches provenance, `dumpsys package` matches the single recorded UID, the capture was filtered to that UID, and destinations were transcribed without normalizing unexpected hosts away. If any correlation cannot be demonstrated, the evidence gate fails and the privacy claim/channel rollout remains blocked.
+
+The workflow creates only `android-network-summary-<sha>`: sanitized endpoint/scenario/UID summary, digest-bound provenance, opaque restricted-record ID, owner, and checklist attestations, retained 30 days. GitHub Actions does not receive or upload the raw capture.
+
+Use only a dedicated fixture account configured in the owner-controlled capture environment. Never use customer credentials. Raw capture must exclude request bodies, passwords, tokens, PIM content, and TLS key material.
+
+## External artifacts and limitations
+
+Play-generated and F-Droid-built outputs are owner-operated post-build gates because this repository cannot fetch or reproduce those final channel artifacts during ordinary CI. The **SilentSuite Android release owner** is accountable for each channel record. Before a privacy claim or rollout, the owner must download the exact channel-delivered APK/APKS, record channel, version, package name, retrieval time, source URL/build ID, SHA-256 and signing-certificate SHA-256, run this scanner against the downloaded final package and extracted splits, attach the sanitized scanner summary to the release evidence, and record pass/fail. A missing digest, certificate, split inventory, scanner result, or named owner blocks rollout. For F-Droid, compare the independently built APK against the submitted version/source and retain the F-Droid build/version reference; for Play, scan Play-generated delivery splits rather than substituting local bundletool output.
+
+- Static signatures are defense in depth, not proof of absence. Reflection, encryption/encoding, runtime downloads, dynamic endpoint construction, obfuscation, and stripped/native code can evade string/signature inspection. Binary strings do not establish reachability.
+- Local bundletool splits do not prove Play delivery behavior, and repository builds do not prove F-Droid infrastructure output.
+- Network evidence proves only the exact artifact, OS/emulator, configuration, UID attribution method, and exercised scenarios. It cannot prove unexercised paths or future server behavior. TLS commonly hides paths/content, while DNS/SNI/proxy metadata may still expose destinations.
+- Raw packet captures can contain account and network metadata even without bodies; keep them restricted and short-lived.

--- a/android/security/android-network-endpoints.txt
+++ b/android/security/android-network-endpoints.txt
@@ -1,0 +1,5 @@
+# Reviewed endpoint policy, schema 1. One lower-case host rule per line.
+# No endpoint is permitted before the user selects/configures a server.
+# Authenticated scenarios substitute only the dedicated test server host supplied
+# as ANDROID_NETWORK_TEST_SERVER_URL; the evidence checker records <user-selected-server>.
+<user-selected-server>

--- a/android/security/fixtures/tracker-scan/clean/dependencies.txt
+++ b/android/security/fixtures/tracker-scan/clean/dependencies.txt
@@ -1,0 +1,2 @@
+io.etebase:client:2.3.2
+org.conscrypt:conscrypt-android:2.5.0

--- a/android/security/fixtures/tracker-scan/positive/dependency/input.txt
+++ b/android/security/fixtures/tracker-scan/positive/dependency/input.txt
@@ -1,0 +1,1 @@
+com.google.firebase:firebase-analytics:22.0.0

--- a/android/security/fixtures/tracker-scan/positive/dex_signature/classes.dex.txt
+++ b/android/security/fixtures/tracker-scan/positive/dex_signature/classes.dex.txt
@@ -1,0 +1,1 @@
+com/mixpanel/android/mpmetrics/MixpanelAPI

--- a/android/security/fixtures/tracker-scan/positive/domain/input.txt
+++ b/android/security/fixtures/tracker-scan/positive/domain/input.txt
@@ -1,0 +1,1 @@
+https://api.mixpanel.com/track

--- a/android/security/fixtures/tracker-scan/positive/identifier_api/input.txt
+++ b/android/security/fixtures/tracker-scan/positive/identifier_api/input.txt
@@ -1,0 +1,1 @@
+com/android/installreferrer/api/InstallReferrerClient

--- a/android/security/fixtures/tracker-scan/positive/manifest_component/AndroidManifest.xml
+++ b/android/security/fixtures/tracker-scan/positive/manifest_component/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<provider android:name="io.sentry.android.core.SentryInitProvider" />

--- a/android/security/fixtures/tracker-scan/positive/native_symbol/libtracker.so.txt
+++ b/android/security/fixtures/tracker-scan/positive/native_symbol/libtracker.so.txt
@@ -1,0 +1,1 @@
+000000 sentry_native_init

--- a/android/security/fixtures/tracker-scan/positive/package/input.txt
+++ b/android/security/fixtures/tracker-scan/positive/package/input.txt
@@ -1,0 +1,1 @@
+com/posthog/android/PostHog

--- a/android/security/tracker-signatures.json
+++ b/android/security/tracker-signatures.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "policy": "No analytics, advertising, crash-reporting, attribution, install-referrer, or device-identifier runtime code in Android artifacts.",
+  "reviewed_on": "2026-07-12",
+  "review_due": "2026-10-12",
+  "catalog_baseline": {
+    "sources": ["Exodus Privacy tracker catalog", "TrackerControl tracker catalog", "Android advertising and identifier APIs"],
+    "manual_owner": "SilentSuite security/privacy owner",
+    "review_record": "Compare catalog additions, dependency graphs, Android APIs, and native libraries; record evidence in the reviewed manifest change."
+  },
+  "signatures": [
+    {"id":"firebase-analytics-dependency","category":"dependency","description":"Analytics, advertising, attribution, Firebase Performance (firebase-performance), or crash dependency coordinate","pattern":"(?:com\\.google\\.firebase:firebase-(?:analytics|crashlytics|performance)(?:[-a-z]*)|com\\.adjust\\.sdk:adjust-android|com\\.appsflyer:af-android-sdk|com\\.facebook\\.android:facebook-(?:core|marketing)|com\\.google\\.android\\.gms:play-services-ads|com\\.amplitude:android-sdk|com\\.bugsnag:bugsnag-android|com\\.datadoghq:dd-sdk-android|com\\.newrelic\\.agent\\.android:android-agent):"},
+    {"id":"tracker-package","category":"package","description":"Catalog-derived tracker package","pattern":"(?:com[./]mixpanel[./]android|com[./]posthog[./]android|io[./]sentry|org[./]acra|com[./]google[./]firebase[./](?:analytics|crashlytics|perf)|com[./]adjust[./]sdk|com[./]appsflyer|com[./]facebook[./]appevents|com[./]google[./]android[./]gms[./]ads|com[./]amplitude|com[./]bugsnag|com[./]datadog|com[./]newrelic)"},
+    {"id":"tracker-domain","category":"domain","description":"Known tracker collection endpoint","pattern":"(?:api\\.mixpanel\\.com|app\\.posthog\\.com|google-analytics\\.com|firebase-settings\\.crashlytics\\.com|sentry\\.io|app-measurement\\.com|adjust\\.com|appsflyer\\.com|graph\\.facebook\\.com|amplitude\\.com|bugsnag\\.com|datadoghq\\.com|newrelic\\.com)"},
+    {"id":"tracker-manifest-component","category":"manifest_component","description":"Tracker manifest component or metadata","pattern":"(?:com\\.google\\.android\\.datatransport\\.runtime\\.scheduling\\.jobscheduling\\.JobInfoSchedulerService|io\\.sentry\\.android\\.core\\.SentryInitProvider|com\\.google\\.firebase\\.components:|com\\.facebook\\.FacebookContentProvider|com\\.bugsnag\\.android\\.BugsnagContentProvider|com\\.newrelic\\.agent\\.android)"},
+    {"id":"identifier-attribution-api","category":"identifier_api","description":"Advertising ID, app-set ID, or install-referrer API","pattern":"(?:AdvertisingIdClient|AppSetIdClient|InstallReferrerClient|com[./]android[./]installreferrer|com[./]google[./]android[./]gms[./]ads[./]identifier)"},
+    {"id":"tracker-dex-signature","category":"dex_signature","description":"Tracker DEX class/string","pattern":"(?:com[./]mixpanel[./]android[./]mpmetrics|com[./]posthog[./]android[./]PostHog|FirebaseAnalytics|getAdvertisingIdInfo|AdjustConfig|AppsFlyerLib|AppEventsLogger|GoogleAds|FirebasePerformance|AmplitudeClient|Bugsnag|Datadog|NewRelic)"},
+    {"id":"tracker-native-symbol","category":"native_symbol","description":"Tracker native symbol/string","pattern":"(?:sentry_native_init|crashpad_handler|posthog_capture|mixpanel_track|appsflyer|bugsnag|datadog|newrelic)"}
+  ],
+  "exceptions": []
+}

--- a/tests/test_android_tracker_scan.py
+++ b/tests/test_android_tracker_scan.py
@@ -1,0 +1,197 @@
+import datetime as dt
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCANNER = ROOT / "android/scripts/scan-tracker-signatures.py"
+MANIFEST = ROOT / "android/security/tracker-signatures.json"
+FIXTURES = ROOT / "android/security/fixtures/tracker-scan"
+
+
+class AndroidTrackerScannerTest(unittest.TestCase):
+    def run_scan(self, *targets: Path, manifest: Path = MANIFEST):
+        return subprocess.run(
+            [sys.executable, str(SCANNER), "--manifest", str(manifest), *map(str, targets)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_clean_fixture_passes(self):
+        result = self.run_scan(FIXTURES / "clean")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("tracker scan passed", result.stdout.lower())
+
+    def test_each_signature_category_has_a_positive_failing_fixture(self):
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        expected = {entry["category"] for entry in manifest["signatures"]}
+        fixtures = {path.name for path in (FIXTURES / "positive").iterdir() if path.is_dir()}
+        self.assertEqual(fixtures, expected)
+        for category in sorted(expected):
+            with self.subTest(category=category):
+                result = self.run_scan(FIXTURES / "positive" / category)
+                self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+                self.assertIn(f"[{category}]", result.stdout)
+
+    def test_scans_nested_apk_aab_split_dex_and_native_payloads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "universal.apks"
+            nested_apk = Path(tmp) / "base.apk"
+            with zipfile.ZipFile(nested_apk, "w") as apk:
+                apk.writestr("classes.dex", b"prefix com/mixpanel/android/mpmetrics suffix")
+                apk.writestr("lib/arm64-v8a/libfixture.so", b"symbol sentry_native_init end")
+            with zipfile.ZipFile(archive, "w") as splits:
+                splits.write(nested_apk, "splits/base-master.apk")
+            result = self.run_scan(archive)
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("[dex_signature]", result.stdout)
+        self.assertIn("[native_symbol]", result.stdout)
+
+    def test_empty_or_malformed_manifest_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for body in ("{}", "not-json"):
+                manifest = Path(tmp) / "manifest.json"
+                manifest.write_text(body, encoding="utf-8")
+                result = self.run_scan(FIXTURES / "clean", manifest=manifest)
+                self.assertEqual(result.returncode, 3)
+                self.assertIn("invalid signature manifest", result.stderr.lower())
+
+    def test_network_evidence_is_uid_scoped_and_allowlisted(self):
+        checker = ROOT / "android/scripts/check-network-evidence.py"
+        allowlist = ROOT / "android/security/android-network-endpoints.txt"
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence = Path(tmp) / "evidence.jsonl"
+            evidence.write_text(
+                '{"scenario":"clean_launch","uid":10123,"host":null,"requests":0}\n'
+                '{"scenario":"foreground_sync","uid":10123,"host":"<user-selected-server>","requests":2}\n',
+                encoding="utf-8",
+            )
+            result = subprocess.run([sys.executable, str(checker), "--allowlist", str(allowlist),
+                                     "--evidence", str(evidence)], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            evidence.write_text(
+                '{"scenario":"clean_launch","uid":10123,"host":"api.mixpanel.com","requests":1}\n',
+                encoding="utf-8",
+            )
+            result = subprocess.run([sys.executable, str(checker), "--allowlist", str(allowlist),
+                                     "--evidence", str(evidence)], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("not allowlisted", result.stderr)
+
+    def test_scoped_unexpired_exception_is_reviewable_but_expired_one_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "dependency-report.txt"
+            target.write_text("com.google.firebase:firebase-analytics:22.0.0", encoding="utf-8")
+            base = json.loads(MANIFEST.read_text(encoding="utf-8"))
+            base["exceptions"] = [{
+                "signature_id": "firebase-analytics-dependency",
+                "path_regex": "dependency-report\\.txt$",
+                "rationale": "Fixture-only review record",
+                "owner": "security",
+                "reviewed_on": "2026-07-12",
+                "expires_on": (dt.date.today() + dt.timedelta(days=30)).isoformat()
+            }]
+            manifest = Path(tmp) / "manifest.json"
+            manifest.write_text(json.dumps(base), encoding="utf-8")
+            result = self.run_scan(target, manifest=manifest)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("1 reviewed exception", result.stdout)
+            base["exceptions"][0]["expires_on"] = "2000-01-01"
+            manifest.write_text(json.dumps(base), encoding="utf-8")
+            result = self.run_scan(target, manifest=manifest)
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("expired", result.stderr.lower())
+
+    def test_network_evidence_rejects_mixed_uids_and_invalid_provenance(self):
+        checker = ROOT / "android/scripts/check-network-evidence.py"
+        allowlist = ROOT / "android/security/android-network-endpoints.txt"
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence = Path(tmp) / "evidence.jsonl"
+            provenance = Path(tmp) / "provenance.json"
+            evidence.write_text(
+                '{"scenario":"clean_launch","uid":10123,"host":null,"requests":0}\n'
+                '{"scenario":"foreground_sync","uid":10124,"host":"<user-selected-server>","requests":2}\n',
+                encoding="utf-8")
+            common = [sys.executable, str(checker), "--allowlist", str(allowlist), "--evidence", str(evidence),
+                      "--app-uid", "10123", "--raw-capture-sha256", "b" * 64,
+                      "--provenance-output", str(provenance)]
+            result = subprocess.run([*common, "--artifact-sha256", "not-a-digest"], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("sha-256", result.stderr.lower())
+            self.assertFalse(provenance.exists())
+            result = subprocess.run([*common, "--artifact-sha256", "a" * 64], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 3)
+            self.assertIn("one app uid", result.stderr.lower())
+
+    def test_network_evidence_writes_digest_bound_provenance(self):
+        checker = ROOT / "android/scripts/check-network-evidence.py"
+        allowlist = ROOT / "android/security/android-network-endpoints.txt"
+        with tempfile.TemporaryDirectory() as tmp:
+            evidence = Path(tmp) / "evidence.jsonl"
+            provenance = Path(tmp) / "provenance.json"
+            evidence.write_text('{"scenario":"clean_launch","uid":10123,"host":null,"requests":0}\n', encoding="utf-8")
+            result = subprocess.run([
+                sys.executable, str(checker), "--allowlist", str(allowlist), "--evidence", str(evidence),
+                "--app-uid", "10123", "--artifact-sha256", "a" * 64,
+                "--raw-capture-sha256", "b" * 64, "--provenance-output", str(provenance),
+            ], text=True, capture_output=True)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            record = json.loads(provenance.read_text(encoding="utf-8"))
+            self.assertEqual(record["app_uid"], 10123)
+            self.assertEqual(record["artifact_sha256"], "a" * 64)
+            self.assertEqual(record["raw_capture_sha256"], "b" * 64)
+            self.assertRegex(record["evidence_jsonl_sha256"], r"^[0-9a-f]{64}$")
+
+    def test_exception_policy_rejects_wildcards_future_reviews_and_long_windows(self):
+        base = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        today = dt.date.today()
+        cases = [
+            (".*", today.isoformat(), (today + dt.timedelta(days=1)).isoformat(), "broad"),
+            (r"dependency-report\.txt$", (today + dt.timedelta(days=1)).isoformat(),
+             (today + dt.timedelta(days=2)).isoformat(), "future"),
+            (r"dependency-report\.txt$", today.isoformat(),
+             (today + dt.timedelta(days=91)).isoformat(), "window"),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "dependency-report.txt"
+            target.write_text("clean", encoding="utf-8")
+            manifest = Path(tmp) / "manifest.json"
+            for path_regex, reviewed, expires, expected in cases:
+                with self.subTest(expected=expected):
+                    base["exceptions"] = [{"signature_id": "firebase-analytics-dependency",
+                        "path_regex": path_regex, "rationale": "Narrow temporary false positive",
+                        "owner": "security", "reviewed_on": reviewed, "expires_on": expires}]
+                    manifest.write_text(json.dumps(base), encoding="utf-8")
+                    result = self.run_scan(target, manifest=manifest)
+                    self.assertEqual(result.returncode, 3)
+                    self.assertIn(expected, result.stderr.lower())
+
+    def test_registry_contains_catalog_baseline_for_common_trackers(self):
+        body = MANIFEST.read_text(encoding="utf-8").lower()
+        for marker in ("adjust", "appsflyer", "facebook", "googleads", "firebase-performance",
+                       "amplitude", "bugsnag", "datadog", "newrelic"):
+            with self.subTest(marker=marker):
+                self.assertIn(marker, body)
+
+    def test_workflows_enforce_restricted_capture_mapping_and_manual_owner_contracts(self):
+        network = (ROOT / ".github/workflows/android-network-evidence.yml").read_text(encoding="utf-8")
+        build = (ROOT / ".github/workflows/build-android.yml").read_text(encoding="utf-8")
+        quarterly = (ROOT / ".github/workflows/android-tracker-quarterly-review.yml").read_text(encoding="utf-8")
+        self.assertNotIn("ANDROID_NETWORK_RAW_CAPTURE_BASE64", network)
+        self.assertNotIn("android-network-raw-restricted", network)
+        for required in ("app_uid", "raw_capture_sha256", "restricted_evidence_reference", "manual_owner"):
+            self.assertIn(required, network)
+        self.assertIn("app/build/outputs/mapping/release/mapping.txt", build)
+        self.assertIn("test -s app/build/outputs/mapping/release/mapping.txt", build)
+        self.assertIn("cron: '17 9 * * 1'", quarterly)
+        self.assertIn("review_record", quarterly)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- scan Android dependency, manifest, mapping, package, DEX, native, and split artifacts for reviewed telemetry signatures
- require UID-scoped sanitized network evidence with restricted raw-capture provenance
- add weekly signature review and Play/F-Droid final-artifact owner contracts

## Verification
- 11 Python fixture tests passed
- Python compilation passed
- workflow YAML validation passed
- mandatory GPT-5.6 Sol review approved
- Android builds remain CI-owned

## Privacy
No tracker is added. Raw PCAP data is never uploaded to public GitHub artifacts.