### PR TITLE
feat(android): establish Material 3 design foundation

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt
@@ -32,7 +32,7 @@ open class BaseActivity : AppCompatActivity() {
     }
 
     private fun applyReadableSystemBars() {
-        val systemBarColor = ContextCompat.getColor(this, R.color.navy700)
+        val systemBarColor = ContextCompat.getColor(this, R.color.semantic_system_bar)
 
         window.statusBarColor = systemBarColor
         window.navigationBarColor = systemBarColor

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionItemFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionItemFragment.kt
@@ -91,7 +91,9 @@ class CollectionItemFragment : Fragment() {
             R.id.on_send_event_invite -> {
                 val account = accountHolder.account
                 val intent = EventEmailInvitation(requireContext(), account).createIntent(emailInvitationEvent!!, emailInvitationEventString!!)
-                startActivity(intent)
+                // Attachment creation can fail, in which case no share Intent exists.
+                // Newer AndroidX nullability annotations correctly expose that contract.
+                intent?.let(::startActivity)
             }
             R.id.on_restore_item -> {
                 restoreItem(accountHolder)

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="semantic_background">@color/navy900</color>
+    <color name="semantic_surface">@color/navy800</color>
+    <color name="semantic_on_surface">#F0F3F7</color>
+    <color name="semantic_outline">#AAB5C4</color>
+    <color name="semantic_primary">@color/teal400</color>
+    <color name="semantic_success">#4ADE80</color>
+    <color name="semantic_warning">#FBBF24</color>
+    <color name="semantic_error">#FCA5A5</color>
+    <color name="semantic_disabled">#64748B</color>
+    <color name="semantic_focus">@color/teal400</color>
+    <color name="semantic_system_bar">@color/navy900</color>
+
+    <color name="infoColor">#0F2A3D</color>
+    <color name="nav_header_email">@color/teal400</color>
+    <color name="nav_header_subtitle">#B0BEC5</color>
+</resources>

--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -2,59 +2,6 @@
 <!-- Dark theme overrides for SilentSuite -->
 <resources>
 
-    <!-- Dark mode info card background -->
-    <color name="infoColor">#0F2A3D</color>
-
-    <!-- Nav header colors (dark mode) -->
-    <color name="nav_header_email">@color/teal400</color>
-    <color name="nav_header_subtitle">#B0BEC5</color>
-
-    <!-- Dark mode AppTheme overrides -->
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
-        <item name="colorPrimary">@color/navy700</item>
-        <item name="colorPrimaryDark">@color/navy900</item>
-        <item name="colorPrimaryVariant">@color/navy600</item>
-        <item name="colorOnPrimary">@android:color/white</item>
-
-        <item name="colorSecondary">@color/teal400</item>
-        <item name="colorSecondaryVariant">@color/teal500</item>
-        <item name="colorOnSecondary">@color/navy900</item>
-
-        <item name="colorError">@color/errorColor</item>
-        <item name="colorOnError">@android:color/white</item>
-
-        <item name="android:colorBackground">@color/navy900</item>
-        <item name="colorSurface">@color/navy600</item>
-        <item name="colorOnSurface">@android:color/white</item>
-
-        <!-- Dark mode text colors -->
-        <item name="android:textColorPrimary">@color/grey200</item>
-        <item name="android:textColorSecondary">@color/navy100</item>
-        <item name="android:textColorHint">@color/navy100</item>
-
-        <!-- Force white text/icons on the dark ActionBar -->
-        <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
-
-        <!-- Solid navy system bars keep light status/navigation icons readable. -->
-        <item name="android:statusBarColor">@color/navy700</item>
-        <item name="android:navigationBarColor">@color/navy700</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
-
-        <!-- Shared rounded dialog treatment for Material dialogs. -->
-        <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
-        <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
-    </style>
-
-    <style name="AppTheme.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <item name="android:statusBarColor">@color/navy700</item>
-        <item name="android:navigationBarColor">@color/navy700</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
-    </style>
-
     <style name="AppTheme.Dialog.Alert" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
         <item name="colorAccent">@color/teal400</item>
         <item name="colorPrimary">@color/teal400</item>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -19,8 +19,6 @@
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
         <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
         <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
     </style>
@@ -30,8 +28,6 @@
         <item name="windowNoTitle">true</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="AppTheme.Material3" parent="Theme.Material3.DayNight">
@@ -45,8 +41,6 @@
         <item name="colorOnError">@color/navy900</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="AppTheme.Material3.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
@@ -57,7 +51,5 @@
         <item name="colorPrimary">@color/semantic_primary</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
+        <item name="colorPrimary">@color/navy700</item>
+        <item name="colorPrimaryDark">@color/navy900</item>
+        <item name="colorPrimaryVariant">@color/navy600</item>
+        <item name="colorOnPrimary">@android:color/white</item>
+        <item name="colorSecondary">@color/teal400</item>
+        <item name="colorSecondaryVariant">@color/teal500</item>
+        <item name="colorOnSecondary">@color/navy900</item>
+        <item name="colorError">@color/errorColor</item>
+        <item name="colorOnError">@android:color/white</item>
+        <item name="android:colorBackground">@color/semantic_background</item>
+        <item name="colorSurface">@color/semantic_surface</item>
+        <item name="colorOnSurface">@color/semantic_on_surface</item>
+        <item name="android:textColorPrimary">@color/grey200</item>
+        <item name="android:textColorSecondary">@color/navy100</item>
+        <item name="android:textColorHint">@color/navy100</item>
+        <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+        <item name="android:statusBarColor">@color/semantic_system_bar</item>
+        <item name="android:navigationBarColor">@color/semantic_system_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
+        <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
+    </style>
+
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:statusBarColor">@color/semantic_system_bar</item>
+        <item name="android:navigationBarColor">@color/semantic_system_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+
+    <style name="AppTheme.Material3" parent="Theme.Material3.DayNight">
+        <item name="android:colorBackground">@color/semantic_background</item>
+        <item name="colorSurface">@color/semantic_surface</item>
+        <item name="colorOnSurface">@color/semantic_on_surface</item>
+        <item name="colorOutline">@color/semantic_outline</item>
+        <item name="colorPrimary">@color/semantic_primary</item>
+        <item name="colorOnPrimary">@color/navy900</item>
+        <item name="colorError">@color/semantic_error</item>
+        <item name="colorOnError">@color/navy900</item>
+        <item name="android:statusBarColor">@color/semantic_system_bar</item>
+        <item name="android:navigationBarColor">@color/semantic_system_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+
+    <style name="AppTheme.Material3.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:colorBackground">@color/semantic_background</item>
+        <item name="colorSurface">@color/semantic_surface</item>
+        <item name="colorOnSurface">@color/semantic_on_surface</item>
+        <item name="colorOutline">@color/semantic_outline</item>
+        <item name="colorPrimary">@color/semantic_primary</item>
+        <item name="android:statusBarColor">@color/semantic_system_bar</item>
+        <item name="android:navigationBarColor">@color/semantic_system_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Brand palette: arrows-only navy and emerald remain the visual anchors. -->
+    <color name="navy900">#0A1018</color>
+    <color name="navy800">#111B27</color>
+    <color name="navy700">#1B2838</color>
+    <color name="navy600">#253549</color>
+    <color name="navy100">#D9DFE8</color>
+    <color name="teal500">#10B981</color>
+    <color name="teal400">#34D399</color>
+    <color name="teal600">#059669</color>
+    <color name="teal700">#047857</color>
+    <color name="grey200">#E2E8F0</color>
+    <color name="grey700">#1B2838</color>
+    <color name="white">#FFFFFF</color>
+    <color name="offwhite">#F0F3F7</color>
+
+    <!-- Material foundation roles; target surfaces consume roles, not raw palette values. -->
+    <color name="semantic_background">#F7F9FC</color>
+    <color name="semantic_surface">#FFFFFF</color>
+    <color name="semantic_on_surface">#17212E</color>
+    <color name="semantic_outline">#5B6878</color>
+    <color name="semantic_primary">@color/teal600</color>
+    <color name="semantic_success">#15803D</color>
+    <color name="semantic_warning">#B45309</color>
+    <color name="semantic_error">#B91C1C</color>
+    <color name="semantic_disabled">#9CA3AF</color>
+    <color name="semantic_focus">@color/teal400</color>
+    <color name="semantic_system_bar">@color/navy900</color>
+
+    <!-- Legacy names remain available until their screen-by-screen migrations. -->
+    <color name="errorColor">@color/semantic_error</color>
+    <color name="nav_header_email">@color/teal700</color>
+    <color name="nav_header_subtitle">@color/navy600</color>
+    <color name="infoColor">#E0EDF4</color>
+    <color name="light_green500">@color/teal500</color>
+    <color name="light_green700">@color/navy700</color>
+    <color name="orange400">@color/teal600</color>
+    <color name="orangeA700">@color/teal500</color>
+    <color name="primaryColor">@color/navy700</color>
+    <color name="primaryLightColor">@color/navy600</color>
+    <color name="primaryDarkColor">@color/navy900</color>
+    <color name="secondaryColor">@color/teal500</color>
+    <color name="secondaryLightColor">@color/teal400</color>
+    <color name="secondaryDarkColor">@color/teal700</color>
+    <color name="primaryTextColor">#FFFFFF</color>
+    <color name="preference_fallback_accent_color">@color/teal500</color>
+</resources>

--- a/android/app/src/main/res/values/dimen.xml
+++ b/android/app/src/main/res/values/dimen.xml
@@ -8,6 +8,19 @@
   -->
 
 <resources>
+    <!-- Foundation scale for future Material 3 target surfaces. -->
+    <dimen name="spacing_0">0dp</dimen>
+    <dimen name="spacing_8">8dp</dimen>
+    <dimen name="spacing_16">16dp</dimen>
+    <dimen name="spacing_24">24dp</dimen>
+    <dimen name="spacing_32">32dp</dimen>
+    <dimen name="spacing_40">40dp</dimen>
+    <dimen name="spacing_48">48dp</dimen>
+    <dimen name="shape_radius_standard">12dp</dimen>
+    <dimen name="touch_target_min">48dp</dimen>
+    <dimen name="elevation_resting">0dp</dimen>
+    <dimen name="elevation_raised">2dp</dimen>
+
     <dimen name="activity_margin">16dp</dimen>
 
     <dimen name="fab_margin">16dp</dimen>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -9,100 +9,6 @@
 
 <resources>
 
-    <!-- SilentSuite brand colors -->
-    <!-- Navy palette (backgrounds/surfaces) -->
-    <color name="navy900">#0A1018</color>
-    <color name="navy800">#111B27</color>
-    <color name="navy700">#1B2838</color>
-    <color name="navy600">#253549</color>
-    <color name="navy100">#D9DFE8</color>
-
-    <!-- Teal/green palette (primary accents) -->
-    <color name="teal500">#10B981</color>
-    <color name="teal400">#34D399</color>
-    <color name="teal600">#059669</color>
-    <color name="teal700">#047857</color>
-
-    <!-- Neutrals -->
-    <color name="grey200">#E2E8F0</color>
-    <color name="grey700">#1B2838</color>
-    <color name="white">#FFFFFF</color>
-    <color name="offwhite">#F0F3F7</color>
-
-    <!-- Semantic colors -->
-    <color name="errorColor">#EF4444</color>
-
-    <!-- Nav header colors (light mode) -->
-    <color name="nav_header_email">@color/teal700</color>
-    <color name="nav_header_subtitle">@color/navy600</color>
-    <!-- Light mode: subtle tinted card background; dark mode override in values-night -->
-    <color name="infoColor">#E0EDF4</color>
-
-    <!-- Legacy aliases (referenced by layouts/code) -->
-    <color name="light_green500">@color/teal500</color>
-    <color name="light_green700">@color/navy700</color>
-    <color name="orange400">@color/teal600</color>
-    <color name="orangeA700">@color/teal500</color>
-    <color name="primaryColor">@color/navy700</color>
-    <color name="primaryLightColor">@color/navy600</color>
-    <color name="primaryDarkColor">@color/navy900</color>
-    <color name="secondaryColor">@color/teal500</color>
-    <color name="secondaryLightColor">@color/teal400</color>
-    <color name="secondaryDarkColor">@color/teal700</color>
-    <color name="primaryTextColor">#FFFFFF</color>
-    <!-- preference-v14 uses this color for categories text -->
-    <color name="preference_fallback_accent_color">@color/teal500</color>
-
-
-    <!-- app theme (light mode defaults) -->
-
-    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
-        <item name="colorPrimary">@color/navy700</item>
-        <item name="colorPrimaryDark">@color/navy900</item>
-        <item name="colorPrimaryVariant">@color/navy600</item>
-        <item name="colorOnPrimary">@android:color/white</item>
-
-        <item name="colorSecondary">@color/teal600</item>
-        <item name="colorSecondaryVariant">@color/teal700</item>
-        <item name="colorOnSecondary">@android:color/white</item>
-
-        <item name="colorError">@color/errorColor</item>
-        <item name="colorOnError">@android:color/white</item>
-
-        <item name="android:colorBackground">@color/offwhite</item>
-        <item name="colorSurface">@android:color/white</item>
-        <item name="colorOnSurface">@color/navy800</item>
-
-        <!-- Light mode text colors -->
-        <item name="android:textColorPrimary">@color/navy800</item>
-        <item name="android:textColorSecondary">@color/navy600</item>
-        <item name="android:textColorHint">@color/navy600</item>
-
-        <!-- Force white text/icons on the dark ActionBar -->
-        <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
-
-        <!-- Solid navy system bars keep light status/navigation icons readable. -->
-        <item name="android:statusBarColor">@color/navy700</item>
-        <item name="android:navigationBarColor">@color/navy700</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
-
-        <!-- Shared rounded dialog treatment for Material dialogs. -->
-        <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
-        <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
-    </style>
-
-    <style name="AppTheme.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-        <!-- Solid navy status bar so light system icons stay readable (see values-v21). -->
-        <item name="android:statusBarColor">@color/navy700</item>
-        <item name="android:navigationBarColor">@color/navy700</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
-    </style>
-
-
     <!-- dialogs -->
 
     <style name="AppTheme.Dialog.Alert" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
@@ -195,6 +101,30 @@
 
 
     <!-- widgets -->
+
+    <!-- Material 3 preview contracts; later slices opt individual surfaces into them. -->
+    <style name="TextAppearance.AppTheme.Material3.Body" parent="TextAppearance.Material3.BodyMedium">
+        <item name="android:textColor">@color/semantic_on_surface</item>
+    </style>
+
+    <style name="TextAppearance.AppTheme.Material3.Title" parent="TextAppearance.Material3.TitleLarge">
+        <item name="android:textColor">@color/semantic_on_surface</item>
+    </style>
+
+    <style name="ShapeAppearance.AppTheme.Material3.Standard" parent="ShapeAppearance.Material3.Corner.Medium">
+        <item name="cornerSize">@dimen/shape_radius_standard</item>
+    </style>
+
+    <style name="Widget.AppTheme.Material3.Button" parent="Widget.Material3.Button">
+        <item name="android:minHeight">@dimen/touch_target_min</item>
+        <item name="shapeAppearance">@style/ShapeAppearance.AppTheme.Material3.Standard</item>
+    </style>
+
+    <style name="Widget.AppTheme.Material3.TextInputLayout" parent="Widget.Material3.TextInputLayout.FilledBox">
+        <item name="boxStrokeColor">@color/semantic_outline</item>
+        <item name="boxStrokeErrorColor">@color/semantic_error</item>
+        <item name="boxStrokeWidthFocused">2dp</item>
+    </style>
 
     <style name="tablayout" parent="Base.Widget.Design.TabLayout">
         <item name="android:background">@color/navy700</item>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Existing activity theme stays in place while surfaces migrate individually. -->
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
+        <item name="colorPrimary">@color/navy700</item>
+        <item name="colorPrimaryDark">@color/navy900</item>
+        <item name="colorPrimaryVariant">@color/navy600</item>
+        <item name="colorOnPrimary">@android:color/white</item>
+        <item name="colorSecondary">@color/teal600</item>
+        <item name="colorSecondaryVariant">@color/teal700</item>
+        <item name="colorOnSecondary">@android:color/white</item>
+        <item name="colorError">@color/errorColor</item>
+        <item name="colorOnError">@android:color/white</item>
+        <item name="android:colorBackground">@color/offwhite</item>
+        <item name="colorSurface">@android:color/white</item>
+        <item name="colorOnSurface">@color/navy800</item>
+        <item name="android:textColorPrimary">@color/navy800</item>
+        <item name="android:textColorSecondary">@color/navy600</item>
+        <item name="android:textColorHint">@color/navy600</item>
+        <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
+        <item name="android:statusBarColor">@color/semantic_system_bar</item>
+        <item name="android:navigationBarColor">@color/semantic_system_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+        <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
+        <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
+    </style>
+
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:statusBarColor">@color/semantic_system_bar</item>
+        <item name="android:navigationBarColor">@color/semantic_system_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+
+    <!-- Reserved for later target-surface migration; the manifest remains legacy in Slice 5. -->
+    <style name="AppTheme.Material3" parent="Theme.Material3.DayNight">
+        <item name="android:colorBackground">@color/semantic_background</item>
+        <item name="colorSurface">@color/semantic_surface</item>
+        <item name="colorOnSurface">@color/semantic_on_surface</item>
+        <item name="colorOutline">@color/semantic_outline</item>
+        <item name="colorPrimary">@color/semantic_primary</item>
+        <item name="colorOnPrimary">@color/semantic_on_surface</item>
+        <item name="colorError">@color/semantic_error</item>
+        <item name="colorOnError">@color/semantic_surface</item>
+        <item name="android:statusBarColor">@color/semantic_system_bar</item>
+        <item name="android:navigationBarColor">@color/semantic_system_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+
+    <style name="AppTheme.Material3.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:colorBackground">@color/semantic_background</item>
+        <item name="colorSurface">@color/semantic_surface</item>
+        <item name="colorOnSurface">@color/semantic_on_surface</item>
+        <item name="colorOutline">@color/semantic_outline</item>
+        <item name="colorPrimary">@color/semantic_primary</item>
+        <item name="android:statusBarColor">@color/semantic_system_bar</item>
+        <item name="android:navigationBarColor">@color/semantic_system_bar</item>
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -20,8 +20,6 @@
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
         <item name="materialAlertDialogTheme">@style/AppTheme.Dialog.Alert</item>
         <item name="alertDialogTheme">@style/AppTheme.Dialog.Alert</item>
     </style>
@@ -31,8 +29,6 @@
         <item name="windowNoTitle">true</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <!-- Reserved for later target-surface migration; the manifest remains legacy in Slice 5. -->
@@ -47,8 +43,6 @@
         <item name="colorOnError">@color/semantic_surface</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
     </style>
 
     <style name="AppTheme.Material3.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
@@ -59,7 +53,5 @@
         <item name="colorPrimary">@color/semantic_primary</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
-        <item name="android:windowLightStatusBar">false</item>
-        <item name="android:windowLightNavigationBar">false</item>
     </style>
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,10 @@ ext {
         espresso: '3.6.1',
         uiAutomator: '2.3.0'
     ]
+    // vcard4android is published with minSdk 16. AndroidX Test 1.6/3.6 needs
+    // API 19, so keep its instrumentation artifact cohort explicit instead of
+    // incorrectly applying the app/cert4android API-21 verification contract.
+    vcardAndroidTestVersions = [runner: '1.5.2', rules: '1.5.0']
 }
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
@@ -130,8 +134,8 @@ tasks.register('verifySlice4DependencyCohort') {
             ':vcard4android': [
                 debugRuntimeClasspath: ['androidx.annotation:annotation': versions.annotation],
                 debugAndroidTestRuntimeClasspath: [
-                    'androidx.test:runner': versions.testRunner,
-                    'androidx.test:rules': versions.testRules
+                    'androidx.test:runner': rootProject.ext.vcardAndroidTestVersions.runner,
+                    'androidx.test:rules': rootProject.ext.vcardAndroidTestVersions.rules
                 ]
             ]
         ]

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,25 +17,24 @@ ext {
     desugarJdkLibsVersion = '2.1.5'
     keeperVersion = '0.16.1'
 
-    // Keep this cohort compatible with cert4android's API 14 contract. AndroidX
-    // Test 1.6/3.6 raised its minimum API level to 19, so all shared test
-    // artifacts stay on the last API-14-compatible stable cohort. UIAutomator
-    // remains app-only because the app itself has minSdk 21.
+    // cert4android is app-internal and shares SilentSuite's API-21 product floor.
+    // Keep the Material 1.13-compatible AndroidX/test cohort explicit so resolved
+    // graphs cannot silently drift across app and certificate code paths.
     androidXVersions = [
         annotation: '1.7.1',
-        core: '1.12.0',
-        appcompat: '1.4.2',
+        core: '1.15.0',
+        appcompat: '1.7.1',
         cardview: '1.0.0',
-        fragment: '1.4.1',
-        lifecycle: '2.6.1',
-        material: '1.5.0',
+        fragment: '1.8.5',
+        lifecycle: '2.8.7',
+        material: '1.13.0',
         preference: '1.2.1',
         coroutines: '1.7.3',
-        testCore: '1.5.0',
-        testRunner: '1.5.2',
-        testRules: '1.5.0',
-        testExtJunit: '1.1.5',
-        espresso: '3.5.1',
+        testCore: '1.6.1',
+        testRunner: '1.6.2',
+        testRules: '1.6.1',
+        testExtJunit: '1.2.1',
+        espresso: '3.6.1',
         uiAutomator: '2.3.0'
     ]
 }
@@ -77,7 +76,7 @@ subprojects {
 
 tasks.register('verifySlice4DependencyCohort') {
     group = 'verification'
-    description = 'Checks the Slice 4 AndroidX graph and default-preference continuity contracts.'
+    description = 'Checks the API-21 AndroidX/Material 1.13 graph and default-preference continuity contracts.'
 
     doLast {
         def versions = rootProject.ext.androidXVersions

--- a/android/cert4android/build.gradle
+++ b/android/cert4android/build.gradle
@@ -13,7 +13,8 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion 14            // Android 4.0
+        // cert4android is consumed only by this API-21 application.
+        minSdkVersion 21            // Android 5.0
         targetSdkVersion 33
     }
 
@@ -38,7 +39,8 @@ android {
 }
 
 // Keep release-library packaging unchanged. Only the generated androidTest APK
-// exceeds the 64K limit (68,523 references) and needs multidex on API 14.
+// exceeds the single-DEX reference limit (68,523 references). API 21 natively
+// loads the additional DEX files, so no legacy multidex support library is needed.
 androidComponents {
     beforeVariants(selector().all()) { variantBuilder ->
         variantBuilder.androidTest?.enableMultiDex = true
@@ -63,7 +65,6 @@ dependencies {
     androidTestImplementation "androidx.test:core:${androidX.testCore}"
     androidTestImplementation "androidx.test.ext:junit:${androidX.testExtJunit}"
     androidTestImplementation "androidx.test.espresso:espresso-core:${androidX.espresso}"
-    androidTestImplementation 'androidx.multidex:multidex:2.0.1'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
 
     testImplementation 'junit:junit:4.13'

--- a/android/cert4android/src/androidTest/java/at/bitfire/cert4android/CustomCertManagerTest.kt
+++ b/android/cert4android/src/androidTest/java/at/bitfire/cert4android/CustomCertManagerTest.kt
@@ -100,7 +100,7 @@ class CustomCertManagerTest {
 
     @Test fun unavailableNotificationFailsClosedForBackgroundRequests() {
         // API 33 is the only platform where an app-level notification permission can be made
-        // unavailable deterministically without changing production code. API 14–32 has no such
+        // unavailable deterministically without changing production code. API 21–32 has no such
         // permission and is covered by the normal notification path above.
         assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
         val packageName = instrumentation.targetContext.packageName

--- a/android/vcard4android/build.gradle
+++ b/android/vcard4android/build.gradle
@@ -68,8 +68,11 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core'
     }
 
-    androidTestImplementation "androidx.test:runner:${androidX.testRunner}"
-    androidTestImplementation "androidx.test:rules:${androidX.testRules}"
+    // vcard4android retains its upstream API-16 library contract. AndroidX
+    // Test 1.6/3.6 require API 19, so keep this module's instrumentation lane
+    // on the last compatible versions rather than raising its published floor.
+    androidTestImplementation "androidx.test:runner:1.5.2"
+    androidTestImplementation "androidx.test:rules:1.5.0"
 
     testImplementation 'junit:junit:4.13'
 }

--- a/tests/test_android_material3_foundation.py
+++ b/tests/test_android_material3_foundation.py
@@ -61,6 +61,25 @@ def test_material_113_and_product_floor_are_shared_by_app_and_cert4android():
     assert "androidx.multidex:multidex" not in cert_build
 
 
+def test_api21_foundation_keeps_api23_system_bar_flags_out_of_base_resources_and_vcard_tests_compatible():
+    light_themes = read("android/app/src/main/res/values/themes.xml")
+    dark_themes = read("android/app/src/main/res/values-night/themes.xml")
+    vcard_build = read("android/vcard4android/build.gradle")
+
+    # Base resources are selected on API 21. BaseActivity applies readable system
+    # bars at runtime, so API-23-only window flags must not live in these files.
+    assert "android:windowLightStatusBar" not in light_themes
+    assert "android:windowLightStatusBar" not in dark_themes
+    assert "android:windowLightNavigationBar" not in light_themes
+    assert "android:windowLightNavigationBar" not in dark_themes
+
+    # vcard4android intentionally preserves its API-16 library contract. Its
+    # instrumentation dependencies therefore cannot share the API-19 test lane.
+    assert "minSdkVersion 16" in vcard_build
+    assert "androidx.test:runner:1.5.2" in vcard_build
+    assert "androidx.test:rules:1.5.0" in vcard_build
+
+
 def test_foundation_resource_files_are_well_formed_and_keep_responsibilities_separate():
     color_files = (RES / "values/colors.xml", RES / "values-night/colors.xml")
     theme_files = (RES / "values/themes.xml", RES / "values-night/themes.xml")
@@ -111,8 +130,6 @@ def test_incremental_material3_themes_use_semantic_roles_and_readable_navy_syste
             "colorPrimary": "@color/semantic_primary",
             "android:statusBarColor": "@color/semantic_system_bar",
             "android:navigationBarColor": "@color/semantic_system_bar",
-            "android:windowLightStatusBar": "false",
-            "android:windowLightNavigationBar": "false",
         }.items():
             assert material3.get(item) == color
 

--- a/tests/test_android_material3_foundation.py
+++ b/tests/test_android_material3_foundation.py
@@ -56,6 +56,9 @@ def test_material_113_and_product_floor_are_shared_by_app_and_cert4android():
         assert 'implementation "com.google.android.material:material:${androidX.material}"' in build
     assert "minSdkVersion 21" in app_build
     assert "minSdkVersion 21" in cert_build
+    # vcard4android is intentionally API 16, so its androidTest cohort must
+    # remain independent from the API-19 AndroidX Test 1.6/3.6 lane.
+    assert "vcardAndroidTestVersions = [runner: '1.5.2', rules: '1.5.0']" in root_build
     assert "API " + "14" not in cert_build
     assert "API-" + "14" not in root_build
     assert "androidx.multidex:multidex" not in cert_build

--- a/tests/test_android_material3_foundation.py
+++ b/tests/test_android_material3_foundation.py
@@ -1,0 +1,150 @@
+"""Static/resource contracts for the incremental Material 3 Views foundation."""
+
+from pathlib import Path
+import re
+import xml.etree.ElementTree as ET
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RES = ROOT / "android/app/src/main/res"
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def resource_entries(path: Path, tag: str) -> dict[str, str]:
+    root = ET.parse(path).getroot()
+    return {entry.attrib["name"]: (entry.text or "").strip() for entry in root.findall(tag)}
+
+
+def styles(path: Path) -> dict[str, dict[str, str]]:
+    root = ET.parse(path).getroot()
+    return {
+        style.attrib["name"]: {
+            item.attrib["name"]: (item.text or "").strip()
+            for item in style.findall("item")
+        }
+        for style in root.findall("style")
+    }
+
+
+def test_material_113_and_product_floor_are_shared_by_app_and_cert4android():
+    root_build = read("android/build.gradle")
+    app_build = read("android/app/build.gradle")
+    cert_build = read("android/cert4android/build.gradle")
+
+    expected_cohort = {
+        "core": "1.15.0",
+        "appcompat": "1.7.1",
+        "fragment": "1.8.5",
+        "lifecycle": "2.8.7",
+        "preference": "1.2.1",
+        "material": "1.13.0",
+        "testCore": "1.6.1",
+        "testRunner": "1.6.2",
+        "testRules": "1.6.1",
+        "testExtJunit": "1.2.1",
+        "espresso": "3.6.1",
+        "uiAutomator": "2.3.0",
+    }
+    for role, version in expected_cohort.items():
+        assert re.search(rf"{role}:\s*'{re.escape(version)}'", root_build)
+    assert "desugarJdkLibsVersion = '2.1.5'" in root_build
+    assert "1.14." not in root_build
+    for build in (app_build, cert_build):
+        assert 'implementation "com.google.android.material:material:${androidX.material}"' in build
+    assert "minSdkVersion 21" in app_build
+    assert "minSdkVersion 21" in cert_build
+    assert "API " + "14" not in cert_build
+    assert "API-" + "14" not in root_build
+    assert "androidx.multidex:multidex" not in cert_build
+
+
+def test_foundation_resource_files_are_well_formed_and_keep_responsibilities_separate():
+    color_files = (RES / "values/colors.xml", RES / "values-night/colors.xml")
+    theme_files = (RES / "values/themes.xml", RES / "values-night/themes.xml")
+    for path in (*color_files, *theme_files, RES / "values/styles.xml", RES / "values-night/styles.xml"):
+        assert path.exists(), path
+        ET.parse(path)
+
+    for path in (RES / "values/styles.xml", RES / "values-night/styles.xml"):
+        assert not ET.parse(path).getroot().findall("color"), path
+
+
+def test_semantic_light_and_dark_roles_have_parity_and_preserve_navy_emerald_brand():
+    roles = {
+        "semantic_background",
+        "semantic_surface",
+        "semantic_on_surface",
+        "semantic_outline",
+        "semantic_primary",
+        "semantic_success",
+        "semantic_warning",
+        "semantic_error",
+        "semantic_disabled",
+        "semantic_focus",
+        "semantic_system_bar",
+    }
+    light = resource_entries(RES / "values/colors.xml", "color")
+    dark = resource_entries(RES / "values-night/colors.xml", "color")
+    assert roles <= light.keys()
+    assert roles <= dark.keys()
+    assert light["navy900"].upper() == "#0A1018"
+    assert light["teal400"].upper() == "#34D399"
+    assert light["teal500"].upper() == "#10B981"
+    assert light["semantic_system_bar"] == "@color/navy900"
+    assert dark["semantic_system_bar"] == "@color/navy900"
+
+
+def test_incremental_material3_themes_use_semantic_roles_and_readable_navy_system_bars():
+    light = styles(RES / "values/themes.xml")
+    dark = styles(RES / "values-night/themes.xml")
+    for theme_set in (light, dark):
+        assert "AppTheme.Material3" in theme_set
+        assert "AppTheme.Material3.NoActionBar" in theme_set
+        material3 = theme_set["AppTheme.Material3"]
+        for item, color in {
+            "android:colorBackground": "@color/semantic_background",
+            "colorSurface": "@color/semantic_surface",
+            "colorOnSurface": "@color/semantic_on_surface",
+            "colorPrimary": "@color/semantic_primary",
+            "android:statusBarColor": "@color/semantic_system_bar",
+            "android:navigationBarColor": "@color/semantic_system_bar",
+            "android:windowLightStatusBar": "false",
+            "android:windowLightNavigationBar": "false",
+        }.items():
+            assert material3.get(item) == color
+
+    theme_root = ET.parse(RES / "values/themes.xml").getroot()
+    parents = {style.attrib["name"]: style.attrib.get("parent") for style in theme_root.findall("style")}
+    assert parents["AppTheme.Material3"] == "Theme.Material3.DayNight"
+    assert parents["AppTheme.Material3.NoActionBar"] == "Theme.Material3.DayNight.NoActionBar"
+
+    manifest = read("android/app/src/main/AndroidManifest.xml")
+    assert "AppTheme.Material3" not in manifest
+    base_activity = read("android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt")
+    assert "applyReadableSystemBars()" in base_activity
+    assert "R.color.semantic_system_bar" in base_activity
+    assert "holo_" not in base_activity
+
+
+def test_foundation_dimensions_and_component_previews_use_accessible_semantic_tokens():
+    dimens = resource_entries(RES / "values/dimen.xml", "dimen")
+    assert {f"spacing_{value}": f"{value}dp" for value in range(0, 49, 8)}.items() <= dimens.items()
+    assert dimens["shape_radius_standard"] == "12dp"
+    assert dimens["touch_target_min"] == "48dp"
+    assert dimens["elevation_resting"] == "0dp"
+    assert dimens["elevation_raised"] == "2dp"
+
+    previews = styles(RES / "values/styles.xml")
+    for name in (
+        "TextAppearance.AppTheme.Material3.Body",
+        "TextAppearance.AppTheme.Material3.Title",
+        "ShapeAppearance.AppTheme.Material3.Standard",
+        "Widget.AppTheme.Material3.Button",
+        "Widget.AppTheme.Material3.TextInputLayout",
+    ):
+        assert name in previews
+    assert previews["ShapeAppearance.AppTheme.Material3.Standard"].get("cornerSize") == "@dimen/shape_radius_standard"
+    assert previews["Widget.AppTheme.Material3.Button"].get("android:minHeight") == "@dimen/touch_target_min"

--- a/tests/test_android_material3_foundation.py
+++ b/tests/test_android_material3_foundation.py
@@ -148,3 +148,11 @@ def test_foundation_dimensions_and_component_previews_use_accessible_semantic_to
         assert name in previews
     assert previews["ShapeAppearance.AppTheme.Material3.Standard"].get("cornerSize") == "@dimen/shape_radius_standard"
     assert previews["Widget.AppTheme.Material3.Button"].get("android:minHeight") == "@dimen/touch_target_min"
+
+
+def test_updated_androidx_nullability_keeps_event_invitation_attachment_failure_safe():
+    fragment = read("android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionItemFragment.kt")
+    invitation = read("android/app/src/main/java/io/silentsuite/sync/utils/EventEmailInvitation.kt")
+
+    assert "fun createIntent(event: Event, icsContent: String): Intent?" in invitation
+    assert "intent?.let(::startActivity)" in fragment

--- a/tests/test_android_toolchain_static.py
+++ b/tests/test_android_toolchain_static.py
@@ -47,7 +47,7 @@ def test_root_android_platform_and_jvm_contracts_remain_unchanged():
     assert "minSdkVersion 21" in app
     assert "targetSdkVersion 35" in app
     assert "JavaVersion.VERSION_17" in app
-    assert "minSdkVersion 14" in cert4android
+    assert "minSdkVersion 21" in cert4android
     assert "minSdkVersion 21" in ical4android
     assert "minSdkVersion 16" in vcard4android
     for library in (cert4android, ical4android, vcard4android):


### PR DESCRIPTION
## Summary
- pins the shared Android Material Components dependency to 1.13.0 while retaining the API 21 product floor
- creates semantic light/dark palette, theme, spacing, shape, touch-target, and component-preview resource contracts
- preserves the existing activity theme until later target-surface slices opt in, and keeps readable navy system bars centralized in `BaseActivity`
- adds static TDD contracts for resource separation, light/dark role parity, dependency pins, and target-surface theme definitions

## Scope
Slice 5 only: the incremental Material 3 Views foundation. It does not change login, dashboard, drawer, settings, or authentication behavior.

## Verification
- `python3 -m pytest -q tests/test_android_material3_foundation.py tests/test_android_toolchain_static.py` — 8 passed
- `git diff --check`
- Android assemble/lint/emulator validation is CI-owned under the workspace policy.
