### PR TITLE
ci(android): add unit and lint quality gates

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -70,6 +70,31 @@ jobs:
       - name: Build 16 KB-aligned Etebase client AAR
         run: scripts/build-etebase-client-16kb.sh
 
+      - name: Run debug unit tests and lint
+        run: ./gradlew app:testDebugUnitTest app:lintDebug --continue --no-daemon -PrequireEtebase16Kb=true
+
+      - name: Upload unit test reports and results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: android-unit-test-results-${{ github.sha }}
+          path: |
+            android/app/build/test-results/testDebugUnitTest/
+            android/app/build/reports/tests/testDebugUnitTest/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload lint reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: android-lint-reports-${{ github.sha }}
+          path: |
+            android/app/build/reports/lint-results-debug.html
+            android/app/build/reports/lint-results-debug.xml
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Capture debug and release runtime dependency graphs
         run: |
           mkdir -p build/privacy-evidence/dependencies

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -123,6 +123,7 @@ android {
          buildConfig = true
     }
     lint {
+        baseline file('lint-baseline.xml')
         disable 'GoogleAppIndexingWarning', 'GradleDependency', 'GradleDynamicVersion', 'IconColors', 'IconLauncherShape', 'IconMissingDensityFolder', 'ImpliedQuantity', 'MissingQuantity', 'MissingTranslation', 'ExtraTranslation', 'Recycle', 'RtlEnabled', 'RtlHardcoded', 'Typos', 'RestrictedApi'
     }
 }

--- a/android/app/lint-baseline.xml
+++ b/android/app/lint-baseline.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.5.2">
+    <issue
+        id="OnClick"
+        severity="Error"
+        message="Corresponding method handler &apos;`public void onAddMemberClicked(android.view.View)`&apos; not found">
+        <location
+            file="src/main/res/layout/view_collection_members.xml"
+            line="31"
+            column="9"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="Call requires API level 22 (current min is 21): `android.accounts.AccountManager#removeAccountExplicitly`">
+        <location
+            file="src/main/java/io/silentsuite/sync/ui/AccountActivity.kt"
+            line="545"
+            column="40"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightStatusBar` requires API level 23 (current min is 21)">
+        <location
+            file="src/main/res/values-v21/styles.xml"
+            line="21"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightNavigationBar` requires API level 27 (current min is 21)">
+        <location
+            file="src/main/res/values-v21/styles.xml"
+            line="22"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightStatusBar` requires API level 23 (current min is 21)">
+        <location
+            file="src/main/res/values-night/styles.xml"
+            line="41"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightNavigationBar` requires API level 27 (current min is 21)">
+        <location
+            file="src/main/res/values-night/styles.xml"
+            line="42"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightStatusBar` requires API level 23 (current min is 21)">
+        <location
+            file="src/main/res/values-night/styles.xml"
+            line="54"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightNavigationBar` requires API level 27 (current min is 21)">
+        <location
+            file="src/main/res/values-night/styles.xml"
+            line="55"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightStatusBar` requires API level 23 (current min is 21)">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="87"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightNavigationBar` requires API level 27 (current min is 21)">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="88"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightStatusBar` requires API level 23 (current min is 21)">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="101"
+            column="15"/>
+    </issue>
+    <issue
+        id="NewApi"
+        severity="Error"
+        message="`android:windowLightNavigationBar` requires API level 27 (current min is 21)">
+        <location
+            file="src/main/res/values/styles.xml"
+            line="102"
+            column="15"/>
+    </issue>
+</issues>


### PR DESCRIPTION
## Summary

- run Android debug unit tests and lint in the unsigned PR/dev/main job
- use Gradle `--continue` so both quality tasks produce reports when either fails
- upload SHA-scoped unit-test and lint reports for every run
- baseline only the 12 pre-existing lint errors discovered by the first real CI run; all warnings and future errors remain active

## First-run evidence

GitHub Actions run `29323466506` exercised the new commands:

- 7 JVM tests passed, 0 failed
- both unit and lint report artifacts uploaded
- lint found 12 pre-existing errors and 214 warnings
- the committed baseline contains exactly those 12 error fingerprints: 1 `OnClick` and 11 `NewApi`; it contains no warnings

## Safety

- no global lint category disable or `abortOnError false`
- no emulator or instrumentation job in this slice
- no release-job or signing-secret changes
- existing APK/AAB, privacy, tracker, ProGuard, and native-alignment gates remain unchanged

## Verification

- YAML and baseline XML parse checks passed
- baseline IDs, severities, messages, files, lines, and columns match the first CI report exactly
- `git diff --check` passed
- final Android execution is delegated to the updated GitHub Actions run per repository policy

Planning reference: `tech-spec-android-material3-ux-modernization.md`, Task 1.
