### PR TITLE
fix(calendar): allow connected month bars

### DIFF
--- a/apps/web/app/(app)/calendar/lib/__tests__/calendar-week-layout-css.test.ts
+++ b/apps/web/app/(app)/calendar/lib/__tests__/calendar-week-layout-css.test.ts
@@ -17,3 +17,11 @@ describe('Schedule-X week layout CSS', () => {
     expect(globalsCss).not.toMatch(/\.sx-silentsuite-calendar \.sx__week-wrapper[\s\S]*min-height: 100%/)
   })
 })
+
+describe('Schedule-X month layout CSS', () => {
+  it('allows connected multi-day bars to keep the width calculated by Schedule-X', () => {
+    expect(globalsCss).toMatch(
+      /\.sx-silentsuite-calendar \.sx__month-grid-event\.ss-month-multiday\s*\{[^}]*max-width:\s*none/,
+    )
+  })
+})

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -441,6 +441,7 @@
 
 .sx-silentsuite-calendar .sx__month-grid-event.ss-month-multiday {
   min-height: 21px;
+  max-width: none;
   border-radius: 6px !important;
   margin-block: 2px !important;
   box-shadow: 0 1px 2px rgb(0 0 0 / 0.08);


### PR DESCRIPTION
## Summary
- remove the one-day width cap only from Schedule-X month events marked as real multi-day spans
- preserve single-day event sizing and all Week/time-grid behavior
- add a CSS regression guard for the multi-day override

## Root cause
Authenticated deployed QA after #537 showed the source event and click identity were correct, but Month displayed the Jul 14 10 PM–Jul 16 2 AM event only inside the Jul 14 cell. The global `.sx__month-grid-event { max-width: 100% }` rule overrode Schedule-X's calculated multi-day inline width.

## Validation
- TDD regression observed red before the CSS override
- `pnpm run test` (321 core + 668 web tests)
- `pnpm --filter @silentsuite/web run lint` (existing warnings only)
- `pnpm --filter @silentsuite/web run build`
- `git diff --check`
- independent Claude Opus 4.8 review: GREEN

## Required post-merge QA
Verify the connected Month bar spans July 14–16, then recheck Week, mobile time-grid, Agenda, click identity, and console.