### PR TITLE
fix(calendar): use Schedule-X-safe render IDs

### DIFF
--- a/apps/web/app/(app)/calendar/components/__tests__/CalendarGrid.test.tsx
+++ b/apps/web/app/(app)/calendar/components/__tests__/CalendarGrid.test.tsx
@@ -237,7 +237,7 @@ describe('CalendarGrid timed-event integration', () => {
 
     await waitFor(() => expect(mocks.setEvents).toHaveBeenCalled())
     const projected = mocks.setEvents.mock.calls.at(-1)?.[0][0]
-    expect(String(projected.id)).toMatch(/^ss-render:[0-9a-f]{32}$/)
+    expect(String(projected.id)).toMatch(/^r[0-9a-f]{32}$/)
 
     act(() => mocks.latestConfig?.callbacks.onEventClick(projected))
     expect(mocks.calendarState.setSelectedEvent).toHaveBeenCalledWith('event-1')

--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-grid-events.test.ts
@@ -342,7 +342,15 @@ describe('hourly projection contracts', () => {
       new Set(reverse.events.map((event) => String(event.id))),
     )
     const ids = forward.events.map((event) => String(event.id))
-    expect(ids.every((id) => /^ss-render:[0-9a-f]{32}$/.test(id))).toBe(true)
+    expect(ids.every((id) => /^r[0-9a-f]{32}$/.test(id))).toBe(true)
+    expect(ids.every((id) => {
+      const probe = document.createElement('div')
+      probe.id = id
+      document.body.appendChild(probe)
+      const found = document.querySelector(`#${id}`) === probe
+      probe.remove()
+      return found
+    })).toBe(true)
     expect(ids.every((id) => !id.includes(first.id) && !id.includes(first.masterId))).toBe(true)
     expect(ids.every((id) => !decodeURIComponent(id).includes('cal-1'))).toBe(true)
   })

--- a/apps/web/app/(app)/calendar/lib/calendar-grid-events.ts
+++ b/apps/web/app/(app)/calendar/lib/calendar-grid-events.ts
@@ -288,7 +288,7 @@ function renderIdentityFor(source: DisplayEvent, segmentDate?: Temporal.PlainDat
     source.endDate.getTime(),
     segmentDate?.toString() ?? null,
   ])
-  return { id: `ss-render:${opaqueDigest(canonicalKey)}`, canonicalKey }
+  return { id: `r${opaqueDigest(canonicalKey)}`, canonicalKey }
 }
 
 /** Build Schedule-X-only objects plus a direct map back to source display events. */


### PR DESCRIPTION
## Summary
- replace opaque Schedule-X render IDs containing `:` with valid CSS identifiers shaped `r<32hex>`
- preserve deterministic opaque mapping and collision handling
- add a real `document.querySelector` regression check and update component identity coverage

## Root cause
Deployed preview QA after #536 showed source events expanding adaptive hours while all Week and Month event chips disappeared. Schedule-X 4.3.1 rejects event IDs that cannot be used as CSS identifiers; `ss-render:<digest>` failed validation and the existing event-service sync catch made the failure silent.

## Validation
- TDD regression observed red against the old ID format
- `pnpm run test` (321 core + 667 web tests)
- `pnpm --filter @silentsuite/web run type-check`
- `pnpm --filter @silentsuite/web run lint`
- `pnpm --filter @silentsuite/web run build`
- `git diff --check`
- independent Claude Opus 4.8 review: GREEN

## Preview QA
After merge and dev preview deploy, repeat the authenticated same-day and multi-day fixtures in Week and Month before declaring the calendar change done.