### PR TITLE
feat(android): record truthful sync outcomes

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -259,7 +259,7 @@ jobs:
           target: google_apis
           emulator-options: -no-window -no-audio -no-boot-anim -camera-back none -gpu swiftshader_indirect
           disable-animations: true
-          script: cd android && ./gradlew app:connectedDebugAndroidTest --no-daemon -PrequireEtebase16Kb=true -Pandroid.testInstrumentationRunnerArguments.class=io.silentsuite.sync.ui.AccountActivityRecreationTest,io.silentsuite.sync.ui.PostLoginSetupRuntimeTest,io.silentsuite.sync.ui.setup.AuthenticatorLifecycleRuntimeTest,io.silentsuite.sync.utils.TaskProviderHandlingRuntimeTest
+          script: cd android && ./gradlew app:connectedDebugAndroidTest --no-daemon -PrequireEtebase16Kb=true -Pandroid.testInstrumentationRunnerArguments.class=io.silentsuite.sync.ui.AccountActivityRecreationTest,io.silentsuite.sync.ui.PostLoginSetupRuntimeTest,io.silentsuite.sync.ui.setup.AuthenticatorLifecycleRuntimeTest,io.silentsuite.sync.utils.TaskProviderHandlingRuntimeTest,io.silentsuite.sync.syncadapter.SyncStatusRuntimeTest
 
       - name: Upload focused androidTest reports and results
         if: always()
@@ -293,6 +293,8 @@ jobs:
             ('io.silentsuite.sync.ui.setup.AuthenticatorLifecycleRuntimeTest','staleLoginActivityRestorationUsesObsoletePathBeforeController'),
             ('io.silentsuite.sync.ui.setup.AuthenticatorLifecycleRuntimeTest','sameProcessRotationPolicyPreservesAuthenticator'),
             ('io.silentsuite.sync.utils.TaskProviderHandlingRuntimeTest','explicitCreatingTargetOnlyReceivesProviderConfiguration'),
+            ('io.silentsuite.sync.syncadapter.SyncStatusRuntimeTest','contactsAttemptExtraRoundTripsAtProviderBoundary'),
+            ('io.silentsuite.sync.syncadapter.SyncStatusRuntimeTest','persistedEvidenceIsExactAccountGenerationScopedAndContainsNoAccountName'),
           }
           seen=[]
           for path in glob.glob('app/build/outputs/androidTest-results/connected/**/*.xml', recursive=True):

--- a/android/app/src/androidTest/java/io/silentsuite/sync/syncadapter/SyncStatusRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/syncadapter/SyncStatusRuntimeTest.kt
@@ -1,0 +1,74 @@
+package io.silentsuite.sync.syncadapter
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.os.Bundle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.silentsuite.sync.AccountSettings
+import io.silentsuite.sync.App
+import io.silentsuite.sync.utils.AndroidCompat
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SyncStatusRuntimeTest {
+    @Test fun contactsAttemptExtraRoundTripsAtProviderBoundary() {
+        val extras = Bundle()
+        putContactsAttempt(extras, "opaque-attempt")
+        assertEquals("opaque-attempt", contactsAttempt(extras))
+    }
+
+    @Test fun persistedEvidenceIsExactAccountGenerationScopedAndContainsNoAccountName() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val manager = AccountManager.get(context)
+        val preferences = context.getSharedPreferences("sync_status_v1", 0)
+        preferences.edit().clear().commit()
+        val first = Account("runtime-first-${System.nanoTime()}@example.invalid", App.accountType)
+        val second = Account("runtime-second-${System.nanoTime()}@example.invalid", App.accountType)
+        check(manager.addAccountExplicitly(first, null, null))
+        check(manager.addAccountExplicitly(second, null, null))
+        check(AccountSettings.writeVerified(manager, first, AccountSettings.KEY_CREATION_ID, "generation-one"))
+        check(AccountSettings.writeVerified(manager, second, AccountSettings.KEY_CREATION_ID, "generation-two"))
+        try {
+            val store = SyncStatusStore(context)
+            store.recordSuccess(first, SyncStatusStore.Service.CALENDAR, 100)
+            store.recordFailure(second, SyncStatusStore.Service.CALENDAR, SyncStatusStore.FailureCategory.PERMISSION, 200)
+
+            assertEquals(100L, store.status(first, SyncStatusStore.Service.CALENDAR).lastSuccessAt)
+            assertNull(store.status(first, SyncStatusStore.Service.CALENDAR).lastFailureAt)
+            assertEquals(SyncStatusStore.FailureCategory.PERMISSION, store.status(second, SyncStatusStore.Service.CALENDAR).lastFailureCategory)
+            val persisted = preferences.all.toString()
+            assertFalse(persisted.contains(first.name))
+            assertFalse(persisted.contains(second.name))
+            assertFalse(persisted.contains("generation-one"))
+            assertFalse(persisted.contains("generation-two"))
+
+            val removedIdentity = store.identity(first)
+            val recordsBeforeRemoval = preferences.all.size
+            AndroidCompat.removeAccount(manager, first)
+            val removalDeadline = android.os.SystemClock.uptimeMillis() + 5000
+            while (manager.getAccountsByType(App.accountType).any { it == first } &&
+                android.os.SystemClock.uptimeMillis() < removalDeadline) {
+                android.os.SystemClock.sleep(25)
+            }
+            assertTrue(manager.getAccountsByType(App.accountType).none { it == first })
+            assertTrue(store.clear(removedIdentity))
+            assertTrue(preferences.all.size < recordsBeforeRemoval)
+            check(manager.addAccountExplicitly(first, null, null))
+            check(AccountSettings.writeVerified(manager, first, AccountSettings.KEY_CREATION_ID, "generation-readded"))
+            assertEquals(SyncStatusStore.Status(), SyncStatusStore(context).status(first, SyncStatusStore.Service.CALENDAR))
+        } finally {
+            AndroidCompat.removeAccount(manager, first)
+            AndroidCompat.removeAccount(manager, second)
+            preferences.edit().clear().commit()
+            val cleanupDeadline = android.os.SystemClock.uptimeMillis() + 5000
+            while (manager.getAccountsByType(App.accountType).any { it == first || it == second } &&
+                android.os.SystemClock.uptimeMillis() < cleanupDeadline) {
+                android.os.SystemClock.sleep(25)
+            }
+            assertTrue(manager.getAccountsByType(App.accountType).none { it == first || it == second })
+        }
+    }
+}

--- a/android/app/src/main/java/io/silentsuite/sync/resource/LocalAddressBook.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/resource/LocalAddressBook.kt
@@ -22,19 +22,26 @@ import at.bitfire.vcard4android.*
 import com.etebase.client.CollectionAccessLevel
 import io.silentsuite.sync.App
 import io.silentsuite.sync.CachedCollection
+import io.silentsuite.sync.R
 import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.model.CollectionInfo
+import io.silentsuite.sync.syncadapter.SyncStatusStore
 
 import java.io.FileNotFoundException
 import java.util.*
 import java.util.logging.Level
 
+internal fun onConfirmedAddressBookRemoval(removed: Boolean, record: () -> Unit) {
+    if (removed) record()
+}
 
 class LocalAddressBook(
         private val context: Context,
         account: Account,
         provider: ContentProviderClient?
 ): AndroidAddressBook<LocalContact, LocalGroup>(account, provider, LocalContact.Factory, LocalGroup.Factory), LocalCollection<LocalAddress> {
+
+    val androidAccount: Account get() = account
 
     companion object {
         val USER_DATA_MAIN_ACCOUNT_TYPE = "real_account_type"
@@ -193,13 +200,29 @@ class LocalAddressBook(
 
     fun delete() {
         val accountManager = AccountManager.get(context)
+        val main = mainAccount
+        val child = account
+        val recordConfirmedRemoval = {
+            val recorded = runCatching { SyncStatusStore(context).recordContactsChildRemoved(main, child) }.getOrDefault(false)
+            if (!recorded) {
+                val extras = Bundle().apply {
+                    putBoolean(ContentResolver.SYNC_EXTRAS_IGNORE_BACKOFF, true)
+                    putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true)
+                }
+                ContentResolver.requestSync(main, context.getString(R.string.address_books_authority), extras)
+            }
+            Unit
+        }
 
         @Suppress("DEPRECATION")
         @TargetApi(Build.VERSION_CODES.LOLLIPOP_MR1)
-        if (Build.VERSION.SDK_INT >= 22)
-            accountManager.removeAccountExplicitly(account)
-        else
-            accountManager.removeAccount(account, null, null)
+        if (Build.VERSION.SDK_INT >= 22) {
+            onConfirmedAddressBookRemoval(accountManager.removeAccountExplicitly(account), recordConfirmedRemoval)
+        } else {
+            accountManager.removeAccount(account, { future ->
+                onConfirmedAddressBookRemoval(runCatching { future.result }.getOrDefault(false), recordConfirmedRemoval)
+            }, null)
+        }
     }
 
     override fun findAll(): List<LocalAddress> =

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/AddressBooksSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/AddressBooksSyncAdapterService.kt
@@ -8,7 +8,6 @@
 package io.silentsuite.sync.syncadapter
 
 import android.accounts.Account
-import android.accounts.AccountManager
 import android.content.*
 import android.os.Bundle
 import android.provider.ContactsContract
@@ -27,17 +26,19 @@ class AddressBooksSyncAdapterService : SyncAdapterService() {
 
 
     private class AddressBooksSyncAdapter(context: Context) : SyncAdapterService.SyncAdapter(context) {
-        override fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
+        override val outcomeService = SyncStatusStore.Service.CONTACTS
+
+        override fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult): Completion {
             val contactsProvider = context.contentResolver.acquireContentProviderClient(ContactsContract.AUTHORITY)
             if (contactsProvider == null) {
                 Logger.log.severe("Couldn't access contacts provider")
                 syncResult.databaseError = true
-                return
+                return Completion.FAILURE
             }
 
             val settings = AccountSettings(context, account)
             if (!extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL) && !checkSyncConditions(settings))
-                return
+                return Completion.SKIPPED
 
             RefreshCollections(
                 account,
@@ -49,17 +50,33 @@ class AddressBooksSyncAdapterService : SyncAdapterService() {
 
             contactsProvider.release()
 
-            val accountManager = AccountManager.get(context)
-            for (addressBookAccount in accountManager.getAccountsByType(App.addressBookAccountType)) {
+            val childAccounts = LocalAddressBook.find(context, null, account).map { it.androidAccount }.toSet()
+            val attemptId = when (val start = SyncStatusStore(context).beginContacts(account, childAccounts)) {
+                is SyncStatusStore.ContactsStart.Started -> start.attemptId
+                SyncStatusStore.ContactsStart.SetupRequired -> return Completion.DISPATCHED
+                SyncStatusStore.ContactsStart.StorageFailure -> {
+                    syncResult.stats.numIoExceptions++
+                    syncResult.delayUntil = maxOf(syncResult.delayUntil, Constants.DEFAULT_RETRY_DELAY)
+                    return Completion.DISPATCHED
+                }
+            }
+            for (addressBookAccount in childAccounts) {
                 Logger.log.log(Level.INFO, "Running sync for address book", addressBookAccount)
                 val syncExtras = Bundle(extras)
                 syncExtras.putBoolean(ContentResolver.SYNC_EXTRAS_IGNORE_SETTINGS, true)
                 syncExtras.putBoolean(ContentResolver.SYNC_EXTRAS_IGNORE_BACKOFF, true)
                 syncExtras.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true)     // run immediately (don't queue)
+                putContactsAttempt(syncExtras, attemptId)
                 ContentResolver.requestSync(addressBookAccount, ContactsContract.AUTHORITY, syncExtras)
             }
 
             Logger.log.info("Address book sync complete")
+            return Completion.DISPATCHED
+        }
+
+        override fun recordFailure(account: Account, extras: Bundle, category: SyncStatusStore.FailureCategory): Boolean {
+            val safeCategory = if (category == SyncStatusStore.FailureCategory.PERMISSION) category else SyncStatusStore.FailureCategory.PARENT_REFRESH
+            return SyncStatusStore(context).failContactsParent(account, safeCategory)
         }
 
         private fun updateLocalAddressBooks(provider: ContentProviderClient, account: Account, settings: AccountSettings) {

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/CalendarsSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/CalendarsSyncAdapterService.kt
@@ -26,10 +26,12 @@ class CalendarsSyncAdapterService : SyncAdapterService() {
 
 
     private class SyncAdapter(context: Context) : SyncAdapterService.SyncAdapter(context) {
-        override fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
+        override val outcomeService = SyncStatusStore.Service.CALENDAR
+
+        override fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult): Completion {
             val settings = AccountSettings(context, account)
             if (!extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL) && !checkSyncConditions(settings))
-                return
+                return Completion.SKIPPED
 
             RefreshCollections(
                 account,
@@ -41,17 +43,26 @@ class CalendarsSyncAdapterService : SyncAdapterService() {
 
             val principal = settings.uri?.toHttpUrlOrNull() ?: run {
                 Logger.log.warning("Calendar sync skipped: no valid URI")
-                return
+                return Completion.SKIPPED
             }
 
+            var providerOutcome = DirectProviderAggregate.NONE
             for (calendar in AndroidCalendar.find(account, provider, LocalCalendar.Factory, CalendarContract.Calendars.SYNC_EVENTS + "!=0", null)) {
                 Logger.log.info("Synchronizing calendar #" + calendar.id)
                 CalendarSyncManager(context, account, settings, extras, authority, syncResult, calendar, principal).use {
-                    it.performSync()
+                    val outcome = it.performSync()
+                    providerOutcome = aggregateDirectProviderOutcome(providerOutcome, outcome)
+                    if (providerOutcome == DirectProviderAggregate.CANCELLED)
+                        return Completion.SKIPPED
                 }
             }
 
             Logger.log.info("Calendar sync complete")
+            return when (providerOutcome) {
+                DirectProviderAggregate.FAILURE -> Completion.FAILURE
+                DirectProviderAggregate.SUCCESS -> Completion.SUCCESS
+                else -> Completion.SKIPPED
+            }
         }
 
         private fun updateLocalCalendars(provider: ContentProviderClient, account: Account, settings: AccountSettings) {

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/ContactsSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/ContactsSyncAdapterService.kt
@@ -19,6 +19,17 @@ import io.silentsuite.sync.log.Logger
 import io.silentsuite.sync.resource.LocalAddressBook
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 
+internal data class ContactsChildTarget(val mainAccount: Account, val attemptId: String)
+
+internal fun contactsChildTarget(mainAccount: Account?, attemptId: String?): ContactsChildTarget? =
+    if (mainAccount == null || attemptId.isNullOrBlank()) null else ContactsChildTarget(mainAccount, attemptId)
+
+internal fun putContactsAttempt(extras: Bundle, attemptId: String) {
+    extras.putString(SyncStatusStore.EXTRA_CONTACTS_ATTEMPT, attemptId)
+}
+
+internal fun contactsAttempt(extras: Bundle): String? = extras.getString(SyncStatusStore.EXTRA_CONTACTS_ATTEMPT)
+
 class ContactsSyncAdapterService : SyncAdapterService() {
 
     override fun syncAdapter(): AbstractThreadedSyncAdapter {
@@ -27,7 +38,7 @@ class ContactsSyncAdapterService : SyncAdapterService() {
 
 
     private class ContactsSyncAdapter(context: Context) : SyncAdapterService.SyncAdapter(context) {
-        override fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
+        override fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult): Completion {
             val addressBook = LocalAddressBook(context, account, provider)
 
             val settings: AccountSettings
@@ -36,28 +47,50 @@ class ContactsSyncAdapterService : SyncAdapterService() {
             } catch (e: InvalidAccountException) {
                 Logger.log.info("Skipping sync due to invalid account.")
                 Logger.log.info("Invalid account: ${e.javaClass.name}")
-                return
+                return Completion.SKIPPED
             } catch (e: ContactsStorageException) {
                 Logger.log.info("Skipping sync due to invalid account.")
                 Logger.log.info("Invalid account: ${e.javaClass.name}")
-                return
+                return Completion.SKIPPED
             }
 
             if (!extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL) && !checkSyncConditions(settings))
-                return
+                return Completion.SKIPPED
 
             Logger.log.info("Synchronizing address book")
             Logger.log.info("Taking settings from main account")
 
             val principal = settings.uri?.toHttpUrlOrNull() ?: run {
                 Logger.log.warning("Contacts sync skipped: no valid URI")
-                return
+                return Completion.SKIPPED
             }
-            ContactsSyncManager(context, account, settings, extras, authority, provider, syncResult, addressBook, principal).use {
-                it.performSync()
-            }
+            val providerOutcome = ContactsSyncManager(context, account, settings, extras, authority, provider, syncResult, addressBook, principal).use { it.performSync() }
 
             Logger.log.info("Contacts sync complete")
+            return when (providerOutcome) {
+                SyncManager.ProviderOutcome.FAILURE -> Completion.FAILURE
+                SyncManager.ProviderOutcome.CANCELLED -> Completion.SKIPPED
+                SyncManager.ProviderOutcome.SUCCESS -> Completion.SUCCESS
+                SyncManager.ProviderOutcome.SKIPPED -> Completion.SKIPPED
+            }
+        }
+
+        override fun recordSuccess(account: Account, extras: Bundle): Boolean =
+            recordChild(account, extras, SyncStatusStore.ChildResult.SUCCESS)
+
+        override fun recordFailure(account: Account, extras: Bundle, category: SyncStatusStore.FailureCategory): Boolean =
+            recordChild(account, extras, SyncStatusStore.ChildResult.FAILURE, category)
+
+        private fun recordChild(
+            child: Account,
+            extras: Bundle,
+            result: SyncStatusStore.ChildResult,
+            category: SyncStatusStore.FailureCategory = SyncStatusStore.FailureCategory.PROVIDER,
+        ): Boolean {
+            val main = runCatching { LocalAddressBook(context, child, null).mainAccount }.getOrNull()
+            val target = contactsChildTarget(main, contactsAttempt(extras)) ?: return false
+            return SyncStatusStore(context).recordContactsChild(target.mainAccount, target.attemptId, child, result, category) !=
+                SyncStatusStore.ChildWrite.STORAGE_FAILURE
         }
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncAdapterService.kt
@@ -36,6 +36,26 @@ import java.lang.Math.abs
 import java.util.*
 import java.util.logging.Level
 
+internal data class SyncCompletionSnapshot(
+    val auth: Long,
+    val io: Long,
+    val parse: Long,
+    val conflict: Long,
+    val databaseError: Boolean,
+    val fullSyncRequested: Boolean,
+)
+
+internal enum class CompletedOutcome { AUTHENTICATION_FAILURE, NETWORK_FAILURE, STORAGE_FAILURE, PROVIDER_FAILURE, SUCCESS, CANCELLED }
+
+internal fun classifyCompletedOutcome(before: SyncCompletionSnapshot, after: SyncCompletionSnapshot, forceFailure: Boolean) = when {
+    after.auth > before.auth -> CompletedOutcome.AUTHENTICATION_FAILURE
+    after.io > before.io -> CompletedOutcome.NETWORK_FAILURE
+    after.databaseError && !before.databaseError -> CompletedOutcome.STORAGE_FAILURE
+    after.parse > before.parse || after.conflict > before.conflict || forceFailure -> CompletedOutcome.PROVIDER_FAILURE
+    after.fullSyncRequested -> CompletedOutcome.CANCELLED
+    else -> CompletedOutcome.SUCCESS
+}
+
 abstract class SyncAdapterService : Service() {
 
     protected abstract fun syncAdapter(): AbstractThreadedSyncAdapter
@@ -48,7 +68,11 @@ abstract class SyncAdapterService : Service() {
         private val syncErrorTitle: Int = R.string.sync_error_generic
         private val notificationManager = SyncNotification(context, "refresh-collections", Constants.NOTIFICATION_REFRESH_COLLECTIONS)
 
-        abstract fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult)
+        protected enum class Completion { SUCCESS, FAILURE, SKIPPED, DISPATCHED }
+
+        protected open val outcomeService: SyncStatusStore.Service? = null
+
+        protected abstract fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult): Completion
 
         override fun onPerformSync(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
             Logger.log.log(Level.INFO, "$authority sync has been initiated.", extras.keySet().toTypedArray())
@@ -66,17 +90,26 @@ abstract class SyncAdapterService : Service() {
                 return
             }
 
+            val before = snapshot(syncResult)
             try {
-                onPerformSyncDo(account, extras, authority, provider, syncResult)
+                val completion = onPerformSyncDo(account, extras, authority, provider, syncResult)
+                when (completion) {
+                    Completion.SUCCESS -> recordCompletedOutcome(account, extras, before, syncResult)
+                    Completion.FAILURE -> recordCompletedOutcome(account, extras, before, syncResult, forceFailure = true)
+                    Completion.SKIPPED, Completion.DISPATCHED -> Unit
+                }
             } catch (e: SecurityException) {
                 // Shouldn't be needed - not sure why it doesn't fail
                 onSecurityException(account, extras, authority, syncResult)
+                persistStatus(syncResult) { recordFailure(account, extras, SyncStatusStore.FailureCategory.PERMISSION) }
             } catch (e: TemporaryServerErrorException) {
                 syncResult.stats.numIoExceptions++
                 syncResult.delayUntil = Constants.DEFAULT_RETRY_DELAY
+                persistStatus(syncResult) { recordFailure(account, extras, SyncStatusStore.FailureCategory.NETWORK) }
             } catch (e: ConnectionException) {
                 syncResult.stats.numIoExceptions++
                 syncResult.delayUntil = Constants.DEFAULT_RETRY_DELAY
+                persistStatus(syncResult) { recordFailure(account, extras, SyncStatusStore.FailureCategory.NETWORK) }
             } catch (e: Exception) {
                 if (e is ContactsStorageException || e is CalendarStorageException || e is SQLiteException) {
                     Logger.log.log(Level.SEVERE, "Couldn't prepare local journals", e)
@@ -96,6 +129,7 @@ abstract class SyncAdapterService : Service() {
                 }
 
                 notificationManager.notify(title, context.getString(syncPhase))
+                persistStatus(syncResult) { recordFailure(account, extras, failureCategory(e)) }
             } catch (e: OutOfMemoryError) {
                 val syncPhase = R.string.sync_phase_journals
                 val title = context.getString(syncErrorTitle, account.name)
@@ -103,8 +137,51 @@ abstract class SyncAdapterService : Service() {
                 val detailsIntent = notificationManager.detailsIntent
                 detailsIntent.putExtra(Constants.KEY_ACCOUNT, account)
                 notificationManager.notify(title, context.getString(syncPhase))
+                persistStatus(syncResult) { recordFailure(account, extras, SyncStatusStore.FailureCategory.UNKNOWN) }
             }
         }
+
+        protected open fun recordSuccess(account: Account, extras: Bundle): Boolean =
+            outcomeService?.let { SyncStatusStore(context).recordSuccess(account, it) } ?: true
+
+        protected open fun recordFailure(account: Account, extras: Bundle, category: SyncStatusStore.FailureCategory): Boolean =
+            outcomeService?.let { SyncStatusStore(context).recordFailure(account, it, category) } ?: true
+
+        private fun recordCompletedOutcome(account: Account, extras: Bundle, before: SyncCompletionSnapshot, result: SyncResult, forceFailure: Boolean = false) {
+            val after = snapshot(result)
+            val write = when (classifyCompletedOutcome(before, after, forceFailure)) {
+                CompletedOutcome.AUTHENTICATION_FAILURE -> { { recordFailure(account, extras, SyncStatusStore.FailureCategory.AUTHENTICATION) } }
+                CompletedOutcome.NETWORK_FAILURE -> { { recordFailure(account, extras, SyncStatusStore.FailureCategory.NETWORK) } }
+                CompletedOutcome.STORAGE_FAILURE -> { { recordFailure(account, extras, SyncStatusStore.FailureCategory.STORAGE) } }
+                CompletedOutcome.PROVIDER_FAILURE -> { { recordFailure(account, extras, SyncStatusStore.FailureCategory.PROVIDER) } }
+                CompletedOutcome.SUCCESS -> { { recordSuccess(account, extras) } }
+                CompletedOutcome.CANCELLED -> null
+            }
+            if (write != null) persistStatus(result, write)
+        }
+
+        private fun persistStatus(result: SyncResult, write: () -> Boolean) {
+            if (!write()) {
+                result.stats.numIoExceptions++
+                result.delayUntil = maxOf(result.delayUntil, Constants.DEFAULT_RETRY_DELAY)
+            }
+        }
+
+        private fun failureCategory(error: Exception) = when (error) {
+            is UnauthorizedException -> SyncStatusStore.FailureCategory.AUTHENTICATION
+            is ContactsStorageException, is CalendarStorageException, is SQLiteException -> SyncStatusStore.FailureCategory.STORAGE
+            else -> SyncStatusStore.FailureCategory.UNKNOWN
+        }
+
+        private fun snapshot(result: SyncResult) =
+            SyncCompletionSnapshot(
+                result.stats.numAuthExceptions,
+                result.stats.numIoExceptions,
+                result.stats.numParseExceptions,
+                result.stats.numConflictDetectedExceptions,
+                result.databaseError,
+                result.fullSyncRequested,
+            )
 
         override fun onSecurityException(account: Account, extras: Bundle, authority: String, syncResult: SyncResult) {
             Logger.log.log(Level.WARNING, "Security exception when opening content provider for $authority")

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncManager.kt
@@ -39,6 +39,21 @@ import java.util.*
 import java.util.logging.Level
 import javax.net.ssl.SSLHandshakeException
 
+internal enum class DirectProviderAggregate { NONE, SUCCESS, FAILURE, CANCELLED }
+
+/** Failure evidence dominates a later cancellation; cancellation dominates only evidence-free work. */
+internal fun aggregateDirectProviderOutcome(
+    current: DirectProviderAggregate,
+    next: SyncManager.ProviderOutcome,
+): DirectProviderAggregate = when {
+    current == DirectProviderAggregate.FAILURE -> DirectProviderAggregate.FAILURE
+    next == SyncManager.ProviderOutcome.FAILURE -> DirectProviderAggregate.FAILURE
+    next == SyncManager.ProviderOutcome.CANCELLED -> DirectProviderAggregate.CANCELLED
+    current == DirectProviderAggregate.CANCELLED -> DirectProviderAggregate.CANCELLED
+    next == SyncManager.ProviderOutcome.SUCCESS -> DirectProviderAggregate.SUCCESS
+    else -> current
+}
+
 abstract class SyncManager<T: LocalResource<*>>
 constructor(protected val context: Context, protected val account: Account, protected val settings: AccountSettings, protected val extras: Bundle, protected val authority: String, protected val syncResult: SyncResult, journalUid: String, protected val serviceType: CollectionInfo.Type, accountName: String): Closeable {
 
@@ -99,7 +114,9 @@ constructor(protected val context: Context, protected val account: Account, prot
     }
 
     @TargetApi(21)
-    fun performSync() {
+    enum class ProviderOutcome { SUCCESS, SKIPPED, FAILURE, CANCELLED }
+
+    fun performSync(): ProviderOutcome {
         syncItemsTotal = 0
         syncItemsDeleted = 0
         syncItemsChanged = 0
@@ -109,7 +126,7 @@ constructor(protected val context: Context, protected val account: Account, prot
             Logger.log.info("Sync phase: " + context.getString(syncPhase))
             if (!prepare()) {
                 Logger.log.info("No reason to synchronize, aborting")
-                return
+                return ProviderOutcome.SKIPPED
             }
 
             if (Thread.interrupted())
@@ -182,6 +199,7 @@ constructor(protected val context: Context, protected val account: Account, prot
             notifyUserOnSync()
 
             Logger.log.info("Finished sync")
+            return ProviderOutcome.SUCCESS
         } catch (e: SSLHandshakeException) {
             syncResult.stats.numIoExceptions++
 
@@ -189,23 +207,29 @@ constructor(protected val context: Context, protected val account: Account, prot
             val detailsIntent = notificationManager.detailsIntent
             detailsIntent.putExtra(KEY_ACCOUNT, account)
             notificationManager.notify(syncErrorTitle, context.getString(syncPhase))
+            return ProviderOutcome.FAILURE
         } catch (e: FileNotFoundException) {
             notificationManager.setThrowable(e)
             val detailsIntent = notificationManager.detailsIntent
             detailsIntent.putExtra(KEY_ACCOUNT, account)
             notificationManager.notify(syncErrorTitle, context.getString(syncPhase))
+            return ProviderOutcome.FAILURE
         } catch (e: IOException) {
             Logger.log.log(Level.WARNING, "I/O exception during sync, trying again later", e)
             syncResult.stats.numIoExceptions++
+            return ProviderOutcome.FAILURE
         } catch (e: TemporaryServerErrorException) {
             syncResult.stats.numIoExceptions++
             syncResult.delayUntil = Constants.DEFAULT_RETRY_DELAY
+            return ProviderOutcome.FAILURE
         } catch (e: ConnectionException) {
             syncResult.stats.numIoExceptions++
             syncResult.delayUntil = Constants.DEFAULT_RETRY_DELAY
+            return ProviderOutcome.FAILURE
         } catch (e: InterruptedException) {
             // Restart sync if interrupted
             syncResult.fullSyncRequested = true
+            return ProviderOutcome.CANCELLED
         } catch (e: Exception) {
             if (e is UnauthorizedException) {
                 syncResult.stats.numAuthExceptions++
@@ -227,14 +251,15 @@ constructor(protected val context: Context, protected val account: Account, prot
             }
 
             notificationManager.notify(syncErrorTitle, context.getString(syncPhase))
+            return ProviderOutcome.FAILURE
         } catch (e: OutOfMemoryError) {
             syncResult.stats.numParseExceptions++
             notificationManager.setThrowable(e)
             val detailsIntent = notificationManager.detailsIntent
             detailsIntent.putExtra(KEY_ACCOUNT, account)
             notificationManager.notify(syncErrorTitle, context.getString(syncPhase))
+            return ProviderOutcome.FAILURE
         }
-
     }
 
     private fun notifyUserOnSync() {

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncStatusStore.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncStatusStore.kt
@@ -170,7 +170,7 @@ class SyncStatusStore internal constructor(
                 current.outcome.copy(successAt = orderedAfter(System.currentTimeMillis(), current.outcome.failureAt))
             else -> current.outcome
         }
-        if (writeContacts(identity, current.copy(outcome = outcome, terminal = terminal)))
+        return if (writeContacts(identity, current.copy(outcome = outcome, terminal = terminal)))
             ChildWrite.RECORDED
         else
             ChildWrite.STORAGE_FAILURE

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncStatusStore.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncStatusStore.kt
@@ -147,10 +147,20 @@ class SyncStatusStore internal constructor(
         failureCategory: FailureCategory = FailureCategory.PROVIDER,
     ): ChildWrite = synchronized(STORE_LOCK) {
         val identity = mainAccountKey(account)
+        recordContactsChild(identity, attemptId, childAccount, result, failureCategory)
+    }
+
+    private fun recordContactsChild(
+        identity: String,
+        attemptId: String,
+        childAccount: Account,
+        result: ChildResult,
+        failureCategory: FailureCategory,
+    ): ChildWrite {
         val current = readContacts(identity)
         val child = childAccountKey(childAccount)
         if (current.attemptId != attemptId || child !in current.expected || child in current.terminal)
-            return@synchronized ChildWrite.REJECTED
+            return ChildWrite.REJECTED
 
         val terminal = current.terminal + (child to result)
         val outcome = when {
@@ -168,8 +178,9 @@ class SyncStatusStore internal constructor(
 
     @Synchronized
     fun recordContactsChildRemoved(account: Account, childAccount: Account): Boolean = synchronized(STORE_LOCK) {
-        val attempt = readContacts(mainAccountKey(account)).attemptId ?: return@synchronized false
-        recordContactsChild(account, attempt, childAccount, ChildResult.REMOVED) == ChildWrite.RECORDED
+        val identity = mainAccountKey(account)
+        val attempt = readContacts(identity).attemptId ?: return@synchronized false
+        recordContactsChild(identity, attempt, childAccount, ChildResult.REMOVED, FailureCategory.PROVIDER) == ChildWrite.RECORDED
     }
 
     @Synchronized
@@ -198,7 +209,7 @@ class SyncStatusStore internal constructor(
         val failureAt = storedFault?.let(::decodeFault) ?: failedWrites[key]
         if (storedFault == null && failureAt == null) return this
         return copy(
-            lastFailureAt = failureAt ?: failureTimestampFor(key),
+            lastFailureAt = failureAt ?: failureTimestampFor(key, 0L),
             lastFailureCategory = FailureCategory.STORAGE,
             latestGenerationIncomplete = latestGenerationIncomplete || key.endsWith(".${Service.CONTACTS.name}"),
         )
@@ -225,7 +236,8 @@ class SyncStatusStore internal constructor(
 
     /** One bounded recovery write. Total-disk failure remains visible in-process and to the caller. */
     private fun persistFaults(keys: Set<String>) {
-        val timestamps = keys.associateWith(::failureTimestampFor)
+        val now = System.currentTimeMillis()
+        val timestamps = keys.associateWith { failureTimestampFor(it, now) }
         val sentinels = timestamps.mapKeys { faultKey(it.key) }.mapValues { encodeFault(it.value) }
         val persisted = storage.commit(sentinels)
         if (persisted) {
@@ -235,15 +247,21 @@ class SyncStatusStore internal constructor(
         }
     }
 
-    private fun failureTimestampFor(key: String): Long {
+    private fun failureTimestampFor(key: String, candidate: Long): Long {
         val parts = storage.get(key)?.split('|', limit = 4).orEmpty()
         val success = parts.getOrNull(1)?.toLongOrNull()
         val failure = parts.getOrNull(2)?.toLongOrNull()
         return maxOf(
-            System.currentTimeMillis(),
-            (success ?: Long.MIN_VALUE) + 1,
-            (failure ?: Long.MIN_VALUE) + 1,
+            candidate,
+            orderedAfterValue(success),
+            orderedAfterValue(failure),
         )
+    }
+
+    private fun orderedAfterValue(value: Long?): Long = when (value) {
+        null -> 0L
+        Long.MAX_VALUE -> Long.MAX_VALUE
+        else -> value + 1
     }
 
     private fun encodeFault(timestamp: Long) = "$FAULT_VERSION|$timestamp|STORAGE"
@@ -251,7 +269,11 @@ class SyncStatusStore internal constructor(
     private fun decodeFault(value: String): Long? {
         val parts = value.split('|', limit = 3)
         if (parts.size != 3 || parts[0] != FAULT_VERSION || parts[2] != "STORAGE") return null
-        return parts[1].toLongOrNull()?.takeIf { it >= 0 }
+        val timestamp = parts[1].toLongOrNull() ?: return null
+        val latestAccepted = System.currentTimeMillis().let { now ->
+            if (now > Long.MAX_VALUE - MAX_FUTURE_SKEW_MILLIS) Long.MAX_VALUE else now + MAX_FUTURE_SKEW_MILLIS
+        }
+        return timestamp.takeIf { it in 0..latestAccepted }
     }
 
     private fun readContacts(identity: String): ContactsRecord {
@@ -306,6 +328,7 @@ class SyncStatusStore internal constructor(
         const val EXTRA_CONTACTS_ATTEMPT = "io.silentsuite.sync.CONTACTS_ATTEMPT"
         private const val RECORD_VERSION = "1"
         private const val FAULT_VERSION = "1"
+        private const val MAX_FUTURE_SKEW_MILLIS = 5 * 60 * 1000L
         private val STORE_LOCK = Any()
         private val failedWrites = mutableMapOf<String, Long>()
 

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncStatusStore.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncStatusStore.kt
@@ -1,0 +1,331 @@
+package io.silentsuite.sync.syncadapter
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Context
+import io.silentsuite.sync.AccountSettings
+import java.security.MessageDigest
+import java.util.UUID
+
+/** Local, privacy-bounded evidence from completed Android provider syncs. */
+class SyncStatusStore internal constructor(
+    private val storage: Storage,
+    private val mainAccountKey: (Account) -> String = { account -> hashIdentity(account.type, account.name, null) },
+    private val childAccountKey: (Account) -> String = { account -> hashIdentity(account.type, account.name, null) },
+) {
+    enum class Service { CALENDAR, CONTACTS, TASKS }
+    enum class FailureCategory {
+        NETWORK, AUTHENTICATION, PERMISSION, PROVIDER, STORAGE, CONFIGURATION, SETUP_REQUIRED,
+        PARENT_REFRESH, CHILD_REMOVED, UNKNOWN
+    }
+    enum class ChildResult { SUCCESS, FAILURE, REMOVED }
+    sealed class ContactsStart {
+        data class Started(val attemptId: String) : ContactsStart()
+        object SetupRequired : ContactsStart()
+        object StorageFailure : ContactsStart()
+    }
+    enum class ChildWrite { RECORDED, REJECTED, STORAGE_FAILURE }
+
+    data class Status(
+        val lastSuccessAt: Long? = null,
+        val lastFailureAt: Long? = null,
+        val lastFailureCategory: FailureCategory? = null,
+        val latestGenerationIncomplete: Boolean = false,
+        val pendingChildren: Int = 0,
+    )
+
+    /** Snapshot this before AccountManager removal, then pass it to [clear] after removal is confirmed. */
+    data class MainIdentity internal constructor(internal val storageKey: String)
+
+    interface Storage {
+        fun get(key: String): String?
+
+        /** Atomically applies the complete mutation and reports whether it reached durable storage. */
+        fun commit(puts: Map<String, String> = emptyMap(), removes: Set<String> = emptySet()): Boolean
+    }
+
+    private data class Outcome(
+        val successAt: Long? = null,
+        val failureAt: Long? = null,
+        val failureCategory: FailureCategory? = null,
+    )
+
+    private data class ContactsRecord(
+        val outcome: Outcome = Outcome(),
+        val attemptId: String? = null,
+        val expected: Set<String> = emptySet(),
+        val terminal: Map<String, ChildResult> = emptyMap(),
+    )
+
+    constructor(context: Context) : this(
+        PreferencesStorage(context.applicationContext),
+        mainAccountKey = { account ->
+            val creationId = AccountManager.get(context.applicationContext)
+                .getUserData(account, AccountSettings.KEY_CREATION_ID)
+            hashIdentity(account.type, account.name, creationId)
+        },
+    )
+
+    fun identity(account: Account): MainIdentity = MainIdentity(mainAccountKey(account))
+
+    @Synchronized
+    fun status(account: Account, service: Service): Status = synchronized(STORE_LOCK) {
+        val identity = mainAccountKey(account)
+        val key = recordKey(identity, service)
+        if (service == Service.CONTACTS) {
+            val record = readContacts(identity)
+            val incomplete = record.attemptId != null && record.terminal.keys != record.expected
+            statusOf(record.outcome, incomplete, (record.expected - record.terminal.keys).size).failClosedIfNeeded(key)
+        } else {
+            statusOf(readOutcome(key)).failClosedIfNeeded(key)
+        }
+    }
+
+    @Synchronized
+    fun recordSuccess(account: Account, service: Service, timestamp: Long = System.currentTimeMillis()): Boolean = synchronized(STORE_LOCK) {
+        require(service != Service.CONTACTS) { "Contacts outcomes are generation-scoped" }
+        val key = recordKey(mainAccountKey(account), service)
+        val current = readOutcome(key)
+        commitRecord(key, encodeOutcome(current.copy(successAt = orderedAfter(timestamp, current.failureAt))))
+    }
+
+    @Synchronized
+    fun recordFailure(
+        account: Account,
+        service: Service,
+        category: FailureCategory,
+        timestamp: Long = System.currentTimeMillis(),
+    ): Boolean = synchronized(STORE_LOCK) {
+        require(service != Service.CONTACTS) { "Contacts outcomes are generation-scoped" }
+        val key = recordKey(mainAccountKey(account), service)
+        val current = readOutcome(key)
+        commitRecord(key, encodeOutcome(current.copy(
+            failureAt = orderedAfter(timestamp, current.successAt),
+            failureCategory = category,
+        )))
+    }
+
+    /** Starts the only Contacts attempt allowed to update user-facing state. */
+    @Synchronized
+    fun beginContacts(account: Account, childAccounts: Set<Account>): ContactsStart = synchronized(STORE_LOCK) {
+        val identity = mainAccountKey(account)
+        val current = readContacts(identity)
+        val expected = childAccounts.mapTo(linkedSetOf()) { childAccountKey(it) }
+        if (expected.isEmpty()) {
+            val failed = current.copy(
+                outcome = failedOutcome(current.outcome, FailureCategory.SETUP_REQUIRED),
+                attemptId = null,
+                expected = emptySet(),
+                terminal = emptyMap(),
+            )
+            if (writeContacts(identity, failed)) ContactsStart.SetupRequired else ContactsStart.StorageFailure
+        } else {
+            val attempt = UUID.randomUUID().toString()
+            val pending = current.copy(attemptId = attempt, expected = expected, terminal = emptyMap())
+            if (writeContacts(identity, pending)) ContactsStart.Started(attempt) else ContactsStart.StorageFailure
+        }
+    }
+
+    @Synchronized
+    fun failContactsParent(account: Account, category: FailureCategory = FailureCategory.PARENT_REFRESH): Boolean = synchronized(STORE_LOCK) {
+        val identity = mainAccountKey(account)
+        val current = readContacts(identity)
+        writeContacts(identity, current.copy(
+            outcome = failedOutcome(current.outcome, category),
+            attemptId = null,
+            expected = emptySet(),
+            terminal = emptyMap(),
+        ))
+    }
+
+    @Synchronized
+    fun recordContactsChild(
+        account: Account,
+        attemptId: String,
+        childAccount: Account,
+        result: ChildResult,
+        failureCategory: FailureCategory = FailureCategory.PROVIDER,
+    ): ChildWrite = synchronized(STORE_LOCK) {
+        val identity = mainAccountKey(account)
+        val current = readContacts(identity)
+        val child = childAccountKey(childAccount)
+        if (current.attemptId != attemptId || child !in current.expected || child in current.terminal)
+            return@synchronized ChildWrite.REJECTED
+
+        val terminal = current.terminal + (child to result)
+        val outcome = when {
+            result == ChildResult.FAILURE -> failedOutcome(current.outcome, failureCategory)
+            result == ChildResult.REMOVED -> failedOutcome(current.outcome, FailureCategory.CHILD_REMOVED)
+            terminal.keys == current.expected && terminal.values.all { it == ChildResult.SUCCESS } ->
+                current.outcome.copy(successAt = orderedAfter(System.currentTimeMillis(), current.outcome.failureAt))
+            else -> current.outcome
+        }
+        if (writeContacts(identity, current.copy(outcome = outcome, terminal = terminal)))
+            ChildWrite.RECORDED
+        else
+            ChildWrite.STORAGE_FAILURE
+    }
+
+    @Synchronized
+    fun recordContactsChildRemoved(account: Account, childAccount: Account): Boolean = synchronized(STORE_LOCK) {
+        val attempt = readContacts(mainAccountKey(account)).attemptId ?: return@synchronized false
+        recordContactsChild(account, attempt, childAccount, ChildResult.REMOVED) == ChildWrite.RECORDED
+    }
+
+    @Synchronized
+    fun clear(account: Account): Boolean = clear(identity(account))
+
+    /** Clears an exact creation generation without consulting a possibly-removed AccountManager row. */
+    @Synchronized
+    fun clear(identity: MainIdentity): Boolean = synchronized(STORE_LOCK) {
+        val keys = Service.values().mapTo(linkedSetOf()) { recordKey(identity.storageKey, it) }
+        val sentinels = keys.mapTo(linkedSetOf(), ::faultKey)
+        val committed = storage.commit(removes = keys + sentinels)
+        if (committed) {
+            keys.forEach { failedWrites.remove(it) }
+        } else {
+            persistFaults(keys)
+        }
+        committed
+    }
+
+    private fun statusOf(outcome: Outcome, incomplete: Boolean = false, pending: Int = 0) = Status(
+        outcome.successAt, outcome.failureAt, outcome.failureCategory, incomplete, pending,
+    )
+
+    private fun Status.failClosedIfNeeded(key: String): Status {
+        val storedFault = storage.get(faultKey(key))
+        val failureAt = storedFault?.let(::decodeFault) ?: failedWrites[key]
+        if (storedFault == null && failureAt == null) return this
+        return copy(
+            lastFailureAt = failureAt ?: failureTimestampFor(key),
+            lastFailureCategory = FailureCategory.STORAGE,
+            latestGenerationIncomplete = latestGenerationIncomplete || key.endsWith(".${Service.CONTACTS.name}"),
+        )
+    }
+
+    private fun failedOutcome(outcome: Outcome, category: FailureCategory, timestamp: Long = System.currentTimeMillis()) =
+        outcome.copy(failureAt = orderedAfter(timestamp, outcome.successAt), failureCategory = category)
+
+    private fun orderedAfter(timestamp: Long, previous: Long?): Long = maxOf(timestamp, (previous ?: Long.MIN_VALUE) + 1)
+    private fun recordKey(identity: String, service: Service) = "status.$identity.${service.name}"
+
+    private fun writeContacts(identity: String, record: ContactsRecord) =
+        recordKey(identity, Service.CONTACTS).let { commitRecord(it, encodeContacts(record)) }
+
+    private fun commitRecord(key: String, value: String): Boolean {
+        val committed = storage.commit(mapOf(key to value), setOf(faultKey(key)))
+        if (committed) {
+            failedWrites.remove(key)
+        } else {
+            persistFaults(setOf(key))
+        }
+        return committed
+    }
+
+    /** One bounded recovery write. Total-disk failure remains visible in-process and to the caller. */
+    private fun persistFaults(keys: Set<String>) {
+        val timestamps = keys.associateWith(::failureTimestampFor)
+        val sentinels = timestamps.mapKeys { faultKey(it.key) }.mapValues { encodeFault(it.value) }
+        val persisted = storage.commit(sentinels)
+        if (persisted) {
+            keys.forEach { failedWrites.remove(it) }
+        } else {
+            failedWrites.putAll(timestamps)
+        }
+    }
+
+    private fun failureTimestampFor(key: String): Long {
+        val parts = storage.get(key)?.split('|', limit = 4).orEmpty()
+        val success = parts.getOrNull(1)?.toLongOrNull()
+        val failure = parts.getOrNull(2)?.toLongOrNull()
+        return maxOf(
+            System.currentTimeMillis(),
+            (success ?: Long.MIN_VALUE) + 1,
+            (failure ?: Long.MIN_VALUE) + 1,
+        )
+    }
+
+    private fun encodeFault(timestamp: Long) = "$FAULT_VERSION|$timestamp|STORAGE"
+
+    private fun decodeFault(value: String): Long? {
+        val parts = value.split('|', limit = 3)
+        if (parts.size != 3 || parts[0] != FAULT_VERSION || parts[2] != "STORAGE") return null
+        return parts[1].toLongOrNull()?.takeIf { it >= 0 }
+    }
+
+    private fun readContacts(identity: String): ContactsRecord {
+        val value = storage.get(recordKey(identity, Service.CONTACTS)) ?: return ContactsRecord()
+        val parts = value.split('|', limit = 6)
+        if (parts.size != 6 || parts[0] != RECORD_VERSION)
+            return ContactsRecord(failedOutcome(Outcome(), FailureCategory.STORAGE))
+        val outcome = decodeOutcome((listOf(RECORD_VERSION) + parts.subList(1, 4)).joinToString("|"))
+        val attempt = parts[4].ifBlank { null }
+        val sets = parts[5].split(';', limit = 2)
+        val expected = sets.getOrElse(0) { "" }.split(',').filter { it.isNotBlank() }.toSet()
+        val terminal = sets.getOrElse(1) { "" }.split(',').mapNotNull {
+            val key = it.substringBefore(':', "")
+            val result = runCatching { ChildResult.valueOf(it.substringAfter(':', "")) }.getOrNull()
+            if (key.isBlank() || result == null) null else key to result
+        }.toMap()
+        if (attempt == null && expected.isEmpty() && terminal.isEmpty()) return ContactsRecord(outcome)
+        if (attempt == null || expected.isEmpty() || terminal.keys.any { it !in expected })
+            return ContactsRecord(failedOutcome(outcome, FailureCategory.STORAGE))
+        return ContactsRecord(outcome, attempt, expected, terminal)
+    }
+
+    private fun encodeContacts(record: ContactsRecord): String {
+        val expected = record.expected.sorted().joinToString(",")
+        val terminal = record.terminal.toSortedMap().entries.joinToString(",") { "${it.key}:${it.value.name}" }
+        return "$RECORD_VERSION|${encodeOutcome(record.outcome).substringAfter('|')}|${record.attemptId.orEmpty()}|$expected;$terminal"
+    }
+
+    private fun readOutcome(key: String) = storage.get(key)?.let(::decodeOutcome) ?: Outcome()
+    private fun encodeOutcome(outcome: Outcome) = listOf(
+        RECORD_VERSION,
+        outcome.successAt?.toString().orEmpty(),
+        outcome.failureAt?.toString().orEmpty(),
+        outcome.failureCategory?.name.orEmpty(),
+    ).joinToString("|")
+
+    private fun decodeOutcome(value: String): Outcome {
+        val parts = value.split('|', limit = 4)
+        if (parts.size != 4 || parts[0] != RECORD_VERSION) return failedOutcome(Outcome(), FailureCategory.STORAGE)
+        val success = parts[1].takeIf { it.isNotBlank() }?.toLongOrNull()
+        val failure = parts[2].takeIf { it.isNotBlank() }?.toLongOrNull()
+        val category = parts[3].takeIf { it.isNotBlank() }?.let { runCatching { FailureCategory.valueOf(it) }.getOrNull() }
+        if ((parts[1].isNotBlank() && success == null) ||
+            (parts[2].isNotBlank() && failure == null) ||
+            (parts[3].isNotBlank() && category == null) ||
+            (failure == null) != (category == null))
+            return failedOutcome(Outcome(successAt = success), FailureCategory.STORAGE)
+        return Outcome(success, failure, category)
+    }
+
+    companion object {
+        const val EXTRA_CONTACTS_ATTEMPT = "io.silentsuite.sync.CONTACTS_ATTEMPT"
+        private const val RECORD_VERSION = "1"
+        private const val FAULT_VERSION = "1"
+        private val STORE_LOCK = Any()
+        private val failedWrites = mutableMapOf<String, Long>()
+
+        private fun hashIdentity(type: String?, name: String?, creationId: String?): String {
+            val bytes = MessageDigest.getInstance("SHA-256")
+                .digest("$type\u0000$name\u0000${creationId.orEmpty()}".toByteArray(Charsets.UTF_8))
+            return bytes.joinToString("") { "%02x".format(it) }
+        }
+
+        private fun faultKey(recordKey: String) = "fault.$recordKey"
+    }
+
+    private class PreferencesStorage(context: Context) : Storage {
+        private val preferences = context.getSharedPreferences("sync_status_v1", Context.MODE_PRIVATE)
+        override fun get(key: String) = preferences.getString(key, null)
+        override fun commit(puts: Map<String, String>, removes: Set<String>): Boolean {
+            val editor = preferences.edit()
+            removes.forEach(editor::remove)
+            puts.forEach(editor::putString)
+            return editor.commit()
+        }
+    }
+}

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/TasksSyncAdapterService.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/TasksSyncAdapterService.kt
@@ -26,6 +26,8 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.dmfs.tasks.contract.TaskContract
 import java.util.*
 
+internal val TASK_OUTCOME_PROVIDERS = setOf(ProviderName.OpenTasks, ProviderName.TasksOrg)
+
 /**
  * Synchronization manager for CalDAV collections; handles tasks ({@code VTODO}).
  */
@@ -37,7 +39,13 @@ class TasksSyncAdapterService: SyncAdapterService() {
             context: Context,
             private val name: ProviderName
     ): SyncAdapter(context) {
-        override fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult) {
+        init {
+            require(name in TASK_OUTCOME_PROVIDERS) { "Unsupported task outcome provider" }
+        }
+
+        override val outcomeService = SyncStatusStore.Service.TASKS
+
+        override fun onPerformSyncDo(account: Account, extras: Bundle, authority: String, provider: ContentProviderClient, syncResult: SyncResult): Completion {
 
             val taskProvider = TaskProvider.fromProviderClient(context, name, provider)
 
@@ -51,7 +59,7 @@ class TasksSyncAdapterService: SyncAdapterService() {
                - this is is an automatic sync (i.e. manual syncs are run regardless of sync conditions)
              */
             if (!extras.containsKey(ContentResolver.SYNC_EXTRAS_MANUAL) && !checkSyncConditions(accountSettings))
-                return
+                return Completion.SKIPPED
 
             RefreshCollections(
                 account,
@@ -63,17 +71,26 @@ class TasksSyncAdapterService: SyncAdapterService() {
 
             val principal = accountSettings.uri?.toHttpUrlOrNull() ?: run {
                 Logger.log.warning("Task sync skipped: no valid URI")
-                return
+                return Completion.SKIPPED
             }
 
+            var providerOutcome = DirectProviderAggregate.NONE
             for (taskList in AndroidTaskList.find(account, taskProvider, LocalTaskList.Factory, "${TaskContract.TaskLists.SYNC_ENABLED}!=0", null)) {
                 Logger.log.info("Synchronizing task list #${taskList.id}")
                 TasksSyncManager(context, account, accountSettings, extras, authority, syncResult, taskList, principal).use {
-                    it.performSync()
+                    val outcome = it.performSync()
+                    providerOutcome = aggregateDirectProviderOutcome(providerOutcome, outcome)
+                    if (providerOutcome == DirectProviderAggregate.CANCELLED)
+                        return Completion.SKIPPED
                 }
             }
 
             Logger.log.info("Task sync complete")
+            return when (providerOutcome) {
+                DirectProviderAggregate.FAILURE -> Completion.FAILURE
+                DirectProviderAggregate.SUCCESS -> Completion.SUCCESS
+                else -> Completion.SKIPPED
+            }
         }
 
         private fun updateLocalTaskLists(provider: TaskProvider, account: Account, settings: AccountSettings) {

--- a/android/app/src/main/java/io/silentsuite/sync/ui/account/AccountDashboardState.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/account/AccountDashboardState.kt
@@ -1,0 +1,36 @@
+package io.silentsuite.sync.ui.account
+
+import io.silentsuite.sync.syncadapter.SyncStatusStore
+
+enum class AccountDashboardState { LOADING, RUNNING, NEVER_SYNCED, SUCCESS, FAILURE, BLOCKED, SETUP_REQUIRED }
+enum class AccountDashboardBlock { MASTER_SYNC, PERMISSION, PROVIDER }
+data class AccountDashboardModel(val state: AccountDashboardState, val blockedBy: AccountDashboardBlock? = null)
+
+data class AccountDashboardInput(
+    val loaded: Boolean,
+    val running: Boolean,
+    val setupComplete: Boolean,
+    val masterSyncEnabled: Boolean,
+    val permissionReady: Boolean,
+    val providerReady: Boolean,
+    val collectionsAvailable: Boolean,
+    val status: SyncStatusStore.Status?,
+)
+
+/** Pure precedence reducer; presentation copy/icons/actions remain a Slice 11 concern. */
+fun reduceAccountDashboardState(input: AccountDashboardInput): AccountDashboardModel = when {
+    !input.loaded -> AccountDashboardModel(AccountDashboardState.LOADING)
+    !input.setupComplete || !input.collectionsAvailable -> AccountDashboardModel(AccountDashboardState.SETUP_REQUIRED)
+    input.running -> AccountDashboardModel(AccountDashboardState.RUNNING)
+    input.status?.lastFailureCategory == SyncStatusStore.FailureCategory.SETUP_REQUIRED &&
+        (input.status.lastFailureAt ?: Long.MIN_VALUE) > (input.status.lastSuccessAt ?: Long.MIN_VALUE) ->
+        AccountDashboardModel(AccountDashboardState.SETUP_REQUIRED)
+    !input.masterSyncEnabled -> AccountDashboardModel(AccountDashboardState.BLOCKED, AccountDashboardBlock.MASTER_SYNC)
+    !input.permissionReady -> AccountDashboardModel(AccountDashboardState.BLOCKED, AccountDashboardBlock.PERMISSION)
+    !input.providerReady -> AccountDashboardModel(AccountDashboardState.BLOCKED, AccountDashboardBlock.PROVIDER)
+    input.status?.latestGenerationIncomplete == true -> AccountDashboardModel(AccountDashboardState.FAILURE)
+    input.status == null || (input.status.lastSuccessAt == null && input.status.lastFailureAt == null) -> AccountDashboardModel(AccountDashboardState.NEVER_SYNCED)
+    (input.status.lastFailureAt ?: Long.MIN_VALUE) > (input.status.lastSuccessAt ?: Long.MIN_VALUE) -> AccountDashboardModel(AccountDashboardState.FAILURE)
+    input.status.lastSuccessAt != null -> AccountDashboardModel(AccountDashboardState.SUCCESS)
+    else -> AccountDashboardModel(AccountDashboardState.FAILURE)
+}

--- a/android/app/src/test/java/io/silentsuite/sync/resource/LocalAddressBookRemovalPolicyTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/resource/LocalAddressBookRemovalPolicyTest.kt
@@ -1,0 +1,14 @@
+package io.silentsuite.sync.resource
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalAddressBookRemovalPolicyTest {
+    @Test fun `child removal is recorded only after true confirmation`() {
+        var recorded = 0
+        onConfirmedAddressBookRemoval(false) { recorded++ }
+        assertEquals(0, recorded)
+        onConfirmedAddressBookRemoval(true) { recorded++ }
+        assertEquals(1, recorded)
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/syncadapter/ProviderBoundaryPolicyTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/syncadapter/ProviderBoundaryPolicyTest.kt
@@ -1,0 +1,55 @@
+package io.silentsuite.sync.syncadapter
+
+import android.accounts.Account
+import at.bitfire.ical4android.TaskProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ProviderBoundaryPolicyTest {
+    private fun aggregate(vararg outcomes: SyncManager.ProviderOutcome) = outcomes.fold(
+        DirectProviderAggregate.NONE,
+        ::aggregateDirectProviderOutcome,
+    )
+
+    @Test fun `empty and all skipped providers are not success`() {
+        assertEquals(DirectProviderAggregate.NONE, aggregate())
+        assertEquals(DirectProviderAggregate.NONE, aggregate(SyncManager.ProviderOutcome.SKIPPED, SyncManager.ProviderOutcome.SKIPPED))
+    }
+
+    @Test fun `success requires a completed provider and failure survives later cancellation`() {
+        assertEquals(DirectProviderAggregate.SUCCESS, aggregate(SyncManager.ProviderOutcome.SUCCESS))
+        assertEquals(DirectProviderAggregate.CANCELLED, aggregate(SyncManager.ProviderOutcome.CANCELLED))
+        assertEquals(
+            DirectProviderAggregate.FAILURE,
+            aggregate(SyncManager.ProviderOutcome.FAILURE, SyncManager.ProviderOutcome.CANCELLED),
+        )
+    }
+
+    @Test fun `outer completion recording preserves known failure despite cancellation`() {
+        val before = SyncCompletionSnapshot(0, 0, 0, 0, false, false)
+        val cancelledAfterIoFailure = SyncCompletionSnapshot(0, 1, 0, 0, false, true)
+        assertEquals(
+            CompletedOutcome.NETWORK_FAILURE,
+            classifyCompletedOutcome(before, cancelledAfterIoFailure, false),
+        )
+        assertEquals(
+            CompletedOutcome.PROVIDER_FAILURE,
+            classifyCompletedOutcome(before, before.copy(fullSyncRequested = true), true),
+        )
+    }
+
+    @Test fun `both supported task wrappers use the shared task adapter policy`() {
+        assertTrue(TASK_OUTCOME_PROVIDERS.containsAll(setOf(
+            TaskProvider.ProviderName.OpenTasks,
+            TaskProvider.ProviderName.TasksOrg,
+        )))
+    }
+
+    @Test fun `contacts child outcome requires exact main mapping and propagated attempt`() {
+        val main = Account("main", "main-type")
+        assertEquals(ContactsChildTarget(main, "attempt"), contactsChildTarget(main, "attempt"))
+        assertEquals(null, contactsChildTarget(main, null))
+        assertEquals(null, contactsChildTarget(null, "attempt"))
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/syncadapter/ProviderBoundaryPolicyTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/syncadapter/ProviderBoundaryPolicyTest.kt
@@ -3,6 +3,7 @@ package io.silentsuite.sync.syncadapter
 import android.accounts.Account
 import at.bitfire.ical4android.TaskProvider
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -48,7 +49,9 @@ class ProviderBoundaryPolicyTest {
 
     @Test fun `contacts child outcome requires exact main mapping and propagated attempt`() {
         val main = Account("main", "main-type")
-        assertEquals(ContactsChildTarget(main, "attempt"), contactsChildTarget(main, "attempt"))
+        val target = contactsChildTarget(main, "attempt")
+        assertSame(main, target?.mainAccount)
+        assertEquals("attempt", target?.attemptId)
         assertEquals(null, contactsChildTarget(main, null))
         assertEquals(null, contactsChildTarget(null, "attempt"))
     }

--- a/android/app/src/test/java/io/silentsuite/sync/syncadapter/SyncStatusStoreTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/syncadapter/SyncStatusStoreTest.kt
@@ -104,6 +104,23 @@ class SyncStatusStoreTest {
         assertEquals(52L, store.status(first, SyncStatusStore.Service.CALENDAR).lastSuccessAt)
     }
 
+    @Test fun `malformed and extreme fault sentinels fail closed with stable bounded evidence`() {
+        assertTrue(store.recordSuccess(first, SyncStatusStore.Service.CALENDAR, 50))
+        storage.failNextCommit = true
+        assertFalse(store.recordFailure(first, SyncStatusStore.Service.CALENDAR, SyncStatusStore.FailureCategory.NETWORK, 60))
+        val faultKey = storage.values.keys.single { it.startsWith("fault.") && it.endsWith(".CALENDAR") }
+
+        storage.values[faultKey] = "malformed"
+        val malformed = freshStore().status(first, SyncStatusStore.Service.CALENDAR)
+        assertEquals(51L, malformed.lastFailureAt)
+        assertEquals(malformed.lastFailureAt, freshStore().status(first, SyncStatusStore.Service.CALENDAR).lastFailureAt)
+
+        storage.values[faultKey] = "1|${Long.MAX_VALUE}|STORAGE"
+        val extreme = freshStore().status(first, SyncStatusStore.Service.CALENDAR)
+        assertEquals(51L, extreme.lastFailureAt)
+        assertEquals(extreme.lastFailureAt, freshStore().status(first, SyncStatusStore.Service.CALENDAR).lastFailureAt)
+    }
+
     @Test fun `latest contacts generation stays incomplete over historical success`() {
         val childOne = child("book-one")
         val firstAttempt = started(store.beginContacts(first, setOf(childOne)))
@@ -197,6 +214,26 @@ class SyncStatusStoreTest {
 
         assertEquals(SyncStatusStore.ContactsStart.SetupRequired, store.beginContacts(second, emptySet()))
         assertEquals(SyncStatusStore.FailureCategory.SETUP_REQUIRED, store.status(second, SyncStatusStore.Service.CONTACTS).lastFailureCategory)
+    }
+
+    @Test fun `confirmed child removal snapshots main generation once`() {
+        val child = child("removed-book")
+        started(store.beginContacts(first, setOf(child)))
+        var lookups = 0
+        val changingIdentityStore = SyncStatusStore(
+            storage,
+            mainAccountKey = {
+                lookups++
+                if (lookups == 1) "first-generation-$namespace" else "readded-generation-$namespace"
+            },
+            childAccountKey = { childKeys[it] ?: error("missing child test identity") },
+        )
+        assertTrue(changingIdentityStore.recordContactsChildRemoved(first, child))
+        assertEquals(1, lookups)
+        assertEquals(
+            SyncStatusStore.FailureCategory.CHILD_REMOVED,
+            store.status(first, SyncStatusStore.Service.CONTACTS).lastFailureCategory,
+        )
     }
 
     @Test fun `new contacts generation supersedes incomplete old attempt`() {

--- a/android/app/src/test/java/io/silentsuite/sync/syncadapter/SyncStatusStoreTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/syncadapter/SyncStatusStoreTest.kt
@@ -1,0 +1,247 @@
+package io.silentsuite.sync.syncadapter
+
+import android.accounts.Account
+import java.util.IdentityHashMap
+import java.util.UUID
+import org.junit.Assert.*
+import org.junit.Test
+
+class SyncStatusStoreTest {
+    private class MemoryStorage : SyncStatusStore.Storage {
+        val values = mutableMapOf<String, String>()
+        var failNextCommit = false
+        var failAllCommits = false
+        var commits = 0
+
+        override fun get(key: String) = values[key]
+        override fun commit(puts: Map<String, String>, removes: Set<String>): Boolean {
+            commits++
+            if (failAllCommits || failNextCommit) {
+                failNextCommit = false
+                return false
+            }
+            val next = values.toMutableMap()
+            removes.forEach(next::remove)
+            next.putAll(puts)
+            values.clear()
+            values.putAll(next)
+            return true
+        }
+    }
+
+    private val first = Account("first@example.invalid", "main")
+    private val second = Account("second@example.invalid", "main")
+    private val readdedFirst = Account("first@example.invalid", "main")
+    private val storage = MemoryStorage()
+    private val namespace = UUID.randomUUID().toString()
+    private val mainKeys = IdentityHashMap<Account, String>().apply {
+        put(first, "first-generation-$namespace")
+        put(second, "second-generation-$namespace")
+        put(readdedFirst, "readded-generation-$namespace")
+    }
+    private val childKeys = IdentityHashMap<Account, String>()
+    private val store = SyncStatusStore(
+        storage,
+        mainAccountKey = { mainKeys[it] ?: error("missing main test identity") },
+        childAccountKey = { childKeys[it] ?: error("missing child test identity") },
+    )
+
+    private fun child(name: String): Account = Account(name, "child").also {
+        childKeys[it] = "child-${childKeys.size}"
+    }
+
+    private fun started(result: SyncStatusStore.ContactsStart) =
+        (result as SyncStatusStore.ContactsStart.Started).attemptId
+
+    private fun freshStore() = SyncStatusStore(
+        storage,
+        mainAccountKey = { mainKeys[it] ?: error("missing main test identity") },
+        childAccountKey = { childKeys[it] ?: error("missing child test identity") },
+    )
+
+    @Test fun `success and bounded failure records are atomic isolated and privacy bounded`() {
+        assertTrue(store.recordSuccess(first, SyncStatusStore.Service.CALENDAR, 10))
+        val before = storage.commits
+        assertTrue(store.recordFailure(first, SyncStatusStore.Service.TASKS, SyncStatusStore.FailureCategory.NETWORK, 20))
+        assertEquals(before + 1, storage.commits)
+
+        assertEquals(10L, store.status(first, SyncStatusStore.Service.CALENDAR).lastSuccessAt)
+        assertEquals(SyncStatusStore.FailureCategory.NETWORK, store.status(first, SyncStatusStore.Service.TASKS).lastFailureCategory)
+        assertEquals(SyncStatusStore.Status(), store.status(second, SyncStatusStore.Service.CALENDAR))
+        assertEquals(SyncStatusStore.Status(), store.status(readdedFirst, SyncStatusStore.Service.CALENDAR))
+        assertFalse(storage.values.toString().contains("example.invalid"))
+    }
+
+    @Test fun `failed direct outcome is durably failed closed and successful retry removes sentinel`() {
+        assertTrue(store.recordSuccess(first, SyncStatusStore.Service.CALENDAR, 50))
+        storage.failNextCommit = true
+        assertFalse(store.recordFailure(first, SyncStatusStore.Service.CALENDAR, SyncStatusStore.FailureCategory.PERMISSION, 60))
+        val failedClosed = freshStore().status(first, SyncStatusStore.Service.CALENDAR)
+        assertEquals(50L, failedClosed.lastSuccessAt)
+        assertEquals(SyncStatusStore.FailureCategory.STORAGE, failedClosed.lastFailureCategory)
+        assertTrue(failedClosed.lastFailureAt!! > failedClosed.lastSuccessAt!!)
+        val persistedFaultAt = storage.values.entries
+            .single { (key, _) -> key.startsWith("fault.") && key.endsWith(".CALENDAR") }
+            .value.split('|')[1].toLong()
+        assertEquals(persistedFaultAt, failedClosed.lastFailureAt)
+        assertEquals(
+            failedClosed.lastFailureAt,
+            freshStore().status(first, SyncStatusStore.Service.CALENDAR).lastFailureAt,
+        )
+
+        assertTrue(store.recordFailure(first, SyncStatusStore.Service.CALENDAR, SyncStatusStore.FailureCategory.PERMISSION, 60))
+        assertEquals(SyncStatusStore.FailureCategory.PERMISSION, freshStore().status(first, SyncStatusStore.Service.CALENDAR).lastFailureCategory)
+    }
+
+    @Test fun `new evidence is ordered without erasing the previous outcome`() {
+        store.recordSuccess(first, SyncStatusStore.Service.CALENDAR, 50)
+        store.recordFailure(first, SyncStatusStore.Service.CALENDAR, SyncStatusStore.FailureCategory.PERMISSION, 50)
+        val failed = store.status(first, SyncStatusStore.Service.CALENDAR)
+        assertEquals(50L, failed.lastSuccessAt)
+        assertEquals(51L, failed.lastFailureAt)
+
+        store.recordSuccess(first, SyncStatusStore.Service.CALENDAR, 50)
+        assertEquals(52L, store.status(first, SyncStatusStore.Service.CALENDAR).lastSuccessAt)
+    }
+
+    @Test fun `latest contacts generation stays incomplete over historical success`() {
+        val childOne = child("book-one")
+        val firstAttempt = started(store.beginContacts(first, setOf(childOne)))
+        assertEquals(SyncStatusStore.ChildWrite.RECORDED, store.recordContactsChild(first, firstAttempt, childOne, SyncStatusStore.ChildResult.SUCCESS))
+        val oldSuccess = store.status(first, SyncStatusStore.Service.CONTACTS).lastSuccessAt
+
+        val childTwo = child("book-two")
+        started(store.beginContacts(first, setOf(childOne, childTwo)))
+        val pending = store.status(first, SyncStatusStore.Service.CONTACTS)
+        assertEquals(oldSuccess, pending.lastSuccessAt)
+        assertTrue(pending.latestGenerationIncomplete)
+        assertEquals(2, pending.pendingChildren)
+    }
+
+    @Test fun `contacts status snapshots creation identity once`() {
+        val child = child("identity-snapshot-book")
+        val attempt = started(store.beginContacts(first, setOf(child)))
+        assertEquals(
+            SyncStatusStore.ChildWrite.RECORDED,
+            store.recordContactsChild(first, attempt, child, SyncStatusStore.ChildResult.SUCCESS),
+        )
+
+        var lookups = 0
+        val changingIdentityStore = SyncStatusStore(
+            storage,
+            mainAccountKey = {
+                lookups++
+                if (lookups == 1) "first-generation-$namespace" else "readded-generation-$namespace"
+            },
+            childAccountKey = { childKeys[it] ?: error("missing child test identity") },
+        )
+        assertNotNull(changingIdentityStore.status(first, SyncStatusStore.Service.CONTACTS).lastSuccessAt)
+        assertEquals(1, lookups)
+    }
+
+    @Test fun `contacts terminal and outcome share one commit and failed commit permits replay`() {
+        val child = child("book")
+        val completedAttempt = started(store.beginContacts(first, setOf(child)))
+        assertEquals(SyncStatusStore.ChildWrite.RECORDED, store.recordContactsChild(first, completedAttempt, child, SyncStatusStore.ChildResult.SUCCESS))
+        val oldSuccess = store.status(first, SyncStatusStore.Service.CONTACTS).lastSuccessAt
+        val attempt = started(store.beginContacts(first, setOf(child)))
+        val before = storage.commits
+        storage.failNextCommit = true
+        assertEquals(SyncStatusStore.ChildWrite.STORAGE_FAILURE, store.recordContactsChild(first, attempt, child, SyncStatusStore.ChildResult.SUCCESS))
+        assertEquals(before + 2, storage.commits)
+        val failed = freshStore().status(first, SyncStatusStore.Service.CONTACTS)
+        assertEquals(oldSuccess, failed.lastSuccessAt)
+        assertEquals(SyncStatusStore.FailureCategory.STORAGE, failed.lastFailureCategory)
+        assertTrue(failed.latestGenerationIncomplete)
+
+        assertEquals(SyncStatusStore.ChildWrite.RECORDED, store.recordContactsChild(first, attempt, child, SyncStatusStore.ChildResult.SUCCESS))
+        val completed = freshStore().status(first, SyncStatusStore.Service.CONTACTS)
+        assertFalse(completed.latestGenerationIncomplete)
+        assertNotNull(completed.lastSuccessAt)
+        assertNotEquals(SyncStatusStore.FailureCategory.STORAGE, completed.lastFailureCategory)
+    }
+
+    @Test fun `failed begin commit does not issue an unpersisted attempt`() {
+        val child = child("book")
+        val completedAttempt = started(store.beginContacts(first, setOf(child)))
+        assertEquals(SyncStatusStore.ChildWrite.RECORDED, store.recordContactsChild(first, completedAttempt, child, SyncStatusStore.ChildResult.SUCCESS))
+        val oldSuccess = store.status(first, SyncStatusStore.Service.CONTACTS).lastSuccessAt
+        storage.failNextCommit = true
+        assertEquals(SyncStatusStore.ContactsStart.StorageFailure, store.beginContacts(first, setOf(child)))
+        val failedClosed = freshStore().status(first, SyncStatusStore.Service.CONTACTS)
+        assertEquals(SyncStatusStore.FailureCategory.STORAGE, failedClosed.lastFailureCategory)
+        assertEquals(oldSuccess, failedClosed.lastSuccessAt)
+        assertTrue(failedClosed.latestGenerationIncomplete)
+    }
+
+    @Test fun `malformed contacts generation cannot expose historical success`() {
+        val child = child("book")
+        val attempt = started(store.beginContacts(first, setOf(child)))
+        assertEquals(SyncStatusStore.ChildWrite.RECORDED, store.recordContactsChild(first, attempt, child, SyncStatusStore.ChildResult.SUCCESS))
+        val contactsKey = storage.values.keys.single { it.endsWith(".CONTACTS") }
+        val outcomeParts = storage.values.getValue(contactsKey).split('|', limit = 6).take(4)
+        storage.values[contactsKey] = outcomeParts.joinToString("|") + "|attempt-without-children|;"
+
+        val failedClosed = store.status(first, SyncStatusStore.Service.CONTACTS)
+        assertEquals(SyncStatusStore.FailureCategory.STORAGE, failedClosed.lastFailureCategory)
+        assertTrue(failedClosed.lastFailureAt!! > failedClosed.lastSuccessAt!!)
+    }
+
+    @Test fun `contacts failure removal zero children and unexpected children cannot produce success`() {
+        val childOne = child("book-one")
+        val childTwo = child("book-two")
+        val attempt = started(store.beginContacts(first, setOf(childOne)))
+        assertEquals(SyncStatusStore.ChildWrite.REJECTED, store.recordContactsChild(first, attempt, childTwo, SyncStatusStore.ChildResult.SUCCESS))
+        assertTrue(store.recordContactsChildRemoved(first, childOne))
+        assertEquals(SyncStatusStore.FailureCategory.CHILD_REMOVED, store.status(first, SyncStatusStore.Service.CONTACTS).lastFailureCategory)
+
+        assertEquals(SyncStatusStore.ContactsStart.SetupRequired, store.beginContacts(second, emptySet()))
+        assertEquals(SyncStatusStore.FailureCategory.SETUP_REQUIRED, store.status(second, SyncStatusStore.Service.CONTACTS).lastFailureCategory)
+    }
+
+    @Test fun `new contacts generation supersedes incomplete old attempt`() {
+        val child = child("book")
+        val oldAttempt = started(store.beginContacts(first, setOf(child)))
+        val currentAttempt = started(store.beginContacts(first, setOf(child)))
+        assertEquals(SyncStatusStore.ChildWrite.REJECTED, store.recordContactsChild(first, oldAttempt, child, SyncStatusStore.ChildResult.SUCCESS))
+        assertEquals(SyncStatusStore.ChildWrite.RECORDED, store.recordContactsChild(first, currentAttempt, child, SyncStatusStore.ChildResult.SUCCESS))
+    }
+
+    @Test fun `parent failure atomically terminates generation and rejects late child success`() {
+        val child = child("book")
+        val attempt = started(store.beginContacts(first, setOf(child)))
+        assertTrue(store.failContactsParent(first))
+        assertEquals(SyncStatusStore.ChildWrite.REJECTED, store.recordContactsChild(first, attempt, child, SyncStatusStore.ChildResult.SUCCESS))
+        assertEquals(SyncStatusStore.FailureCategory.PARENT_REFRESH, store.status(first, SyncStatusStore.Service.CONTACTS).lastFailureCategory)
+    }
+
+    @Test fun `exact identity clears after account data vanished and readd remains isolated`() {
+        store.recordSuccess(first, SyncStatusStore.Service.TASKS, 1)
+        store.recordSuccess(second, SyncStatusStore.Service.TASKS, 2)
+        val removedIdentity = store.identity(first)
+        mainKeys.remove(first) // models AccountManager user data disappearing after removal
+        assertTrue(store.clear(removedIdentity))
+        assertEquals(2L, store.status(second, SyncStatusStore.Service.TASKS).lastSuccessAt)
+        assertEquals(SyncStatusStore.Status(), store.status(readdedFirst, SyncStatusStore.Service.TASKS))
+        assertFalse(storage.values.keys.any { it.contains("first-generation") })
+    }
+
+    @Test fun `failed clear preserves evidence for a safe retry`() {
+        store.recordSuccess(first, SyncStatusStore.Service.TASKS, 1)
+        val identity = store.identity(first)
+        storage.failNextCommit = true
+        assertFalse(store.clear(identity))
+        val failed = freshStore().status(first, SyncStatusStore.Service.TASKS)
+        assertEquals(1L, failed.lastSuccessAt)
+        assertEquals(SyncStatusStore.FailureCategory.STORAGE, failed.lastFailureCategory)
+        assertTrue(store.clear(identity))
+        assertEquals(SyncStatusStore.Status(), freshStore().status(first, SyncStatusStore.Service.TASKS))
+    }
+
+    @Test fun `total disk failure remains failed closed in process and reports failure`() {
+        assertTrue(store.recordSuccess(first, SyncStatusStore.Service.TASKS, 1))
+        storage.failAllCommits = true
+        assertFalse(store.recordFailure(first, SyncStatusStore.Service.TASKS, SyncStatusStore.FailureCategory.NETWORK, 2))
+        assertEquals(SyncStatusStore.FailureCategory.STORAGE, store.status(first, SyncStatusStore.Service.TASKS).lastFailureCategory)
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/ui/account/AccountDashboardStateTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/account/AccountDashboardStateTest.kt
@@ -1,0 +1,38 @@
+package io.silentsuite.sync.ui.account
+
+import io.silentsuite.sync.syncadapter.SyncStatusStore
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccountDashboardStateTest {
+    private fun input(
+        loaded: Boolean = true, running: Boolean = false, setup: Boolean = true,
+        master: Boolean = true, permission: Boolean = true, provider: Boolean = true,
+        collections: Boolean = true, status: SyncStatusStore.Status? = SyncStatusStore.Status(),
+    ) = AccountDashboardInput(loaded, running, setup, master, permission, provider, collections, status)
+
+    @Test fun `all visible states have deterministic precedence`() {
+        assertEquals(AccountDashboardState.LOADING, reduceAccountDashboardState(input(loaded = false, running = true)).state)
+        assertEquals(AccountDashboardState.SETUP_REQUIRED, reduceAccountDashboardState(input(setup = false, running = true)).state)
+        assertEquals(AccountDashboardState.SETUP_REQUIRED, reduceAccountDashboardState(input(collections = false)).state)
+        assertEquals(AccountDashboardState.RUNNING, reduceAccountDashboardState(input(running = true, master = false)).state)
+        assertEquals(AccountDashboardBlock.MASTER_SYNC, reduceAccountDashboardState(input(master = false)).blockedBy)
+        assertEquals(AccountDashboardBlock.PERMISSION, reduceAccountDashboardState(input(permission = false)).blockedBy)
+        assertEquals(AccountDashboardBlock.PROVIDER, reduceAccountDashboardState(input(provider = false)).blockedBy)
+        assertEquals(AccountDashboardState.NEVER_SYNCED, reduceAccountDashboardState(input(status = null)).state)
+        assertEquals(AccountDashboardState.NEVER_SYNCED, reduceAccountDashboardState(input()).state)
+        assertEquals(AccountDashboardState.SETUP_REQUIRED, reduceAccountDashboardState(input(status = SyncStatusStore.Status(lastFailureAt = 30, lastFailureCategory = SyncStatusStore.FailureCategory.SETUP_REQUIRED))).state)
+        assertEquals(AccountDashboardState.SUCCESS, reduceAccountDashboardState(input(status = SyncStatusStore.Status(lastSuccessAt = 20, lastFailureAt = 10, lastFailureCategory = SyncStatusStore.FailureCategory.NETWORK))).state)
+        assertEquals(AccountDashboardState.FAILURE, reduceAccountDashboardState(input(status = SyncStatusStore.Status(lastSuccessAt = 10, lastFailureAt = 20, lastFailureCategory = SyncStatusStore.FailureCategory.PERMISSION))).state)
+    }
+
+    @Test fun `inactive without evidence is never success`() {
+        assertEquals(AccountDashboardState.NEVER_SYNCED, reduceAccountDashboardState(input(running = false, status = SyncStatusStore.Status())).state)
+    }
+
+    @Test fun `inactive incomplete latest contacts generation cannot expose old success`() {
+        val status = SyncStatusStore.Status(lastSuccessAt = 10, latestGenerationIncomplete = true, pendingChildren = 1)
+        assertEquals(AccountDashboardState.FAILURE, reduceAccountDashboardState(input(running = false, status = status)).state)
+        assertEquals(AccountDashboardState.RUNNING, reduceAccountDashboardState(input(running = true, status = status)).state)
+    }
+}


### PR DESCRIPTION
## Summary

- persist privacy-bounded Calendar, Contacts, and Tasks outcome evidence by exact account creation generation
- model Contacts parent/child attempts atomically so incomplete or failed latest generations cannot expose historical success
- record stable durable storage-fault sentinels and propagate retry when outcome persistence fails
- preserve provider failure across later cancellation and avoid success for empty, skipped, requested, or cancelled work
- clear exact generation state after confirmed account removal and record child removal only after platform confirmation
- add the pure dashboard-state reducer consumed by the later dashboard UI slice

## Safety properties

- hashed account/child identities only; no account names, secrets, collection content, or provider payloads persisted
- one atomic record per outcome/generation
- successful retry removes record fault sentinel atomically
- exact remove/re-add generation isolation
- SyncResult counters remain preserved

## Review

Substantive GPT-5.6 Sol review: GREEN after resolving incomplete-generation visibility, atomic persistence, failure/cancellation precedence, removal cleanup, provider-boundary evidence, durable fresh-process storage faults, stable failure timestamps, and single-snapshot identity lookup.

## Verification

- `git diff --check`
- reviewed patch digest preserved exactly across rebase onto `dev` `6439d6b`
- no local Gradle, Android, emulator, ADB, lint, or Python execution; executable verification is CI-only
- CI must run unit/lint/build plus focused `SyncStatusRuntimeTest` methods on API 21 and API 35