### PR TITLE
fix: support macOS CardDAV account principal alias

### DIFF
--- a/apps/docs/user-guide/apps/macos.md
+++ b/apps/docs/user-guide/apps/macos.md
@@ -92,7 +92,7 @@ An initial anonymous `401 Unauthorized` followed by a successful authenticated r
 
 macOS may limit sync to recent events. Open **Calendar > Settings > Accounts**, select your DAV account, and check the sync range.
 
-### Apple Internet Accounts still fails with `/principals/`
+### Apple Internet Accounts still fails during principal discovery
 
 Current Bridge builds provide an authenticated, non-enumerating `/principals/` discovery container while keeping your account's normal `/your@email.com/` path canonical. If HTTPS + Advanced setup still fails, collect an ordered, redacted bridge trace for support. Include the method, path, Depth value, status, and returned href classes for paths such as:
 
@@ -101,4 +101,4 @@ Current Bridge builds provide an authenticated, non-enumerating `/principals/` d
 - `/.well-known/carddav`
 - `/your@email.com/`
 
-Do **not** include passwords, Authorization headers, session tokens, contact/calendar contents, or full private logs. Record whether macOS requests `/principals/your@email.com/`; that account-specific alias remains denied unless real Apple protocol evidence proves it is required.
+Do **not** include passwords, Authorization headers, session tokens, contact/calendar contents, or full private logs. Apple may also probe `/principals/your@email.com/`. For an authenticated exact same-account probe, the Bridge resolves that compatibility path to the canonical `/your@email.com/` account home; it does not create a separate principal or storage namespace.

--- a/bridge/pyproject.toml
+++ b/bridge/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "etebase>=0.31.0",
-    "radicale>=3.2.0,<3.3.0",
+    "radicale==3.2.3",
     "peewee>=3.14.0,<4.0.0",
     "msgpack>=1.0.0",
     "vobject>=0.9.6",

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
 
 from . import __version__, config
 
@@ -25,6 +26,7 @@ _ACCOUNT_ACTION_FLAGS = (
     "--logout",
     "--remove-account",
 )
+_RADICALE_SERVER_APPLICATION_LOCK = threading.Lock()
 
 
 def configure_logging():
@@ -96,8 +98,7 @@ def _verify_radicale_ssl_schema(schema) -> None:
     missing = [key for key in ("ssl", "certificate", "key") if key not in server_schema]
     if missing:
         raise RuntimeError(
-            "Installed Radicale does not expose required SSL server config key(s): "
-            + ", ".join(missing)
+            "Installed Radicale does not expose required SSL server config key(s): " + ", ".join(missing)
         )
 
 
@@ -316,11 +317,20 @@ def _generate_localhost_certificate(cert_path: str, key_path: str) -> None:
         try:
             result = subprocess.run(
                 [
-                    "openssl", "req", "-x509", "-newkey", "rsa:2048", "-nodes",
-                    "-days", str(_CERT_VALIDITY_DAYS),
-                    "-keyout", key_path,
-                    "-out", cert_path,
-                    "-config", cfg_path,
+                    "openssl",
+                    "req",
+                    "-x509",
+                    "-newkey",
+                    "rsa:2048",
+                    "-nodes",
+                    "-days",
+                    str(_CERT_VALIDITY_DAYS),
+                    "-keyout",
+                    key_path,
+                    "-out",
+                    cert_path,
+                    "-config",
+                    cfg_path,
                 ],
                 capture_output=True,
                 text=True,
@@ -497,8 +507,6 @@ def setup_macos_apple_accounts() -> int:
 
 def run_server():
     """Start the Radicale server with SilentSuite backends."""
-    from radicale.server import serve
-
     configuration = build_radicale_configuration()
 
     logger.info(
@@ -536,7 +544,7 @@ def run_server():
         tray = start_tray()
 
     try:
-        serve(configuration)
+        _serve_radicale_with_bridge_application(configuration)
     except KeyboardInterrupt:
         logger.info("Bridge stopped by user")
     except Exception:
@@ -544,6 +552,34 @@ def run_server():
         if tray:
             tray.update_state("error", "Bridge crashed")
         sys.exit(1)
+
+
+def _serve_radicale_with_bridge_application(configuration) -> None:
+    """Run Radicale once with the Bridge's narrowly compatible application.
+
+    Radicale 3.2.3 constructs its module-global ``Application`` internally.
+    Keep the temporary replacement single-process, non-reentrant, and
+    ownership-aware so another caller cannot have its replacement overwritten.
+    """
+    from radicale import server as radicale_server
+    from radicale.app import Application as RadicaleApplication
+
+    from .radicale.application import Application as BridgeApplication
+
+    if not _RADICALE_SERVER_APPLICATION_LOCK.acquire(blocking=False):
+        raise RuntimeError("Radicale server application injection is already active")
+    try:
+        if radicale_server.Application is not RadicaleApplication:
+            raise RuntimeError("Unexpected Radicale server Application entry state")
+        expected_application = radicale_server.Application
+        radicale_server.Application = BridgeApplication
+        try:
+            radicale_server.serve(configuration)
+        finally:
+            if radicale_server.Application is BridgeApplication:
+                radicale_server.Application = expected_application
+    finally:
+        _RADICALE_SERVER_APPLICATION_LOCK.release()
 
 
 def main():

--- a/bridge/src/silentsuite_bridge/radicale/application.py
+++ b/bridge/src/silentsuite_bridge/radicale/application.py
@@ -1,0 +1,22 @@
+"""Narrow Radicale application compatibility adapters."""
+
+from radicale.app import Application as RadicaleApplication
+
+
+def canonical_principal_alias_path(path: str, user: str) -> str:
+    """Map an exact authenticated principal alias to its canonical DAV path."""
+    if user and path == f"/principals/{user}/":
+        return f"/{user}/"
+    return path
+
+
+class Application(RadicaleApplication):
+    """Radicale application with macOS's same-account principal alias support."""
+
+    def do_PROPFIND(self, environ, base_prefix, path, user):  # noqa: N802
+        return super().do_PROPFIND(
+            environ,
+            base_prefix,
+            canonical_principal_alias_path(path, user),
+            user,
+        )

--- a/bridge/tests/test_macos_dav_discovery.py
+++ b/bridge/tests/test_macos_dav_discovery.py
@@ -7,11 +7,13 @@ import xml.etree.ElementTree as ET
 from unittest.mock import MagicMock
 from urllib.parse import quote
 
-from radicale.app import Application
+import pytest
 
 from silentsuite_bridge import __main__ as bridge_main
 from silentsuite_bridge import config
+from silentsuite_bridge.radicale import application as bridge_application
 from silentsuite_bridge.radicale import storage as bridge_storage
+from silentsuite_bridge.radicale.application import Application
 from silentsuite_bridge.radicale.creds import Credentials
 
 USERNAME = "alice@example.test"
@@ -35,6 +37,9 @@ APPLE_PRINCIPAL_BODY = b"""<?xml version="1.0" encoding="utf-8"?>
 """
 ALLPROP_BODY = b'<d:propfind xmlns:d="DAV:"><d:allprop /></d:propfind>'
 PROPNAME_BODY = b'<d:propfind xmlns:d="DAV:"><d:propname /></d:propfind>'
+UNKNOWN_PROPERTY_BODY = b"""<d:propfind xmlns:d="DAV:" xmlns:x="urn:example:unsupported">
+  <d:prop><x:unsupported-property /></d:prop>
+</d:propfind>"""
 
 
 def _seed_user(credentials_file: str) -> None:
@@ -101,7 +106,7 @@ def _request(
     return captured["status"], captured["headers"], response_body
 
 
-def _application(tmp_path, monkeypatch):
+def _application(tmp_path, monkeypatch, application_class=Application):
     credentials_file = str(tmp_path / "credentials.json")
     monkeypatch.setattr(config, "CREDS_FILE", credentials_file)
     monkeypatch.setattr(config, "DATABASE_FILE", str(tmp_path / "bridge.sqlite"))
@@ -125,7 +130,7 @@ def _application(tmp_path, monkeypatch):
         "silentsuite_bridge.radicale.storage.etesync_for_user",
         lambda _user: context,
     )
-    return Application(bridge_main.build_radicale_configuration())
+    return application_class(bridge_main.build_radicale_configuration())
 
 
 def _response_hrefs(body: bytes) -> list[str]:
@@ -139,24 +144,63 @@ def _prop_names(body: bytes) -> set[str]:
     return {child.tag for child in prop}
 
 
+def _normalized_xml_value(element: ET.Element) -> tuple:
+    """Return a stable representation of an XML element regardless of child order."""
+    return (
+        element.tag,
+        element.text or "",
+        tuple(sorted(_normalized_xml_value(child) for child in element)),
+    )
+
+
+def _normalized_propfind_response(body: bytes) -> tuple:
+    """Normalize DAV response properties, values, hrefs, and propstat partitions."""
+    normalized_responses = []
+    for response in ET.fromstring(body).findall(f"{DAV}response"):
+        propstats: dict[int, dict[str, tuple]] = {}
+        for propstat in response.findall(f"{DAV}propstat"):
+            status = propstat.findtext(f"{DAV}status")
+            assert status is not None
+            status_code = int(status.split()[1])
+            assert status_code in {200, 404}
+            prop = propstat.find(f"{DAV}prop")
+            assert prop is not None
+            properties = propstats.setdefault(status_code, {})
+            properties.update({child.tag: _normalized_xml_value(child) for child in prop})
+        normalized_responses.append(
+            (
+                response.findtext(f"{DAV}href") or "",
+                tuple(
+                    sorted(
+                        (status_code, tuple(sorted(properties.items())))
+                        for status_code, properties in propstats.items()
+                    )
+                ),
+            )
+        )
+    return tuple(sorted(normalized_responses))
+
+
 def test_authenticated_apple_principal_container_points_to_canonical_home(tmp_path, monkeypatch):
     app = _application(tmp_path, monkeypatch)
     start_sync_thread = MagicMock()
     etesync_for_user = MagicMock()
+    etesync = MagicMock()
+    etesync.list.return_value = []
+    context = MagicMock()
+    context.__enter__.return_value = (etesync, False)
+    context.__exit__.return_value = False
+    etesync_for_user.return_value = context
     monkeypatch.setattr(bridge_storage, "start_sync_thread", start_sync_thread)
     monkeypatch.setattr(bridge_storage, "etesync_for_user", etesync_for_user)
-    status, _headers, body = _request(
-        app, "/principals/", body=APPLE_PRINCIPAL_BODY, auth=_basic_auth()
-    )
+    status, _headers, body = _request(app, "/principals/", body=APPLE_PRINCIPAL_BODY, auth=_basic_auth())
 
     assert status == "207 Multi-Status"
     root = ET.fromstring(body)
     responses = root.findall(f"{DAV}response")
     assert len(responses) == 1
     assert responses[0].findtext(f"{DAV}href") == "/principals/"
-    principal_href = responses[0].find(
-        f"{DAV}propstat/{DAV}prop/{DAV}current-user-principal/{DAV}href"
-    )
+    principal_href = responses[0].find(f"{DAV}propstat/{DAV}prop/{DAV}current-user-principal/{DAV}href")
     assert principal_href is not None
     assert principal_href.text == f"/{quote(USERNAME)}/"
     resource_type = responses[0].find(f"{DAV}propstat/{DAV}prop/{DAV}resourcetype")
@@ -209,9 +253,7 @@ def test_authenticated_allprop_and_empty_body_expose_only_static_metadata(tmp_pa
         f"{DAV}owner",
     }
     for body in (ALLPROP_BODY, b""):
-        status, _headers, response_body = _request(
-            app, "/principals/", body=body, auth=_basic_auth()
-        )
+        status, _headers, response_body = _request(app, "/principals/", body=body, auth=_basic_auth())
         assert status == "207 Multi-Status"
         assert _prop_names(response_body) == expected_properties
         assert _response_hrefs(response_body) == [
@@ -223,9 +265,7 @@ def test_authenticated_allprop_and_empty_body_expose_only_static_metadata(tmp_pa
 
 def test_authenticated_propname_exposes_only_static_property_names(tmp_path, monkeypatch):
     app = _application(tmp_path, monkeypatch)
-    status, _headers, body = _request(
-        app, "/principals/", body=PROPNAME_BODY, auth=_basic_auth()
-    )
+    status, _headers, body = _request(app, "/principals/", body=PROPNAME_BODY, auth=_basic_auth())
     assert status == "207 Multi-Status"
     assert _prop_names(body) == {
         f"{DAV}principal-collection-set",
@@ -252,15 +292,33 @@ def test_authenticated_depth_forms_never_enumerate_principals(tmp_path, monkeypa
         assert _response_hrefs(body) == ["/principals/", f"/{quote(USERNAME)}/"]
 
 
-def test_principal_aliases_do_not_reveal_account_existence(tmp_path, monkeypatch):
+def test_authenticated_same_account_principal_alias_resolves_to_canonical_home(tmp_path, monkeypatch):
     app = _application(tmp_path, monkeypatch)
-    responses = [
-        _request(app, "/principals/bob@example.test/", auth=_basic_auth()),
-        _request(app, "/principals/nobody@example.test/", auth=_basic_auth()),
-        _request(app, f"/principals/{USERNAME}/", auth=_basic_auth()),
-    ]
-    assert responses[0] == responses[1] == responses[2]
-    assert responses[0][0] == "403 Forbidden"
+    status, _headers, body = _request(
+        app,
+        f"/principals/{USERNAME}/",
+        body=APPLE_PRINCIPAL_BODY,
+        auth=_basic_auth(),
+        user_agent="macOS/15.7.7 AddressBookCore/2695.500.71",
+    )
+
+    assert status == "207 Multi-Status"
+    root = ET.fromstring(body)
+    response = root.find(f"{DAV}response")
+    assert response is not None
+    assert response.findtext(f"{DAV}href") == f"/{quote(USERNAME)}/"
+    properties = response.find(f"{DAV}propstat/{DAV}prop")
+    assert properties is not None
+    resource_type = properties.find(f"{DAV}resourcetype")
+    assert resource_type is not None
+    assert resource_type.find(f"{DAV}principal") is not None
+    assert resource_type.find(f"{DAV}collection") is not None
+    expected_href = f"/{quote(USERNAME)}/"
+    assert properties.findtext(f"{DAV}current-user-principal/{DAV}href") == expected_href
+    assert properties.findtext(f"{DAV}principal-URL/{DAV}href") == expected_href
+    assert properties.findtext(f"{CALDAV}calendar-home-set/{DAV}href") == expected_href
+    assert properties.findtext(f"{CARDDAV}addressbook-home-set/{DAV}href") == expected_href
+    assert f"/principals/{quote(USERNAME)}/" not in _response_hrefs(body)
 
 
 def test_principal_path_sanitation_preserves_existing_owner_boundary(tmp_path, monkeypatch):
@@ -277,11 +335,6 @@ def test_principal_path_sanitation_preserves_existing_owner_boundary(tmp_path, m
         assert _response_hrefs(body)[0] == "/principals/"
 
     for path in (
-        f"/principals/{USERNAME}/",
-        f"/principals//{USERNAME}/",
-        f"/principals%2F{USERNAME}/",
-        f"/principals/%2F{USERNAME}/",
-        f"/principals/%2e%2e/{USERNAME}/",
         f"/principals\\{USERNAME}/",
         "/Principals/",
         "/príncipals/",
@@ -289,26 +342,154 @@ def test_principal_path_sanitation_preserves_existing_owner_boundary(tmp_path, m
         status, _headers, _body = _request(app, path, auth=_basic_auth())
         assert status == "403 Forbidden"
 
-    status, _headers, body = _request(
-        app, f"/principals/../{USERNAME}/", auth=_basic_auth()
-    )
+    status, _headers, body = _request(app, f"/principals/../{USERNAME}/", auth=_basic_auth())
     assert status == "207 Multi-Status"
     assert _response_hrefs(body)[0] == f"/{quote(USERNAME)}/"
-    status, _headers, _body = _request(
-        app, "/principals/../bob@example.test/", auth=_basic_auth()
-    )
+    status, _headers, _body = _request(app, "/principals/../bob@example.test/", auth=_basic_auth())
     assert status == "403 Forbidden"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(APPLE_PRINCIPAL_BODY, id="explicit"),
+        pytest.param(ALLPROP_BODY, id="allprop"),
+        pytest.param(PROPNAME_BODY, id="propname"),
+        pytest.param(b"", id="empty"),
+        pytest.param(UNKNOWN_PROPERTY_BODY, id="unsupported-property"),
+    ],
+)
+@pytest.mark.parametrize("depth", ["0", "1", None, "", "infinity", "2", "unknown"])
+def test_same_account_alias_matches_canonical_property_and_depth_semantics(tmp_path, monkeypatch, body, depth):
+    app = _application(tmp_path, monkeypatch)
+    alias = _request(app, f"/principals/{USERNAME}/", body=body, depth=depth, auth=_basic_auth())
+    canonical = _request(app, f"/{USERNAME}/", body=body, depth=depth, auth=_basic_auth())
+
+    assert alias[0] == canonical[0] == "207 Multi-Status"
+    assert _normalized_propfind_response(alias[2]) == _normalized_propfind_response(canonical[2])
+    assert f"/principals/{quote(USERNAME)}/" not in _response_hrefs(alias[2])
+
+
+def test_same_account_alias_depth_zero_avoids_backend_and_depth_one_matches_canonical(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    start_sync_thread = MagicMock()
+    etesync_for_user = MagicMock()
+    etesync = MagicMock()
+    etesync.list.return_value = []
+    context = MagicMock()
+    context.__enter__.return_value = (etesync, False)
+    context.__exit__.return_value = False
+    etesync_for_user.return_value = context
+    monkeypatch.setattr(bridge_storage, "start_sync_thread", start_sync_thread)
+    monkeypatch.setattr(bridge_storage, "etesync_for_user", etesync_for_user)
+
+    status, _headers, _body = _request(app, f"/principals/{USERNAME}/", auth=_basic_auth(), depth="0")
+    assert status == "207 Multi-Status"
+    start_sync_thread.assert_not_called()
+    etesync_for_user.assert_not_called()
+
+    alias = _request(app, f"/principals/{USERNAME}/", auth=_basic_auth(), depth="1")
+    alias_accessor_calls = (
+        start_sync_thread.call_args_list,
+        etesync_for_user.call_args_list,
+        etesync.list.call_args_list,
+    )
+    start_sync_thread.reset_mock()
+    etesync_for_user.reset_mock()
+    etesync.list.reset_mock()
+
+    canonical = _request(app, f"/{USERNAME}/", auth=_basic_auth(), depth="1")
+    canonical_accessor_calls = (
+        start_sync_thread.call_args_list,
+        etesync_for_user.call_args_list,
+        etesync.list.call_args_list,
+    )
+
+    assert alias[0] == canonical[0] == "207 Multi-Status"
+    assert _response_hrefs(alias[2]) == _response_hrefs(canonical[2])
+    assert alias_accessor_calls == canonical_accessor_calls
+    assert start_sync_thread.call_args_list == [((USERNAME,), {})]
+    assert etesync_for_user.call_args_list == [((USERNAME,), {})]
+    assert etesync.list.call_args_list == [()]
+
+
+def test_alias_authentication_and_cross_account_denials_remain_fail_closed(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    start_sync_thread = MagicMock()
+    etesync_for_user = MagicMock()
+    monkeypatch.setattr(bridge_storage, "start_sync_thread", start_sync_thread)
+    monkeypatch.setattr(bridge_storage, "etesync_for_user", etesync_for_user)
+    for auth in (
+        None,
+        _basic_auth("unknown@example.test", PASSWORD),
+        _basic_auth(USERNAME, ""),
+        _basic_auth(USERNAME, "wrong"),
+    ):
+        status, headers, _body = _request(app, f"/principals/{USERNAME}/", auth=auth)
+        assert status == "401 Unauthorized"
+        assert headers["WWW-Authenticate"] == 'Basic realm="Radicale - Password Required"'
+
+    start_sync_thread.assert_not_called()
+    etesync_for_user.assert_not_called()
+
+    responses = [
+        _request(app, "/principals/bob@example.test/", auth=_basic_auth()),
+        _request(app, "/principals/nobody@example.test/", auth=_basic_auth()),
+        _request(app, "/principals/Alice@example.test/", auth=_basic_auth()),
+        _request(app, f"/principals/{USERNAME}/child/", auth=_basic_auth()),
+    ]
+    assert all(response[0] == "403 Forbidden" for response in responses)
+    assert responses[0] == responses[1]
+    start_sync_thread.assert_not_called()
+    etesync_for_user.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("authorization", "expected_status"),
+    [
+        ("Basic !!!", "500 Internal Server Error"),
+        ("Basic bm9jb2xvbg==", "500 Internal Server Error"),
+        ("Basic /zo=", "401 Unauthorized"),
+    ],
+)
+def test_malformed_basic_auth_stays_pre_dispatch(tmp_path, monkeypatch, authorization, expected_status):
+    app = _application(tmp_path, monkeypatch)
+    helper = MagicMock(wraps=bridge_application.canonical_principal_alias_path)
+    start_sync_thread = MagicMock()
+    etesync_for_user = MagicMock()
+    monkeypatch.setattr(bridge_application, "canonical_principal_alias_path", helper)
+    monkeypatch.setattr(bridge_storage, "start_sync_thread", start_sync_thread)
+    monkeypatch.setattr(bridge_storage, "etesync_for_user", etesync_for_user)
+
+    status, _headers, _body = _request(app, f"/principals/{USERNAME}/", auth=authorization)
+    assert status == expected_status
+    helper.assert_not_called()
+    start_sync_thread.assert_not_called()
+    etesync_for_user.assert_not_called()
+
+
+@pytest.mark.parametrize("method", ["PUT", "DELETE", "MKCOL", "MKCALENDAR", "PROPPATCH", "REPORT", "OPTIONS"])
+def test_alias_non_propfind_methods_are_not_canonicalized(tmp_path, monkeypatch, method):
+    from radicale.app import Application as RadicaleApplication
+
+    upstream_app = _application(tmp_path, monkeypatch, application_class=RadicaleApplication)
+    app = _application(tmp_path, monkeypatch)
+    helper = MagicMock(wraps=bridge_application.canonical_principal_alias_path)
+    monkeypatch.setattr(bridge_application, "canonical_principal_alias_path", helper)
+
+    path = f"/principals/{USERNAME}/"
+    upstream_response = _request(upstream_app, path, method=method, auth=_basic_auth())
+    bridge_response = _request(app, path, method=method, auth=_basic_auth())
+
+    assert bridge_response == upstream_response
+    helper.assert_not_called()
 
 
 def test_direct_dav_paths_and_user_agent_behavior_are_unchanged(tmp_path, monkeypatch):
     app = _application(tmp_path, monkeypatch)
     for user_agent in ("macOS/15.7.7 AddressBookCore/2695.500.71", None):
-        root_status, _headers, root_body = _request(
-            app, "/", auth=_basic_auth(), user_agent=user_agent
-        )
-        home_status, _headers, home_body = _request(
-            app, f"/{USERNAME}/", auth=_basic_auth(), user_agent=user_agent
-        )
+        root_status, _headers, root_body = _request(app, "/", auth=_basic_auth(), user_agent=user_agent)
+        home_status, _headers, home_body = _request(app, f"/{USERNAME}/", auth=_basic_auth(), user_agent=user_agent)
         assert root_status == home_status == "207 Multi-Status"
         assert f"/{quote(USERNAME)}/" in _response_hrefs(root_body)
         assert _response_hrefs(home_body)[0] == f"/{quote(USERNAME)}/"

--- a/bridge/tests/test_main_startup.py
+++ b/bridge/tests/test_main_startup.py
@@ -2,11 +2,19 @@
 
 import logging
 import sys
+import threading
+from importlib.metadata import version
+from unittest.mock import MagicMock
 
 import pytest
 
 from silentsuite_bridge import __main__ as bridge_main
 from silentsuite_bridge import config
+from silentsuite_bridge.radicale.application import Application as BridgeApplication
+
+
+def test_radicale_runtime_is_pinned_to_the_server_adapter_contract():
+    assert version("Radicale") == "3.2.3"
 
 
 def test_check_credentials_allows_no_accounts_when_dashboard_enabled(tmp_path, monkeypatch, capsys):
@@ -140,6 +148,127 @@ def _run_server_until_keyboard_interrupt(monkeypatch):
     monkeypatch.setattr(bridge_main, "start_tray", lambda: None)
     monkeypatch.setattr(radicale_server, "serve", stop_server)
     bridge_main.run_server()
+
+
+@pytest.mark.parametrize("outcome", [None, RuntimeError("boom"), KeyboardInterrupt()])
+def test_server_application_injection_restores_upstream_application(monkeypatch, outcome):
+    from radicale import server as radicale_server
+    from radicale.app import Application as RadicaleApplication
+
+    def serve(_configuration):
+        assert radicale_server.Application is BridgeApplication
+        if outcome is not None:
+            raise outcome
+
+    monkeypatch.setattr(radicale_server, "serve", serve)
+    if isinstance(outcome, BaseException):
+        with pytest.raises(type(outcome)):
+            bridge_main._serve_radicale_with_bridge_application(object())
+    else:
+        bridge_main._serve_radicale_with_bridge_application(object())
+    assert radicale_server.Application is RadicaleApplication
+
+
+def test_server_application_injection_rejects_nested_entry(monkeypatch):
+    from radicale import server as radicale_server
+
+    def serve(_configuration):
+        with pytest.raises(RuntimeError, match="already active"):
+            bridge_main._serve_radicale_with_bridge_application(object())
+
+    monkeypatch.setattr(radicale_server, "serve", serve)
+    bridge_main._serve_radicale_with_bridge_application(object())
+
+
+def test_server_application_injection_rejects_real_two_thread_contention(monkeypatch):
+    from radicale import server as radicale_server
+    from radicale.app import Application as RadicaleApplication
+
+    entered_serve = threading.Event()
+    release_serve = threading.Event()
+    serve_barrier = threading.Barrier(2)
+    holder_errors = []
+
+    def serve(_configuration):
+        assert radicale_server.Application is BridgeApplication
+        entered_serve.set()
+        serve_barrier.wait()
+        assert release_serve.wait(timeout=5)
+
+    def hold_server():
+        try:
+            bridge_main._serve_radicale_with_bridge_application(object())
+        except BaseException as exc:  # pragma: no cover - asserted from the parent thread
+            holder_errors.append(exc)
+
+    monkeypatch.setattr(radicale_server, "serve", serve)
+    holder = threading.Thread(target=hold_server)
+    holder.start()
+    assert entered_serve.wait(timeout=5)
+    serve_barrier.wait()
+
+    try:
+        with pytest.raises(RuntimeError, match="already active"):
+            bridge_main._serve_radicale_with_bridge_application(object())
+    finally:
+        release_serve.set()
+
+    holder.join(timeout=5)
+    assert not holder.is_alive()
+    assert holder_errors == []
+    assert radicale_server.Application is RadicaleApplication
+
+    serve_after_release = MagicMock()
+    monkeypatch.setattr(radicale_server, "serve", serve_after_release)
+    bridge_main._serve_radicale_with_bridge_application(object())
+    serve_after_release.assert_called_once()
+    assert radicale_server.Application is RadicaleApplication
+
+
+def test_server_application_injection_rejects_unexpected_entry_state(monkeypatch):
+    from radicale import server as radicale_server
+
+    unexpected = object()
+    monkeypatch.setattr(radicale_server, "Application", unexpected)
+    with pytest.raises(RuntimeError, match="Unexpected Radicale"):
+        bridge_main._serve_radicale_with_bridge_application(object())
+    assert radicale_server.Application is unexpected
+
+
+def test_server_application_injection_does_not_overwrite_third_party_replacement(monkeypatch):
+    from radicale import server as radicale_server
+
+    replacement = object()
+    monkeypatch.setattr(radicale_server, "Application", radicale_server.Application)
+
+    def serve(_configuration):
+        radicale_server.Application = replacement
+
+    monkeypatch.setattr(radicale_server, "serve", serve)
+    bridge_main._serve_radicale_with_bridge_application(object())
+    assert radicale_server.Application is replacement
+
+
+def test_real_radicale_serve_constructs_bridge_application_before_no_bind_error(monkeypatch):
+    from radicale import server as radicale_server
+
+    from silentsuite_bridge.radicale import application as bridge_application
+
+    constructed = MagicMock()
+
+    class SpyApplication(BridgeApplication):
+        def __init__(self, *args, **kwargs):
+            constructed(*args, **kwargs)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(bridge_application, "Application", SpyApplication)
+    monkeypatch.setattr(radicale_server.socket, "getaddrinfo", lambda *_args: [])
+    configuration = bridge_main.build_radicale_configuration()
+
+    with pytest.raises(RuntimeError, match="No servers started"):
+        bridge_main._serve_radicale_with_bridge_application(configuration)
+
+    constructed.assert_called_once()
 
 
 def test_remote_bind_warning_mentions_plaintext_when_ssl_disabled(monkeypatch, caplog):

--- a/bridge/tests/test_radicale_request_path_boundary.py
+++ b/bridge/tests/test_radicale_request_path_boundary.py
@@ -1,0 +1,227 @@
+"""Radicale 3.2.3 request-target decoding and path-sanitization contract."""
+
+import base64
+import hashlib
+import io
+import wsgiref.simple_server
+import xml.etree.ElementTree as ET
+from unittest.mock import MagicMock
+from urllib.parse import quote, unquote
+
+import pytest
+from radicale import pathutils
+from radicale.server import RequestHandler
+
+from silentsuite_bridge import __main__ as bridge_main
+from silentsuite_bridge import config
+from silentsuite_bridge.radicale import application as bridge_application
+from silentsuite_bridge.radicale import storage as bridge_storage
+from silentsuite_bridge.radicale.application import Application
+from silentsuite_bridge.radicale.creds import Credentials
+
+USER = "alice@example.test"
+PASSWORD = "correct-test-password"
+DAV = "{DAV:}"
+PATH_CASES = [
+    (
+        "/principals/alice@example.test/",
+        "/principals/alice@example.test/",
+        "/principals/alice@example.test/",
+        "207",
+        True,
+    ),
+    (
+        "/principals//alice@example.test/",
+        "/principals//alice@example.test/",
+        "/principals/alice@example.test/",
+        "207",
+        True,
+    ),
+    (
+        "/principals%2Falice@example.test/",
+        "/principals/alice@example.test/",
+        "/principals/alice@example.test/",
+        "207",
+        True,
+    ),
+    (
+        "/principals/%2Falice@example.test/",
+        "/principals//alice@example.test/",
+        "/principals/alice@example.test/",
+        "207",
+        True,
+    ),
+    (
+        "/principals/other/%2e%2e/alice@example.test/",
+        "/principals/other/../alice@example.test/",
+        "/principals/alice@example.test/",
+        "207",
+        True,
+    ),
+    (
+        "/principals/alice@example.test/child/%2e%2e/",
+        "/principals/alice@example.test/child/../",
+        "/principals/alice@example.test/",
+        "207",
+        True,
+    ),
+    (
+        "/principals/%2e%2e/alice@example.test/",
+        "/principals/../alice@example.test/",
+        "/alice@example.test/",
+        "207",
+        True,
+    ),
+    (
+        "/principals/alice@example.test%2Fchild/",
+        "/principals/alice@example.test/child/",
+        "/principals/alice@example.test/child/",
+        "403",
+        False,
+    ),
+    (
+        "/principals/bob@example.test/",
+        "/principals/bob@example.test/",
+        "/principals/bob@example.test/",
+        "403",
+        False,
+    ),
+    (
+        "/principals/alice@example.test/%2e%2e/bob@example.test/",
+        "/principals/alice@example.test/../bob@example.test/",
+        "/principals/bob@example.test/",
+        "403",
+        False,
+    ),
+    (
+        "/Principals/alice@example.test/",
+        "/Principals/alice@example.test/",
+        "/Principals/alice@example.test/",
+        "403",
+        False,
+    ),
+    (
+        "/principals/Alice@example.test/",
+        "/principals/Alice@example.test/",
+        "/principals/Alice@example.test/",
+        "403",
+        False,
+    ),
+    (
+        "/principals/alice@example.test/child/",
+        "/principals/alice@example.test/child/",
+        "/principals/alice@example.test/child/",
+        "403",
+        False,
+    ),
+]
+
+
+def _seed_user(credentials_file: str) -> None:
+    credentials = Credentials(filename=credentials_file)
+    credentials.set_etebase(USER, "fake-session", "https://server.test")
+    credentials.set_password_hash(USER, hashlib.sha256(PASSWORD.encode()).hexdigest())
+    credentials.save()
+
+
+def _basic_auth() -> str:
+    return "Basic " + base64.b64encode(f"{USER}:{PASSWORD}".encode()).decode()
+
+
+def _request(app, path: str):
+    captured = {}
+
+    def start_response(status, headers):
+        captured["status"] = status
+        captured["headers"] = dict(headers)
+
+    environ = {
+        "REQUEST_METHOD": "PROPFIND",
+        "PATH_INFO": path,
+        "QUERY_STRING": "",
+        "SCRIPT_NAME": "",
+        "HTTP_HOST": "127.0.0.1:37358",
+        "SERVER_NAME": "127.0.0.1",
+        "SERVER_PORT": "37358",
+        "SERVER_PROTOCOL": "HTTP/1.1",
+        "REMOTE_ADDR": "127.0.0.1",
+        "CONTENT_LENGTH": "0",
+        "CONTENT_TYPE": "application/xml; charset=utf-8",
+        "HTTP_AUTHORIZATION": _basic_auth(),
+        "HTTP_DEPTH": "0",
+        "wsgi.version": (1, 0),
+        "wsgi.url_scheme": "http",
+        "wsgi.input": io.BytesIO(),
+        "wsgi.errors": io.StringIO(),
+        "wsgi.multithread": False,
+        "wsgi.multiprocess": False,
+        "wsgi.run_once": False,
+    }
+    body = b"".join(app(environ, start_response))
+    return captured["status"], body
+
+
+def _application(tmp_path, monkeypatch):
+    credentials_file = str(tmp_path / "credentials.json")
+    monkeypatch.setattr(config, "CREDS_FILE", credentials_file)
+    monkeypatch.setattr(config, "DATABASE_FILE", str(tmp_path / "bridge.sqlite"))
+    monkeypatch.setattr(config, "SETTINGS_FILE", str(tmp_path / "settings.json"))
+    monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:37358")
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+    _seed_user(credentials_file)
+    return Application(bridge_main.build_radicale_configuration())
+
+
+def _paths_from_raw_target(monkeypatch, raw_target: str) -> tuple[str, str]:
+    monkeypatch.setattr(wsgiref.simple_server.WSGIRequestHandler, "get_environ", lambda _self: {})
+    handler = object.__new__(RequestHandler)
+    handler.path = raw_target + "?ignored=query"
+    handler.connection = object()
+    decoded_path = handler.get_environ()["PATH_INFO"]
+    return decoded_path, pathutils.sanitize_path(decoded_path)
+
+
+@pytest.mark.parametrize(
+    ("raw_target", "decoded_path", "sanitized_path", "expected_status", "has_canonical_href"),
+    PATH_CASES,
+)
+def test_request_handler_decodes_sanitizes_and_dispatches_to_bridge(
+    tmp_path,
+    monkeypatch,
+    raw_target,
+    decoded_path,
+    sanitized_path,
+    expected_status,
+    has_canonical_href,
+):
+    app = _application(tmp_path, monkeypatch)
+    start_sync_thread = MagicMock()
+    etesync_for_user = MagicMock()
+    monkeypatch.setattr(bridge_storage, "start_sync_thread", start_sync_thread)
+    monkeypatch.setattr(bridge_storage, "etesync_for_user", etesync_for_user)
+
+    actual_decoded_path, actual_sanitized_path = _paths_from_raw_target(monkeypatch, raw_target)
+    assert actual_decoded_path == decoded_path
+    assert actual_sanitized_path == sanitized_path
+    assert actual_decoded_path == unquote(raw_target)
+
+    status, body = _request(app, actual_sanitized_path)
+    assert status == f"{expected_status} {'Multi-Status' if expected_status == '207' else 'Forbidden'}"
+    if has_canonical_href:
+        hrefs = [element.text or "" for element in ET.fromstring(body).iter(f"{DAV}href")]
+        assert hrefs[0] == f"/{quote(USER)}/"
+        assert f"/principals/{quote(USER)}/" not in hrefs
+    else:
+        assert f"/principals/{quote(USER)}/" not in body.decode()
+        assert f"/{quote(USER)}/" not in body.decode()
+    start_sync_thread.assert_not_called()
+    etesync_for_user.assert_not_called()
+
+
+def test_same_account_alias_requires_canonicalization_at_wsgi_boundary(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    monkeypatch.setattr(bridge_application, "canonical_principal_alias_path", lambda path, _user: path)
+
+    status, _body = _request(app, f"/principals/{USER}/")
+
+    assert status == "403 Forbidden"


### PR DESCRIPTION
## Summary
- canonicalize authenticated exact same-account `PROPFIND /principals/<account>/` requests to the canonical account home
- preserve canonical DAV hrefs and existing authorization/storage behavior
- guard Radicale Application startup injection and pin the internal contract to Radicale 3.2.3
- add protocol, raw-path, authentication, method, startup-lifecycle, and macOS documentation coverage

## Verification
- focused Bridge suite: 125 passed
- full Bridge suite: 336 passed
- changed-file Ruff: passed
- `git diff --check`: passed
- independent substantive review: approved after all findings were resolved

Addresses #498. Keep #498 open until both macOS QA artifacts pass and real Apple Contacts bidirectional CRUD/convergence is confirmed.