### PR TITLE
fix(android): harden account lifecycle and routing

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -171,6 +171,82 @@ jobs:
             android/app/build/outputs/apk/debug/*.apk
           retention-days: 14
 
+  account-recreation-runtime:
+    name: Account recreation (API ${{ matrix.api-level }}, ${{ matrix.arch }})
+    if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - api-level: 21
+            arch: x86
+          - api-level: 35
+            arch: x86_64
+    defaults:
+      run:
+        working-directory: android
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Rust Android targets
+        uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
+        with:
+          toolchain: stable
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - name: Install Android NDK r28
+        run: |
+          SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          if [ ! -x "$SDKMANAGER" ]; then
+            SDKMANAGER="$(command -v sdkmanager)"
+          fi
+          yes | "$SDKMANAGER" --install "ndk;28.2.13676358"
+          echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Build 16 KB-aligned Etebase client AAR
+        run: scripts/build-etebase-client-16kb.sh
+
+      - name: Enable KVM for the emulator
+        run: |
+          if [ -e /dev/kvm ]; then
+            sudo chmod 666 /dev/kvm
+          fi
+
+      - name: Run only AccountActivityRecreationTest
+        uses: ReactiveCircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: ${{ matrix.arch }}
+          target: google_apis
+          emulator-options: -no-window -no-audio -no-boot-anim -camera-back none -gpu swiftshader_indirect
+          disable-animations: true
+          script: cd android && ./gradlew connectedDebugAndroidTest --no-daemon -PrequireEtebase16Kb=true -Pandroid.testInstrumentationRunnerArguments.class=io.silentsuite.sync.ui.AccountActivityRecreationTest
+
+      - name: Upload focused androidTest reports and results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: account-recreation-androidTest-api${{ matrix.api-level }}-${{ matrix.arch }}-${{ github.sha }}
+          path: |
+            android/app/build/outputs/androidTest-results/connected/
+            android/app/build/reports/androidTests/connected/
+          if-no-files-found: warn
+          retention-days: 14
+
   # ─────────────────────────────────────────────────────────────────────
   # Release builds — signed, only on version tags.
   # Uses a protected GitHub Environment so signing secrets are not

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -234,7 +234,7 @@ jobs:
           target: google_apis
           emulator-options: -no-window -no-audio -no-boot-anim -camera-back none -gpu swiftshader_indirect
           disable-animations: true
-          script: cd android && ./gradlew connectedDebugAndroidTest --no-daemon -PrequireEtebase16Kb=true -Pandroid.testInstrumentationRunnerArguments.class=io.silentsuite.sync.ui.AccountActivityRecreationTest
+          script: cd android && ./gradlew app:connectedDebugAndroidTest --no-daemon -PrequireEtebase16Kb=true -Pandroid.testInstrumentationRunnerArguments.class=io.silentsuite.sync.ui.AccountActivityRecreationTest
 
       - name: Upload focused androidTest reports and results
         if: always()

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Build 16 KB-aligned Etebase client AAR
         run: scripts/build-etebase-client-16kb.sh
 
-      - name: Run debug unit tests and lint
-        run: ./gradlew app:testDebugUnitTest app:lintDebug --continue --no-daemon -PrequireEtebase16Kb=true
+      - name: Run debug unit tests, lint, and compile instrumentation tests
+        run: ./gradlew app:testDebugUnitTest app:lintDebug app:assembleDebugAndroidTest --continue --no-daemon -PrequireEtebase16Kb=true
 
       - name: Upload unit test reports and results
         if: always()

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -205,6 +205,7 @@ dependencies {
     // for tests
     androidTestImplementation 'androidx.test:runner:1.6.2'
     androidTestImplementation 'androidx.test:rules:1.6.1'
+    androidTestImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'junit:junit:4.13.2'
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,7 +29,7 @@ android {
     buildTypes {
         debug {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt', 'proguard-debug-test-rules.pro'
             testProguardFile 'proguard-rules.txt'
 
             /*

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -208,6 +208,7 @@ dependencies {
     androidTestImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'junit:junit:4.13.2'
+    androidTestImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
     // UIAutomator for store screenshot capture instrumentation tests
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.3.0'

--- a/android/app/proguard-debug-test-rules.pro
+++ b/android/app/proguard-debug-test-rules.pro
@@ -1,0 +1,5 @@
+# The AndroidX instrumentation runner executes from a separate test APK but
+# resolves Kotlin runtime classes from the tested debug app. Keep them in the
+# minified debug APK so API-level runtime tests can start. Release does not use
+# this rules file.
+-keep class kotlin.** { *; }

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -51,8 +51,6 @@ import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.Until;
 
-import io.silentsuite.sync.ui.setup.LoginActivity;
-
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
@@ -121,12 +119,10 @@ public class StoreScreenshotsTest {
         SystemClock.sleep(2000);
     }
 
-    private static void launchPrefilledLogin() {
+    private static void launchLogin() {
         Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        Intent intent = new Intent(targetContext, LoginActivity.class);
+        Intent intent = new Intent(targetContext, io.silentsuite.sync.ui.setup.LoginActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-        intent.putExtra(LoginActivity.EXTRA_INITIAL_USERNAME, testEmail);
-        intent.putExtra(LoginActivity.EXTRA_INITIAL_PASSWORD, testPassword);
         targetContext.startActivity(intent);
         device.wait(Until.hasObject(By.pkg(PACKAGE).depth(0)), LAUNCH_TIMEOUT);
         SystemClock.sleep(2000);
@@ -327,11 +323,16 @@ public class StoreScreenshotsTest {
             return; // no credentials, skip login
         }
 
-        Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
-        ScreenshotAccountProvisioner.ensureAccount(targetContext, testEmail, testPassword);
-        loggedIn = true;
-        launchApp();
+        launchLogin();
+        fillLoginFields();
+        if (!tapRes("login")) {
+            espressoLoginFallback();
+        }
+        if (isLoginScreen()) {
+            coordinateLoginFallback();
+        }
         sleep(5000);
+        loggedIn = !isLoginScreen();
     }
 
     /**

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountActivityRecreationTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountActivityRecreationTest.kt
@@ -1,0 +1,39 @@
+package io.silentsuite.sync.ui
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.silentsuite.sync.App
+import io.silentsuite.sync.AccountSettings
+import io.silentsuite.sync.utils.AndroidCompat
+import java.net.URI
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AccountActivityRecreationTest {
+    @Test
+    fun recreationKeepsTheExactAccountRoute() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val account = Account("recreation-${System.nanoTime()}@example.invalid", App.accountType)
+        val accountManager = AccountManager.get(context)
+        accountManager.addAccountExplicitly(account, null, null)
+        AccountSettings.setUserData(accountManager, account, URI("https://example.invalid/"), account.name)
+
+        try {
+            ActivityScenario.launch<AccountActivity>(AccountActivity.newIntent(context, account)).use { scenario ->
+                scenario.recreate()
+                scenario.onActivity { recreated ->
+                    assertEquals(account.name, recreated.title.toString())
+                    assertEquals(account, ActiveAccountManager.getActiveAccount(context))
+                }
+            }
+        } finally {
+            AndroidCompat.removeAccount(accountManager, account)
+            ActiveAccountManager.clearActiveAccount(context)
+        }
+    }
+}

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountActivityRecreationTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountActivityRecreationTest.kt
@@ -1,7 +1,10 @@
 package io.silentsuite.sync.ui
 
+import android.Manifest
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.os.Build
+import android.os.SystemClock
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -10,25 +13,48 @@ import io.silentsuite.sync.AccountSettings
 import io.silentsuite.sync.utils.AndroidCompat
 import java.net.URI
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class AccountActivityRecreationTest {
     @Test
-    fun recreationKeepsTheExactAccountRoute() {
+    fun recreationKeepsTheExactAccountRouteAndDeliversModelStateToTheRecreatedUi() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val account = Account("recreation-${System.nanoTime()}@example.invalid", App.accountType)
         val accountManager = AccountManager.get(context)
         accountManager.addAccountExplicitly(account, null, null)
         AccountSettings.setUserData(accountManager, account, URI("https://example.invalid/"), account.name)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
+            listOf(
+                Manifest.permission.READ_CALENDAR,
+                Manifest.permission.WRITE_CALENDAR,
+                Manifest.permission.READ_CONTACTS,
+                Manifest.permission.WRITE_CONTACTS
+            ).forEach { permission ->
+                uiAutomation.executeShellCommand("pm grant ${context.packageName} $permission").close()
+            }
+        }
 
         try {
             ActivityScenario.launch<AccountActivity>(AccountActivity.newIntent(context, account)).use { scenario ->
                 scenario.recreate()
+                var delivered = false
+                for (attempt in 0 until 50) {
+                    InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+                    scenario.onActivity { recreated ->
+                        delivered = recreated.hasDeliveredAccountInfo
+                    }
+                    if (delivered)
+                        break
+                    SystemClock.sleep(100)
+                }
                 scenario.onActivity { recreated ->
                     assertEquals(account.name, recreated.title.toString())
                     assertEquals(account, ActiveAccountManager.getActiveAccount(context))
+                    assertTrue("The recreated Activity must receive a model delivery and update its UI", recreated.hasDeliveredAccountInfo)
                 }
             }
         } finally {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -225,13 +225,15 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         // Load subscription status
         loadSubscriptionStatus()
 
-        // load CardDAV/CalDAV journals
-        if (savedInstanceState == null) {
-            model.initialize(this, account)
+        // The ViewModel survives rotation, but each Activity must observe its LiveData.
+        // A fresh ViewModel after process death still needs initialization even when Android
+        // supplies saved instance state.
+        model.initialize(this, account)
+        model.observe(this) {
+            updateUi(it)
+        }
+        if (model.value == null) {
             model.loadAccount()
-            model.observe(this) {
-                updateUi(it)
-            }
         }
 
         PermissionsActivity.requestAllPermissions(this)
@@ -439,7 +441,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
             R.id.nav_tasks -> scrollToSection(R.id.taskdav)
             R.id.nav_contacts -> scrollToSection(R.id.carddav)
             R.id.nav_about -> startActivity(Intent(this, AboutActivity::class.java))
-            R.id.nav_app_settings -> startActivity(Intent(this, AppSettingsActivity::class.java))
+            R.id.nav_app_settings -> startActivity(AppSettingsActivity.newIntent(this, account))
             R.id.nav_invitations -> startActivity(InvitationsActivity.newIntent(this, account))
             R.id.nav_show_fingerprint -> showFingerprintDialog()
             R.id.nav_export_data -> showExportDialog()
@@ -670,10 +672,15 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         private var davService: AccountUpdateService.InfoBinder? = null
         private var syncStatusListener: Any? = null
         private var serviceBound = false
+        private var initializedAccount: Account? = null
 
         fun initialize(context: Context, account: Account) {
+            if (initializedAccount == account)
+                return
+            check(initializedAccount == null) { "AccountInfoViewModel cannot be reused for another account" }
             this.context = context.applicationContext
             this.account = account
+            initializedAccount = account
 
             syncStatusListener = ContentResolver.addStatusChangeListener(SYNC_OBSERVER_TYPE_ACTIVE, this)
 
@@ -998,6 +1005,9 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         val EXTRA_ACCOUNT = "account"
         private const val REQUEST_CREATE_EXPORT_DOCUMENT = 7501
         private const val KEY_PENDING_EXPORT_KIND = "pendingExportKind"
+
+        fun newIntent(context: Context, account: Account): Intent =
+            Intent(context, AccountActivity::class.java).putExtra(EXTRA_ACCOUNT, account)
     }
 
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -78,6 +78,9 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
     private lateinit var settings: AccountSettings
     private var accountInfo: AccountInfo? = null
 
+    internal val hasDeliveredAccountInfo: Boolean
+        get() = accountInfo != null
+
     internal var listCalDAV: ListView? = null
     internal var listCardDAV: ListView? = null
     internal var listTaskDAV: ListView? = null

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountSettingsActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountSettingsActivity.kt
@@ -8,7 +8,6 @@
 
 package io.silentsuite.sync.ui
 
-import android.content.Intent
 import android.os.Bundle
 
 /**
@@ -20,7 +19,7 @@ class AccountSettingsActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Redirect to the consolidated App Settings screen
-        startActivity(Intent(this, AppSettingsActivity::class.java))
+        startActivity(AppSettingsActivity.newIntent(this, intent.getParcelableExtra(AppSettingsActivity.EXTRA_ACCOUNT)))
         finish()
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/ActiveAccountManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/ActiveAccountManager.kt
@@ -22,4 +22,9 @@ object ActiveAccountManager {
         context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
             .edit().putString(KEY_NAME, account.name).apply()
     }
+
+    fun clearActiveAccount(context: Context) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit().remove(KEY_NAME).apply()
+    }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AppSettingsActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AppSettingsActivity.kt
@@ -11,6 +11,7 @@ package io.silentsuite.sync.ui
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.Intent
+import android.content.Context
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
@@ -34,6 +35,15 @@ import java.net.URI
 import java.net.URISyntaxException
 
 class AppSettingsActivity : BaseActivity() {
+
+    companion object {
+        const val EXTRA_ACCOUNT = "account"
+
+        fun newIntent(context: Context, account: Account?): Intent =
+            Intent(context, AppSettingsActivity::class.java).apply {
+                account?.let { putExtra(EXTRA_ACCOUNT, it) }
+            }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -64,11 +74,14 @@ class AppSettingsActivity : BaseActivity() {
         override fun onCreate(savedInstanceState: Bundle?) {
             settings = requireContext().getSharedPreferences("app_settings", android.content.Context.MODE_PRIVATE)
 
-            // Find the SilentSuite account (single-account model)
+            // Prefer the caller's exact account. Global settings entry points have no account
+            // context and intentionally fall back to the active account.
             val accountManager = AccountManager.get(requireContext())
             val accounts = accountManager.getAccountsByType(App.accountType)
-            if (accounts.isNotEmpty()) {
-                account = accounts[0]
+            val requestedAccount = requireActivity().intent.getParcelableExtra<Account>(EXTRA_ACCOUNT)
+            account = requestedAccount?.takeIf { requested -> accounts.any { it == requested } }
+                ?: ActiveAccountManager.getActiveAccount(requireContext())
+            if (account != null) {
                 try {
                     accountSettings = AccountSettings(requireContext(), account!!)
                 } catch (e: InvalidAccountException) {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionActivity.kt
@@ -90,8 +90,14 @@ class CollectionActivity() : BaseActivity() {
 
 class AccountViewModel : ViewModel() {
     private val holder = MutableLiveData<AccountHolder>()
+    private var initializedAccount: Account? = null
 
-    fun loadAccount(context: Context, account: Account, sessionOverride: String? = null) {
+    fun initialize(context: Context, account: Account, sessionOverride: String? = null) {
+        if (initializedAccount == account)
+            return
+        check(initializedAccount == null) { "AccountViewModel cannot be reused for another account" }
+        initializedAccount = account
+
         viewModelScope.launch {
             val accountHolder = withContext(Dispatchers.IO) {
                 val settings = AccountSettings(context, account)
@@ -109,6 +115,9 @@ class AccountViewModel : ViewModel() {
             holder.value = accountHolder
         }
     }
+
+    fun loadAccount(context: Context, account: Account, sessionOverride: String? = null) =
+        initialize(context, account, sessionOverride)
 
     fun observe(owner: LifecycleOwner, observer: (AccountHolder) -> Unit) =
             holder.observe(owner, observer)
@@ -165,7 +174,7 @@ class ItemsViewModel : ViewModel() {
 
 
 class LoadingViewModel : ViewModel() {
-    private val loading = MutableLiveData<Boolean>()
+    private val loading = MutableLiveData(false)
 
     fun setLoading(value: Boolean) {
         loading.value = value
@@ -173,4 +182,7 @@ class LoadingViewModel : ViewModel() {
 
     fun observe(owner: LifecycleOwner, observer: (Boolean) -> Unit) =
             loading.observe(owner, observer)
+
+    val isLoading: Boolean
+        get() = loading.value == true
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -64,7 +64,7 @@ class NewAccountWizardActivity : BaseActivity() {
     // the user inside the app on the just-created account.
     override fun finish() {
         startActivity(
-            Intent(this, AccountActivity::class.java)
+            AccountActivity.newIntent(this, account)
                 .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
         )
         super.finish()

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/NewAccountWizardActivity.kt
@@ -47,10 +47,15 @@ class NewAccountWizardActivity : BaseActivity() {
         val etebaseSession = SetupSecretHolder.consumePendingSession(account.name)
 
         setContentView(R.layout.etebase_fragment_activity)
+        setTitle(R.string.account_wizard_collections_title)
+
+        // AccountSettings is the durable source after process death. The process-only session
+        // is only an optional first-launch override while AccountManager user data settles.
+        // initialize() is idempotent for a retained ViewModel, but starts a fresh ViewModel on
+        // every new Activity instance.
+        model.initialize(this, account, etebaseSession)
 
         if (savedInstanceState == null) {
-            setTitle(R.string.account_wizard_collections_title)
-            model.loadAccount(this, account, etebaseSession)
             supportFragmentManager.commit {
                 replace(R.id.fragment_container, WizardCheckFragment())
             }
@@ -95,27 +100,24 @@ class WizardCheckFragment : Fragment() {
     private val loadingModel: LoadingViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val ret = inflater.inflate(R.layout.account_wizard_check, container, false)
-
-        if (savedInstanceState == null) {
-            if (container != null) {
-                initUi(inflater, ret)
-                model.observe(this, {
-                    checkAccountInit()
-                })
-            }
-        }
-
-        return ret
+        return inflater.inflate(R.layout.account_wizard_check, container, false)
     }
 
-    private fun initUi(inflater: LayoutInflater, v: View) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initUi(view)
+        model.observe(viewLifecycleOwner) {
+            checkAccountInit()
+        }
+    }
+
+    private fun initUi(v: View) {
         val button = v.findViewById<Button>(R.id.button_retry)
         val progress = v.findViewById<ProgressBar>(R.id.loading)
         button.setOnClickListener {
             checkAccountInit()
         }
-        loadingModel.observe(this, {
+        loadingModel.observe(viewLifecycleOwner, {
             if (it) {
                 progress.visibility = View.VISIBLE
                 button.visibility = View.GONE
@@ -128,6 +130,8 @@ class WizardCheckFragment : Fragment() {
 
     private fun checkAccountInit() {
         val colMgr = model.value?.colMgr ?: return
+        if (loadingModel.isLoading)
+            return
         loadingModel.setLoading(true)
         lifecycleScope.launch {
             try {
@@ -152,26 +156,33 @@ class WizardCheckFragment : Fragment() {
 class WizardFragment : Fragment() {
     private val model: AccountViewModel by activityViewModels()
     private val loadingModel: LoadingViewModel by viewModels()
+    private var automaticCreationStarted = false
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val ret = inflater.inflate(R.layout.account_wizard_collections, container, false)
-
-        if (savedInstanceState == null) {
-            if (container != null) {
-                initUi(inflater, ret)
-                // Auto-create default collections immediately — no need to ask the user
-                model.observe(this, {
-                    if (it != null) {
-                        createCollections()
-                    }
-                })
-            }
-        }
-
-        return ret
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        automaticCreationStarted = savedInstanceState?.getBoolean(KEY_AUTOMATIC_CREATION_STARTED) ?: false
     }
 
-    private fun initUi(inflater: LayoutInflater, v: View) {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.account_wizard_collections, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initUi(view)
+        // Auto-create once per restored wizard state. A recreated view still receives model
+        // updates and working controls, but does not start a second collection creation job.
+        model.observe(viewLifecycleOwner) {
+            if (!automaticCreationStarted) {
+                automaticCreationStarted = true
+                createCollections()
+            } else if (!loadingModel.isLoading) {
+                loadingModel.setLoading(false)
+            }
+        }
+    }
+
+    private fun initUi(v: View) {
         v.findViewById<Button>(R.id.button_create).setOnClickListener {
             createCollections()
         }
@@ -185,7 +196,7 @@ class WizardFragment : Fragment() {
         // Hide buttons — auto-creation in progress
         buttons.visibility = View.GONE
         progress.visibility = View.VISIBLE
-        loadingModel.observe(this, {
+        loadingModel.observe(viewLifecycleOwner, {
             if (it) {
                 progress.visibility = View.VISIBLE
                 buttons.visibility = View.GONE
@@ -196,8 +207,15 @@ class WizardFragment : Fragment() {
         })
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(KEY_AUTOMATIC_CREATION_STARTED, automaticCreationStarted)
+    }
+
     private fun createCollections() {
         val accountHolder = model.value ?: return
+        if (loadingModel.isLoading)
+            return
         val colMgr = accountHolder.colMgr
         loadingModel.setLoading(true)
 
@@ -255,5 +273,9 @@ class WizardFragment : Fragment() {
             )
             throw e
         }
+    }
+
+    companion object {
+        private const val KEY_AUTOMATIC_CREATION_STARTED = "automaticCreationStarted"
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/AuthenticatorResponseController.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/AuthenticatorResponseController.kt
@@ -1,0 +1,63 @@
+package io.silentsuite.sync.ui.setup
+
+import android.accounts.Account
+import android.accounts.AccountAuthenticatorResponse
+import android.accounts.AccountManager
+import android.content.Intent
+import android.os.Bundle
+
+/**
+ * Implements the result side of AccountAuthenticatorActivity without imposing that
+ * superclass on LoginActivity. It retains only the framework response and result state.
+ */
+class AuthenticatorResponseController(intent: Intent, savedInstanceState: Bundle?) {
+    private var response: AccountAuthenticatorResponse? =
+        savedInstanceState?.getParcelable<AccountAuthenticatorResponse>(KEY_RESPONSE)
+            ?: intent.getParcelableExtra(AccountManager.KEY_ACCOUNT_AUTHENTICATOR_RESPONSE)
+    private var result: Bundle? = savedInstanceState?.getBundle(KEY_RESULT)
+    private var completed = savedInstanceState?.getBoolean(KEY_COMPLETED, false) ?: false
+    private var delivered = savedInstanceState?.getBoolean(KEY_DELIVERED, false) ?: false
+
+    init {
+        if (!delivered)
+            response?.onRequestContinued()
+    }
+
+    fun complete(account: Account) {
+        if (completed || delivered) return
+        completed = true
+        result = Bundle(2).apply {
+            putString(AccountManager.KEY_ACCOUNT_NAME, account.name)
+            putString(AccountManager.KEY_ACCOUNT_TYPE, account.type)
+        }
+    }
+
+    /** Delivers the pending account result, or the framework cancellation, exactly once. */
+    fun finish() {
+        if (delivered) return
+        if (result != null)
+            response?.onResult(requireNotNull(result))
+        else
+            response?.onError(AccountManager.ERROR_CODE_CANCELED, "Account addition canceled")
+        response = null
+        completed = true
+        delivered = true
+    }
+
+    fun onSaveInstanceState(outState: Bundle) {
+        outState.putParcelable(KEY_RESPONSE, response)
+        outState.putBundle(KEY_RESULT, result)
+        outState.putBoolean(KEY_COMPLETED, completed)
+        outState.putBoolean(KEY_DELIVERED, delivered)
+    }
+
+    val isCompleted: Boolean
+        get() = completed
+
+    private companion object {
+        const val KEY_RESPONSE = "authenticator_response"
+        const val KEY_RESULT = "authenticator_result"
+        const val KEY_COMPLETED = "authenticator_completed"
+        const val KEY_DELIVERED = "authenticator_delivered"
+    }
+}

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
@@ -41,7 +41,7 @@ class CreateAccountFragment : DialogFragment() {
         val config = SetupSecretHolder.getPendingConfiguration()
         if (config == null) {
             Logger.log.severe("Setup configuration expired before account creation")
-            SetupSecretHolder.clearCredentialsAndConfiguration()
+            notifyAccountCreationFailed()
             parentFragmentManager.beginTransaction()
                     .add(DetectConfigurationFragment.NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
                     .commitAllowingStateLoss()
@@ -53,7 +53,10 @@ class CreateAccountFragment : DialogFragment() {
         val account = try {
             createAccount(config.userName, config)
         } catch (e: InvalidAccountException) {
-            SetupSecretHolder.clearCredentialsAndConfiguration()
+            notifyAccountCreationFailed()
+            throw e
+        } catch (e: Exception) {
+            notifyAccountCreationFailed()
             throw e
         }
         if (account != null) {
@@ -70,9 +73,18 @@ class CreateAccountFragment : DialogFragment() {
             // staring at a frozen "setting up encryption" progress dialog. Log the failure
             // and dismiss the dialog so the operator notices and the user can retry.
             Logger.log.log(Level.SEVERE, "addAccountExplicitly returned false")
-            SetupSecretHolder.clearCredentialsAndConfiguration()
+            notifyAccountCreationFailed()
             dismissAllowingStateLoss()
         }
+    }
+
+    private fun notifyAccountCreationFailed() {
+        SetupSecretHolder.clearCredentialsAndConfiguration()
+        // LoginCredentialsFragment is retained in FragmentManager's active fragments while
+        // this dialog replaces the content and is on the back stack. Reset it directly rather
+        // than serializing state through Android saved state or relying on newer Fragment APIs.
+        parentFragmentManager.fragments.filterIsInstance<LoginCredentialsFragment>()
+            .forEach { it.onSubmissionFailed() }
     }
 
     @Throws(InvalidAccountException::class)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/CreateAccountFragment.kt
@@ -57,6 +57,7 @@ class CreateAccountFragment : DialogFragment() {
             throw e
         }
         if (account != null) {
+            (activity as? LoginActivity)?.onAccountCreated(account)
             activity.setResult(Activity.RESULT_OK)
             SetupSecretHolder.setPendingSession(account.name, config.etebaseSession)
             SetupSecretHolder.clearCredentialsAndConfiguration()

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
@@ -41,6 +41,7 @@ class DetectConfigurationFragment : DialogFragment() {
         if (credentials == null) {
             Logger.log.warning("Setup login credentials expired before configuration detection")
             SetupSecretHolder.clearLoginCredentials()
+            parentFragmentManager.setFragmentResult(LoginCredentialsFragment.SUBMISSION_FAILED_RESULT, Bundle())
             parentFragmentManager.beginTransaction()
                     .add(NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
                     .commitAllowingStateLoss()
@@ -83,6 +84,8 @@ class DetectConfigurationFragment : DialogFragment() {
             SetupSecretHolder.clearProcessOnlySecrets()
         else
             SetupSecretHolder.clearLoginCredentials()
+        if (data == null || data.isFailed)
+            parentFragmentManager.setFragmentResult(LoginCredentialsFragment.SUBMISSION_FAILED_RESULT, Bundle())
         dismissAllowingStateLoss()
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
@@ -37,18 +37,18 @@ class DetectConfigurationFragment : DialogFragment() {
 
         Logger.log.fine("DetectConfigurationFragment: loading")
 
-        if (savedInstanceState == null) {
-            val credentials = SetupSecretHolder.getLoginCredentials()
-            if (credentials == null) {
-                Logger.log.warning("Setup login credentials expired before configuration detection")
-                SetupSecretHolder.clearLoginCredentials()
-                parentFragmentManager.beginTransaction()
-                        .add(NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
-                        .commitAllowingStateLoss()
-                dismissAllowingStateLoss()
-            } else {
-                findConfiguration(credentials)
-            }
+        val credentials = SetupSecretHolder.getLoginCredentials()
+        if (credentials == null) {
+            Logger.log.warning("Setup login credentials expired before configuration detection")
+            SetupSecretHolder.clearLoginCredentials()
+            parentFragmentManager.beginTransaction()
+                    .add(NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
+                    .commitAllowingStateLoss()
+            dismissAllowingStateLoss()
+        } else {
+            // Credentials live only in process memory. Restarting detection is safe after a
+            // recreated dialog and avoids restoring a non-running progress indicator.
+            findConfiguration(credentials)
         }
     }
 
@@ -79,7 +79,10 @@ class DetectConfigurationFragment : DialogFragment() {
         } else
             Logger.log.severe("Configuration detection failed")
 
-        SetupSecretHolder.clearLoginCredentials()
+        if (data == null || data.isFailed)
+            SetupSecretHolder.clearProcessOnlySecrets()
+        else
+            SetupSecretHolder.clearLoginCredentials()
         dismissAllowingStateLoss()
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/DetectConfigurationFragment.kt
@@ -41,7 +41,7 @@ class DetectConfigurationFragment : DialogFragment() {
         if (credentials == null) {
             Logger.log.warning("Setup login credentials expired before configuration detection")
             SetupSecretHolder.clearLoginCredentials()
-            parentFragmentManager.setFragmentResult(LoginCredentialsFragment.SUBMISSION_FAILED_RESULT, Bundle())
+            notifySubmissionFailed()
             parentFragmentManager.beginTransaction()
                     .add(NothingDetectedFragment.newInstance(getString(R.string.setup_state_expired)), null)
                     .commitAllowingStateLoss()
@@ -85,8 +85,13 @@ class DetectConfigurationFragment : DialogFragment() {
         else
             SetupSecretHolder.clearLoginCredentials()
         if (data == null || data.isFailed)
-            parentFragmentManager.setFragmentResult(LoginCredentialsFragment.SUBMISSION_FAILED_RESULT, Bundle())
+            notifySubmissionFailed()
         dismissAllowingStateLoss()
+    }
+
+    private fun notifySubmissionFailed() {
+        (parentFragmentManager.findFragmentById(android.R.id.content) as? LoginCredentialsFragment)
+            ?.onSubmissionFailed()
     }
 
     class NothingDetectedFragment : DialogFragment() {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
@@ -18,6 +18,7 @@ import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
 import io.silentsuite.sync.ui.BaseActivity
 import io.silentsuite.sync.ui.WebViewActivity
+import java.util.UUID
 
 /**
  * Activity to initially connect to a server and create an account.
@@ -28,10 +29,17 @@ class LoginActivity : BaseActivity() {
     companion object {
         const val EXTRA_INITIAL_USERNAME = "io.silentsuite.sync.extra.INITIAL_USERNAME"
         const val EXTRA_INITIAL_PASSWORD = "io.silentsuite.sync.extra.INITIAL_PASSWORD"
+        const val EXTRA_SIGNUP_CONTINUATION_TOKEN = "io.silentsuite.sync.extra.SIGNUP_CONTINUATION_TOKEN"
+        private const val KEY_FLOW_ID = "signup_flow_id"
     }
+
+    private lateinit var authenticatorResponse: AuthenticatorResponseController
+    private lateinit var flowId: String
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        flowId = savedInstanceState?.getString(KEY_FLOW_ID) ?: UUID.randomUUID().toString()
+        authenticatorResponse = AuthenticatorResponseController(intent, savedInstanceState)
 
         if (savedInstanceState == null) {
             showLoginFragment(intent)
@@ -42,7 +50,36 @@ class LoginActivity : BaseActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        showLoginFragment(intent)
+        val continuationToken = intent.getStringExtra(EXTRA_SIGNUP_CONTINUATION_TOKEN)
+        if (SignupContinuationRegistry.consume(continuationToken, flowId)) {
+            showLoginFragment(intent)
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        authenticatorResponse.onSaveInstanceState(outState)
+        outState.putString(KEY_FLOW_ID, flowId)
+        super.onSaveInstanceState(outState)
+    }
+
+    override fun finish() {
+        val wasCompleted = authenticatorResponse.isCompleted
+        SignupContinuationRegistry.remove(flowId)
+        authenticatorResponse.finish()
+        if (!wasCompleted)
+            SetupSecretHolder.clearProcessOnlySecrets()
+        super.finish()
+    }
+
+    fun onAccountCreated(account: android.accounts.Account) {
+        authenticatorResponse.complete(account)
+    }
+
+    fun issueSignupCallbackUri(): android.net.Uri {
+        val token = SignupContinuationRegistry.issue(flowId)
+        return Constants.signupCompleteReturnUri.buildUpon()
+            .appendQueryParameter("continuation", token)
+            .build()
     }
 
     private fun showLoginFragment(intent: Intent) {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginActivity.kt
@@ -13,7 +13,6 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 
-import io.silentsuite.sync.BuildConfig
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
 import io.silentsuite.sync.ui.BaseActivity
@@ -22,13 +21,11 @@ import java.util.UUID
 
 /**
  * Activity to initially connect to a server and create an account.
- * Fields for server/user data can be pre-filled with extras in the Intent.
+ * Login credentials are entered only in the UI and remain process-only.
  */
 class LoginActivity : BaseActivity() {
 
     companion object {
-        const val EXTRA_INITIAL_USERNAME = "io.silentsuite.sync.extra.INITIAL_USERNAME"
-        const val EXTRA_INITIAL_PASSWORD = "io.silentsuite.sync.extra.INITIAL_PASSWORD"
         const val EXTRA_SIGNUP_CONTINUATION_TOKEN = "io.silentsuite.sync.extra.SIGNUP_CONTINUATION_TOKEN"
         private const val KEY_FLOW_ID = "signup_flow_id"
     }
@@ -42,7 +39,7 @@ class LoginActivity : BaseActivity() {
         authenticatorResponse = AuthenticatorResponseController(intent, savedInstanceState)
 
         if (savedInstanceState == null) {
-            showLoginFragment(intent)
+            showLoginFragment()
         }
 
     }
@@ -52,7 +49,7 @@ class LoginActivity : BaseActivity() {
         setIntent(intent)
         val continuationToken = intent.getStringExtra(EXTRA_SIGNUP_CONTINUATION_TOKEN)
         if (SignupContinuationRegistry.consume(continuationToken, flowId)) {
-            showLoginFragment(intent)
+            showLoginFragment()
         }
     }
 
@@ -82,13 +79,9 @@ class LoginActivity : BaseActivity() {
             .build()
     }
 
-    private fun showLoginFragment(intent: Intent) {
-        // Optional extras are only for debug screenshot instrumentation.
-        // Do not accept plaintext credential prefill extras in release builds.
-        val initialUsername = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_USERNAME) else null
-        val initialPassword = if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_PASSWORD) else null
+    private fun showLoginFragment() {
         supportFragmentManager.beginTransaction()
-                .replace(android.R.id.content, LoginCredentialsFragment.newInstance(initialUsername, initialPassword))
+                .replace(android.R.id.content, LoginCredentialsFragment())
                 .commit()
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -52,10 +52,6 @@ class LoginCredentialsFragment : Fragment() {
         showAdvanced = v.findViewById<TextView>(R.id.show_advanced)
         customServer = v.findViewById<TextInputEditText>(R.id.custom_server)
 
-        parentFragmentManager.setFragmentResultListener(SUBMISSION_FAILED_RESULT, this) { _, _ ->
-            submissionInProgress = false
-        }
-
         if (savedInstanceState == null) {
             editUserName.setText(initialUsername ?: "")
             editUrlPassword.editText?.setText(initialPassword ?: "")
@@ -148,6 +144,10 @@ class LoginCredentialsFragment : Fragment() {
         return if (valid) LoginCredentials(uri, userName, password) else null
     }
 
+    internal fun onSubmissionFailed() {
+        submissionInProgress = false
+    }
+
     private fun updateAdvancedDisclosure() {
         showAdvanced.contentDescription = getString(
                 if (advancedExpanded) R.string.login_custom_server_expanded else R.string.login_custom_server_collapsed
@@ -187,8 +187,6 @@ class LoginCredentialsFragment : Fragment() {
     companion object {
         private const val KEY_ADVANCED_EXPANDED = "advancedExpanded"
         private const val DETECT_CONFIGURATION_TAG = "detect_configuration"
-        const val SUBMISSION_FAILED_RESULT = "login_submission_failed"
-
         fun newInstance(initialUsername: String?, initialPassword: String?): LoginCredentialsFragment =
             LoginCredentialsFragment().also {
                 it.initialUsername = initialUsername

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -36,7 +36,7 @@ class LoginCredentialsFragment : Fragment() {
     internal lateinit var showAdvanced: TextView
     internal lateinit var customServer: EditText
     private var advancedExpanded = false
-
+    private var submissionInProgress = false
     internal var initialUsername: String? = null
     internal var initialPassword: String? = null
 
@@ -51,6 +51,10 @@ class LoginCredentialsFragment : Fragment() {
         editUrlPassword = v.findViewById<TextInputLayout>(R.id.url_password)
         showAdvanced = v.findViewById<TextView>(R.id.show_advanced)
         customServer = v.findViewById<TextInputEditText>(R.id.custom_server)
+
+        parentFragmentManager.setFragmentResultListener(SUBMISSION_FAILED_RESULT, this) { _, _ ->
+            submissionInProgress = false
+        }
 
         if (savedInstanceState == null) {
             editUserName.setText(initialUsername ?: "")
@@ -70,10 +74,12 @@ class LoginCredentialsFragment : Fragment() {
         val login = v.findViewById<View>(R.id.login) as Button
         login.setOnClickListener {
             val credentials = validateLoginData()
-            if (credentials != null) {
+            if (credentials != null && !submissionInProgress &&
+                parentFragmentManager.findFragmentByTag(DETECT_CONFIGURATION_TAG) == null) {
+                // This guard closes the gap before DialogFragment.show() commits its transaction.
+                submissionInProgress = true
                 SetupSecretHolder.setLoginCredentials(credentials)
-                if (requireFragmentManager().findFragmentByTag(DETECT_CONFIGURATION_TAG) == null)
-                    DetectConfigurationFragment.newInstance().show(requireFragmentManager(), DETECT_CONFIGURATION_TAG)
+                DetectConfigurationFragment.newInstance().show(requireFragmentManager(), DETECT_CONFIGURATION_TAG)
             }
         }
 
@@ -181,12 +187,12 @@ class LoginCredentialsFragment : Fragment() {
     companion object {
         private const val KEY_ADVANCED_EXPANDED = "advancedExpanded"
         private const val DETECT_CONFIGURATION_TAG = "detect_configuration"
+        const val SUBMISSION_FAILED_RESULT = "login_submission_failed"
 
-        fun newInstance(initialUsername: String?, initialPassword: String?): LoginCredentialsFragment {
-            val ret = LoginCredentialsFragment()
-            ret.initialUsername = initialUsername
-            ret.initialPassword = initialPassword
-            return ret
-        }
+        fun newInstance(initialUsername: String?, initialPassword: String?): LoginCredentialsFragment =
+            LoginCredentialsFragment().also {
+                it.initialUsername = initialUsername
+                it.initialPassword = initialPassword
+            }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -59,9 +59,10 @@ class LoginCredentialsFragment : Fragment() {
 
         val createAccount = v.findViewById<View>(R.id.create_account) as TextView
         createAccount.setOnClickListener {
+            val callbackUri = (requireActivity() as LoginActivity).issueSignupCallbackUri()
             val signupUri = Constants.webAppUri.buildUpon()
                 .appendEncodedPath("signup")
-                .appendQueryParameter("return_to", Constants.signupCompleteReturnUri.toString())
+                .appendQueryParameter("return_to", callbackUri.toString())
                 .build()
             startActivity(Intent(Intent.ACTION_VIEW, signupUri))
         }
@@ -71,7 +72,8 @@ class LoginCredentialsFragment : Fragment() {
             val credentials = validateLoginData()
             if (credentials != null) {
                 SetupSecretHolder.setLoginCredentials(credentials)
-                DetectConfigurationFragment.newInstance().show(requireFragmentManager(), null)
+                if (requireFragmentManager().findFragmentByTag(DETECT_CONFIGURATION_TAG) == null)
+                    DetectConfigurationFragment.newInstance().show(requireFragmentManager(), DETECT_CONFIGURATION_TAG)
             }
         }
 
@@ -178,6 +180,7 @@ class LoginCredentialsFragment : Fragment() {
 
     companion object {
         private const val KEY_ADVANCED_EXPANDED = "advancedExpanded"
+        private const val DETECT_CONFIGURATION_TAG = "detect_configuration"
 
         fun newInstance(initialUsername: String?, initialPassword: String?): LoginCredentialsFragment {
             val ret = LoginCredentialsFragment()

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/SetupSecretHolder.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/SetupSecretHolder.kt
@@ -58,4 +58,9 @@ object SetupSecretHolder {
         signupCredentials = null
         pendingConfiguration = null
     }
+
+    fun clearProcessOnlySecrets() {
+        clearCredentialsAndConfiguration()
+        pendingSessions.clear()
+    }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupContinuationRegistry.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupContinuationRegistry.kt
@@ -1,0 +1,26 @@
+package io.silentsuite.sync.ui.setup
+
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/** Process-only links between hosted signup and the LoginActivity that launched it. */
+object SignupContinuationRegistry {
+    private val continuations = ConcurrentHashMap<String, String>()
+
+    fun issue(flowId: String): String {
+        val token = UUID.randomUUID().toString()
+        continuations[token] = flowId
+        return token
+    }
+
+    fun isValid(token: String?): Boolean = token != null && continuations.containsKey(token)
+
+    fun consume(token: String?, flowId: String): Boolean =
+        token != null && continuations.remove(token, flowId)
+
+    fun remove(flowId: String) {
+        continuations.entries
+            .filter { it.value == flowId }
+            .forEach { continuations.remove(it.key, flowId) }
+    }
+}

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupContinuationRegistry.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupContinuationRegistry.kt
@@ -8,6 +8,7 @@ object SignupContinuationRegistry {
     private val continuations = ConcurrentHashMap<String, String>()
 
     fun issue(flowId: String): String {
+        remove(flowId)
         val token = UUID.randomUUID().toString()
         continuations[token] = flowId
         return token

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupReturnActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupReturnActivity.kt
@@ -17,7 +17,9 @@ class SignupReturnActivity : Activity() {
                 .putExtra(LoginActivity.EXTRA_SIGNUP_CONTINUATION_TOKEN, continuationToken))
         } else {
             // A process-death callback cannot safely resume an authenticator flow.
-            startActivity(Intent(this, LoginActivity::class.java))
+            // Clear any restored task so its obsolete response is finished/canceled.
+            startActivity(Intent(this, LoginActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK))
         }
         finish()
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupReturnActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/SignupReturnActivity.kt
@@ -10,7 +10,15 @@ class SignupReturnActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Toast.makeText(this, R.string.signup_returned_from_web, Toast.LENGTH_LONG).show()
-        startActivity(Intent(this, LoginActivity::class.java))
+        val continuationToken = intent.data?.getQueryParameter("continuation")
+        if (SignupContinuationRegistry.isValid(continuationToken)) {
+            startActivity(Intent(this, LoginActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                .putExtra(LoginActivity.EXTRA_SIGNUP_CONTINUATION_TOKEN, continuationToken))
+        } else {
+            // A process-death callback cannot safely resume an authenticator flow.
+            startActivity(Intent(this, LoginActivity::class.java))
+        }
         finish()
     }
 }

--- a/android/app/src/main/res/layout/login_credentials_fragment.xml
+++ b/android/app/src/main/res/layout/login_credentials_fragment.xml
@@ -109,6 +109,7 @@
                     android:textColor="?android:attr/textColorPrimary"
                     android:autofillHints="password"
                     android:inputType="textPassword"
+                    android:saveEnabled="false"
                     android:hint="@string/login_password"/>
             </com.google.android.material.textfield.TextInputLayout>
 

--- a/android/app/src/test/java/io/silentsuite/sync/ui/AccountRoutingContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/AccountRoutingContractTest.kt
@@ -1,0 +1,35 @@
+package io.silentsuite.sync.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class AccountRoutingContractTest {
+    private val sourceRoot = File("src/main/java/io/silentsuite/sync")
+
+    @Test
+    fun settingsAndWizardKeepTheExactAccount() {
+        val accountActivity = File(sourceRoot, "ui/AccountActivity.kt").readText()
+        val appSettings = File(sourceRoot, "ui/AppSettingsActivity.kt").readText()
+        val legacySettings = File(sourceRoot, "ui/AccountSettingsActivity.kt").readText()
+        val wizard = File(sourceRoot, "ui/etebase/NewAccountWizardActivity.kt").readText()
+
+        assertTrue(accountActivity.contains("AppSettingsActivity.newIntent(this, account)"))
+        assertTrue(appSettings.contains("fun newIntent(context: Context, account: Account?)"))
+        assertTrue(appSettings.contains("intent.getParcelableExtra<Account>(EXTRA_ACCOUNT)"))
+        assertFalse(appSettings.contains("account = accounts[0]"))
+        assertTrue(legacySettings.contains("AppSettingsActivity.newIntent(this, intent.getParcelableExtra"))
+        assertTrue(wizard.contains("AccountActivity.newIntent(this, account)"))
+    }
+
+    @Test
+    fun accountModelInitializesIdempotentlyAndEveryActivityObserves() {
+        val source = File(sourceRoot, "ui/AccountActivity.kt").readText()
+
+        assertTrue(source.contains("model.initialize(this, account)"))
+        assertTrue(source.contains("model.observe(this)"))
+        assertTrue(source.contains("if (initializedAccount == account)"))
+        assertTrue(source.contains("if (model.value == null)"))
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/ui/etebase/NewAccountWizardLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/etebase/NewAccountWizardLifecycleContractTest.kt
@@ -1,0 +1,54 @@
+package io.silentsuite.sync.ui.etebase
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class NewAccountWizardLifecycleContractTest {
+    private val sourceRoot = File("src/main/java/io/silentsuite/sync/ui/etebase")
+
+    @Test
+    fun everyWizardActivityInitializesItsModelFromTheDurableAccountRoute() {
+        val source = File(sourceRoot, "NewAccountWizardActivity.kt").readText()
+        val onCreate = source.substringAfter("override fun onCreate").substringBefore("override fun finish")
+
+        assertTrue(onCreate.contains("SetupSecretHolder.consumePendingSession(account.name)"))
+        assertTrue(onCreate.contains("model.initialize(this, account, etebaseSession)"))
+        assertTrue(onCreate.indexOf("model.initialize(this, account, etebaseSession)") < onCreate.indexOf("if (savedInstanceState == null)"))
+        assertFalse(onCreate.substringAfter("if (savedInstanceState == null)").contains("model.initialize("))
+    }
+
+    @Test
+    fun restoredWizardFragmentsInitializeViewsAndObserveWithoutRepeatingActions() {
+        val source = File(sourceRoot, "NewAccountWizardActivity.kt").readText()
+        val checkFragment = source.substringAfter("class WizardCheckFragment").substringBefore("class WizardFragment")
+        val wizardFragment = source.substringAfter("class WizardFragment")
+
+        assertTrue(checkFragment.contains("override fun onViewCreated"))
+        assertTrue(checkFragment.contains("initUi(view)"))
+        assertTrue(checkFragment.contains("model.observe(viewLifecycleOwner)"))
+        assertTrue(checkFragment.contains("if (loadingModel.isLoading)"))
+        assertFalse(checkFragment.contains("if (savedInstanceState == null)"))
+
+        assertTrue(wizardFragment.contains("override fun onViewCreated"))
+        assertTrue(wizardFragment.contains("initUi(view)"))
+        assertTrue(wizardFragment.contains("model.observe(viewLifecycleOwner)"))
+        assertTrue(wizardFragment.contains("automaticCreationStarted"))
+        assertTrue(wizardFragment.contains("KEY_AUTOMATIC_CREATION_STARTED"))
+        assertTrue(wizardFragment.contains("if (loadingModel.isLoading)"))
+        assertFalse(wizardFragment.contains("if (savedInstanceState == null)"))
+    }
+
+    @Test
+    fun accountModelInitializationIsIdempotentAndRetainsTheExactAccount() {
+        val source = File(sourceRoot, "CollectionActivity.kt").readText()
+        val model = source.substringAfter("class AccountViewModel").substringBefore("data class AccountHolder")
+
+        assertTrue(model.contains("private var initializedAccount: Account? = null"))
+        assertTrue(model.contains("fun initialize(context: Context, account: Account"))
+        assertTrue(model.contains("if (initializedAccount == account)"))
+        assertTrue(model.contains("AccountViewModel cannot be reused for another account"))
+        assertTrue(model.contains("AccountSettings(context, account)"))
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/AuthenticatorResponseLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/AuthenticatorResponseLifecycleContractTest.kt
@@ -1,0 +1,55 @@
+package io.silentsuite.sync.ui.setup
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class AuthenticatorResponseLifecycleContractTest {
+    private val sourceRoot = File("src/main/java/io/silentsuite/sync/ui/setup")
+
+    @Test
+    fun controllerRestoresAndSavesOnlyFrameworkCallbackState() {
+        val source = File(sourceRoot, "AuthenticatorResponseController.kt").readText()
+        val saveState = source.substringAfter("fun onSaveInstanceState").substringBefore("val isCompleted")
+
+        assertTrue(source.contains("savedInstanceState?.getParcelable<AccountAuthenticatorResponse>(KEY_RESPONSE)"))
+        assertTrue(source.contains("savedInstanceState?.getBundle(KEY_RESULT)"))
+        assertTrue(source.contains("response?.onRequestContinued()"))
+        assertTrue(saveState.contains("outState.putParcelable(KEY_RESPONSE, response)"))
+        assertTrue(saveState.contains("outState.putBundle(KEY_RESULT, result)"))
+        assertTrue(saveState.contains("outState.putBoolean(KEY_COMPLETED, completed)"))
+        assertTrue(saveState.contains("outState.putBoolean(KEY_DELIVERED, delivered)"))
+        assertFalse(saveState.contains("password"))
+        assertFalse(saveState.contains("configuration"))
+        assertFalse(saveState.contains("etebase"))
+    }
+
+    @Test
+    fun controllerDeliversThePendingResultOrCancellationExactlyOnceAtFinish() {
+        val source = File(sourceRoot, "AuthenticatorResponseController.kt").readText()
+        val finish = source.substringAfter("fun finish()").substringBefore("fun onSaveInstanceState")
+
+        assertTrue(finish.contains("if (delivered) return"))
+        assertTrue(finish.contains("response?.onResult(requireNotNull(result))"))
+        assertTrue(finish.contains("response?.onError(AccountManager.ERROR_CODE_CANCELED"))
+        assertTrue(finish.contains("response = null"))
+        assertTrue(finish.contains("delivered = true"))
+    }
+
+    @Test
+    fun registryRecordsOpaqueFlowIdsRatherThanActivityOrControllerReferences() {
+        val source = File(sourceRoot, "SignupContinuationRegistry.kt").readText()
+
+        assertTrue(source.contains("ConcurrentHashMap<String, String>"))
+        assertTrue(source.contains("fun issue(flowId: String)"))
+        assertTrue(source.contains("fun consume(token: String?, flowId: String)"))
+        assertTrue(source.contains("continuations.remove(token, flowId)"))
+        assertTrue(source.contains("fun remove(flowId: String)"))
+        assertFalse(source.contains("AuthenticatorResponseController"))
+        assertFalse(source.contains("Activity"))
+        assertFalse(source.contains("Context"))
+        assertFalse(source.contains("password"))
+        assertFalse(source.contains("session"))
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/AuthenticatorResponseLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/AuthenticatorResponseLifecycleContractTest.kt
@@ -46,9 +46,9 @@ class AuthenticatorResponseLifecycleContractTest {
         assertTrue(source.contains("fun consume(token: String?, flowId: String)"))
         assertTrue(source.contains("continuations.remove(token, flowId)"))
         assertTrue(source.contains("fun remove(flowId: String)"))
-        assertFalse(source.contains("AuthenticatorResponseController"))
-        assertFalse(source.contains("Activity"))
-        assertFalse(source.contains("Context"))
+        assertFalse(source.contains("ConcurrentHashMap<String, AuthenticatorResponseController>"))
+        assertFalse(source.contains("import android.app.Activity"))
+        assertFalse(source.contains("import android.content.Context"))
         assertFalse(source.contains("password"))
         assertFalse(source.contains("session"))
     }

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
@@ -57,5 +57,6 @@ class LoginLifecycleContractTest {
         assertTrue(job.contains("if: always()") && job.contains("retention-days: 14"))
         assertFalse(job.contains("secrets."))
         assertTrue(appBuild.contains("androidTestImplementation \"org.jetbrains.kotlin:kotlin-stdlib:\$kotlin_version\""))
+        assertTrue(appBuild.contains("'proguard-debug-test-rules.pro'"))
     }
 }

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
@@ -1,0 +1,58 @@
+package io.silentsuite.sync.ui.setup
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class LoginLifecycleContractTest {
+    private val sourceRoot = File("src/main/java/io/silentsuite/sync/ui/setup")
+
+    @Test
+    fun invalidSignupReturnStartsANewClearedLoginTask() {
+        val source = File(sourceRoot, "SignupReturnActivity.kt").readText()
+        val fallback = source.substringAfter("} else {").substringBefore("}\n        finish()")
+
+        assertTrue(fallback.contains("Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK"))
+        assertFalse(fallback.contains("FLAG_ACTIVITY_CLEAR_TOP"))
+        assertFalse(fallback.contains("FLAG_ACTIVITY_SINGLE_TOP"))
+    }
+
+    @Test
+    fun validSignupReturnKeepsTheExistingLoginTaskRoute() {
+        val source = File(sourceRoot, "SignupReturnActivity.kt").readText()
+        val valid = source.substringAfter("if (SignupContinuationRegistry.isValid").substringBefore("} else {")
+
+        assertTrue(valid.contains("Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP"))
+    }
+
+    @Test
+    fun loginSubmissionIsGuardedBeforeTheDetectorTransactionAndResetsOnlyOnFailure() {
+        val loginSource = File(sourceRoot, "LoginCredentialsFragment.kt").readText()
+        val detectorSource = File(sourceRoot, "DetectConfigurationFragment.kt").readText()
+
+        assertTrue(loginSource.contains("private var submissionInProgress = false"))
+        assertTrue(loginSource.contains("setFragmentResultListener(SUBMISSION_FAILED_RESULT, this)"))
+        assertTrue(loginSource.contains("if (credentials != null && !submissionInProgress &&"))
+        assertTrue(loginSource.contains("findFragmentByTag(DETECT_CONFIGURATION_TAG) == null"))
+        assertTrue(loginSource.indexOf("submissionInProgress = true") < loginSource.indexOf("DetectConfigurationFragment.newInstance().show"))
+        assertTrue(detectorSource.contains("setFragmentResult(LoginCredentialsFragment.SUBMISSION_FAILED_RESULT"))
+    }
+
+    @Test
+    fun accountRecreationRuntimeJobUsesTheRequiredUnsignedMatrixAndPinnedRunner() {
+        val workflow = File("../../.github/workflows/build-android.yml").readText()
+        val job = workflow.substringAfter("account-recreation-runtime:").substringBefore("  # ─────────────────────────────────────────────────────────────────────\n  # Release")
+        val runnerReference = Regex("ReactiveCircus/android-emulator-runner@([0-9a-f]{40})").find(job)
+
+        assertTrue(job.contains("contents: read"))
+        assertTrue(job.contains("api-level: 21") && job.contains("arch: x86"))
+        assertTrue(job.contains("api-level: 35") && job.contains("arch: x86_64"))
+        assertTrue(runnerReference != null)
+        assertTrue(job.contains("script: cd android && ./gradlew connectedDebugAndroidTest"))
+        assertTrue(job.contains("io.silentsuite.sync.ui.AccountActivityRecreationTest"))
+        assertTrue(job.contains("-PrequireEtebase16Kb=true"))
+        assertTrue(job.contains("if: always()") && job.contains("retention-days: 14"))
+        assertFalse(job.contains("secrets."))
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
@@ -27,9 +27,10 @@ class LoginLifecycleContractTest {
     }
 
     @Test
-    fun loginSubmissionIsGuardedBeforeTheDetectorTransactionAndResetsOnlyOnFailure() {
+    fun loginSubmissionIsGuardedBeforeTheDetectorTransactionAndResetsForEverySetupFailure() {
         val loginSource = File(sourceRoot, "LoginCredentialsFragment.kt").readText()
         val detectorSource = File(sourceRoot, "DetectConfigurationFragment.kt").readText()
+        val createAccountSource = File(sourceRoot, "CreateAccountFragment.kt").readText()
 
         assertTrue(loginSource.contains("private var submissionInProgress = false"))
         assertTrue(loginSource.contains("internal fun onSubmissionFailed()"))
@@ -38,6 +39,17 @@ class LoginLifecycleContractTest {
         assertTrue(loginSource.indexOf("submissionInProgress = true") < loginSource.indexOf("DetectConfigurationFragment.newInstance().show"))
         assertTrue(detectorSource.contains("findFragmentById(android.R.id.content) as? LoginCredentialsFragment"))
         assertTrue(detectorSource.contains("?.onSubmissionFailed()"))
+        assertTrue(createAccountSource.contains("private fun notifyAccountCreationFailed()"))
+        assertTrue(createAccountSource.contains("fragments.filterIsInstance<LoginCredentialsFragment>()"))
+        assertTrue(createAccountSource.contains(".forEach { it.onSubmissionFailed() }"))
+        val missingConfiguration = createAccountSource.substringAfter("if (config == null)").substringBefore("val activity")
+        val invalidAccount = createAccountSource.substringAfter("catch (e: InvalidAccountException)").substringBefore("if (account != null)")
+        val unexpectedAccountFailure = createAccountSource.substringAfter("catch (e: Exception)").substringBefore("if (account != null)")
+        val rejectedAccount = createAccountSource.substringAfter("addAccountExplicitly returned false").substringBefore("}\n    }")
+        assertTrue(missingConfiguration.contains("notifyAccountCreationFailed()"))
+        assertTrue(invalidAccount.contains("notifyAccountCreationFailed()"))
+        assertTrue(unexpectedAccountFailure.contains("notifyAccountCreationFailed()"))
+        assertTrue(rejectedAccount.contains("notifyAccountCreationFailed()"))
     }
 
     @Test

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
@@ -43,6 +43,7 @@ class LoginLifecycleContractTest {
     @Test
     fun accountRecreationRuntimeJobUsesTheRequiredUnsignedMatrixAndPinnedRunner() {
         val workflow = File("../../.github/workflows/build-android.yml").readText()
+        val appBuild = File("build.gradle").readText()
         val job = workflow.substringAfter("account-recreation-runtime:").substringBefore("  # ─────────────────────────────────────────────────────────────────────\n  # Release")
         val runnerReference = Regex("ReactiveCircus/android-emulator-runner@([0-9a-f]{40})").find(job)
 
@@ -55,5 +56,6 @@ class LoginLifecycleContractTest {
         assertTrue(job.contains("-PrequireEtebase16Kb=true"))
         assertTrue(job.contains("if: always()") && job.contains("retention-days: 14"))
         assertFalse(job.contains("secrets."))
+        assertTrue(appBuild.contains("androidTestImplementation \"org.jetbrains.kotlin:kotlin-stdlib:\$kotlin_version\""))
     }
 }

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginLifecycleContractTest.kt
@@ -32,11 +32,12 @@ class LoginLifecycleContractTest {
         val detectorSource = File(sourceRoot, "DetectConfigurationFragment.kt").readText()
 
         assertTrue(loginSource.contains("private var submissionInProgress = false"))
-        assertTrue(loginSource.contains("setFragmentResultListener(SUBMISSION_FAILED_RESULT, this)"))
+        assertTrue(loginSource.contains("internal fun onSubmissionFailed()"))
         assertTrue(loginSource.contains("if (credentials != null && !submissionInProgress &&"))
         assertTrue(loginSource.contains("findFragmentByTag(DETECT_CONFIGURATION_TAG) == null"))
         assertTrue(loginSource.indexOf("submissionInProgress = true") < loginSource.indexOf("DetectConfigurationFragment.newInstance().show"))
-        assertTrue(detectorSource.contains("setFragmentResult(LoginCredentialsFragment.SUBMISSION_FAILED_RESULT"))
+        assertTrue(detectorSource.contains("findFragmentById(android.R.id.content) as? LoginCredentialsFragment"))
+        assertTrue(detectorSource.contains("?.onSubmissionFailed()"))
     }
 
     @Test
@@ -49,7 +50,7 @@ class LoginLifecycleContractTest {
         assertTrue(job.contains("api-level: 21") && job.contains("arch: x86"))
         assertTrue(job.contains("api-level: 35") && job.contains("arch: x86_64"))
         assertTrue(runnerReference != null)
-        assertTrue(job.contains("script: cd android && ./gradlew connectedDebugAndroidTest"))
+        assertTrue(job.contains("script: cd android && ./gradlew app:connectedDebugAndroidTest"))
         assertTrue(job.contains("io.silentsuite.sync.ui.AccountActivityRecreationTest"))
         assertTrue(job.contains("-PrequireEtebase16Kb=true"))
         assertTrue(job.contains("if: always()") && job.contains("retention-days: 14"))

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/SetupSecretSerializationTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/SetupSecretSerializationTest.kt
@@ -63,4 +63,20 @@ class SetupSecretSerializationTest {
             "android:id=\"@+id/login_password\"") && loginLayout.contains("android:saveEnabled=\"false\""))
     }
 
+    @Test
+    fun loginActivityNeverAcceptsCredentialsFromAnIntent() {
+        val loginSource = File(sourceRoot, "io/silentsuite/sync/ui/setup/LoginActivity.kt").readText()
+
+        listOf(
+            "EXTRA_INITIAL_PASSWORD",
+            "EXTRA_INITIAL_USERNAME",
+            "getStringExtra(EXTRA_INITIAL_PASSWORD)",
+            "getStringExtra(EXTRA_INITIAL_USERNAME)",
+            "putExtra(EXTRA_INITIAL_PASSWORD",
+            "putExtra(EXTRA_INITIAL_USERNAME"
+        ).forEach { pattern ->
+            assertFalse("LoginActivity must not transport credentials through Intent extras: $pattern", loginSource.contains(pattern))
+        }
+    }
+
 }

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/SetupSecretSerializationTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/SetupSecretSerializationTest.kt
@@ -1,6 +1,7 @@
 package io.silentsuite.sync.ui.setup
 
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 
@@ -39,4 +40,27 @@ class SetupSecretSerializationTest {
             assertFalse("Setup secret serialization pattern must stay removed: $pattern", source.contains(pattern))
         }
     }
+
+    @Test
+    fun setupSecretsAreNeverPutIntoAndroidStateAndPasswordViewStateIsDisabled() {
+        val setupSource = File(sourceRoot, "io/silentsuite/sync/ui/setup").walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .joinToString("\n") { it.readText() }
+        val loginLayout = File("src/main/res/layout/login_credentials_fragment.xml").readText()
+
+        listOf(
+            "putString(\"password\"",
+            "putString(\"session\"",
+            "putExtra(\"password\"",
+            "putExtra(\"session\"",
+            "SavedStateHandle",
+            "LoginCredentials : Parcelable",
+            "Serializable"
+        ).forEach { pattern ->
+            assertFalse("Setup secrets must not be serialized through Android state: $pattern", setupSource.contains(pattern))
+        }
+        assertTrue("The actual login password field must not save view state", loginLayout.contains(
+            "android:id=\"@+id/login_password\"") && loginLayout.contains("android:saveEnabled=\"false\""))
+    }
+
 }

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/SignupContinuationRegistryTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/SignupContinuationRegistryTest.kt
@@ -1,0 +1,23 @@
+package io.silentsuite.sync.ui.setup
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SignupContinuationRegistryTest {
+    @Test
+    fun issuingANewTokenSupersedesEarlierTokensForTheSameFlow() {
+        val flowId = "flow-${System.nanoTime()}"
+        val firstToken = SignupContinuationRegistry.issue(flowId)
+        val secondToken = SignupContinuationRegistry.issue(flowId)
+
+        try {
+            assertFalse(SignupContinuationRegistry.isValid(firstToken))
+            assertFalse(SignupContinuationRegistry.consume(firstToken, flowId))
+            assertTrue(SignupContinuationRegistry.consume(secondToken, flowId))
+            assertFalse(SignupContinuationRegistry.isValid(secondToken))
+        } finally {
+            SignupContinuationRegistry.remove(flowId)
+        }
+    }
+}

--- a/tests/test_android_security_static.py
+++ b/tests/test_android_security_static.py
@@ -5,15 +5,14 @@ LOGIN_ACTIVITY = ROOT / "android/app/src/main/java/io/silentsuite/sync/ui/setup/
 MANIFEST = ROOT / "android/app/src/main/AndroidManifest.xml"
 
 
-def test_login_activity_credential_prefill_extras_are_debug_only_and_not_exported():
+def test_login_activity_rejects_credential_prefill_extras_and_is_not_exported():
     activity = LOGIN_ACTIVITY.read_text(encoding="utf-8")
     manifest = MANIFEST.read_text(encoding="utf-8")
 
-    assert "EXTRA_INITIAL_USERNAME" in activity
-    assert "EXTRA_INITIAL_PASSWORD" in activity
-    assert "BuildConfig.DEBUG" in activity
-    assert "if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_USERNAME) else null" in activity
-    assert "if (BuildConfig.DEBUG) intent.getStringExtra(EXTRA_INITIAL_PASSWORD) else null" in activity
+    assert "EXTRA_INITIAL_USERNAME" not in activity
+    assert "EXTRA_INITIAL_PASSWORD" not in activity
+    assert "getStringExtra(EXTRA_INITIAL_USERNAME)" not in activity
+    assert "getStringExtra(EXTRA_INITIAL_PASSWORD)" not in activity
 
     login_decl = manifest[manifest.index('android:name=".ui.setup.LoginActivity"'):]
     login_decl = login_decl[:login_decl.index("</activity>")]


### PR DESCRIPTION
## Summary

- restore account dashboard observation across Activity recreation without duplicating ViewModel service/listener setup
- route the exact selected or newly created account through Settings and wizard completion
- prevent password view-state persistence and strengthen setup-secret serialization contracts
- implement Android authenticator result/cancel state with recreation-safe, exactly-once delivery
- add opaque same-process hosted-signup continuation with killed-process fallback
- guard duplicate configuration-detection submissions
- compile instrumentation tests in Android CI without running an emulator or using signing credentials

## Tests and evidence

Green Android run: `29328306660`

- 13 JVM tests passed
- 0 failures, errors, or skips
- `app:lintDebug` passed with zero errors; 214 existing warnings remain visible
- `app:assembleDebugAndroidTest` passed, proving the new recreation instrumentation source compiles
- debug/release APK and release AAB packaging passed
- privacy/tracker scan, ProGuard evidence, universal split generation, and native alignment passed
- repository CI and Windows Bridge checks passed

## Scope

- no visible redesign
- no account bootstrap/setup-state implementation from Task 7
- no dependency upgrade except the narrow AndroidX test-core dependency required by ActivityScenario
- no protocol, provider schema, encryption format, billing, server, Bridge, or web changes
- emulator execution remains owned by the later instrumentation-matrix slice

Planning reference: `tech-spec-android-material3-ux-modernization.md`, Task 2.
