### PR TITLE
fix(android): make setup retries and settings routes account-safe

### DIFF
--- a/android/app/src/test/java/io/silentsuite/sync/ui/SettingsAccountRoutePolicyTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/SettingsAccountRoutePolicyTest.kt
@@ -1,0 +1,59 @@
+package io.silentsuite.sync.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SettingsAccountRoutePolicyTest {
+    private val availableAccounts = setOf("active@example.com", "requested@example.com")
+
+    @Test
+    fun validExplicitRouteKeepsTheRequestedAccount() {
+        assertEquals(
+            "requested@example.com",
+            resolveSettingsAccountName(
+                hasExplicitRoute = true,
+                requestedAccountName = "requested@example.com",
+                availableAccountNames = availableAccounts,
+                activeAccountName = "active@example.com",
+            ),
+        )
+    }
+
+    @Test
+    fun staleExplicitRouteFailsClosedInsteadOfUsingActiveAccount() {
+        assertNull(
+            resolveSettingsAccountName(
+                hasExplicitRoute = true,
+                requestedAccountName = "removed@example.com",
+                availableAccountNames = availableAccounts,
+                activeAccountName = "active@example.com",
+            ),
+        )
+    }
+
+    @Test
+    fun globalRouteUsesAnAvailableActiveAccount() {
+        assertEquals(
+            "active@example.com",
+            resolveSettingsAccountName(
+                hasExplicitRoute = false,
+                requestedAccountName = null,
+                availableAccountNames = availableAccounts,
+                activeAccountName = "active@example.com",
+            ),
+        )
+    }
+
+    @Test
+    fun globalRouteRejectsAStaleActiveAccount() {
+        assertNull(
+            resolveSettingsAccountName(
+                hasExplicitRoute = false,
+                requestedAccountName = null,
+                availableAccountNames = availableAccounts,
+                activeAccountName = "removed@example.com",
+            ),
+        )
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/ui/etebase/DefaultCollectionPolicyTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/etebase/DefaultCollectionPolicyTest.kt
@@ -1,0 +1,46 @@
+package io.silentsuite.sync.ui.etebase
+
+import io.silentsuite.sync.Constants.ETEBASE_TYPE_ADDRESS_BOOK
+import io.silentsuite.sync.Constants.ETEBASE_TYPE_CALENDAR
+import io.silentsuite.sync.Constants.ETEBASE_TYPE_TASKS
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DefaultCollectionPolicyTest {
+    @Test
+    fun partialCompletionCreatesOnlyMissingDefaultTypes() {
+        val missing = missingDefaultCollections(setOf(ETEBASE_TYPE_ADDRESS_BOOK))
+
+        assertEquals(
+            listOf(ETEBASE_TYPE_CALENDAR, ETEBASE_TYPE_TASKS),
+            missing.map { it.collectionType },
+        )
+    }
+
+    @Test
+    fun completeDefaultsCreateNothingOnRetry() {
+        val missing = missingDefaultCollections(
+            setOf(
+                ETEBASE_TYPE_ADDRESS_BOOK,
+                ETEBASE_TYPE_CALENDAR,
+                ETEBASE_TYPE_TASKS,
+            ),
+        )
+
+        assertEquals(emptyList<DefaultCollectionSpec>(), missing)
+    }
+
+    @Test
+    fun unrelatedCollectionsDoNotSuppressDefaults() {
+        val missing = missingDefaultCollections(setOf("io.silentsuite.notes"))
+
+        assertEquals(
+            listOf(
+                ETEBASE_TYPE_ADDRESS_BOOK,
+                ETEBASE_TYPE_CALENDAR,
+                ETEBASE_TYPE_TASKS,
+            ),
+            missing.map { it.collectionType },
+        )
+    }
+}


### PR DESCRIPTION
## In progress

Release-blocking fix for #549 using strict RED/GREEN tests.

### Surface map
See #549. Scope is limited to default-collection reconciliation across recreation/retry and fail-closed explicit Settings account routing.

### RED evidence
The first commit contains only desired-behavior tests for:
- partial and complete default-collection reconciliation
- valid/stale explicit Settings routes
- valid/stale global active-account fallback

Android CI is expected to fail compilation because the two policy APIs do not exist yet. Production implementation follows only after that failure is observed.

Closes #549