### PR TITLE
fix(android): unblock signed release split generation

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -260,12 +260,16 @@ jobs:
             "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar" \
             --output "$RUNNER_TEMP/bundletool.jar"
           echo "$BUNDLETOOL_SHA256  $RUNNER_TEMP/bundletool.jar" | sha256sum --check --strict
+          umask 077
+          BUNDLETOOL_PASSWORD_FILE="$RUNNER_TEMP/keystore/bundletool-password"
+          printf '%s' "$KSTOREPWD" > "$BUNDLETOOL_PASSWORD_FILE"
           java -jar "$RUNNER_TEMP/bundletool.jar" build-apks \
             --bundle app/build/outputs/bundle/release/app-release.aab \
             --output build/privacy-evidence/signed-release.apks \
             --mode universal \
             --ks="$KEYSTORE_PATH" --ks-key-alias="$KEY_ALIAS" \
-            --ks-pass=env:KSTOREPWD --key-pass=env:KSTOREPWD
+            --ks-pass="file:$BUNDLETOOL_PASSWORD_FILE" \
+            --key-pass="file:$BUNDLETOOL_PASSWORD_FILE"
           unzip -q build/privacy-evidence/signed-release.apks \
             -d build/privacy-evidence/signed-release-splits
           test -s app/build/outputs/mapping/release/mapping.txt

--- a/tests/test_android_security_static.py
+++ b/tests/test_android_security_static.py
@@ -5,6 +5,7 @@ LOGIN_ACTIVITY = ROOT / "android/app/src/main/java/io/silentsuite/sync/ui/setup/
 MANIFEST = ROOT / "android/app/src/main/AndroidManifest.xml"
 APP_GRADLE = ROOT / "android/app/build.gradle"
 APP_RESOURCES = ROOT / "android/app/src/main/res"
+ANDROID_BUILD_WORKFLOW = ROOT / ".github/workflows/build-android.yml"
 
 
 def test_login_activity_credential_prefill_extras_are_debug_only_and_not_exported():
@@ -34,3 +35,15 @@ def test_android_resources_do_not_reference_tourguide_owned_white():
     )
 
     assert "@color/White" not in resource_xml
+
+
+def test_bundletool_uses_a_private_temporary_password_file():
+    workflow = ANDROID_BUILD_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "--ks-pass=env:" not in workflow
+    assert "--key-pass=env:" not in workflow
+    assert "umask 077" in workflow
+    assert 'BUNDLETOOL_PASSWORD_FILE="$RUNNER_TEMP/keystore/bundletool-password"' in workflow
+    assert 'printf \'%s\' "$KSTOREPWD" > "$BUNDLETOOL_PASSWORD_FILE"' in workflow
+    assert '--ks-pass="file:$BUNDLETOOL_PASSWORD_FILE"' in workflow
+    assert '--key-pass="file:$BUNDLETOOL_PASSWORD_FILE"' in workflow


### PR DESCRIPTION
## Summary
- replace unsupported bundletool `env:` password flags with a private temporary password file
- create the file under the existing temporary keystore directory with `umask 077`
- retain unconditional keystore-directory cleanup
- add a static regression guard for the secure supported password-source contract

## Failure evidence
The first `v0.4.2-beta` tag run compiled the signed APK/AAB, then bundletool 1.18.1 failed with `Passwords must be prefixed with pass: or file:`. No Android release assets were attached.

## Verification
- RED: new guard failed on `--ks-pass=env:KSTOREPWD`
- GREEN: 18 release/security static checks pass
- `git diff --check` passes
- no app/runtime source or release version change

## Production/release impact
After exact-tree CI and two required production reviews, merge to `main`, delete the unpublished old tag/draft, recreate `v0.4.2-beta` at corrected main, then verify the complete signed Android and Bridge asset matrix before publication.

Closes #553