### PR TITLE
fix(android): preserve exact collection lifecycle state

### DIFF
--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionActivity.kt
@@ -1,6 +1,7 @@
 package io.silentsuite.sync.ui.etebase
 
 import android.accounts.Account
+import android.accounts.AccountManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -16,6 +17,7 @@ import com.etebase.client.CollectionManager
 import com.etebase.client.ItemMetadata
 import io.silentsuite.sync.*
 import io.silentsuite.sync.ui.BaseActivity
+import io.silentsuite.sync.ui.setup.ExactAccountRouting
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -25,42 +27,65 @@ class CollectionActivity() : BaseActivity() {
     private val model: AccountViewModel by viewModels()
     private val collectionModel: CollectionViewModel by viewModels()
     private val itemsModel: ItemsViewModel by viewModels()
+    private var installInitialView = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val extras = requireNotNull(intent.extras) { "CollectionActivity requires intent extras" }
-        account = requireNotNull(extras.getParcelable(EXTRA_ACCOUNT)) { "CollectionActivity requires EXTRA_ACCOUNT" }
-        val colUid = extras.getString(EXTRA_COLLECTION_UID)
-        val colType = extras.getString(EXTRA_COLLECTION_TYPE)
-
+        val route = intentRoute() ?: run {
+            finish()
+            return
+        }
+        val exactAccount = ExactAccountRouting.validate(route.account, route.creationId, App.accountType, AccountManager.get(this))
+        if (exactAccount == null) {
+            finish()
+            return
+        }
+        account = exactAccount
         setContentView(R.layout.etebase_fragment_activity)
+        val hasRestoredFragment = supportFragmentManager.findFragmentById(R.id.fragment_container) != null
+        installInitialView = route.collectionUid != null && !hasRestoredFragment
 
-        if (savedInstanceState == null) {
-            model.loadAccount(this, account)
+        model.loadAccount(this, account)
+        model.observe(this) { accountHolder ->
+            val colUid = route.collectionUid
             if (colUid != null) {
-                model.observe(this) {
-                    collectionModel.loadCollection(it, colUid)
-                    collectionModel.observe(this) { cachedCollection ->
-                        itemsModel.loadItems(it, cachedCollection)
+                collectionModel.loadCollection(accountHolder, colUid)
+            } else if (collectionModel.value == null) {
+                lifecycleScope.launch {
+                    val cachedCollection = withContext(Dispatchers.IO) {
+                        val meta = ItemMetadata()
+                        meta.name = ""
+                        CachedCollection(accountHolder.colMgr.create(requireNotNull(route.collectionType), meta, ""), meta, route.collectionType)
                     }
+                    collectionModel.setCollection(cachedCollection)
                 }
-                supportFragmentManager.commit {
-                    replace(R.id.fragment_container, ViewCollectionFragment())
-                }
-            } else if (colType != null) {
-                model.observe(this) {
-                    lifecycleScope.launch {
-                        val cachedCollection = withContext(Dispatchers.IO) {
-                            val meta = ItemMetadata()
-                            meta.name = ""
-                            CachedCollection(it.colMgr.create(colType, meta, ""), meta, colType)
-                        }
+            }
+        }
+        collectionModel.observe(this) { cachedCollection ->
+            model.value?.let { accountHolder ->
+                if (route.collectionUid != null) {
+                    itemsModel.loadItems(accountHolder, cachedCollection)
+                    if (installInitialView) {
+                        installInitialView = false
+                        val exactIdentity = CollectionLifecycleIdentity.existing(
+                            account,
+                            route.creationId,
+                            cachedCollection.col.uid,
+                            cachedCollection.collectionType
+                        )
                         supportFragmentManager.commit {
-                            replace(R.id.fragment_container, EditCollectionFragment.newInstance(cachedCollection, true))
+                            replace(R.id.fragment_container, ViewCollectionFragment.newInstance(exactIdentity))
                         }
                     }
                 }
+            }
+        }
+
+        if (route.collectionUid == null && !hasRestoredFragment) {
+            val identity = CollectionLifecycleIdentity.creating(account, route.creationId, requireNotNull(route.collectionType))
+            supportFragmentManager.commit {
+                replace(R.id.fragment_container, EditCollectionFragment.newInstance(identity, true))
             }
         }
 
@@ -68,13 +93,16 @@ class CollectionActivity() : BaseActivity() {
     }
 
     companion object {
-        private val EXTRA_ACCOUNT = "account"
-        private val EXTRA_COLLECTION_UID = "collectionUid"
-        private val EXTRA_COLLECTION_TYPE = "collectionType"
+        private const val EXTRA_ACCOUNT = "account"
+        private const val EXTRA_COLLECTION_UID = "collectionUid"
+        private const val EXTRA_COLLECTION_TYPE = "collectionType"
+        private const val EXTRA_CREATION_ID = "creationId"
 
         fun newIntent(context: Context, account: Account, colUid: String): Intent {
+            require(colUid.isNotBlank()) { "Collection UID must be nonblank" }
             val intent = Intent(context, CollectionActivity::class.java)
             intent.putExtra(EXTRA_ACCOUNT, account)
+            intent.putExtra(EXTRA_CREATION_ID, currentCreationId(context, account))
             intent.putExtra(EXTRA_COLLECTION_UID, colUid)
             return intent
         }
@@ -82,8 +110,37 @@ class CollectionActivity() : BaseActivity() {
         fun newCreateCollectionIntent(context: Context, account: Account, colType: String): Intent {
             val intent = Intent(context, CollectionActivity::class.java)
             intent.putExtra(EXTRA_ACCOUNT, account)
+            intent.putExtra(EXTRA_CREATION_ID, currentCreationId(context, account))
             intent.putExtra(EXTRA_COLLECTION_TYPE, colType)
             return intent
+        }
+
+        private fun currentCreationId(context: Context, account: Account): String? =
+            AccountManager.get(context).getUserData(account, AccountSettings.KEY_CREATION_ID)
+                ?.takeIf { it.isNotBlank() }
+    }
+
+    private data class CollectionRoute(
+        val account: Account,
+        val creationId: String,
+        val collectionUid: String?,
+        val collectionType: String?
+    )
+
+    private fun intentRoute(): CollectionRoute? {
+        val extras = intent.extras ?: return null
+        val exactAccount = extras.getParcelable<Account>(EXTRA_ACCOUNT) ?: return null
+        val creationId = extras.getString(EXTRA_CREATION_ID)?.takeIf { it.isNotBlank() } ?: return null
+        val uid = extras.getString(EXTRA_COLLECTION_UID)
+        val type = extras.getString(EXTRA_COLLECTION_TYPE)
+        if ((uid == null) == (type == null)) return null
+        return if (uid != null) {
+            if (uid.isBlank()) null else CollectionRoute(exactAccount, creationId, uid, null)
+        } else {
+            runCatching {
+                CollectionLifecycleIdentity.creating(exactAccount, creationId, type!!)
+                CollectionRoute(exactAccount, creationId, null, type)
+            }.getOrNull()
         }
     }
 }
@@ -130,8 +187,12 @@ data class AccountHolder(val account: Account, val etebaseLocalCache: EtebaseLoc
 
 class CollectionViewModel : ViewModel() {
     private val collection = MutableLiveData<CachedCollection>()
+    private var initializedUid: String? = null
 
     fun loadCollection(accountHolder: AccountHolder, colUid: String) {
+        if (initializedUid == colUid) return
+        check(initializedUid == null) { "CollectionViewModel cannot be reused for another collection" }
+        initializedUid = colUid
         viewModelScope.launch {
             val cachedCollection = withContext(Dispatchers.IO) {
                 val etebaseLocalCache = accountHolder.etebaseLocalCache
@@ -149,6 +210,12 @@ class CollectionViewModel : ViewModel() {
 
     val value: CachedCollection?
         get() = collection.value
+
+    fun setCollection(cachedCollection: CachedCollection) {
+        check(initializedUid == null || initializedUid == cachedCollection.col.uid)
+        initializedUid = cachedCollection.col.uid
+        collection.value = cachedCollection
+    }
 }
 
 class ItemsViewModel : ViewModel() {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionLifecycleIdentity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionLifecycleIdentity.kt
@@ -1,0 +1,63 @@
+package io.silentsuite.sync.ui.etebase
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Context
+import android.os.Bundle
+import io.silentsuite.sync.Constants
+import io.silentsuite.sync.App
+import io.silentsuite.sync.ui.setup.ExactAccountRouting
+
+/** Non-secret identity required to restore an active collection surface exactly. */
+data class CollectionLifecycleIdentity(
+    val account: Account,
+    val creationId: String,
+    val collectionUid: String?,
+    val collectionType: String
+) {
+    init {
+        require(account.name.isNotBlank()) { "Collection identity requires an account name" }
+        require(account.type == App.accountType) { "Collection identity requires the app account type" }
+        require(creationId.isNotBlank()) { "Collection identity requires a creation generation" }
+        require(collectionUid == null || collectionUid.isNotBlank()) { "Collection UID must be nonblank" }
+        require(collectionType in SUPPORTED_TYPES) { "Unsupported collection type" }
+    }
+
+    fun toBundle(): Bundle = Bundle().apply {
+        putParcelable(ARG_ACCOUNT, account)
+        putString(ARG_CREATION_ID, creationId)
+        collectionUid?.let { putString(ARG_COLLECTION_UID, it) }
+        putString(ARG_COLLECTION_TYPE, collectionType)
+    }
+
+    companion object {
+        const val ARG_ACCOUNT = "collection.identity.account"
+        const val ARG_CREATION_ID = "collection.identity.creationId"
+        const val ARG_COLLECTION_UID = "collection.identity.uid"
+        const val ARG_COLLECTION_TYPE = "collection.identity.type"
+
+        private val SUPPORTED_TYPES = setOf(
+            Constants.ETEBASE_TYPE_CALENDAR,
+            Constants.ETEBASE_TYPE_TASKS,
+            Constants.ETEBASE_TYPE_ADDRESS_BOOK
+        )
+
+        fun existing(account: Account, creationId: String, uid: String, type: String) =
+            CollectionLifecycleIdentity(account, creationId, uid, type)
+
+        fun creating(account: Account, creationId: String, type: String) =
+            CollectionLifecycleIdentity(account, creationId, null, type)
+
+        fun from(bundle: Bundle?): CollectionLifecycleIdentity? {
+            bundle ?: return null
+            val account = bundle.getParcelable<Account>(ARG_ACCOUNT) ?: return null
+            val creationId = bundle.getString(ARG_CREATION_ID) ?: return null
+            val type = bundle.getString(ARG_COLLECTION_TYPE) ?: return null
+            val uid = bundle.getString(ARG_COLLECTION_UID)
+            return runCatching { CollectionLifecycleIdentity(account, creationId, uid, type) }.getOrNull()
+        }
+    }
+
+    fun validate(context: Context): Boolean =
+        ExactAccountRouting.validate(account, creationId, App.accountType, AccountManager.get(context)) == account
+}

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionMembersFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionMembersFragment.kt
@@ -13,6 +13,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModel
 import com.etebase.client.CollectionAccessLevel
 import com.etebase.client.Utils
 import com.etebase.client.exceptions.EtebaseException
@@ -28,33 +29,51 @@ import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.UUID
 
 class CollectionMembersFragment : Fragment() {
     private val model: AccountViewModel by activityViewModels()
     private val collectionModel: CollectionViewModel by activityViewModels()
+    private val loadingModel: LoadingViewModel by activityViewModels()
+    private val memberActions: MemberActionViewModel by activityViewModels()
     private var isAdmin: Boolean = false
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        if (identity?.collectionUid == null || !identity.validate(requireContext())) {
+            requireActivity().finish()
+            return
+        }
+        isAdmin = requireArguments().getBoolean(ARG_IS_ADMIN)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val ret = if (collectionModel.value!!.col.accessLevel == CollectionAccessLevel.Admin) {
-            isAdmin = true
+        val ret = if (isAdmin) {
             inflater.inflate(R.layout.etebase_view_collection_members, container, false)
         } else {
             inflater.inflate(R.layout.etebase_view_collection_members_no_access, container, false)
         }
 
-        if (savedInstanceState == null) {
-            collectionModel.observe(this) {
-                (activity as? BaseActivity?)?.supportActionBar?.setTitle(R.string.collection_members_title)
-                if (container != null) {
-                    initUi(inflater, ret, it)
-                }
-            }
-        }
-
         return ret
     }
 
-    private fun initUi(inflater: LayoutInflater, v: View, cachedCollection: CachedCollection) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        collectionModel.observe(viewLifecycleOwner) {
+            val identity = CollectionLifecycleIdentity.from(arguments)
+            if (identity == null || identity.account != model.value?.account ||
+                identity.collectionUid != it.col.uid || identity.collectionType != it.collectionType ||
+                isAdmin != (it.col.accessLevel == CollectionAccessLevel.Admin)) {
+                requireActivity().finish()
+                return@observe
+            }
+            (activity as? BaseActivity?)?.supportActionBar?.setTitle(R.string.collection_members_title)
+            initUi(view, it)
+        }
+    }
+
+    private fun initUi(v: View, cachedCollection: CachedCollection) {
         val meta = cachedCollection.meta
         val collectionType = cachedCollection.collectionType
         val colorSquare = v.findViewById<View>(R.id.color)
@@ -83,16 +102,27 @@ class CollectionMembersFragment : Fragment() {
             }
         } else {
             v.findViewById<Button>(R.id.leave).setOnClickListener {
+                val identity = CollectionLifecycleIdentity.from(arguments)
+                if (identity == null || !identity.validate(requireContext())) {
+                    requireActivity().finish()
+                    return@setOnClickListener
+                }
+                if (loadingModel.isLoading) return@setOnClickListener
+                loadingModel.setLoading(true)
                 lifecycleScope.launch {
-                    withContext(Dispatchers.IO) {
-                        val membersManager = model.value!!.colMgr.getMemberManager(cachedCollection.col)
-                        membersManager.leave()
-                        val applicationContext = activity?.applicationContext
-                        if (applicationContext != null) {
-                            requestSync(applicationContext, model.value!!.account)
+                    try {
+                        withContext(Dispatchers.IO) {
+                            val membersManager = model.value!!.colMgr.getMemberManager(cachedCollection.col)
+                            membersManager.leave()
+                            val applicationContext = activity?.applicationContext
+                            if (applicationContext != null) {
+                                requestSync(applicationContext, model.value!!.account)
+                            }
                         }
+                        activity?.finish()
+                    } finally {
+                        loadingModel.setLoading(false)
                     }
-                    activity?.finish()
                 }
             }
         }
@@ -102,27 +132,62 @@ class CollectionMembersFragment : Fragment() {
 
     private fun addMemberClicked() {
         val view = View.inflate(requireContext(), R.layout.add_member_fragment, null)
+        view.findViewById<EditText>(R.id.username).isSaveEnabled = false
         val dialog = MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.collection_members_add)
                 .setIcon(R.drawable.ic_account_add_dark)
                 .setPositiveButton(android.R.string.yes) { _, _ ->
+                    val identity = CollectionLifecycleIdentity.from(arguments)
+                    if (identity == null || !identity.validate(requireContext())) {
+                        requireActivity().finish()
+                        return@setPositiveButton
+                    }
                     val username = view.findViewById<EditText>(R.id.username).text.toString()
                     val readOnly = view.findViewById<CheckBox>(R.id.read_only).isChecked
 
-                    val frag = AddMemberFragment.newInstance(model.value!!, collectionModel.value!!, username, if (readOnly) CollectionAccessLevel.ReadOnly else CollectionAccessLevel.ReadWrite)
+                    val frag = AddMemberFragment.newInstance(
+                        identity,
+                        memberActions.put(username, if (readOnly) CollectionAccessLevel.ReadOnly else CollectionAccessLevel.ReadWrite)
+                    )
                     frag.show(childFragmentManager, null)
                 }
                 .setNegativeButton(android.R.string.no) { _, _ -> }
         dialog.setView(view)
         dialog.show()
     }
+
+    companion object {
+        private const val ARG_IS_ADMIN = "collection.members.isAdmin"
+
+        fun newInstance(identity: CollectionLifecycleIdentity, isAdmin: Boolean) = CollectionMembersFragment().apply {
+            arguments = identity.toBundle().apply { putBoolean(ARG_IS_ADMIN, isAdmin) }
+        }
+    }
 }
 
 class AddMemberFragment : DialogFragment() {
-    private lateinit var accountHolder: AccountHolder
-    private lateinit var cachedCollection: CachedCollection
-    private lateinit var username: String
-    private lateinit var accessLevel: CollectionAccessLevel
+    private val accountModel: AccountViewModel by activityViewModels()
+    private val collectionModel: CollectionViewModel by activityViewModels()
+    private val loadingModel: LoadingViewModel by activityViewModels()
+    private val memberActions: MemberActionViewModel by activityViewModels()
+    private var username = ""
+    private var accessLevel = CollectionAccessLevel.ReadOnly
+    private var actionAvailable = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        val token = arguments?.getString(ARG_ACTION_TOKEN)
+        val action = token?.let(memberActions::get)
+        if (identity?.collectionUid == null || !identity.validate(requireContext()) || action == null) {
+            token?.let(memberActions::remove)
+            dismissAllowingStateLoss()
+            return
+        }
+        username = action.username
+        accessLevel = action.accessLevel
+        actionAvailable = true
+    }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         isCancelable = false
@@ -131,8 +196,23 @@ class AddMemberFragment : DialogFragment() {
             R.string.collection_members_adding,
             getString(R.string.please_wait)
         )
+        if (!actionAvailable) {
+            progress.setOnShowListener { dismissAllowingStateLoss() }
+            return progress
+        }
 
         lifecycleScope.launch {
+            val identity = CollectionLifecycleIdentity.from(arguments)
+            val accountHolder = accountModel.value
+            val cachedCollection = collectionModel.value
+            if (identity == null || !identity.validate(requireContext()) ||
+                accountHolder == null || cachedCollection == null ||
+                identity.account != accountHolder.account || identity.collectionUid != cachedCollection.col.uid ||
+                identity.collectionType != cachedCollection.collectionType) {
+                clearAction()
+                dismissAllowingStateLoss()
+                return@launch
+            }
             val invitationManager = accountHolder.etebase.invitationManager
             try {
                 val profile = withContext(Dispatchers.IO) {
@@ -147,10 +227,25 @@ class AddMemberFragment : DialogFragment() {
                         .setTitle(R.string.trust_fingerprint_title)
                         .setView(view)
                         .setPositiveButton(android.R.string.ok) { _, _ ->
+                            if (!identity.validate(requireContext())) {
+                                clearAction()
+                                requireActivity().finish()
+                                return@setPositiveButton
+                            }
+                            if (loadingModel.isLoading) return@setPositiveButton
+                            loadingModel.setLoading(true)
+                            val applicationContext = requireContext().applicationContext
                             lifecycleScope.launch {
                                 try {
-                                    withContext(Dispatchers.IO) {
+                                    val invited = withContext(Dispatchers.IO) {
+                                        if (!identity.validate(applicationContext)) return@withContext false
                                         invitationManager.invite(cachedCollection.col, username, profile.pubkey, accessLevel)
+                                        true
+                                    }
+                                    if (!invited) {
+                                        clearAction()
+                                        activity?.finish()
+                                        return@launch
                                     }
                                     MaterialAlertDialogBuilder(requireContext())
                                         .setTitle(R.string.collection_members_add)
@@ -159,12 +254,18 @@ class AddMemberFragment : DialogFragment() {
                                         .setPositiveButton(android.R.string.yes) { _, _ -> }
                                         .show()
                                     dismiss()
+                                    clearAction()
                                 } catch (e: EtebaseException) {
                                     handleError(e.localizedMessage)
+                                } finally {
+                                    loadingModel.setLoading(false)
                                 }
                             }
                         }
-                        .setNegativeButton(android.R.string.cancel) { _, _ -> dismiss() }.show()
+                        .setNegativeButton(android.R.string.cancel) { _, _ ->
+                            clearAction()
+                            dismiss()
+                        }.show()
             } catch (e: NotFoundException) {
                 handleError(getString(R.string.collection_members_error_user_not_found, username))
             } catch (e: EtebaseException) {
@@ -181,18 +282,34 @@ class AddMemberFragment : DialogFragment() {
                 .setTitle(R.string.collection_members_add_error)
                 .setMessage(message)
                 .setPositiveButton(android.R.string.yes) { _, _ -> }.show()
+        clearAction()
         dismiss()
     }
 
-    companion object {
-        fun newInstance(accountHolder: AccountHolder, cachedCollection: CachedCollection,
-                        username: String, accessLevel: CollectionAccessLevel): AddMemberFragment {
-            val ret = AddMemberFragment()
-            ret.accountHolder = accountHolder
-            ret.cachedCollection = cachedCollection
-            ret.username = username
-            ret.accessLevel = accessLevel
-            return ret
-        }
+    private fun clearAction() {
+        arguments?.getString(ARG_ACTION_TOKEN)?.let(memberActions::remove)
+        actionAvailable = false
     }
+
+    companion object {
+        private const val ARG_ACTION_TOKEN = "collection.members.actionToken"
+
+        fun newInstance(identity: CollectionLifecycleIdentity, actionToken: String) =
+            AddMemberFragment().apply {
+                arguments = identity.toBundle().apply {
+                    putString(ARG_ACTION_TOKEN, actionToken)
+                }
+            }
+    }
+}
+
+class MemberActionViewModel : ViewModel() {
+    data class Action(val username: String, val accessLevel: CollectionAccessLevel)
+    private val actions = mutableMapOf<String, Action>()
+
+    fun put(username: String, accessLevel: CollectionAccessLevel): String =
+        UUID.randomUUID().toString().also { actions[it] = Action(username, accessLevel) }
+
+    fun get(token: String): Action? = actions[token]
+    fun remove(token: String) { actions.remove(token) }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionMembersFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/CollectionMembersFragment.kt
@@ -109,15 +109,19 @@ class CollectionMembersFragment : Fragment() {
                 }
                 if (loadingModel.isLoading) return@setOnClickListener
                 loadingModel.setLoading(true)
+                val applicationContext = requireContext().applicationContext
                 lifecycleScope.launch {
                     try {
-                        withContext(Dispatchers.IO) {
+                        val left = withContext(Dispatchers.IO) {
+                            if (!identity.validate(applicationContext)) return@withContext false
                             val membersManager = model.value!!.colMgr.getMemberManager(cachedCollection.col)
                             membersManager.leave()
-                            val applicationContext = activity?.applicationContext
-                            if (applicationContext != null) {
-                                requestSync(applicationContext, model.value!!.account)
-                            }
+                            requestSync(applicationContext, model.value!!.account)
+                            true
+                        }
+                        if (!left) {
+                            activity?.finish()
+                            return@launch
                         }
                         activity?.finish()
                     } finally {
@@ -215,8 +219,15 @@ class AddMemberFragment : DialogFragment() {
             }
             val invitationManager = accountHolder.etebase.invitationManager
             try {
+                val applicationContext = requireContext().applicationContext
                 val profile = withContext(Dispatchers.IO) {
+                    if (!identity.validate(applicationContext)) return@withContext null
                     invitationManager.fetchUserProfile(username)
+                }
+                if (profile == null) {
+                    clearAction()
+                    activity?.finish()
+                    return@launch
                 }
                 val fingerprint = Utils.prettyFingerprint(profile.pubkey)
                 val view = LayoutInflater.from(context).inflate(R.layout.fingerprint_alertdialog, null)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/EditCollectionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/EditCollectionFragment.kt
@@ -102,7 +102,7 @@ class EditCollectionFragment : Fragment() {
         desc.isSaveEnabled = false
 
         val meta = cachedCollection.meta
-        draft.initialize(meta.name, meta.description, LocalCalendar.parseColor(meta.color))
+        draft.initialize(meta.name.orEmpty(), meta.description, LocalCalendar.parseColor(meta.color))
         title.setText(draft.name)
         desc.setText(draft.description)
         title.addTextChangedListener(DraftWatcher { draft.name = it })
@@ -187,25 +187,30 @@ class EditCollectionFragment : Fragment() {
     }
 
     private fun doDeleteCollection() {
-        if (!requireNotNull(CollectionLifecycleIdentity.from(arguments)).validate(requireContext())) {
+        val identity = requireNotNull(CollectionLifecycleIdentity.from(arguments))
+        if (!identity.validate(requireContext())) {
             requireActivity().finish()
             return
         }
         if (loadingModel.isLoading) return
         loadingModel.setLoading(true)
+        val applicationContext = requireContext().applicationContext
         lifecycleScope.launch {
             try {
-                withContext(Dispatchers.IO) {
+                val deleted = withContext(Dispatchers.IO) {
+                    if (!identity.validate(applicationContext)) return@withContext false
                     val col = cachedCollection.col
                     val meta = col.meta
                     meta.mtime = System.currentTimeMillis()
                     col.meta = meta
                     col.delete()
                     uploadCollection(col)
-                    val applicationContext = activity?.applicationContext
-                    if (applicationContext != null) {
-                        requestSync(applicationContext, model.value!!.account)
-                    }
+                    requestSync(applicationContext, model.value!!.account)
+                    true
+                }
+                if (!deleted) {
+                    activity?.finish()
+                    return@launch
                 }
                 activity?.finish()
             } catch (e: EtebaseException) {
@@ -224,7 +229,8 @@ class EditCollectionFragment : Fragment() {
     }
 
     private fun saveCollection() {
-        if (!requireNotNull(CollectionLifecycleIdentity.from(arguments)).validate(requireContext())) {
+        val identity = requireNotNull(CollectionLifecycleIdentity.from(arguments))
+        if (!identity.validate(requireContext())) {
             requireActivity().finish()
             return
         }
@@ -258,17 +264,20 @@ class EditCollectionFragment : Fragment() {
             }
 
             loadingModel.setLoading(true)
+            val applicationContext = requireContext().applicationContext
             lifecycleScope.launch {
                 try {
                     val colUid = withContext(Dispatchers.IO) {
+                        if (!identity.validate(applicationContext)) return@withContext null
                         val col = cachedCollection.col
                         col.meta = meta
                         uploadCollection(col)
-                        val applicationContext = activity?.applicationContext
-                        if (applicationContext != null) {
-                            requestSync(applicationContext, model.value!!.account)
-                        }
+                        requestSync(applicationContext, model.value!!.account)
                         col.uid
+                    }
+                    if (colUid == null) {
+                        activity?.finish()
+                        return@launch
                     }
                     collectionModel.loadCollection(model.value!!, colUid)
                     if (isCreating) {
@@ -277,7 +286,7 @@ class EditCollectionFragment : Fragment() {
                         parentFragmentManager.commit {
                             val identity = CollectionLifecycleIdentity.existing(
                                 model.value!!.account,
-                                requireNotNull(CollectionLifecycleIdentity.from(arguments)).creationId,
+                                identity.creationId,
                                 colUid,
                                 cachedCollection.collectionType
                             )

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/EditCollectionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/EditCollectionFragment.kt
@@ -3,13 +3,16 @@ package io.silentsuite.sync.ui.etebase
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.text.TextUtils
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.*
 import android.widget.EditText
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModel
+import androidx.fragment.app.commit
 import com.etebase.client.Collection
 import com.etebase.client.exceptions.EtebaseException
 import io.silentsuite.sync.CachedCollection
@@ -30,23 +33,44 @@ class EditCollectionFragment : Fragment() {
     private val model: AccountViewModel by activityViewModels()
     private val collectionModel: CollectionViewModel by activityViewModels()
     private val itemsModel: ItemsViewModel by activityViewModels()
-    private val loadingModel: LoadingViewModel by viewModels()
+    private val loadingModel: LoadingViewModel by activityViewModels()
+    private val draft: CollectionDraftViewModel by viewModels()
 
-    private lateinit var cachedCollection: CachedCollection
     private var isCreating: Boolean = false
+
+    private val cachedCollection: CachedCollection
+        get() = requireNotNull(collectionModel.value) { "Collection is not loaded" }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        if (identity == null || !identity.validate(requireContext()) ||
+            (identity.collectionUid == null) != requireArguments().getBoolean(ARG_IS_CREATING)) {
+            requireActivity().finish()
+            return
+        }
+        isCreating = requireArguments().getBoolean(ARG_IS_CREATING)
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val ret = inflater.inflate(R.layout.activity_create_collection, container, false)
         setHasOptionsMenu(true)
 
-        if (savedInstanceState == null) {
-            updateTitle()
-            if (container != null) {
-                initUi(inflater, ret)
-            }
-        }
-
         return ret
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        collectionModel.observe(viewLifecycleOwner) { collection ->
+            val identity = CollectionLifecycleIdentity.from(arguments)
+            if (identity == null || identity.account != model.value?.account || identity.collectionType != collection.collectionType ||
+                (identity.collectionUid != null && identity.collectionUid != collection.col.uid)) {
+                requireActivity().finish()
+                return@observe
+            }
+            updateTitle()
+            initUi(view)
+        }
     }
 
     fun updateTitle() {
@@ -71,21 +95,25 @@ class EditCollectionFragment : Fragment() {
         }
     }
 
-    private fun initUi(inflater: LayoutInflater, v: View) {
+    private fun initUi(v: View) {
         val title = v.findViewById<EditText>(R.id.display_name)
         val desc = v.findViewById<EditText>(R.id.description)
+        title.isSaveEnabled = false
+        desc.isSaveEnabled = false
 
         val meta = cachedCollection.meta
-
-        title.setText(meta.name)
-        desc.setText(meta.description)
+        draft.initialize(meta.name, meta.description, LocalCalendar.parseColor(meta.color))
+        title.setText(draft.name)
+        desc.setText(draft.description)
+        title.addTextChangedListener(DraftWatcher { draft.name = it })
+        desc.addTextChangedListener(DraftWatcher { draft.description = it })
 
         val colorSquare = v.findViewById<View>(R.id.color)
         when (cachedCollection.collectionType) {
             Constants.ETEBASE_TYPE_CALENDAR -> {
                 title.setHint(R.string.create_calendar_display_name_hint)
 
-                val color = LocalCalendar.parseColor(meta.color)
+                val color = draft.color
                 colorSquare.setBackgroundColor(color)
                 colorSquare.setOnClickListener {
                     AmbilWarnaDialog(context, (colorSquare.background as ColorDrawable).color, true, object : AmbilWarnaDialog.OnAmbilWarnaListener {
@@ -93,6 +121,7 @@ class EditCollectionFragment : Fragment() {
 
                         override fun onOk(dialog: AmbilWarnaDialog, color: Int) {
                             colorSquare.setBackgroundColor(color)
+                            draft.color = color
                         }
                     }).show()
                 }
@@ -100,7 +129,7 @@ class EditCollectionFragment : Fragment() {
             Constants.ETEBASE_TYPE_TASKS -> {
                 title.setHint(R.string.create_tasklist_display_name_hint)
 
-                val color = LocalCalendar.parseColor(meta.color)
+                val color = draft.color
                 colorSquare.setBackgroundColor(color)
                 colorSquare.setOnClickListener {
                     AmbilWarnaDialog(context, (colorSquare.background as ColorDrawable).color, true, object : AmbilWarnaDialog.OnAmbilWarnaListener {
@@ -108,6 +137,7 @@ class EditCollectionFragment : Fragment() {
 
                         override fun onOk(dialog: AmbilWarnaDialog, color: Int) {
                             colorSquare.setBackgroundColor(color)
+                            draft.color = color
                         }
                     }).show()
                 }
@@ -157,6 +187,11 @@ class EditCollectionFragment : Fragment() {
     }
 
     private fun doDeleteCollection() {
+        if (!requireNotNull(CollectionLifecycleIdentity.from(arguments)).validate(requireContext())) {
+            requireActivity().finish()
+            return
+        }
+        if (loadingModel.isLoading) return
         loadingModel.setLoading(true)
         lifecycleScope.launch {
             try {
@@ -189,6 +224,11 @@ class EditCollectionFragment : Fragment() {
     }
 
     private fun saveCollection() {
+        if (!requireNotNull(CollectionLifecycleIdentity.from(arguments)).validate(requireContext())) {
+            requireActivity().finish()
+            return
+        }
+        if (loadingModel.isLoading) return
         var ok = true
 
         val meta = cachedCollection.meta
@@ -235,7 +275,13 @@ class EditCollectionFragment : Fragment() {
                         // Load the items since we just created it
                         itemsModel.loadItems(model.value!!, cachedCollection)
                         parentFragmentManager.commit {
-                            replace(R.id.fragment_container, ViewCollectionFragment())
+                            val identity = CollectionLifecycleIdentity.existing(
+                                model.value!!.account,
+                                requireNotNull(CollectionLifecycleIdentity.from(arguments)).creationId,
+                                colUid,
+                                cachedCollection.collectionType
+                            )
+                            replace(R.id.fragment_container, ViewCollectionFragment.newInstance(identity))
                         }
                     } else {
                         parentFragmentManager.popBackStack()
@@ -267,11 +313,32 @@ class EditCollectionFragment : Fragment() {
     }
 
     companion object {
-        fun newInstance(cachedCollection: CachedCollection, isCreating: Boolean = false): EditCollectionFragment {
-            val ret = EditCollectionFragment()
-            ret.cachedCollection = cachedCollection
-            ret.isCreating = isCreating
-            return ret
-        }
+        private const val ARG_IS_CREATING = "collection.edit.isCreating"
+
+        fun newInstance(identity: CollectionLifecycleIdentity, isCreating: Boolean = false) =
+            EditCollectionFragment().apply {
+                arguments = identity.toBundle().apply { putBoolean(ARG_IS_CREATING, isCreating) }
+            }
     }
+}
+
+class CollectionDraftViewModel : ViewModel() {
+    var name = ""
+    var description: String? = null
+    var color = 0
+    private var initialized = false
+
+    fun initialize(name: String, description: String?, color: Int) {
+        if (initialized) return
+        initialized = true
+        this.name = name
+        this.description = description
+        this.color = color
+    }
+}
+
+private class DraftWatcher(private val changed: (String) -> Unit) : TextWatcher {
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = changed(s?.toString().orEmpty())
+    override fun afterTextChanged(s: Editable?) = Unit
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ViewCollectionFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/etebase/ViewCollectionFragment.kt
@@ -31,23 +31,44 @@ class ViewCollectionFragment : Fragment() {
     private val collectionModel: CollectionViewModel by activityViewModels()
     private val itemsModel: ItemsViewModel by activityViewModels()
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        if (identity?.collectionUid == null || !identity.validate(requireContext()))
+            requireActivity().finish()
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val ret = inflater.inflate(R.layout.view_collection_fragment, container, false)
         setHasOptionsMenu(true)
 
-        if (savedInstanceState == null) {
-            collectionModel.observe(this) {
-                (activity as? BaseActivity?)?.supportActionBar?.title = it.meta.name
-                if (container != null) {
-                    initUi(inflater, ret, it)
-                }
-            }
-        }
-
         return ret
     }
 
-    private fun initUi(inflater: LayoutInflater, container: View, cachedCollection: CachedCollection) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        collectionModel.observe(viewLifecycleOwner) {
+            val identity = CollectionLifecycleIdentity.from(arguments)
+            if (identity == null || identity.account != accountModel.value?.account ||
+                identity.collectionUid != it.col.uid || identity.collectionType != it.collectionType) {
+                requireActivity().finish()
+                return@observe
+            }
+            (activity as? BaseActivity?)?.supportActionBar?.title = it.meta.name
+            initUi(view, it)
+        }
+        itemsModel.observe(viewLifecycleOwner) {
+            val stats = view.findViewById<TextView>(R.id.stats)
+            view.findViewById<View>(R.id.progressBar).visibility = View.GONE
+            stats.text = if (it.isEmpty()) {
+                getString(R.string.collection_recent_activity_none)
+            } else {
+                resources.getQuantityString(R.plurals.collection_recent_activity_items, it.size, it.size)
+            }
+        }
+    }
+
+    private fun initUi(container: View, cachedCollection: CachedCollection) {
         val title = container.findViewById<TextView>(R.id.display_name)
 
         val col = cachedCollection.col
@@ -87,15 +108,6 @@ class ViewCollectionFragment : Fragment() {
             owner.text = getString(R.string.collection_shared_with_us)
         }
 
-        itemsModel.observe(this) {
-            val stats = container.findViewById<TextView>(R.id.stats)
-            container.findViewById<View>(R.id.progressBar).visibility = View.GONE
-            stats.text = if (it.isEmpty()) {
-                getString(R.string.collection_recent_activity_none)
-            } else {
-                resources.getQuantityString(R.plurals.collection_recent_activity_items, it.size, it.size)
-            }
-        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -114,7 +126,7 @@ class ViewCollectionFragment : Fragment() {
             R.id.on_edit -> {
                 if (cachedCollection.col.accessLevel == CollectionAccessLevel.Admin) {
                     parentFragmentManager.commit {
-                        replace(R.id.fragment_container, EditCollectionFragment.newInstance(cachedCollection))
+                        replace(R.id.fragment_container, EditCollectionFragment.newInstance(requireIdentity(), false))
                         addToBackStack(EditCollectionFragment::class.java.name)
                     }
                 } else {
@@ -128,7 +140,7 @@ class ViewCollectionFragment : Fragment() {
             }
             R.id.on_manage_members -> {
                 parentFragmentManager.commit {
-                    replace(R.id.fragment_container, CollectionMembersFragment())
+                    replace(R.id.fragment_container, CollectionMembersFragment.newInstance(requireIdentity(), cachedCollection.col.accessLevel == CollectionAccessLevel.Admin))
                     addToBackStack(null)
                 }
             }
@@ -155,6 +167,10 @@ class ViewCollectionFragment : Fragment() {
             return
         }
 
+        if (!requireIdentity().validate(requireContext())) {
+            requireActivity().finish()
+            return
+        }
         val accountHolder = accountModel.value
         if (accountHolder == null) {
             Toast.makeText(context, R.string.loading_error_title, Toast.LENGTH_LONG).show()
@@ -162,11 +178,15 @@ class ViewCollectionFragment : Fragment() {
         }
 
         parentFragmentManager.commit {
-            add(ImportFragment.newInstance(accountHolder.account, cachedCollection), null)
+            add(ImportFragment.newInstance(requireIdentity()), null)
         }
     }
 
     private fun createExportDocument(cachedCollection: CachedCollection) {
+        if (!requireIdentity().validate(requireContext())) {
+            requireActivity().finish()
+            return
+        }
         val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
             type = AndroidDataExporter.collectionMimeType(cachedCollection.collectionType)
@@ -182,6 +202,12 @@ class ViewCollectionFragment : Fragment() {
         val uri = if (resultCode == Activity.RESULT_OK) data?.data else null
         if (uri == null) return
 
+        val identity = requireIdentity()
+        if (!identity.validate(requireContext())) {
+            requireActivity().finish()
+            return
+        }
+
         val cachedCollection = collectionModel.value ?: run {
             Toast.makeText(context, R.string.loading_error_title, Toast.LENGTH_LONG).show()
             return
@@ -191,14 +217,21 @@ class ViewCollectionFragment : Fragment() {
             ?.map { it.content }
             ?: emptyList()
 
+        val applicationContext = requireContext().applicationContext
         viewLifecycleOwner.lifecycleScope.launch {
             try {
-                withContext(Dispatchers.IO) {
-                    val outputStream = requireContext().contentResolver.openOutputStream(uri)
+                val exported = withContext(Dispatchers.IO) {
+                    if (!identity.validate(applicationContext)) return@withContext false
+                    val outputStream = applicationContext.contentResolver.openOutputStream(uri)
                             ?: throw IOException("Could not open export destination")
                     outputStream.use {
                         AndroidDataExporter.writeCollectionExport(cachedCollection.collectionType, itemContents, it)
                     }
+                    true
+                }
+                if (!exported) {
+                    activity?.finish()
+                    return@launch
                 }
                 Toast.makeText(requireContext(), R.string.export_data_success, Toast.LENGTH_LONG).show()
             } catch (e: Exception) {
@@ -211,5 +244,11 @@ class ViewCollectionFragment : Fragment() {
 
     companion object {
         private const val REQUEST_CREATE_COLLECTION_EXPORT_DOCUMENT = 6385
+
+        fun newInstance(identity: CollectionLifecycleIdentity) = ViewCollectionFragment().apply {
+            arguments = identity.toBundle()
+        }
     }
+
+    private fun requireIdentity() = requireNotNull(CollectionLifecycleIdentity.from(arguments))
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportActivity.kt
@@ -1,6 +1,7 @@
 package io.silentsuite.sync.ui.importlocal
 
 import android.accounts.Account
+import android.accounts.AccountManager
 import android.app.Activity
 import android.content.Context
 import android.content.DialogInterface
@@ -10,13 +11,17 @@ import android.view.*
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import io.silentsuite.sync.AccountSettings
+import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
 import io.silentsuite.sync.model.CollectionInfo
 import io.silentsuite.sync.ui.BaseActivity
+import io.silentsuite.sync.ui.etebase.CollectionLifecycleIdentity
 
 class ImportActivity : BaseActivity(), SelectImportMethod, DialogInterface {
 
     private lateinit var account: Account
+    private lateinit var identity: CollectionLifecycleIdentity
     protected lateinit var info: CollectionInfo
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,6 +34,24 @@ class ImportActivity : BaseActivity(), SelectImportMethod, DialogInterface {
         val extras = requireNotNull(intent.extras) { "ImportActivity requires intent extras" }
         account = requireNotNull(extras.getParcelable(EXTRA_ACCOUNT)) { "ImportActivity requires EXTRA_ACCOUNT" }
         info = requireNotNull(extras.getSerializable(EXTRA_COLLECTION_INFO) as? CollectionInfo) { "ImportActivity requires EXTRA_COLLECTION_INFO" }
+        val creationId = extras.getString(EXTRA_CREATION_ID)?.takeIf { it.isNotBlank() }
+        val uid = info.uid?.takeIf { it.isNotBlank() }
+        val type = when (info.enumType) {
+            CollectionInfo.Type.CALENDAR -> Constants.ETEBASE_TYPE_CALENDAR
+            CollectionInfo.Type.TASKS -> Constants.ETEBASE_TYPE_TASKS
+            CollectionInfo.Type.ADDRESS_BOOK -> Constants.ETEBASE_TYPE_ADDRESS_BOOK
+            null -> null
+        }
+        identity = runCatching {
+            CollectionLifecycleIdentity.existing(account, requireNotNull(creationId), requireNotNull(uid), requireNotNull(type))
+        }.getOrNull() ?: run {
+            finish()
+            return
+        }
+        if (!identity.validate(this)) {
+            finish()
+            return
+        }
 
         if (savedInstanceState == null)
             supportFragmentManager.beginTransaction()
@@ -38,7 +61,7 @@ class ImportActivity : BaseActivity(), SelectImportMethod, DialogInterface {
 
     override fun importFile() {
         supportFragmentManager.beginTransaction()
-                .add(ImportFragment.newInstance(account, info), null)
+                .add(ImportFragment.newInstance(identity), null)
                 .commit()
 
     }
@@ -47,13 +70,13 @@ class ImportActivity : BaseActivity(), SelectImportMethod, DialogInterface {
         if (info.enumType == CollectionInfo.Type.CALENDAR) {
             supportFragmentManager.beginTransaction()
                     .replace(android.R.id.content,
-                            LocalCalendarImportFragment.newInstance(account, info.uid!!))
+                            LocalCalendarImportFragment.newInstance(identity))
                     .addToBackStack(LocalCalendarImportFragment::class.java.name)
                     .commit()
         } else if (info.enumType == CollectionInfo.Type.ADDRESS_BOOK) {
             supportFragmentManager.beginTransaction()
                     .replace(android.R.id.content,
-                            LocalContactImportFragment.newInstance(account, info.uid!!))
+                            LocalContactImportFragment.newInstance(identity))
                     .addToBackStack(LocalContactImportFragment::class.java.name)
                     .commit()
         }
@@ -149,11 +172,16 @@ class ImportActivity : BaseActivity(), SelectImportMethod, DialogInterface {
     companion object {
         val EXTRA_ACCOUNT = "account"
         val EXTRA_COLLECTION_INFO = "collectionInfo"
+        private const val EXTRA_CREATION_ID = "creationId"
 
         fun newIntent(context: Context, account: Account, info: CollectionInfo): Intent {
             val intent = Intent(context, ImportActivity::class.java)
             intent.putExtra(ImportActivity.EXTRA_ACCOUNT, account)
             intent.putExtra(ImportActivity.EXTRA_COLLECTION_INFO, info)
+            intent.putExtra(
+                EXTRA_CREATION_ID,
+                AccountManager.get(context).getUserData(account, AccountSettings.KEY_CREATION_ID)?.takeIf { it.isNotBlank() },
+            )
             return intent
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
@@ -15,7 +15,6 @@ import at.bitfire.vcard4android.BatchOperation
 import at.bitfire.vcard4android.Contact
 import at.bitfire.vcard4android.ContactsStorageException
 import ezvcard.io.CannotParseException
-import io.silentsuite.sync.CachedCollection
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_ADDRESS_BOOK
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_CALENDAR
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_TASKS
@@ -146,6 +145,12 @@ class ImportFragment : DialogFragment() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         when (requestCode) {
             REQUEST_CODE -> {
+                if (!activeProcessWork || CollectionLifecycleIdentity.from(arguments)?.validate(requireContext()) != true) {
+                    activeProcessWork = false
+                    dismissAllowingStateLoss()
+                    super.onActivityResult(requestCode, resultCode, data)
+                    return
+                }
                 if (resultCode == Activity.RESULT_OK) {
                     val uri = data?.data
                     if (uri != null) {
@@ -261,6 +266,8 @@ class ImportFragment : DialogFragment() {
 
                         finishParsingFile(events.size)
 
+                        if (!identity.validate(context))
+                            return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                         val provider = context.contentResolver.acquireContentProviderClient(CalendarContract.CONTENT_URI)
                         if (provider == null) {
                             result.e = Exception("Failed to acquire calendar content provider.")
@@ -286,6 +293,8 @@ class ImportFragment : DialogFragment() {
                             }
 
                             for (event in events) {
+                                if (!identity.validate(context))
+                                    return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                                 try {
                                     var localEvent = localCalendar.findByUid(event.uid!!)
                                     if (localEvent != null) {
@@ -318,6 +327,8 @@ class ImportFragment : DialogFragment() {
 
                         finishParsingFile(tasks.size)
 
+                        if (!identity.validate(context))
+                            return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                         val providerName = TaskProviderHandling.getWantedTaskSyncProvider(context)
                         if (providerName == null) {
                             result.e = Exception("Failed to acquire tasks content provider.")
@@ -345,6 +356,8 @@ class ImportFragment : DialogFragment() {
                             }
 
                             for (task in tasks) {
+                                if (!identity.validate(context))
+                                    return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                                 try {
                                     var localTask = localTaskList.findByUid(task.uid!!)
                                     if (localTask != null) {
@@ -381,6 +394,8 @@ class ImportFragment : DialogFragment() {
 
                         finishParsingFile(contacts.size)
 
+                        if (!identity.validate(context))
+                            return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                         val provider = context.contentResolver.acquireContentProviderClient(ContactsContract.RawContacts.CONTENT_URI)
                         if (provider == null) {
                             result.e = Exception("Failed to acquire contacts content provider.")
@@ -395,6 +410,8 @@ class ImportFragment : DialogFragment() {
                             }
 
                             for (contact in contacts.filter { contact -> !contact.group }) {
+                                if (!identity.validate(context))
+                                    return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                                 try {
                                     var localContact = localAddressBook.findByUid(contact.uid!!) as LocalContact?
                                     var addedContact = false
@@ -412,8 +429,12 @@ class ImportFragment : DialogFragment() {
                                     // Apply categories
                                     val batch = BatchOperation(localAddressBook.provider!!)
                                     for (category in contact.categories) {
+                                        if (!identity.validate(context))
+                                            return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                                         localContact.addToGroup(batch, localAddressBook.findOrCreateGroup(category))
                                     }
+                                    if (!identity.validate(context))
+                                        return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                                     batch.commit()
 
                                     if (addedContact)
@@ -429,6 +450,8 @@ class ImportFragment : DialogFragment() {
                             }
 
                             for (contact in contacts.filter { contact -> contact.group }) {
+                                if (!identity.validate(context))
+                                    return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                                 try {
                                     val memberIds = contact.members.mapNotNull { memberUid ->
                                         uidToLocalId[memberUid]
@@ -501,43 +524,10 @@ class ImportFragment : DialogFragment() {
 
         private val TAG_PROGRESS_MAX = "progressMax"
 
-        fun newInstance(account: Account, info: CollectionInfo): ImportFragment {
-            val uid = requireNotNull(info.uid) { "Import requires a collection UID" }
-            val type = requireNotNull(info.enumType) { "Import requires a collection type" }.toEtebaseType()
-            return ImportFragment().apply {
-                arguments = Bundle().apply {
-                    putParcelable(CollectionLifecycleIdentity.ARG_ACCOUNT, account)
-                    putString(CollectionLifecycleIdentity.ARG_COLLECTION_UID, uid)
-                    putString(CollectionLifecycleIdentity.ARG_COLLECTION_TYPE, type)
-                }
-            }
-        }
-
-        fun newInstance(account: Account, cachedCollection: CachedCollection): ImportFragment {
-            when (cachedCollection.collectionType) {
-                ETEBASE_TYPE_CALENDAR -> CollectionInfo.Type.CALENDAR
-                ETEBASE_TYPE_TASKS -> CollectionInfo.Type.TASKS
-                ETEBASE_TYPE_ADDRESS_BOOK -> CollectionInfo.Type.ADDRESS_BOOK
-                else -> throw Exception("Got unsupported collection type")
-            }
-            return ImportFragment().apply {
-                arguments = Bundle().apply {
-                    putParcelable(CollectionLifecycleIdentity.ARG_ACCOUNT, account)
-                    putString(CollectionLifecycleIdentity.ARG_COLLECTION_UID, cachedCollection.col.uid)
-                    putString(CollectionLifecycleIdentity.ARG_COLLECTION_TYPE, cachedCollection.collectionType)
-                }
-            }
-        }
-
         fun newInstance(identity: CollectionLifecycleIdentity) = ImportFragment().apply {
             requireNotNull(identity.collectionUid) { "Import requires an existing collection" }
             arguments = identity.toBundle()
         }
 
-        private fun CollectionInfo.Type.toEtebaseType() = when (this) {
-            CollectionInfo.Type.CALENDAR -> ETEBASE_TYPE_CALENDAR
-            CollectionInfo.Type.TASKS -> ETEBASE_TYPE_TASKS
-            CollectionInfo.Type.ADDRESS_BOOK -> ETEBASE_TYPE_ADDRESS_BOOK
-        }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
@@ -245,8 +245,10 @@ class ImportFragment : DialogFragment() {
             try {
                 val context = requireContext()
                 val identity = CollectionLifecycleIdentity.from(arguments)
-                if (identity == null || !identity.validate(context))
+                if (identity == null || !identity.validate(context)) {
+                    closeSelectedInput()
                     return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
+                }
                 val importReader = InputStreamReader(
                         inputStream ?: throw FileNotFoundException("Failed to open selected file."),
                         StandardCharsets.UTF_8
@@ -509,6 +511,14 @@ class ImportFragment : DialogFragment() {
                 return result
             }
 
+        }
+    }
+
+    private fun closeSelectedInput() {
+        try {
+            inputStream?.close()
+        } finally {
+            inputStream = null
         }
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/ImportFragment.kt
@@ -25,6 +25,7 @@ import io.silentsuite.sync.model.CollectionInfo
 import io.silentsuite.sync.resource.*
 import io.silentsuite.sync.syncadapter.ContactsSyncManager
 import io.silentsuite.sync.ui.Refreshable
+import io.silentsuite.sync.ui.etebase.CollectionLifecycleIdentity
 import io.silentsuite.sync.ui.importlocal.ResultFragment.ImportResult
 import io.silentsuite.sync.utils.ProgressDialogHelper
 import io.silentsuite.sync.utils.TaskProviderHandling
@@ -41,9 +42,25 @@ class ImportFragment : DialogFragment() {
     private lateinit var enumType: CollectionInfo.Type
 
     private var inputStream: InputStream? = null
+    // Process-only: a process-restored fragment cancels instead of replaying chooser/import work.
+    private var activeProcessWork = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        val type = when (identity?.collectionType) {
+            ETEBASE_TYPE_CALENDAR -> CollectionInfo.Type.CALENDAR
+            ETEBASE_TYPE_TASKS -> CollectionInfo.Type.TASKS
+            ETEBASE_TYPE_ADDRESS_BOOK -> CollectionInfo.Type.ADDRESS_BOOK
+            else -> null
+        }
+        if (identity?.collectionUid == null || type == null || !identity.validate(requireContext())) {
+            dismissAllowingStateLoss()
+            return
+        }
+        account = identity.account
+        uid = identity.collectionUid
+        enumType = type
         isCancelable = false
         retainInstance = true
     }
@@ -60,7 +77,10 @@ class ImportFragment : DialogFragment() {
         )
 
         if (savedInstanceState == null) {
+            activeProcessWork = true
             chooseFile()
+        } else if (!activeProcessWork) {
+            progress.setOnShowListener { dismissAllowingStateLoss() }
         } else {
             progress.setOnShowListener {
                 setDialogAddEntries(progress, savedInstanceState.getInt(TAG_PROGRESS_MAX))
@@ -92,6 +112,11 @@ class ImportFragment : DialogFragment() {
     }
 
     fun chooseFile() {
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        if (identity == null || !identity.validate(requireContext())) {
+            dismissAllowingStateLoss()
+            return
+        }
         val intent = Intent()
         intent.addCategory(Intent.CATEGORY_OPENABLE)
         intent.action = Intent.ACTION_GET_CONTENT
@@ -107,6 +132,7 @@ class ImportFragment : DialogFragment() {
         try {
             startActivityForResult(chooser, REQUEST_CODE)
         } catch (e: ActivityNotFoundException) {
+            activeProcessWork = false
             val data = ImportResult()
             data.e = Exception("Failed to open file chooser.\nPlease install one.")
 
@@ -121,15 +147,16 @@ class ImportFragment : DialogFragment() {
         when (requestCode) {
             REQUEST_CODE -> {
                 if (resultCode == Activity.RESULT_OK) {
-                    if (data != null) {
+                    val uri = data?.data
+                    if (uri != null) {
                         // Get the URI of the selected file
-                        val uri = data.data!!
                         Logger.log.info("Starting import from selected file")
                         try {
                             inputStream = requireActivity().contentResolver.openInputStream(uri)
 
                             Thread(ImportEntriesLoader()).start()
                         } catch (e: Exception) {
+                            activeProcessWork = false
                             Logger.log.severe("File select error: ${e.javaClass.name}")
 
                             val importResult = ImportResult()
@@ -139,9 +166,12 @@ class ImportFragment : DialogFragment() {
 
                             dismissAllowingStateLoss()
                         }
-
+                    } else {
+                        activeProcessWork = false
+                        dismissAllowingStateLoss()
                     }
                 } else {
+                    activeProcessWork = false
                     dismissAllowingStateLoss()
                 }
             }
@@ -150,6 +180,7 @@ class ImportFragment : DialogFragment() {
     }
 
     fun loadFinished(data: ImportResult) {
+        activeProcessWork = false
         onImportResult(data)
 
         Logger.log.info("Finished import")
@@ -208,6 +239,9 @@ class ImportFragment : DialogFragment() {
 
             try {
                 val context = requireContext()
+                val identity = CollectionLifecycleIdentity.from(arguments)
+                if (identity == null || !identity.validate(context))
+                    return safeFailureResult(R.string.import_dialog_failed_generic, "The account route is no longer valid.")
                 val importReader = InputStreamReader(
                         inputStream ?: throw FileNotFoundException("Failed to open selected file."),
                         StandardCharsets.UTF_8
@@ -468,25 +502,42 @@ class ImportFragment : DialogFragment() {
         private val TAG_PROGRESS_MAX = "progressMax"
 
         fun newInstance(account: Account, info: CollectionInfo): ImportFragment {
-            val ret = ImportFragment()
-            ret.account = account
-            ret.uid = info.uid!!
-            ret.enumType = info.enumType!!
-            return ret
+            val uid = requireNotNull(info.uid) { "Import requires a collection UID" }
+            val type = requireNotNull(info.enumType) { "Import requires a collection type" }.toEtebaseType()
+            return ImportFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelable(CollectionLifecycleIdentity.ARG_ACCOUNT, account)
+                    putString(CollectionLifecycleIdentity.ARG_COLLECTION_UID, uid)
+                    putString(CollectionLifecycleIdentity.ARG_COLLECTION_TYPE, type)
+                }
+            }
         }
 
         fun newInstance(account: Account, cachedCollection: CachedCollection): ImportFragment {
-            val enumType = when (cachedCollection.collectionType) {
+            when (cachedCollection.collectionType) {
                 ETEBASE_TYPE_CALENDAR -> CollectionInfo.Type.CALENDAR
                 ETEBASE_TYPE_TASKS -> CollectionInfo.Type.TASKS
                 ETEBASE_TYPE_ADDRESS_BOOK -> CollectionInfo.Type.ADDRESS_BOOK
                 else -> throw Exception("Got unsupported collection type")
             }
-            val ret = ImportFragment()
-            ret.account = account
-            ret.uid = cachedCollection.col.uid
-            ret.enumType = enumType
-            return ret
+            return ImportFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelable(CollectionLifecycleIdentity.ARG_ACCOUNT, account)
+                    putString(CollectionLifecycleIdentity.ARG_COLLECTION_UID, cachedCollection.col.uid)
+                    putString(CollectionLifecycleIdentity.ARG_COLLECTION_TYPE, cachedCollection.collectionType)
+                }
+            }
+        }
+
+        fun newInstance(identity: CollectionLifecycleIdentity) = ImportFragment().apply {
+            requireNotNull(identity.collectionUid) { "Import requires an existing collection" }
+            arguments = identity.toBundle()
+        }
+
+        private fun CollectionInfo.Type.toEtebaseType() = when (this) {
+            CollectionInfo.Type.CALENDAR -> ETEBASE_TYPE_CALENDAR
+            CollectionInfo.Type.TASKS -> ETEBASE_TYPE_TASKS
+            CollectionInfo.Type.ADDRESS_BOOK -> ETEBASE_TYPE_ADDRESS_BOOK
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/LocalCalendarImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/LocalCalendarImportFragment.kt
@@ -17,11 +17,13 @@ import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
 import at.bitfire.ical4android.CalendarStorageException
 import io.silentsuite.sync.R
+import io.silentsuite.sync.Constants
 import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.model.CollectionInfo
 import io.silentsuite.sync.resource.LocalCalendar
 import io.silentsuite.sync.resource.LocalEvent
 import io.silentsuite.sync.utils.ProgressDialogHelper
+import io.silentsuite.sync.ui.etebase.CollectionLifecycleIdentity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -30,9 +32,18 @@ import kotlinx.coroutines.withContext
 class LocalCalendarImportFragment : ListFragment() {
     private lateinit var account: Account
     private lateinit var uid: String
+    private var importInProgress = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        if (identity?.collectionUid == null || !identity.validate(requireContext()) ||
+            identity.collectionType !in setOf(Constants.ETEBASE_TYPE_CALENDAR, Constants.ETEBASE_TYPE_TASKS)) {
+            requireActivity().finish()
+            return
+        }
+        account = identity.account
+        uid = identity.collectionUid
         retainInstance = true
     }
 
@@ -167,6 +178,13 @@ class LocalCalendarImportFragment : ListFragment() {
     }
 
     private fun importEvents(fromCalendar: LocalCalendar) {
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        if (identity == null || !identity.validate(requireContext())) {
+            requireActivity().finish()
+            return
+        }
+        if (importInProgress) return
+        importInProgress = true
         val progressDialog = ProgressDialogHelper.createHorizontal(
             requireContext(),
             R.string.import_dialog_title,
@@ -176,8 +194,10 @@ class LocalCalendarImportFragment : ListFragment() {
         progressDialog.show()
 
         lifecycleScope.launch {
-            val result = withContext(Dispatchers.IO) {
-                doImportEvents(fromCalendar, progressDialog)
+            val result = try {
+                withContext(Dispatchers.IO) { doImportEvents(fromCalendar, progressDialog) }
+            } finally {
+                importInProgress = false
             }
 
             val currentActivity = activity
@@ -248,11 +268,18 @@ class LocalCalendarImportFragment : ListFragment() {
 
     companion object {
 
-        fun newInstance(account: Account, uid: String): LocalCalendarImportFragment {
-            val ret = LocalCalendarImportFragment()
-            ret.account = account
-            ret.uid = uid
-            return ret
+        fun newInstance(identity: CollectionLifecycleIdentity) =
+            LocalCalendarImportFragment().apply {
+                requireNotNull(identity.collectionUid)
+                arguments = identity.toBundle()
+            }
+
+        fun newInstance(account: Account, uid: String) = LocalCalendarImportFragment().apply {
+            arguments = Bundle().apply {
+                putParcelable(CollectionLifecycleIdentity.ARG_ACCOUNT, account)
+                putString(CollectionLifecycleIdentity.ARG_COLLECTION_UID, uid)
+                putString(CollectionLifecycleIdentity.ARG_COLLECTION_TYPE, Constants.ETEBASE_TYPE_CALENDAR)
+            }
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/LocalCalendarImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/LocalCalendarImportFragment.kt
@@ -192,10 +192,11 @@ class LocalCalendarImportFragment : ListFragment() {
             iconRes = R.drawable.ic_import_export_black
         )
         progressDialog.show()
+        val applicationContext = requireContext().applicationContext
 
         lifecycleScope.launch {
             val result = try {
-                withContext(Dispatchers.IO) { doImportEvents(fromCalendar, progressDialog) }
+                withContext(Dispatchers.IO) { doImportEvents(fromCalendar, progressDialog, identity, applicationContext) }
             } finally {
                 importInProgress = false
             }
@@ -213,23 +214,30 @@ class LocalCalendarImportFragment : ListFragment() {
         }
     }
 
-    private fun doImportEvents(fromCalendar: LocalCalendar, progressDialog: Dialog): ResultFragment.ImportResult {
+    private fun doImportEvents(
+        fromCalendar: LocalCalendar,
+        progressDialog: Dialog,
+        identity: CollectionLifecycleIdentity,
+        applicationContext: Context,
+    ): ResultFragment.ImportResult {
         val result = ResultFragment.ImportResult()
         try {
-            val localCalendar = LocalCalendar.findByName(account,
-                    requireContext().contentResolver.acquireContentProviderClient(CalendarContract.CONTENT_URI)!!,
-                    LocalCalendar.Factory, uid)
             val localEvents = fromCalendar.findAll()
+            if (!identity.validate(applicationContext)) return staleImportResult()
+            val provider = applicationContext.contentResolver.acquireContentProviderClient(CalendarContract.CONTENT_URI)
+                ?: throw Exception("Could not acquire calendar provider")
+            try {
+                val localCalendar = LocalCalendar.findByName(account, provider, LocalCalendar.Factory, uid)
+                    ?: throw Exception("Could not find calendar")
             val total = localEvents.size
             val progressBar = ProgressDialogHelper.getProgressBar(progressDialog)
             activity?.runOnUiThread { progressBar.max = total }
             result.total = total.toLong()
             var progress = 0
             for (currentLocalEvent in localEvents) {
+                if (!identity.validate(applicationContext)) return staleImportResult()
                 val event = currentLocalEvent.event
                 try {
-                    localCalendar!!
-
                     var localEvent = if (event == null || event.uid == null)
                         null
                     else
@@ -251,12 +259,19 @@ class LocalCalendarImportFragment : ListFragment() {
                 val currentProgress = ++progress
                 activity?.runOnUiThread { progressBar.progress = currentProgress }
             }
+            } finally {
+                provider.release()
+            }
         } catch (e: Exception) {
             e.printStackTrace()
             result.e = e
         }
 
         return result
+    }
+
+    private fun staleImportResult() = ResultFragment.ImportResult().apply {
+        e = Exception("The account route is no longer valid.")
     }
 
     fun onImportResult(importResult: ResultFragment.ImportResult) {
@@ -274,12 +289,5 @@ class LocalCalendarImportFragment : ListFragment() {
                 arguments = identity.toBundle()
             }
 
-        fun newInstance(account: Account, uid: String) = LocalCalendarImportFragment().apply {
-            arguments = Bundle().apply {
-                putParcelable(CollectionLifecycleIdentity.ARG_ACCOUNT, account)
-                putString(CollectionLifecycleIdentity.ARG_COLLECTION_UID, uid)
-                putString(CollectionLifecycleIdentity.ARG_COLLECTION_TYPE, Constants.ETEBASE_TYPE_CALENDAR)
-            }
-        }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/LocalContactImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/LocalContactImportFragment.kt
@@ -23,12 +23,14 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import at.bitfire.vcard4android.ContactsStorageException
 import io.silentsuite.sync.R
+import io.silentsuite.sync.Constants
 import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.model.CollectionInfo
 import io.silentsuite.sync.resource.LocalAddressBook
 import io.silentsuite.sync.resource.LocalContact
 import io.silentsuite.sync.resource.LocalGroup
 import io.silentsuite.sync.utils.ProgressDialogHelper
+import io.silentsuite.sync.ui.etebase.CollectionLifecycleIdentity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -38,11 +40,20 @@ import java.util.*
 class LocalContactImportFragment : Fragment() {
     private lateinit var account: Account
     private lateinit var uid: String
+    private var importInProgress = false
 
     private var recyclerView: RecyclerView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        if (identity?.collectionUid == null || !identity.validate(requireContext()) ||
+            identity.collectionType != Constants.ETEBASE_TYPE_ADDRESS_BOOK) {
+            requireActivity().finish()
+            return
+        }
+        account = identity.account
+        uid = identity.collectionUid
         retainInstance = true
     }
 
@@ -102,6 +113,13 @@ class LocalContactImportFragment : Fragment() {
     }
 
     private fun importContacts(localAddressBook: LocalAddressBook) {
+        val identity = CollectionLifecycleIdentity.from(arguments)
+        if (identity == null || !identity.validate(requireContext())) {
+            requireActivity().finish()
+            return
+        }
+        if (importInProgress) return
+        importInProgress = true
         val progressDialog = ProgressDialogHelper.createHorizontal(
             requireContext(),
             R.string.import_dialog_title,
@@ -111,8 +129,10 @@ class LocalContactImportFragment : Fragment() {
         progressDialog.show()
 
         lifecycleScope.launch {
-            val result = withContext(Dispatchers.IO) {
-                doImportContacts(localAddressBook, progressDialog)
+            val result = try {
+                withContext(Dispatchers.IO) { doImportContacts(localAddressBook, progressDialog) }
+            } finally {
+                importInProgress = false
             }
 
             val currentActivity = activity
@@ -316,11 +336,17 @@ class LocalContactImportFragment : Fragment() {
 
     companion object {
 
-        fun newInstance(account: Account, uid: String): LocalContactImportFragment {
-            val ret = LocalContactImportFragment()
-            ret.account = account
-            ret.uid = uid
-            return ret
+        fun newInstance(identity: CollectionLifecycleIdentity) = LocalContactImportFragment().apply {
+            requireNotNull(identity.collectionUid)
+            arguments = identity.toBundle()
+        }
+
+        fun newInstance(account: Account, uid: String) = LocalContactImportFragment().apply {
+            arguments = Bundle().apply {
+                putParcelable(CollectionLifecycleIdentity.ARG_ACCOUNT, account)
+                putString(CollectionLifecycleIdentity.ARG_COLLECTION_UID, uid)
+                putString(CollectionLifecycleIdentity.ARG_COLLECTION_TYPE, Constants.ETEBASE_TYPE_ADDRESS_BOOK)
+            }
         }
     }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/LocalContactImportFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/importlocal/LocalContactImportFragment.kt
@@ -127,10 +127,11 @@ class LocalContactImportFragment : Fragment() {
             iconRes = R.drawable.ic_import_export_black
         )
         progressDialog.show()
+        val applicationContext = requireContext().applicationContext
 
         lifecycleScope.launch {
             val result = try {
-                withContext(Dispatchers.IO) { doImportContacts(localAddressBook, progressDialog) }
+                withContext(Dispatchers.IO) { doImportContacts(localAddressBook, progressDialog, identity, applicationContext) }
             } finally {
                 importInProgress = false
             }
@@ -148,15 +149,22 @@ class LocalContactImportFragment : Fragment() {
         }
     }
 
-    private fun doImportContacts(localAddressBook: LocalAddressBook, progressDialog: Dialog): ResultFragment.ImportResult {
+    private fun doImportContacts(
+        localAddressBook: LocalAddressBook,
+        progressDialog: Dialog,
+        identity: CollectionLifecycleIdentity,
+        applicationContext: Context,
+    ): ResultFragment.ImportResult {
         val result = ResultFragment.ImportResult()
         try {
-            val addressBook = LocalAddressBook.findByUid(requireContext(),
-                    requireContext().contentResolver.acquireContentProviderClient(ContactsContract.RawContacts.CONTENT_URI)!!,
-                    account, uid)
-                    ?: throw Exception("Could not find address book")
             val localContacts = localAddressBook.findAllContacts()
             val localGroups = localAddressBook.findAllGroups()
+            if (!identity.validate(applicationContext)) return staleImportResult()
+            val provider = applicationContext.contentResolver.acquireContentProviderClient(ContactsContract.RawContacts.CONTENT_URI)
+                ?: throw Exception("Could not acquire contacts provider")
+            try {
+                val addressBook = LocalAddressBook.findByUid(applicationContext, provider, account, uid)
+                    ?: throw Exception("Could not find address book")
             val oldIdToNewId = HashMap<Long, Long>()
             val total = localContacts.size + localGroups.size
             val progressBar = ProgressDialogHelper.getProgressBar(progressDialog)
@@ -164,6 +172,7 @@ class LocalContactImportFragment : Fragment() {
             result.total = total.toLong()
             var progress = 0
             for (currentLocalContact in localContacts) {
+                if (!identity.validate(applicationContext)) return staleImportResult()
                 val contact = currentLocalContact.contact
 
                 try {
@@ -192,6 +201,7 @@ class LocalContactImportFragment : Fragment() {
                 activity?.runOnUiThread { progressBar.progress = currentProgress }
             }
             for (currentLocalGroup in localGroups) {
+                if (!identity.validate(applicationContext)) return staleImportResult()
                 val group = currentLocalGroup.contact
 
                 try {
@@ -221,11 +231,18 @@ class LocalContactImportFragment : Fragment() {
                 val currentProgress = ++progress
                 activity?.runOnUiThread { progressBar.progress = currentProgress }
             }
+            } finally {
+                provider.release()
+            }
         } catch (e: Exception) {
             result.e = e
         }
 
         return result
+    }
+
+    private fun staleImportResult() = ResultFragment.ImportResult().apply {
+        e = Exception("The account route is no longer valid.")
     }
 
     fun onImportResult(importResult: ResultFragment.ImportResult) {
@@ -341,12 +358,5 @@ class LocalContactImportFragment : Fragment() {
             arguments = identity.toBundle()
         }
 
-        fun newInstance(account: Account, uid: String) = LocalContactImportFragment().apply {
-            arguments = Bundle().apply {
-                putParcelable(CollectionLifecycleIdentity.ARG_ACCOUNT, account)
-                putString(CollectionLifecycleIdentity.ARG_COLLECTION_UID, uid)
-                putString(CollectionLifecycleIdentity.ARG_COLLECTION_TYPE, Constants.ETEBASE_TYPE_ADDRESS_BOOK)
-            }
-        }
     }
 }

--- a/android/app/src/test/java/io/silentsuite/sync/ui/etebase/CollectionLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/etebase/CollectionLifecycleContractTest.kt
@@ -32,6 +32,7 @@ class CollectionLifecycleContractTest {
     @Test
     fun everyActiveFragmentRestoresExactNonSecretIdentityFromArguments() {
         val activity = File(etebase, "CollectionActivity.kt").readText()
+        val importActivity = File(imports, "ImportActivity.kt").readText()
         val identity = File(etebase, "CollectionLifecycleIdentity.kt").readText()
         val sources = listOf(
             File(etebase, "ViewCollectionFragment.kt"),
@@ -53,6 +54,11 @@ class CollectionLifecycleContractTest {
         assertTrue(activity.contains("ExactAccountRouting.validate(route.account, route.creationId"))
         assertTrue(activity.contains("private data class CollectionRoute"))
         assertFalse(activity.contains("provisional"))
+        assertTrue(importActivity.contains("EXTRA_CREATION_ID"))
+        assertTrue(importActivity.contains("CollectionLifecycleIdentity.existing"))
+        assertTrue(importActivity.contains("ImportFragment.newInstance(identity)"))
+        assertTrue(importActivity.contains("LocalCalendarImportFragment.newInstance(identity)"))
+        assertTrue(importActivity.contains("LocalContactImportFragment.newInstance(identity)"))
         sources.forEach { source ->
             assertTrue(source.contains("CollectionLifecycleIdentity.from(arguments)"))
             assertTrue(source.contains("identity.validate(requireContext())"))
@@ -80,11 +86,17 @@ class CollectionLifecycleContractTest {
         assertTrue(members.contains("MemberActionViewModel by activityViewModels()"))
         assertTrue(members.contains("ARG_ACTION_TOKEN"))
         assertTrue(members.contains("identity.validate(applicationContext)"))
+        assertTrue(members.split("identity.validate(applicationContext)").size - 1 >= 3)
         assertTrue(edit.contains("LoadingViewModel by activityViewModels()"))
         assertTrue(edit.contains("if (loadingModel.isLoading) return"))
+        assertTrue(edit.split("identity.validate(applicationContext)").size - 1 >= 2)
         assertTrue(fileImport.contains("if (savedInstanceState == null)"))
+        assertTrue(fileImport.contains("if (!activeProcessWork ||"))
+        assertTrue(fileImport.split("identity.validate(context)").size - 1 >= 8)
         assertTrue(calendarImport.contains("if (importInProgress) return"))
+        assertTrue(calendarImport.split("identity.validate(applicationContext)").size - 1 >= 2)
         assertTrue(contactImport.contains("if (importInProgress) return"))
+        assertTrue(contactImport.split("identity.validate(applicationContext)").size - 1 >= 3)
         val view = File(etebase, "ViewCollectionFragment.kt").readText()
         val export = view.substringAfter("private fun createExportDocument")
         assertTrue(export.contains("identity.validate(applicationContext)"))

--- a/android/app/src/test/java/io/silentsuite/sync/ui/etebase/CollectionLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/etebase/CollectionLifecycleContractTest.kt
@@ -93,6 +93,8 @@ class CollectionLifecycleContractTest {
         assertTrue(fileImport.contains("if (savedInstanceState == null)"))
         assertTrue(fileImport.contains("if (!activeProcessWork ||"))
         assertTrue(fileImport.split("identity.validate(context)").size - 1 >= 8)
+        assertTrue(fileImport.contains("closeSelectedInput()"))
+        assertTrue(fileImport.contains("inputStream?.close()"))
         assertTrue(calendarImport.contains("if (importInProgress) return"))
         assertTrue(calendarImport.split("identity.validate(applicationContext)").size - 1 >= 2)
         assertTrue(contactImport.contains("if (importInProgress) return"))

--- a/android/app/src/test/java/io/silentsuite/sync/ui/etebase/CollectionLifecycleContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/etebase/CollectionLifecycleContractTest.kt
@@ -1,0 +1,92 @@
+package io.silentsuite.sync.ui.etebase
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class CollectionLifecycleContractTest {
+    private val etebase = File("src/main/java/io/silentsuite/sync/ui/etebase")
+    private val imports = File("src/main/java/io/silentsuite/sync/ui/importlocal")
+
+    @Test
+    fun activityReinitializesModelsWhileRestoredFragmentsReattachViewObservers() {
+        val activity = File(etebase, "CollectionActivity.kt").readText()
+        val view = File(etebase, "ViewCollectionFragment.kt").readText()
+        val members = File(etebase, "CollectionMembersFragment.kt").readText()
+        val edit = File(etebase, "EditCollectionFragment.kt").readText()
+
+        val initialization = activity.substringAfter("setContentView(R.layout.etebase_fragment_activity)")
+            .substringBefore("supportActionBar?.setDisplayHomeAsUpEnabled")
+        assertTrue(initialization.contains("model.loadAccount(this, account)"))
+        assertTrue(initialization.contains("findFragmentById(R.id.fragment_container)"))
+        assertTrue(initialization.contains("!hasRestoredFragment"))
+        listOf(view, members, edit).forEach { source ->
+            assertTrue(source.contains("override fun onViewCreated"))
+            assertTrue(source.contains("observe(viewLifecycleOwner)"))
+        }
+        assertTrue(view.contains("itemsModel.observe(viewLifecycleOwner)"))
+        assertFalse(view.contains("itemsModel.observe(this)"))
+    }
+
+    @Test
+    fun everyActiveFragmentRestoresExactNonSecretIdentityFromArguments() {
+        val activity = File(etebase, "CollectionActivity.kt").readText()
+        val identity = File(etebase, "CollectionLifecycleIdentity.kt").readText()
+        val sources = listOf(
+            File(etebase, "ViewCollectionFragment.kt"),
+            File(etebase, "CollectionMembersFragment.kt"),
+            File(etebase, "EditCollectionFragment.kt"),
+            File(imports, "ImportFragment.kt"),
+            File(imports, "LocalCalendarImportFragment.kt"),
+            File(imports, "LocalContactImportFragment.kt")
+        ).map { it.readText() }
+
+        assertTrue(identity.contains("ARG_ACCOUNT"))
+        assertTrue(identity.contains("ARG_CREATION_ID"))
+        assertTrue(identity.contains("ARG_COLLECTION_UID"))
+        assertTrue(identity.contains("ARG_COLLECTION_TYPE"))
+        assertTrue(identity.contains("creationId.isNotBlank()"))
+        assertTrue(identity.contains("ExactAccountRouting.validate"))
+        assertTrue(activity.contains("EXTRA_CREATION_ID"))
+        assertTrue(activity.contains("AccountSettings.KEY_CREATION_ID"))
+        assertTrue(activity.contains("ExactAccountRouting.validate(route.account, route.creationId"))
+        assertTrue(activity.contains("private data class CollectionRoute"))
+        assertFalse(activity.contains("provisional"))
+        sources.forEach { source ->
+            assertTrue(source.contains("CollectionLifecycleIdentity.from(arguments)"))
+            assertTrue(source.contains("identity.validate(requireContext())"))
+        }
+        listOf("password", "session", "content", "inputStream").forEach { forbidden ->
+            assertFalse(identity.contains("putString($forbidden", ignoreCase = true))
+        }
+    }
+
+    @Test
+    fun plaintextDraftsAndMemberActionsNeverEnterSavedState() {
+        val members = File(etebase, "CollectionMembersFragment.kt").readText()
+        val edit = File(etebase, "EditCollectionFragment.kt").readText()
+        val fileImport = File(imports, "ImportFragment.kt").readText()
+        val calendarImport = File(imports, "LocalCalendarImportFragment.kt").readText()
+        val contactImport = File(imports, "LocalContactImportFragment.kt").readText()
+
+        assertFalse(edit.contains("STATE_NAME"))
+        assertFalse(edit.contains("STATE_DESCRIPTION"))
+        assertFalse(members.contains("ARG_USERNAME"))
+        assertFalse(edit.contains("outState.putString"))
+        assertFalse(members.contains("putString(ARG_USERNAME"))
+        assertTrue(edit.contains("CollectionDraftViewModel by viewModels()"))
+        assertTrue(edit.contains("isSaveEnabled = false"))
+        assertTrue(members.contains("MemberActionViewModel by activityViewModels()"))
+        assertTrue(members.contains("ARG_ACTION_TOKEN"))
+        assertTrue(members.contains("identity.validate(applicationContext)"))
+        assertTrue(edit.contains("LoadingViewModel by activityViewModels()"))
+        assertTrue(edit.contains("if (loadingModel.isLoading) return"))
+        assertTrue(fileImport.contains("if (savedInstanceState == null)"))
+        assertTrue(calendarImport.contains("if (importInProgress) return"))
+        assertTrue(contactImport.contains("if (importInProgress) return"))
+        val view = File(etebase, "ViewCollectionFragment.kt").readText()
+        val export = view.substringAfter("private fun createExportDocument")
+        assertTrue(export.contains("identity.validate(applicationContext)"))
+    }
+}


### PR DESCRIPTION
## Summary

- preserve exact account creation generation, collection UID, and type across active collection/import recreation
- restore activity models and fragment observers without duplicate initial fragments or stale view observers
- keep collection drafts and member actions process-only, with no plaintext saved-state persistence
- prevent duplicate create/edit/delete/leave/invite/import actions and revalidate exact generation at remote/export mutation boundaries
- fail closed on stale same-name account replacement and process-restored chooser/member work

## Scope

This is the independent Slice 13A lifecycle foundation for active collection and import surfaces. Final cross-surface accessibility/navigation integration remains in the later Slice 13 lane.

## Review

Substantive GPT-5.6 Sol review: GREEN after resolving recreation, observer ownership, export-generation, and Add Member mutation-boundary findings.

## Verification

- `git diff --check`
- static exact-generation and plaintext-persistence scans
- reviewed patch digest preserved exactly across rebase onto `dev` `6439d6b`
- no local Gradle, Android, emulator, ADB, lint, or Python execution; Android verification is CI-only