### PR TITLE
feat(android): sync contact favorites with native starred state

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/ContactsSyncManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/ContactsSyncManager.kt
@@ -106,6 +106,36 @@ constructor(context: Context, account: Account, settings: AccountSettings, extra
         batch.commit()
     }
 
+    /**
+     * On a read-only collection, a native/OEM Contacts app may still let the
+     * user toggle the star. That local change must never be uploaded; instead
+     * we reapply the authoritative cached remote vCard (already downloaded in
+     * this sync) over the SilentSuite raw row so STARRED and every other field
+     * are restored to the server's state before the dirty flag is cleared.
+     */
+    override fun restoreLocalFromRemote(local: LocalAddress): String? {
+        if (local !is LocalContact)
+            return null
+        // The Etebase cache is keyed by the item/file UID, not the vCard UID.
+        val itemUid = local.fileName
+            ?: throw ContactsStorageException("Cannot restore read-only contact without cached item UID")
+
+        val cached = synchronized(etebaseLocalCache) {
+            etebaseLocalCache.itemGet(itemMgr, cachedCollection.col.uid, itemUid)
+        }
+        if (cached == null || cached.item.isDeleted)
+            throw ContactsStorageException("Authoritative cached read-only contact is unavailable")
+
+        val remote = Contact.fromReader(StringReader(cached.content), resourceDownloader)
+        if (remote.isEmpty())
+            throw ContactsStorageException("Authoritative cached read-only contact is invalid")
+
+        Logger.log.info("Reapplying authoritative remote contact over a discarded read-only change")
+        local.eTag = cached.item.etag
+        local.update(remote[0])
+        return cached.item.etag
+    }
+
     @Throws(CalendarStorageException::class, ContactsStorageException::class)
     override fun postProcess() {
         super.postProcess()

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncManager.kt
@@ -496,7 +496,10 @@ constructor(protected val context: Context, protected val account: Account, prot
                     // If it was only local, delete.
                     local.delete()
                 } else {
-                    local.clearDirty(null)
+                    // Reapply the authoritative cached remote content in this same
+                    // sync so discarded local edits (e.g. a native star toggle on a
+                    // read-only collection) are visibly reverted, then clear dirty.
+                    local.clearDirty(restoreLocalFromRemote(local))
                 }
                 numDiscarded++
             }
@@ -504,6 +507,15 @@ constructor(protected val context: Context, protected val account: Account, prot
             localDirty = LinkedList()
         }
     }
+
+    /**
+     * Reapply authoritative cached remote content over a locally-modified
+     * resource on a read-only collection, so a discarded local edit is visibly
+     * reverted within the same sync (no server write occurs). Default: no-op;
+     * resource-specific managers may override to rewrite provider fields.
+     */
+    @Throws(CalendarStorageException::class, ContactsStorageException::class)
+    protected open fun restoreLocalFromRemote(local: T): String? = null
 
     /**
      * For post-processing of entries, for instance assigning groups.

--- a/android/vcard4android/src/androidTest/java/at/bitfire/vcard4android/AndroidContactTest.kt
+++ b/android/vcard4android/src/androidTest/java/at/bitfire/vcard4android/AndroidContactTest.kt
@@ -248,6 +248,228 @@ class AndroidContactTest {
     }
 
 
+    // ── favorite ↔ RawContacts.STARRED ──
+
+    private fun rawContactInt(id: Long, column: String): Int? {
+        provider.query(
+            ContactsContract.RawContacts.CONTENT_URI,
+            arrayOf(column),
+            "${ContactsContract.RawContacts._ID}=?",
+            arrayOf(id.toString()), null
+        )?.use { c ->
+            if (c.moveToNext() && !c.isNull(0)) return c.getInt(0)
+        }
+        return null
+    }
+
+    private fun aggregateStarred(rawId: Long): Int? {
+        var contactId: Long? = null
+        provider.query(
+            ContactsContract.RawContacts.CONTENT_URI,
+            arrayOf(ContactsContract.RawContacts.CONTACT_ID),
+            "${ContactsContract.RawContacts._ID}=?",
+            arrayOf(rawId.toString()), null
+        )?.use { c ->
+            if (c.moveToNext() && !c.isNull(0)) contactId = c.getLong(0)
+        }
+        val cid = contactId ?: return null
+        provider.query(
+            ContactsContract.Contacts.CONTENT_URI,
+            arrayOf(ContactsContract.Contacts.STARRED),
+            "${ContactsContract.Contacts._ID}=?",
+            arrayOf(cid.toString()), null
+        )?.use { c ->
+            if (c.moveToNext() && !c.isNull(0)) return c.getInt(0)
+        }
+        return null
+    }
+
+    @Test
+    @SmallTest
+    fun testFavoriteWritesStarredOnInsert() {
+        val vcard = Contact()
+        vcard.displayName = "Star Me"
+        vcard.givenName = "Star"
+        vcard.favorite = true
+
+        val contact = AndroidContact(addressBook, vcard, null, null)
+        contact.add()
+        val id = contact.id!!
+        try {
+            val readBack = addressBook.findContactByID(id).contact!!
+            assertTrue(readBack.favorite)
+            assertEquals(1, rawContactInt(id, ContactsContract.RawContacts.STARRED))
+            assertEquals(1, aggregateStarred(id))
+            assertEquals(0, rawContactInt(id, ContactsContract.RawContacts.DIRTY))
+            assertEquals(0, rawContactInt(id, ContactsContract.RawContacts.DELETED))
+        } finally {
+            addressBook.findContactByID(id).delete()
+        }
+    }
+
+    @Test
+    @SmallTest
+    fun testNonFavoriteWritesUnstarred() {
+        val vcard = Contact()
+        vcard.displayName = "Not Star"
+        vcard.favorite = false
+
+        val contact = AndroidContact(addressBook, vcard, null, null)
+        contact.add()
+        val id = contact.id!!
+        try {
+            assertFalse(addressBook.findContactByID(id).contact!!.favorite)
+            assertEquals(0, rawContactInt(id, ContactsContract.RawContacts.STARRED))
+        } finally {
+            addressBook.findContactByID(id).delete()
+        }
+    }
+
+    @Test
+    @SmallTest
+    fun testRemoteFavoriteUpdateSetsStarWithoutDirtyLoop() {
+        val original = Contact().apply { displayName = "Become Star"; favorite = false }
+        val contact = AndroidContact(addressBook, original, null, "etag-1")
+        contact.add()
+        val id = contact.id!!
+        try {
+            val local = addressBook.findContactByID(id)
+            local.eTag = "etag-2"
+            local.update(Contact().apply { displayName = "Become Star"; favorite = true })
+            assertEquals(1, rawContactInt(id, ContactsContract.RawContacts.STARRED))
+            assertEquals(0, rawContactInt(id, ContactsContract.RawContacts.DIRTY))
+            assertTrue(addressBook.findContactByID(id).contact!!.favorite)
+        } finally {
+            addressBook.findContactByID(id).delete()
+        }
+    }
+
+    @Test
+    @SmallTest
+    fun testFavoriteUpdatePreservesUnknownOemDataRow() {
+        val original = Contact().apply { displayName = "OEM Row"; favorite = false }
+        val contact = AndroidContact(addressBook, original, null, "etag-1")
+        contact.add()
+        val id = contact.id!!
+        val customMime = "vnd.android.cursor.item/important_people"
+        try {
+            val values = android.content.ContentValues().apply {
+                put(ContactsContract.Data.RAW_CONTACT_ID, id)
+                put(ContactsContract.Data.MIMETYPE, customMime)
+                put(ContactsContract.Data.DATA1, "opaque-oem-value")
+            }
+            assertNotNull(provider.insert(ContactsContract.Data.CONTENT_URI, values))
+            addressBook.findContactByID(id).update(Contact().apply { displayName = "OEM Row"; favorite = true })
+            provider.query(
+                ContactsContract.Data.CONTENT_URI,
+                arrayOf(ContactsContract.Data.DATA1),
+                "${ContactsContract.Data.RAW_CONTACT_ID}=? AND ${ContactsContract.Data.MIMETYPE}=?",
+                arrayOf(id.toString(), customMime), null
+            )?.use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("opaque-oem-value", cursor.getString(0))
+            }
+        } finally {
+            addressBook.findContactByID(id).delete()
+        }
+    }
+
+    @Test
+    @SmallTest
+    fun testRemoteUnfavoriteClearsStarWithoutDirtyLoop() {
+        val starred = Contact()
+        starred.displayName = "Was Star"
+        starred.favorite = true
+
+        val contact = AndroidContact(addressBook, starred, null, "etag-1")
+        contact.add()
+        val id = contact.id!!
+        try {
+            assertEquals(1, rawContactInt(id, ContactsContract.RawContacts.STARRED))
+
+            // Apply a remote revision without the favorite property.
+            val remote = Contact()
+            remote.displayName = "Was Star"
+            remote.favorite = false
+            val local = addressBook.findContactByID(id)
+            local.eTag = "etag-2"
+            local.update(remote)
+
+            assertEquals(0, rawContactInt(id, ContactsContract.RawContacts.STARRED))
+            assertEquals(0, rawContactInt(id, ContactsContract.RawContacts.DIRTY))
+            assertFalse(addressBook.findContactByID(id).contact!!.favorite)
+        } finally {
+            addressBook.findContactByID(id).delete()
+        }
+    }
+
+    @Test
+    @SmallTest
+    fun testNativeStarChangeIsReadBackAsFavorite() {
+        val vcard = Contact()
+        vcard.displayName = "Native Star"
+        vcard.favorite = false
+
+        val contact = AndroidContact(addressBook, vcard, null, null)
+        contact.add()
+        val id = contact.id!!
+        try {
+            // Simulate a native Contacts/Dialer app starring the aggregate.
+            var aggregateId: Long? = null
+            provider.query(
+                ContactsContract.RawContacts.CONTENT_URI,
+                arrayOf(ContactsContract.RawContacts.CONTACT_ID),
+                "${ContactsContract.RawContacts._ID}=?",
+                arrayOf(id.toString()), null
+            )?.use { cursor ->
+                if (cursor.moveToNext()) aggregateId = cursor.getLong(0)
+            }
+            assertNotNull(aggregateId)
+            val values = android.content.ContentValues(1)
+            values.put(ContactsContract.Contacts.STARRED, 1)
+            provider.update(
+                android.content.ContentUris.withAppendedId(ContactsContract.Contacts.CONTENT_URI, aggregateId!!),
+                values,
+                null,
+                null
+            )
+
+            // Inspect constituent ownership explicitly; serialization below is
+            // performed only through this address book's raw-contact row.
+            provider.query(
+                ContactsContract.RawContacts.CONTENT_URI,
+                arrayOf(
+                    ContactsContract.RawContacts._ID,
+                    ContactsContract.RawContacts.ACCOUNT_NAME,
+                    ContactsContract.RawContacts.ACCOUNT_TYPE,
+                    ContactsContract.RawContacts.STARRED
+                ),
+                "${ContactsContract.RawContacts.CONTACT_ID}=?",
+                arrayOf(aggregateId.toString()), null
+            )?.use { cursor ->
+                var foundOwnedRow = false
+                while (cursor.moveToNext()) {
+                    if (cursor.getLong(0) == id) {
+                        assertEquals(testAccount.name, cursor.getString(1))
+                        assertEquals(testAccount.type, cursor.getString(2))
+                        assertEquals(1, cursor.getInt(3))
+                        foundOwnedRow = true
+                    }
+                }
+                assertTrue(foundOwnedRow)
+            }
+            val serialized = addressBook.findContactByID(id).contact!!
+            assertTrue(serialized.favorite)
+            assertEquals(1, rawContactInt(id, ContactsContract.RawContacts.DIRTY))
+            val os = ByteArrayOutputStream()
+            serialized.write(VCardVersion.V4_0, GroupMethod.GROUP_VCARDS, os)
+            assertEquals(1, Regex("X-SILENTSUITE-FAVORITE:1").findAll(os.toString()).count())
+        } finally {
+            addressBook.findContactByID(id).delete()
+        }
+    }
+
+
     @Test
     fun testLabelToXName() {
         assertEquals("X-AUNTIES_HOME", AndroidContact.labelToXName("auntie's home"))

--- a/android/vcard4android/src/main/java/at/bitfire/vcard4android/AndroidContact.kt
+++ b/android/vcard4android/src/main/java/at/bitfire/vcard4android/AndroidContact.kt
@@ -183,6 +183,9 @@ open class AndroidContact(
         eTag = row.getAsString(COLUMN_ETAG)
 
         contact!!.uid = row.getAsString(COLUMN_UID)
+
+        // Native favorite/star state lives on this SilentSuite raw-contact row.
+        contact!!.favorite = (row.getAsInteger(RawContacts.STARRED) ?: 0) != 0
     }
 
     protected open fun populateStructuredName(row: ContentValues) {
@@ -618,6 +621,10 @@ open class AndroidContact(
                 .withValue(COLUMN_FILENAME, fileName)
                 .withValue(COLUMN_ETAG, eTag)
                 .withValue(COLUMN_UID, contact!!.uid)
+                // Only ever write this SilentSuite raw row's STARRED. Android
+                // recomputes the aggregate Contacts.STARRED from constituent
+                // rows; we never touch other accounts' rows.
+                .withValue(RawContacts.STARRED, if (contact!!.favorite) 1 else 0)
 
         if (addressBook.readOnly)
             builder.withValue(RawContacts.RAW_CONTACT_IS_READ_ONLY, 1)

--- a/android/vcard4android/src/main/java/at/bitfire/vcard4android/Contact.kt
+++ b/android/vcard4android/src/main/java/at/bitfire/vcard4android/Contact.kt
@@ -69,6 +69,10 @@ class Contact {
 
     var photo: ByteArray? = null
 
+    /** SilentSuite favorite/starred state, round-tripped via the
+     *  [PROPERTY_FAVORITE] extension (`X-SILENTSUITE-FAVORITE:1`). */
+    var favorite: Boolean = false
+
     /** unknown properties in text VCARD format */
     var unknownProperties: String? = null
 
@@ -85,6 +89,11 @@ class Contact {
         const val PROPERTY_PHONETIC_MIDDLE_NAME = "X-PHONETIC-MIDDLE-NAME"
         const val PROPERTY_PHONETIC_LAST_NAME = "X-PHONETIC-LAST-NAME"
         const val PROPERTY_SIP = "X-SIP"
+
+        /** SilentSuite-owned favorite flag. Canonical wire form is exactly
+         *  `X-SILENTSUITE-FAVORITE:1`; any other or absent value is false. */
+        const val PROPERTY_FAVORITE = "X-SILENTSUITE-FAVORITE"
+        const val PROPERTY_FAVORITE_VALUE = "1"
 
         val PHONE_TYPE_CALLBACK = TelephoneType.get("x-callback")!!
         val PHONE_TYPE_COMPANY_MAIN = TelephoneType.get("x-company_main")!!
@@ -258,6 +267,14 @@ class Contact {
                     PROPERTY_PHONETIC_LAST_NAME   -> c.phoneticFamilyName = StringUtils.trimToNull(prop.value)
 
                     PROPERTY_SIP -> c.impps += LabeledProperty(Impp("sip", prop.value), findLabel(prop.group))
+
+                    PROPERTY_FAVORITE ->
+                        // Reduce duplicates with "any exact `1` wins". Never trim
+                        // or unescape the scalar; leave remove = true so every
+                        // canonical property (1 or 0) is stripped and cannot leak
+                        // into unknownProperties.
+                        if (prop.value == PROPERTY_FAVORITE_VALUE)
+                            c.favorite = true
 
                     else -> remove = false      // don't remove unknown extended properties
                 }
@@ -485,6 +502,13 @@ class Contact {
             vCard.categories = cat
         }
 
+        // FAVORITE (SilentSuite-owned). Strip any canonical remnants that may
+        // have survived in the reparsed unknownProperties, then emit exactly
+        // one ungrouped, parameterless property when true.
+        vCard.removeExtendedProperty(PROPERTY_FAVORITE)
+        if (favorite)
+            vCard.addExtendedProperty(PROPERTY_FAVORITE, PROPERTY_FAVORITE_VALUE)
+
         // ANNIVERSARY, BDAY
         fun<T: DateOrTimeProperty> dateOrPartialDate(prop: T, generator: (Date) -> T): T? {
             if (vCardVersion == VCardVersion.V4_0 || prop.date != null)
@@ -549,7 +573,8 @@ class Contact {
         phoneNumbers, emails, impps, addresses,
         /* categories, */ urls, relations,
         note, anniversary, birthDay,
-        photo
+        photo,
+        favorite
         /* unknownProperties */
     )
 
@@ -566,7 +591,9 @@ class Contact {
 
     override fun toString(): String {
         val builder = ReflectionToStringBuilder(this)
-        builder.setExcludeFieldNames("photo")
+        // Favorite status is sensitive relationship metadata. Keep it out of
+        // diagnostic/log stringification just like contact photos.
+        builder.setExcludeFieldNames("photo", "favorite")
         return builder.toString()
     }
 

--- a/android/vcard4android/src/test/java/at/bitfire/vcard4android/ContactTest.kt
+++ b/android/vcard4android/src/test/java/at/bitfire/vcard4android/ContactTest.kt
@@ -488,4 +488,126 @@ class ContactTest {
         assertNull(c.unknownProperties)
     }
 
+
+    // ── X-SILENTSUITE-FAVORITE (favorite flag) ──
+
+    private fun parseInline(vararg propLines: String): Contact {
+        val vcard = (listOf("BEGIN:VCARD", "VERSION:3.0", "UID:fav-test", "FN:Fav Test") +
+                propLines.toList() + listOf("END:VCARD")).joinToString("\r\n")
+        return Contact.fromReader(StringReader(vcard), null).first()
+    }
+
+    @Test
+    fun testFavoriteDefaultsFalse() {
+        assertFalse(parseInline().favorite)
+    }
+
+    @Test
+    fun testFavoriteParsesCanonicalTrue() {
+        assertTrue(parseInline("X-SILENTSUITE-FAVORITE:1").favorite)
+    }
+
+    @Test
+    fun testFavoriteZeroAndMalformedAreFalse() {
+        assertFalse(parseInline("X-SILENTSUITE-FAVORITE:0").favorite)
+        assertFalse(parseInline("X-SILENTSUITE-FAVORITE:true").favorite)
+        assertFalse(parseInline("X-SILENTSUITE-FAVORITE:").favorite)
+    }
+
+    @Test
+    fun testFavoriteDuplicateAnyOneWins() {
+        assertTrue(parseInline("X-SILENTSUITE-FAVORITE:0", "X-SILENTSUITE-FAVORITE:1").favorite)
+        assertTrue(parseInline("X-SILENTSUITE-FAVORITE:1", "X-SILENTSUITE-FAVORITE:0").favorite)
+    }
+
+    @Test
+    fun testFavoriteNormalizesCaseGroupParametersAndFolding() {
+        assertTrue(parseInline("x-silentsuite-favorite:1").favorite)
+        assertTrue(parseInline("item3.X-SILENTSUITE-FAVORITE:1").favorite)
+        assertTrue(parseInline("X-SILENTSUITE-FAVORITE;TYPE=pref:1").favorite)
+        assertTrue(parseInline("X-SILENTSUITE-FAVORITE:", " 1").favorite)
+        assertFalse(parseInline("X-SILENTSUITE-FAVORITE: 1").favorite)
+        assertFalse(parseInline("X-SILENTSUITE-FAVORITE:1 ").favorite)
+    }
+
+    @Test
+    fun testFavoriteDoesNotLeakIntoUnknownProperties() {
+        val c = parseInline("X-SILENTSUITE-FAVORITE:1", "X-SILENTSUITE-FAVORITE:0")
+        assertTrue(c.favorite)
+        assertTrue(c.unknownProperties == null || !c.unknownProperties!!.contains("X-SILENTSUITE-FAVORITE"))
+    }
+
+    @Test
+    fun testFavoritePreservesUnrelatedUnknownProperties() {
+        val c = parseInline("X-SILENTSUITE-FAVORITE:1", "X-CUSTOM-OEM-FIELD:keepme")
+        assertTrue(c.favorite)
+        assertNotNull(c.unknownProperties)
+        assertTrue(c.unknownProperties!!.contains("X-CUSTOM-OEM-FIELD"))
+        assertFalse(c.unknownProperties!!.contains("X-SILENTSUITE-FAVORITE"))
+    }
+
+    @Test
+    fun testFavoriteEmitsExactlyOneCanonicalProperty() {
+        val c = Contact()
+        c.uid = UUID.randomUUID().toString()
+        c.favorite = true
+        val vCard = toString(c, GroupMethod.GROUP_VCARDS, VCardVersion.V4_0)
+        assertEquals(1, Regex("X-SILENTSUITE-FAVORITE:1").findAll(vCard).count())
+
+        val regenerated = regenerate(c, VCardVersion.V4_0)
+        assertTrue(regenerated.favorite)
+    }
+
+    @Test
+    fun testFavoriteFalseEmitsNoProperty() {
+        val c = Contact()
+        c.uid = UUID.randomUUID().toString()
+        c.favorite = false
+        val vCard = toString(c, GroupMethod.GROUP_VCARDS, VCardVersion.V4_0)
+        assertFalse(vCard.contains("X-SILENTSUITE-FAVORITE"))
+    }
+
+    @Test
+    fun testFavoriteTrueToFalseRemovesProperty() {
+        val c = parseInline("X-SILENTSUITE-FAVORITE:1")
+        assertTrue(c.favorite)
+        c.favorite = false
+        val vCard = toString(c, GroupMethod.GROUP_VCARDS, VCardVersion.V4_0)
+        assertFalse(vCard.contains("X-SILENTSUITE-FAVORITE"))
+    }
+
+    @Test
+    fun testFavoriteCanonicalizesMixedUnknownRemnantsOnWrite() {
+        val c = Contact().apply {
+            uid = "unknown-favorite"
+            favorite = true
+            unknownProperties = listOf(
+                "BEGIN:VCARD", "VERSION:4.0",
+                "item1.x-silentsuite-favorite;TYPE=pref:0",
+                "X-SILENTSUITE-FAVORITE:1",
+                "X-CUSTOM-OEM-FIELD:keepme", "END:VCARD"
+            ).joinToString("\r\n")
+        }
+
+        val favorite = toString(c, GroupMethod.GROUP_VCARDS, VCardVersion.V4_0)
+        assertEquals(1, Regex("(?im)^(?:[^.:;]+\\.)?X-SILENTSUITE-FAVORITE(?:;[^:]*)?:1\\r?$").findAll(favorite).count())
+        assertFalse(favorite.contains("X-SILENTSUITE-FAVORITE:0", ignoreCase = true))
+        assertTrue(favorite.contains("X-CUSTOM-OEM-FIELD:keepme"))
+
+        c.favorite = false
+        val notFavorite = toString(c, GroupMethod.GROUP_VCARDS, VCardVersion.V4_0)
+        assertFalse(notFavorite.contains("X-SILENTSUITE-FAVORITE", ignoreCase = true))
+        assertTrue(notFavorite.contains("X-CUSTOM-OEM-FIELD:keepme"))
+    }
+
+    @Test
+    fun testFavoriteParticipatesInEquality() {
+        val a = Contact().apply { uid = "eq"; favorite = false }
+        val b = Contact().apply { uid = "eq"; favorite = true }
+        assertNotEquals(a, b)
+        assertNotEquals(a.hashCode(), b.hashCode())
+        b.favorite = false
+        assertEquals(a, b)
+    }
+
 }


### PR DESCRIPTION
## Summary
- map the encrypted contact favorite extension to Android native starred state
- preserve canonical favorite serialization while retaining unrelated OEM contact rows
- restore unauthorized read-only changes from authoritative cached contact data
- add JVM and instrumentation coverage for parsing, provider updates, dirty state, aggregate behavior, and OEM preservation

## Validation
- exact diff contains only six Android files
- whitespace and process-reference scans pass
- shared contract fixture is present on `dev`
- Android compilation, JVM tests, and instrumentation remain GitHub CI/device gates under repository policy