### PR TITLE
feat(android): modernize combined sign-in

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -235,6 +235,7 @@
             android:name=".ui.setup.LoginActivity"
             android:exported="false"
             android:label="@string/login_title"
+            android:theme="@style/AppTheme.Material3"
             android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".ui.AccountActivity">
             <intent-filter>

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -13,6 +13,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
@@ -76,6 +77,22 @@ class LoginCredentialsFragment : Fragment() {
                 submissionInProgress = true
                 SetupSecretHolder.setLoginCredentials(credentials)
                 DetectConfigurationFragment.newInstance().show(requireFragmentManager(), DETECT_CONFIGURATION_TAG)
+            }
+        }
+        editUrlPassword.editText?.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                login.performClick()
+                true
+            } else {
+                false
+            }
+        }
+        customServer.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                login.performClick()
+                true
+            } else {
+                false
             }
         }
 

--- a/android/app/src/main/res/layout/login_credentials_fragment.xml
+++ b/android/app/src/main/res/layout/login_credentials_fragment.xml
@@ -9,16 +9,21 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <ScrollView android:layout_width="match_parent"
-                android:layout_height="0dp"
-                android:layout_weight="1"
-                android:layout_margin="@dimen/activity_margin"
-                android:clipToPadding="false"
-                android:paddingBottom="8dp">
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:fillViewport="true"
+        android:paddingStart="@dimen/spacing_24"
+        android:paddingTop="@dimen/spacing_24"
+        android:paddingEnd="@dimen/spacing_24"
+        android:paddingBottom="@dimen/spacing_16">
+
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -27,102 +32,56 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                style="@style/login_type_headline"
-                android:text="@string/login_enter_service_details"
-                android:layout_marginBottom="16dp"/>
+                android:text="@string/login_sign_in_title"
+                android:textAppearance="@style/TextAppearance.AppTheme.Material3.Title" />
 
-            <!-- Info banner: leading icon + rounded, padded background -->
-            <LinearLayout
+            <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="center_vertical"
-                android:background="@drawable/login_info_banner_bg"
-                android:padding="16dp"
-                android:layout_marginBottom="16dp">
-
-                <ImageView
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_marginEnd="12dp"
-                    android:src="@drawable/ic_sync_dark"
-                    app:tint="?android:attr/textColorPrimary"
-                    android:contentDescription="@null" />
-
-                <LinearLayout
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:orientation="vertical">
-
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="@string/login_bridge_sync"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="?android:attr/textColorPrimary" />
-
-                    <TextView
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="4dp"
-                        android:text="@string/login_bridge_encrypted"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="?android:attr/textColorPrimary" />
-
-                </LinearLayout>
-
-            </LinearLayout>
+                android:layout_marginTop="@dimen/spacing_8"
+                android:layout_marginBottom="@dimen/spacing_24"
+                android:text="@string/login_sign_in_supporting_copy"
+                android:textAppearance="@style/TextAppearance.AppTheme.Material3.Body" />
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                style="@style/Widget.AppTheme.Material3.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="14dp"
-                app:boxStrokeColor="@color/login_input_stroke"
-                app:boxStrokeWidth="1dp"
-                app:boxStrokeWidthFocused="2dp">
+                android:hint="@string/login_email_address">
+
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/user_name"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="@string/login_email_address"
-                    android:textColor="?android:attr/textColorPrimary"
                     android:autofillHints="emailAddress"
-                    android:inputType="textEmailAddress"/>
+                    android:imeOptions="actionNext"
+                    android:inputType="textEmailAddress" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                 android:id="@+id/url_password"
+                style="@style/Widget.AppTheme.Material3.TextInputLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:passwordToggleEnabled="true"
-                app:boxStrokeColor="@color/login_input_stroke"
-                app:boxStrokeWidth="1dp"
-                app:boxStrokeWidthFocused="2dp">
+                android:layout_marginTop="@dimen/spacing_16"
+                android:hint="@string/login_password"
+                app:endIconMode="password_toggle">
+
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/login_password"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:fontFamily="monospace"
-                    android:textColor="?android:attr/textColorPrimary"
                     android:autofillHints="password"
+                    android:fontFamily="monospace"
+                    android:imeOptions="actionDone"
                     android:inputType="textPassword"
-                    android:saveEnabled="false"
-                    android:hint="@string/login_password"/>
+                    android:saveEnabled="false" />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <!-- Unified secondary links: same size, left-aligned, ripple -->
             <TextView
                 android:id="@+id/forgot_password"
                 style="@style/login_link"
                 android:text="@string/login_forgot_password" />
-
-            <TextView
-                android:id="@+id/create_account"
-                style="@style/login_link"
-                android:text="@string/login_signup_prompt" />
 
             <TextView
                 android:id="@+id/show_advanced"
@@ -135,22 +94,31 @@
                 android:layout_height="wrap_content">
 
                 <com.google.android.material.textfield.TextInputLayout
-                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    style="@style/Widget.AppTheme.Material3.TextInputLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:boxStrokeColor="@color/login_input_stroke"
-                    app:boxStrokeWidth="1dp"
-                    app:boxStrokeWidthFocused="2dp">
+                    android:hint="@string/login_custom_server">
+
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/custom_server"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:hint="@string/login_custom_server"
-                        android:inputType="textUri"/>
+                        android:imeOptions="actionDone"
+                        android:inputType="textUri" />
                 </com.google.android.material.textfield.TextInputLayout>
-
             </net.cachapa.expandablelayout.ExpandableLayout>
 
+            <TextView
+                android:id="@+id/create_account"
+                style="@style/login_link"
+                android:text="@string/login_signup_prompt" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacing_8"
+                android:text="@string/login_privacy_reassurance"
+                android:textAppearance="@style/TextAppearance.AppTheme.Material3.Body" />
         </LinearLayout>
     </ScrollView>
 
@@ -158,14 +126,16 @@
         android:id="@+id/login_action_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        style="@style/stepper_nav_bar">
+        android:background="@color/semantic_surface"
+        android:elevation="@dimen/elevation_raised"
+        android:orientation="vertical"
+        android:padding="@dimen/spacing_16">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/login"
-            style="@style/login_button"
-            app:backgroundTint="?attr/colorSecondary"
-            android:textColor="?attr/colorOnSecondary"
-            android:text="@string/login_login" />
-
+            style="@style/Widget.AppTheme.Material3.Button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/login_sign_in_and_connect" />
     </LinearLayout>
 </LinearLayout>

--- a/android/app/src/main/res/menu/activity_login.xml
+++ b/android/app/src/main/res/menu/activity_login.xml
@@ -13,6 +13,7 @@
     <item
         android:title="@string/help"
         android:icon="@drawable/ic_help_light"
+        app:iconTint="@color/semantic_on_surface"
         app:showAsAction="always"
         android:onClick="showHelp">
     </item>

--- a/android/app/src/main/res/values-night/themes.xml
+++ b/android/app/src/main/res/values-night/themes.xml
@@ -49,6 +49,7 @@
         <item name="colorOnSurface">@color/semantic_on_surface</item>
         <item name="colorOutline">@color/semantic_outline</item>
         <item name="colorPrimary">@color/semantic_primary</item>
+        <item name="colorOnPrimary">@color/navy900</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
     </style>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -289,11 +289,15 @@
     <string name="login_encryption_extra_info">* This password is used to encrypt your data, unlike the previous one, which is used to log into the service.\nYou are asked to choose a separate encryption password for security reasons. For more information, please refer to the FAQ at: %s</string>
     <string name="login_password_required">Password required</string>
     <string name="login_login">Log In</string>
+    <string name="login_sign_in_and_connect">Sign in and connect</string>
     <string name="login_signup">Sign Up</string>
     <string name="login_signup_prompt">Don\'t have an account? Sign up</string>
     <string name="login_finish">Finish</string>
     <string name="login_back">Back</string>
     <string name="login_enter_service_details">Connect Android sync</string>
+    <string name="login_sign_in_title">Sign in to SilentSuite</string>
+    <string name="login_sign_in_supporting_copy">Connect your account to sync your calendars, contacts, and tasks with Android.</string>
+    <string name="login_privacy_reassurance">Your password is used only to sign in and is not saved on this device.</string>
     <string name="login_bridge_sync">Syncs with your phone\'s calendar, contacts, and task apps.</string>
     <string name="login_bridge_encrypted">Your data is encrypted before it leaves this device.</string>
     <string name="login_enter_encryption_details">Secret Encryption Password</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -297,7 +297,7 @@
     <string name="login_enter_service_details">Connect Android sync</string>
     <string name="login_sign_in_title">Sign in to SilentSuite</string>
     <string name="login_sign_in_supporting_copy">Connect your account to sync your calendars, contacts, and tasks with Android.</string>
-    <string name="login_privacy_reassurance">Your password is used only to sign in and is not saved on this device.</string>
+    <string name="login_privacy_reassurance">SilentSuite does not save your password. Your Android autofill service may offer to save it.</string>
     <string name="login_bridge_sync">Syncs with your phone\'s calendar, contacts, and task apps.</string>
     <string name="login_bridge_encrypted">Your data is encrypted before it leaves this device.</string>
     <string name="login_enter_encryption_details">Secret Encryption Password</string>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -38,7 +38,7 @@
         <item name="colorOnSurface">@color/semantic_on_surface</item>
         <item name="colorOutline">@color/semantic_outline</item>
         <item name="colorPrimary">@color/semantic_primary</item>
-        <item name="colorOnPrimary">@color/semantic_on_surface</item>
+        <item name="colorOnPrimary">@color/navy900</item>
         <item name="colorError">@color/semantic_error</item>
         <item name="colorOnError">@color/semantic_surface</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -51,6 +51,7 @@
         <item name="colorOnSurface">@color/semantic_on_surface</item>
         <item name="colorOutline">@color/semantic_outline</item>
         <item name="colorPrimary">@color/semantic_primary</item>
+        <item name="colorOnPrimary">@color/navy900</item>
         <item name="android:statusBarColor">@color/semantic_system_bar</item>
         <item name="android:navigationBarColor">@color/semantic_system_bar</item>
     </style>

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginMaterial3ContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginMaterial3ContractTest.kt
@@ -10,6 +10,7 @@ class LoginMaterial3ContractTest {
     private val layout = File("src/main/res/layout/login_credentials_fragment.xml").readText()
     private val strings = File("src/main/res/values/strings.xml").readText()
     private val manifest = File("src/main/AndroidManifest.xml").readText()
+    private val menu = File("src/main/res/menu/activity_login.xml").readText()
     private val fragment = File("src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt").readText()
 
     @Test
@@ -18,6 +19,8 @@ class LoginMaterial3ContractTest {
             .substringBefore("</activity>")
 
         assertTrue(loginActivity.contains("android:theme=\"@style/AppTheme.Material3\""))
+        assertTrue(menu.contains("android:icon=\"@drawable/ic_help_light\""))
+        assertTrue(menu.contains("app:iconTint=\"@color/semantic_on_surface\""))
         assertTrue(layout.contains("@style/TextAppearance.AppTheme.Material3.Title"))
         assertTrue(layout.contains("@style/TextAppearance.AppTheme.Material3.Body"))
         assertEquals(3, Regex("@style/Widget.AppTheme.Material3.TextInputLayout").findAll(layout).count())

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginMaterial3ContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginMaterial3ContractTest.kt
@@ -32,6 +32,8 @@ class LoginMaterial3ContractTest {
         assertEquals(1, Regex("<com\\.google\\.android\\.material\\.button\\.MaterialButton").findAll(layout).count())
         assertTrue(layout.contains("android:text=\"@string/login_sign_in_and_connect\""))
         assertTrue(strings.contains("<string name=\"login_sign_in_and_connect\">Sign in and connect</string>"))
+        assertTrue(strings.contains("<string name=\"login_privacy_reassurance\">SilentSuite does not save your password. Your Android autofill service may offer to save it.</string>"))
+        assertFalse(strings.contains("<string name=\"login_privacy_reassurance\">Your password is used only to sign in and is not saved on this device.</string>"))
         assertTrue(strings.contains("<string name=\"login_forgot_password\">Forgot password?</string>"))
         assertTrue(strings.contains("<string name=\"login_toggle_advanced\">Custom server</string>"))
         assertTrue(strings.contains("<string name=\"login_signup_prompt\">Don\\'t have an account? Sign up</string>"))

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginMaterial3ContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/LoginMaterial3ContractTest.kt
@@ -1,0 +1,60 @@
+package io.silentsuite.sync.ui.setup
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class LoginMaterial3ContractTest {
+    private val layout = File("src/main/res/layout/login_credentials_fragment.xml").readText()
+    private val strings = File("src/main/res/values/strings.xml").readText()
+    private val manifest = File("src/main/AndroidManifest.xml").readText()
+    private val fragment = File("src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt").readText()
+
+    @Test
+    fun loginActivityAndCombinedCredentialsSurfaceUseMaterial3() {
+        val loginActivity = manifest.substringAfter("android:name=\".ui.setup.LoginActivity\"")
+            .substringBefore("</activity>")
+
+        assertTrue(loginActivity.contains("android:theme=\"@style/AppTheme.Material3\""))
+        assertTrue(layout.contains("@style/TextAppearance.AppTheme.Material3.Title"))
+        assertTrue(layout.contains("@style/TextAppearance.AppTheme.Material3.Body"))
+        assertEquals(3, Regex("@style/Widget.AppTheme.Material3.TextInputLayout").findAll(layout).count())
+        assertTrue(layout.contains("@style/Widget.AppTheme.Material3.Button"))
+    }
+
+    @Test
+    fun surfaceHasOneClearCombinedSignInActionAndCompactSupportingCopy() {
+        assertTrue(layout.contains("android:text=\"@string/login_sign_in_title\""))
+        assertTrue(layout.contains("android:text=\"@string/login_sign_in_supporting_copy\""))
+        assertTrue(layout.contains("android:text=\"@string/login_privacy_reassurance\""))
+        assertEquals(1, Regex("<com\\.google\\.android\\.material\\.button\\.MaterialButton").findAll(layout).count())
+        assertTrue(layout.contains("android:text=\"@string/login_sign_in_and_connect\""))
+        assertTrue(strings.contains("<string name=\"login_sign_in_and_connect\">Sign in and connect</string>"))
+        assertTrue(strings.contains("<string name=\"login_forgot_password\">Forgot password?</string>"))
+        assertTrue(strings.contains("<string name=\"login_toggle_advanced\">Custom server</string>"))
+        assertTrue(strings.contains("<string name=\"login_signup_prompt\">Don\\'t have an account? Sign up</string>"))
+        assertFalse(layout.contains("@string/login_bridge_sync"))
+        assertFalse(layout.contains("@string/login_bridge_encrypted"))
+    }
+
+    @Test
+    fun stableBehavioralIdsAndSecretAndDisclosureContractsRemain() {
+        listOf(
+            "user_name", "url_password", "login_password", "forgot_password", "create_account",
+            "show_advanced", "advanced_layout", "custom_server", "login_action_bar", "login"
+        ).forEach { id -> assertTrue("Missing stable login ID: $id", layout.contains("android:id=\"@+id/$id\"")) }
+
+        assertTrue(layout.contains("android:autofillHints=\"emailAddress\""))
+        assertTrue(layout.contains("android:autofillHints=\"password\""))
+        assertTrue(layout.contains("android:saveEnabled=\"false\""))
+        assertTrue(layout.contains("android:imeOptions=\"actionDone\""))
+        assertTrue(fragment.contains("setOnEditorActionListener"))
+        assertTrue(fragment.contains("EditorInfo.IME_ACTION_DONE"))
+        assertTrue(fragment.contains("login.performClick()"))
+        assertTrue(fragment.contains("KEY_ADVANCED_EXPANDED"))
+        assertTrue(fragment.contains("applyLoginActionBarInsets"))
+        assertTrue(layout.contains("<net.cachapa.expandablelayout.ExpandableLayout"))
+    }
+}

--- a/tests/test_android_material3_foundation.py
+++ b/tests/test_android_material3_foundation.py
@@ -131,6 +131,7 @@ def test_incremental_material3_themes_use_semantic_roles_and_readable_navy_syste
             "colorSurface": "@color/semantic_surface",
             "colorOnSurface": "@color/semantic_on_surface",
             "colorPrimary": "@color/semantic_primary",
+            "colorOnPrimary": "@color/navy900",
             "android:statusBarColor": "@color/semantic_system_bar",
             "android:navigationBarColor": "@color/semantic_system_bar",
         }.items():
@@ -141,8 +142,6 @@ def test_incremental_material3_themes_use_semantic_roles_and_readable_navy_syste
     assert parents["AppTheme.Material3"] == "Theme.Material3.DayNight"
     assert parents["AppTheme.Material3.NoActionBar"] == "Theme.Material3.DayNight.NoActionBar"
 
-    manifest = read("android/app/src/main/AndroidManifest.xml")
-    assert "AppTheme.Material3" not in manifest
     base_activity = read("android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt")
     assert "applyReadableSystemBars()" in base_activity
     assert "R.color.semantic_system_bar" in base_activity

--- a/tests/test_android_material3_foundation.py
+++ b/tests/test_android_material3_foundation.py
@@ -125,17 +125,18 @@ def test_incremental_material3_themes_use_semantic_roles_and_readable_navy_syste
     for theme_set in (light, dark):
         assert "AppTheme.Material3" in theme_set
         assert "AppTheme.Material3.NoActionBar" in theme_set
-        material3 = theme_set["AppTheme.Material3"]
-        for item, color in {
-            "android:colorBackground": "@color/semantic_background",
-            "colorSurface": "@color/semantic_surface",
-            "colorOnSurface": "@color/semantic_on_surface",
-            "colorPrimary": "@color/semantic_primary",
-            "colorOnPrimary": "@color/navy900",
-            "android:statusBarColor": "@color/semantic_system_bar",
-            "android:navigationBarColor": "@color/semantic_system_bar",
-        }.items():
-            assert material3.get(item) == color
+        for theme_name in ("AppTheme.Material3", "AppTheme.Material3.NoActionBar"):
+            material3 = theme_set[theme_name]
+            for item, color in {
+                "android:colorBackground": "@color/semantic_background",
+                "colorSurface": "@color/semantic_surface",
+                "colorOnSurface": "@color/semantic_on_surface",
+                "colorPrimary": "@color/semantic_primary",
+                "colorOnPrimary": "@color/navy900",
+                "android:statusBarColor": "@color/semantic_system_bar",
+                "android:navigationBarColor": "@color/semantic_system_bar",
+            }.items():
+                assert material3.get(item) == color
 
     theme_root = ET.parse(RES / "values/themes.xml").getroot()
     parents = {style.attrib["name"]: style.attrib.get("parent") for style in theme_root.findall("style")}


### PR DESCRIPTION
## Summary
- apply the supported Material 3 theme to the combined Android sign-in activity
- clarify the email/password sign-in hierarchy while retaining custom-server, signup, recovery, autofill, and secret-handling paths
- preserve IME submission and bottom action-bar inset handling with a focused contract test

## Verification
- `git diff --check origin/dev...HEAD`
- focused `LoginMaterial3ContractTest` and existing `LoginLifecycleContractTest`
- `:app:lintDebug`
- independent exact-head review: GREEN

## Scope
Slice 6 of the Android Material 3 UX modernization program. Does not change authentication or server semantics.