### PR TITLE
chore: align release versions for 0.4.2-beta

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 35
 
-        versionCode 12
-        versionName "0.4.1-beta"
+        versionCode 13
+        versionName "0.4.2-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,1 +1,1 @@
-SilentSuite v0.4.2-beta aligns the Android package with the latest release. Android sync behavior is unchanged; this patch fixes macOS Contacts/CardDAV Bridge account discovery.
+Adds encrypted contact favorite synchronization with Android's native starred state and improves macOS Contacts/CardDAV Bridge account discovery.

--- a/android/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,0 +1,1 @@
+SilentSuite v0.4.2-beta aligns the Android package with the latest release. Android sync behavior is unchanged; this patch fixes macOS Contacts/CardDAV Bridge account discovery.

--- a/android/fastlane/metadata/android/en-US/google-play-listing-copy.md
+++ b/android/fastlane/metadata/android/en-US/google-play-listing-copy.md
@@ -1,4 +1,4 @@
-# Store listing paste copy for SilentSuite v0.4.1-beta
+# Store listing paste copy for SilentSuite v0.4.2-beta
 
 Use with the final 8 screenshots exported from Figma on 2026-06-27.
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/docs",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/apps/web/app/lib/constants.ts
+++ b/apps/web/app/lib/constants.ts
@@ -11,7 +11,7 @@
  * Update this on release so displayed versions don't go stale. Keep in sync
  * with the current release tag.
  */
-export const DISPLAY_VERSION = '0.4.1-beta'
+export const DISPLAY_VERSION = '0.4.2-beta'
 
 // ── Time unit multipliers (ms) ──────────────────────────────────────────
 export const MS_PER_SECOND = 1_000

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/web",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",

--- a/bridge/pyproject.toml
+++ b/bridge/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "silentsuite-bridge"
-version = "0.4.1-beta"
+version = "0.4.2-beta"
 description = "SilentSuite Bridge — Local E2EE CalDAV/CardDAV sync daemon"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/bridge/src/silentsuite_bridge/__init__.py
+++ b/bridge/src/silentsuite_bridge/__init__.py
@@ -13,7 +13,7 @@ from importlib import metadata as _metadata
 # Kept in sync with pyproject.toml [project].version. Used only as a
 # last-resort fallback when neither a build stamp nor package metadata is
 # available (e.g. running straight from source without an editable install).
-_FALLBACK_VERSION = "0.4.1-beta"
+_FALLBACK_VERSION = "0.4.2-beta"
 
 
 def _resolve_version() -> str:

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,1 +1,1 @@
-SilentSuite v0.4.2-beta aligns the Android package with the latest release. Android sync behavior is unchanged; this patch fixes macOS Contacts/CardDAV Bridge account discovery.
+Adds encrypted contact favorite synchronization with Android's native starred state and improves macOS Contacts/CardDAV Bridge account discovery.

--- a/fastlane/metadata/android/en-US/changelogs/13.txt
+++ b/fastlane/metadata/android/en-US/changelogs/13.txt
@@ -1,0 +1,1 @@
+SilentSuite v0.4.2-beta aligns the Android package with the latest release. Android sync behavior is unchanged; this patch fixes macOS Contacts/CardDAV Bridge account discovery.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silentsuite",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "private": true,
   "author": "SilentSuite <info@silentsuite.io>",
   "scripts": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/config",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "private": true,
   "files": [
     "typescript",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/core",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/ui",
-  "version": "0.4.1-beta",
+  "version": "0.4.2-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/tests/test_release_versions_static.py
+++ b/tests/test_release_versions_static.py
@@ -10,8 +10,8 @@ import json
 import re
 
 ROOT = Path(__file__).resolve().parents[1]
-CURRENT_RELEASE_VERSION = "0.4.1-beta"
-CURRENT_ANDROID_VERSION_CODE = 12
+CURRENT_RELEASE_VERSION = "0.4.2-beta"
+CURRENT_ANDROID_VERSION_CODE = 13
 
 PACKAGE_JSON_PATHS = [
     "package.json",

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/silent-suite/silentsuite
-release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.4.1-beta/silentsuite-android-v0.4.1-beta.apk
+release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.4.2-beta/silentsuite-android-v0.4.2-beta.apk
 pubkey: npub1zuusadlzq6vehhaqhqpup0mhnx70q9cnf9hs48t79g6qn4wpg2eqsy8m35
 name: SilentSuite
 summary: End-to-end encrypted sync for calendar, contacts, and tasks
@@ -26,14 +26,14 @@ tags:
   - sync
 license: GPL-3.0-only
 website: https://silentsuite.io
-icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/icon.png
+icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/icon.png
 images:
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-calendar-contacts-tasks.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-personal-work.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-android-apps.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-import-export.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/5-open-source.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/6-encryption.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/7-built-for-android.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/8-server-choice.png
-release_notes: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.1-beta/android/fastlane/metadata/android/en-US/changelogs/12.txt
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-calendar-contacts-tasks.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-personal-work.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-android-apps.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-import-export.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/5-open-source.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/6-encryption.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/7-built-for-android.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/8-server-choice.png
+release_notes: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.4.2-beta/android/fastlane/metadata/android/en-US/changelogs/13.txt


### PR DESCRIPTION
## Summary
- align web, docs, package, Bridge, and Android version metadata to `0.4.2-beta`
- increment Android `versionCode` to 13 and add matching Fastlane changelogs
- update Zapstore and Google Play paste metadata for the new release tag

## Verification
- `python3 -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py tests/test_android_security_static.py -q` — 15 passed
- changelog copies match
- no active `0.4.1-beta` references remain
- `git diff --check` passed