### PR TITLE
feat(android): simplify account drawer and sign-out

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -259,7 +259,7 @@ jobs:
           target: google_apis
           emulator-options: -no-window -no-audio -no-boot-anim -camera-back none -gpu swiftshader_indirect
           disable-animations: true
-          script: cd android && ./gradlew app:connectedDebugAndroidTest --no-daemon -PrequireEtebase16Kb=true -Pandroid.testInstrumentationRunnerArguments.class=io.silentsuite.sync.ui.AccountActivityRecreationTest,io.silentsuite.sync.ui.PostLoginSetupRuntimeTest,io.silentsuite.sync.ui.setup.AuthenticatorLifecycleRuntimeTest,io.silentsuite.sync.utils.TaskProviderHandlingRuntimeTest,io.silentsuite.sync.syncadapter.SyncStatusRuntimeTest
+          script: cd android && ./gradlew app:connectedDebugAndroidTest --no-daemon -PrequireEtebase16Kb=true -Pandroid.testInstrumentationRunnerArguments.class=io.silentsuite.sync.ui.AccountActivityRecreationTest,io.silentsuite.sync.ui.AccountDrawerSignOutRuntimeTest,io.silentsuite.sync.ui.PostLoginSetupRuntimeTest,io.silentsuite.sync.ui.setup.AuthenticatorLifecycleRuntimeTest,io.silentsuite.sync.utils.TaskProviderHandlingRuntimeTest,io.silentsuite.sync.syncadapter.SyncStatusRuntimeTest
 
       - name: Upload focused androidTest reports and results
         if: always()
@@ -281,6 +281,11 @@ jobs:
           expected={
             ('io.silentsuite.sync.ui.AccountActivityRecreationTest','recreationKeepsTheExactAccountRouteAndDeliversModelStateToTheRecreatedUi'),
             ('io.silentsuite.sync.ui.AccountActivityRecreationTest','readyDoneCompletesOnlyTheExactGeneratedAccount'),
+            ('io.silentsuite.sync.ui.AccountDrawerSignOutRuntimeTest','oneAccountSwitcherExposesAddRowAndCurrentSemanticsAfterRecreation'),
+            ('io.silentsuite.sync.ui.AccountDrawerSignOutRuntimeTest','delayedRemovalFailureSurvivesRecreationAndDuplicateTapStartsOnce'),
+            ('io.silentsuite.sync.ui.AccountDrawerSignOutRuntimeTest','actualTwoAccountSignOutRemovesExactMainAndChildAndActivatesSibling'),
+            ('io.silentsuite.sync.ui.AccountDrawerSignOutRuntimeTest','adapterRefusesToRemoveSameNameReplacementGeneration'),
+            ('io.silentsuite.sync.ui.AccountDrawerSignOutRuntimeTest','delayedSuccessfulRemovalAfterRecreationRoutesRetainedSibling'),
             ('io.silentsuite.sync.ui.PostLoginSetupRuntimeTest','noNetworkDashboardShellRoutesExactAccountAfterReadyDone'),
             ('io.silentsuite.sync.ui.PostLoginSetupRuntimeTest','recoveryRemovalConfirmedRoutesCleanLoginAndPreservesSibling'),
             ('io.silentsuite.sync.ui.PostLoginSetupRuntimeTest','permissionsRecoveryBlocksActionsAndLimitedSkipReachesReady'),

--- a/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
+++ b/android/app/src/androidTest/java/io/silentsuite/screenshots/StoreScreenshotsTest.java
@@ -452,7 +452,10 @@ public class StoreScreenshotsTest {
             drawer.click();
             sleep(1000);
         }
-        tapTextContains("Invitations");
+        UiObject2 invitations = device.wait(
+                Until.findObject(By.res(device.getCurrentPackageName(), "nav_invitations")), NAV_TIMEOUT);
+        if (invitations == null) throw new AssertionError("Stable Invitations drawer row not found");
+        invitations.click();
         sleep(2000);
         capture("6-invitations");
         device.pressBack();

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
@@ -89,9 +89,11 @@ class AccountDrawerSignOutRuntimeTest {
         val target = Fixture("actual-target")
         val sibling = Fixture("actual-sibling")
         val child = Account("child-${System.nanoTime()}@example.invalid", App.addressBookAccountType)
-        check(target.manager.addAccountExplicitly(child, null, null))
-        target.manager.setUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_TYPE, target.account.type)
-        target.manager.setUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_NAME, target.account.name)
+        check(target.manager.addAccountExplicitly(
+            child,
+            null,
+            LocalAddressBook.initialUserData(target.account, "https://example.invalid/address-book"),
+        ))
         try {
             assertTrue(ActiveAccountManager.setActiveAccount(target.context, target.account))
             val statusStore = SyncStatusStore(target.context)

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.os.Build
 import android.view.View
 import androidx.core.view.ViewCompat
+import androidx.core.view.GravityCompat
+import androidx.drawerlayout.widget.DrawerLayout
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -32,6 +34,8 @@ class AccountDrawerSignOutRuntimeTest {
             ActivityScenario.launch<AccountActivity>(AccountActivity.newIntent(fixture.context, account)).use { scenario ->
                 scenario.recreate()
                 scenario.onActivity { activity ->
+                    activity.findViewById<DrawerLayout>(R.id.drawer_layout)
+                        .openDrawer(GravityCompat.START, false)
                     val header = activity.findViewById<View>(R.id.nav_account_header)
                     header.performClick()
                     val add = activity.findViewById<View>(R.id.nav_add_account_row)
@@ -143,8 +147,13 @@ class AccountDrawerSignOutRuntimeTest {
             assertTrue(AccountSettings.writeVerified(
                 fixture.manager, fixture.account, AccountSettings.KEY_CREATION_ID, "replacement-generation"))
 
+            val callbackReceived = CountDownLatch(1)
             var callback: Boolean? = null
-            adapter.removeMain(oldIdentity) { callback = it }
+            adapter.removeMain(oldIdentity) {
+                callback = it
+                callbackReceived.countDown()
+            }
+            assertTrue("replacement refusal callback timed out", callbackReceived.await(10, TimeUnit.SECONDS))
             assertEquals(false, callback)
             assertTrue(adapter.mainGenerationAbsent(oldIdentity))
             assertTrue(fixture.account in fixture.manager.getAccountsByType(fixture.account.type))

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
@@ -5,6 +5,7 @@ import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.Context
 import android.os.Build
+import android.os.Bundle
 import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.GravityCompat
@@ -145,9 +146,15 @@ class AccountDrawerSignOutRuntimeTest {
             val oldIdentity = ExactAccountIdentity(fixture.account.type, fixture.account.name, fixture.creationId)
             val adapter = AndroidCurrentAccountSignOut(fixture.context, fixture.account, fixture.creationId)
             removeAccountAndWait(fixture.manager, fixture.account)
-            assertTrue(fixture.manager.addAccountExplicitly(fixture.account, null, null))
-            assertTrue(AccountSettings.writeVerified(
-                fixture.manager, fixture.account, AccountSettings.KEY_CREATION_ID, "replacement-generation"))
+            val replacementGeneration = "replacement-generation"
+            val replacementData = Bundle().apply {
+                putString(AccountSettings.KEY_CREATION_ID, replacementGeneration)
+            }
+            assertTrue(fixture.manager.addAccountExplicitly(fixture.account, null, replacementData))
+            val replacementRow = fixture.manager.getAccountsByType(fixture.account.type)
+                .single { it.name == fixture.account.name }
+            assertEquals(replacementGeneration,
+                fixture.manager.getUserData(replacementRow, AccountSettings.KEY_CREATION_ID))
 
             val callbackReceived = CountDownLatch(1)
             var callback: Boolean? = null

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
@@ -1,0 +1,268 @@
+package io.silentsuite.sync.ui
+
+import android.Manifest
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.Context
+import android.os.Build
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.silentsuite.sync.AccountSettings
+import io.silentsuite.sync.App
+import io.silentsuite.sync.R
+import io.silentsuite.sync.resource.LocalAddressBook
+import io.silentsuite.sync.ui.setup.PostLoginSetupState
+import io.silentsuite.sync.utils.AndroidCompat
+import java.net.URI
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AccountDrawerSignOutRuntimeTest {
+    @Test fun oneAccountSwitcherExposesAddRowAndCurrentSemanticsAfterRecreation() {
+        val fixture = Fixture("switcher")
+        fixture.use { account ->
+            ActivityScenario.launch<AccountActivity>(AccountActivity.newIntent(fixture.context, account)).use { scenario ->
+                scenario.recreate()
+                scenario.onActivity { activity ->
+                    val header = activity.findViewById<View>(R.id.nav_account_header)
+                    header.performClick()
+                    val add = activity.findViewById<View>(R.id.nav_add_account_row)
+                    val row = activity.findViewById<View>(AccountActivity.accountRowViewId(
+                        ExactAccountIdentity(account.type, account.name, fixture.creationId)))
+                    assertTrue(add.isShown)
+                    assertTrue(add.isClickable)
+                    assertTrue(row.isShown)
+                    assertTrue(row.isSelected)
+                    assertEquals(activity.getString(R.string.account_switcher_current),
+                        ViewCompat.getStateDescription(row)?.toString())
+                    assertEquals(activity.getString(R.string.account_switcher_expanded),
+                        ViewCompat.getStateDescription(header)?.toString())
+                }
+            }
+        }
+    }
+
+    @Test fun delayedRemovalFailureSurvivesRecreationAndDuplicateTapStartsOnce() {
+        val fixture = Fixture("failure")
+        val fake = DelayedFailureSeams(fixture.account)
+        CurrentAccountSignOutViewModel.seamsFactory = { _, exact, generation ->
+            assertEquals(fixture.account, exact)
+            assertEquals(fixture.creationId, generation)
+            fake
+        }
+        try {
+            ActivityScenario.launch<AccountActivity>(AccountActivity.newIntent(fixture.context, fixture.account)).use { scenario ->
+                scenario.onActivity { activity ->
+                    val model = androidx.lifecycle.ViewModelProvider(activity)[CurrentAccountSignOutViewModel::class.java]
+                    model.begin()
+                    model.begin()
+                    assertEquals(1, fake.removeCalls)
+                }
+                scenario.recreate()
+                fake.callback!!(false)
+                InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+                scenario.onActivity { activity ->
+                    assertTrue(activity.findViewById<com.google.android.material.navigation.NavigationView>(R.id.nav_view)
+                        .menu.findItem(R.id.nav_logout).isEnabled)
+                    assertEquals(0, fake.destructiveCleanupCalls)
+                }
+            }
+        } finally {
+            CurrentAccountSignOutViewModel.seamsFactory = null
+            fixture.close()
+        }
+    }
+
+    @Test fun actualTwoAccountSignOutRemovesExactMainAndChildAndActivatesSibling() {
+        val target = Fixture("actual-target")
+        val sibling = Fixture("actual-sibling")
+        val child = Account("child-${System.nanoTime()}@example.invalid", App.addressBookAccountType)
+        check(target.manager.addAccountExplicitly(child, null, null))
+        target.manager.setUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_TYPE, target.account.type)
+        target.manager.setUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_NAME, target.account.name)
+        try {
+            assertTrue(ActiveAccountManager.setActiveAccount(target.context, target.account))
+            val expectedReplacement = target.manager.getAccountsByType(App.accountType).mapNotNull { candidate ->
+                target.manager.getUserData(candidate, AccountSettings.KEY_CREATION_ID)?.takeIf(String::isNotBlank)?.let {
+                    ExactAccountIdentity(candidate.type, candidate.name, it)
+                }
+            }.let(AccountSwitcherPolicy::ordered).first { it != ExactAccountIdentity(
+                target.account.type, target.account.name, target.creationId) }
+            val completed = CountDownLatch(1)
+            var finalState: CurrentAccountSignOutState? = null
+            val coordinator = CurrentAccountSignOutCoordinator(
+                AndroidCurrentAccountSignOut(target.context, target.account, target.creationId)
+            ) { state ->
+                if (state is CurrentAccountSignOutState.Complete) {
+                    finalState = state
+                    completed.countDown()
+                }
+            }
+            coordinator.begin()
+            assertTrue("sign-out did not complete", completed.await(15, TimeUnit.SECONDS))
+            assertEquals(expectedReplacement, (finalState as CurrentAccountSignOutState.Complete).replacement)
+            assertFalse(target.account in target.manager.getAccountsByType(target.account.type))
+            assertFalse(child in target.manager.getAccountsByType(child.type))
+            assertEquals(
+                Account(expectedReplacement.name, expectedReplacement.type),
+                ActiveAccountManager.getActiveAccount(target.context),
+            )
+        } finally {
+            removeAccountAndWait(target.manager, child)
+            sibling.close()
+            target.close()
+        }
+    }
+
+    @Test fun adapterRefusesToRemoveSameNameReplacementGeneration() {
+        val fixture = Fixture("replacement")
+        try {
+            val oldIdentity = ExactAccountIdentity(fixture.account.type, fixture.account.name, fixture.creationId)
+            val adapter = AndroidCurrentAccountSignOut(fixture.context, fixture.account, fixture.creationId)
+            removeAccountAndWait(fixture.manager, fixture.account)
+            assertTrue(fixture.manager.addAccountExplicitly(fixture.account, null, null))
+            assertTrue(AccountSettings.writeVerified(
+                fixture.manager, fixture.account, AccountSettings.KEY_CREATION_ID, "replacement-generation"))
+
+            var callback: Boolean? = null
+            adapter.removeMain(oldIdentity) { callback = it }
+            assertEquals(false, callback)
+            assertTrue(adapter.mainGenerationAbsent(oldIdentity))
+            assertTrue(fixture.account in fixture.manager.getAccountsByType(fixture.account.type))
+        } finally {
+            fixture.close()
+        }
+    }
+
+    @Test fun delayedSuccessfulRemovalAfterRecreationRoutesRetainedSibling() {
+        val target = Fixture("retained-target")
+        val sibling = Fixture("retained-sibling")
+        val siblingIdentity = ExactAccountIdentity(sibling.account.type, sibling.account.name, sibling.creationId)
+        val fake = DelayedSuccessSeams(target.context, target.account, target.creationId, sibling.account, siblingIdentity)
+        CurrentAccountSignOutViewModel.seamsFactory = { _, _, _ -> fake }
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        try {
+            ActivityScenario.launch<AccountActivity>(AccountActivity.newIntent(target.context, target.account)).use { scenario ->
+                scenario.onActivity { activity ->
+                    androidx.lifecycle.ViewModelProvider(activity)[CurrentAccountSignOutViewModel::class.java].begin()
+                }
+                // The platform row disappears while the retained coordinator still awaits its
+                // callback. The recreated Activity must attach to that coordinator before trying
+                // to validate its now-stale explicit route.
+                removeAccountAndWait(target.manager, target.account)
+                scenario.recreate()
+                val monitor = instrumentation.addMonitor(AccountActivity::class.java.name, null, false)
+                var launched: android.app.Activity? = null
+                try {
+                    fake.absent = true
+                    fake.callback!!(true)
+                    launched = instrumentation.waitForMonitorWithTimeout(monitor, 10_000)
+                    val replacementActivity = requireNotNull(launched) { "replacement AccountActivity was not launched" }
+                    instrumentation.waitForIdleSync()
+                    assertEquals(sibling.account,
+                        replacementActivity.intent.getParcelableExtra<Account>(AccountActivity.EXTRA_ACCOUNT))
+                    assertEquals(sibling.creationId,
+                        replacementActivity.intent.getStringExtra(AccountActivity.EXTRA_CREATION_ID))
+                    assertFalse("replacement AccountActivity rejected its exact route", replacementActivity.isFinishing)
+                    assertEquals(1, fake.removeCalls)
+                    assertEquals(sibling.account, ActiveAccountManager.getActiveAccount(target.context))
+                } finally {
+                    launched?.finish()
+                    instrumentation.removeMonitor(monitor)
+                }
+            }
+        } finally {
+            CurrentAccountSignOutViewModel.seamsFactory = null
+            sibling.close()
+            target.close()
+        }
+    }
+
+    private class DelayedFailureSeams(account: Account) : CurrentAccountSignOutCoordinator.Seams {
+        private val identity = ExactAccountIdentity(account.type, account.name, "failure-generation")
+        var removeCalls = 0
+        var destructiveCleanupCalls = 0
+        var callback: ((Boolean) -> Unit)? = null
+        override fun snapshot() = CurrentAccountSignOutSnapshot(identity, emptyList(), listOf(identity))
+        override fun cancelSync(identity: Pair<String, String>) = Unit
+        override fun removeMain(main: ExactAccountIdentity, callback: (Boolean) -> Unit) {
+            removeCalls++
+            this.callback = callback
+        }
+        override fun mainGenerationAbsent(main: ExactAccountIdentity) = false
+        override fun clearCache(main: ExactAccountIdentity) = true.also { destructiveCleanupCalls++ }
+        override fun clearStatus(main: ExactAccountIdentity) = true.also { destructiveCleanupCalls++ }
+        override fun reconcileActive(main: ExactAccountIdentity, replacement: ExactAccountIdentity?) =
+            ActiveAccountReconciliation(true, replacement).also { destructiveCleanupCalls++ }
+        override fun removeAndVerifyChildren(snapshot: CurrentAccountSignOutSnapshot, callback: (Boolean) -> Unit) {
+            destructiveCleanupCalls++
+            callback(true)
+        }
+    }
+
+    private class DelayedSuccessSeams(
+        private val context: Context,
+        target: Account,
+        generation: String,
+        private val siblingAccount: Account,
+        private val sibling: ExactAccountIdentity,
+    ) : CurrentAccountSignOutCoordinator.Seams {
+        private val targetIdentity = ExactAccountIdentity(target.type, target.name, generation)
+        var absent = false
+        var removeCalls = 0
+        var callback: ((Boolean) -> Unit)? = null
+        override fun snapshot() = CurrentAccountSignOutSnapshot(targetIdentity, emptyList(), listOf(targetIdentity, sibling))
+        override fun cancelSync(identity: Pair<String, String>) = Unit
+        override fun removeMain(main: ExactAccountIdentity, callback: (Boolean) -> Unit) {
+            removeCalls++
+            this.callback = callback
+        }
+        override fun mainGenerationAbsent(main: ExactAccountIdentity) = absent
+        override fun clearCache(main: ExactAccountIdentity) = true
+        override fun clearStatus(main: ExactAccountIdentity) = true
+        override fun reconcileActive(main: ExactAccountIdentity, replacement: ExactAccountIdentity?) =
+            ActiveAccountReconciliation(ActiveAccountManager.setActiveAccount(context, siblingAccount), sibling)
+        override fun removeAndVerifyChildren(snapshot: CurrentAccountSignOutSnapshot, callback: (Boolean) -> Unit) = callback(true)
+    }
+
+    private fun removeAccountAndWait(manager: AccountManager, account: Account) {
+        if (account !in manager.getAccountsByType(account.type)) return
+        val removed = CountDownLatch(1)
+        AndroidCompat.removeAccount(manager, account) { removed.countDown() }
+        assertTrue("account removal callback timed out", removed.await(10, TimeUnit.SECONDS))
+        assertFalse("account row remained after confirmed removal", account in manager.getAccountsByType(account.type))
+    }
+
+    private inner class Fixture(private val label: String) : AutoCloseable {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val manager = AccountManager.get(context)
+        val account = Account("$label-${System.nanoTime()}@example.invalid", App.accountType)
+        val creationId = "$label-generation"
+        private val previousBootstrap = App.postLoginBootstrapSucceeded
+        init {
+            check(manager.addAccountExplicitly(account, null, null))
+            AccountSettings.setUserData(manager, account, URI("https://example.invalid/"), account.name)
+            check(AccountSettings.writeVerified(manager, account, AccountSettings.KEY_CREATION_ID, creationId))
+            check(AccountSettings.writeVerified(manager, account, AccountSettings.KEY_LIMITED_INTEGRATIONS, "true"))
+            check(AccountSettings.writeSetupState(manager, account, PostLoginSetupState.COMPLETE))
+            App.postLoginBootstrapSucceeded = true
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                InstrumentationRegistry.getInstrumentation().uiAutomation
+                    .executeShellCommand("pm grant ${context.packageName} ${Manifest.permission.POST_NOTIFICATIONS}").close()
+            }
+        }
+        fun use(block: (Account) -> Unit) = try { block(account) } finally { close() }
+        override fun close() {
+            App.postLoginBootstrapSucceeded = previousBootstrap
+            removeAccountAndWait(manager, account)
+            ActiveAccountManager.clearActiveAccount(context)
+        }
+    }
+}

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
@@ -14,6 +14,7 @@ import io.silentsuite.sync.AccountSettings
 import io.silentsuite.sync.App
 import io.silentsuite.sync.R
 import io.silentsuite.sync.resource.LocalAddressBook
+import io.silentsuite.sync.syncadapter.SyncStatusStore
 import io.silentsuite.sync.ui.setup.PostLoginSetupState
 import io.silentsuite.sync.utils.AndroidCompat
 import java.net.URI
@@ -89,6 +90,10 @@ class AccountDrawerSignOutRuntimeTest {
         target.manager.setUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_NAME, target.account.name)
         try {
             assertTrue(ActiveAccountManager.setActiveAccount(target.context, target.account))
+            val statusStore = SyncStatusStore(target.context)
+            assertTrue(statusStore.recordSuccess(target.account, SyncStatusStore.Service.CALENDAR, 123L))
+            assertEquals(123L,
+                statusStore.status(target.account, SyncStatusStore.Service.CALENDAR).lastSuccessAt)
             val expectedReplacement = target.manager.getAccountsByType(App.accountType).mapNotNull { candidate ->
                 target.manager.getUserData(candidate, AccountSettings.KEY_CREATION_ID)?.takeIf(String::isNotBlank)?.let {
                     ExactAccountIdentity(candidate.type, candidate.name, it)
@@ -110,6 +115,13 @@ class AccountDrawerSignOutRuntimeTest {
             assertEquals(expectedReplacement, (finalState as CurrentAccountSignOutState.Complete).replacement)
             assertFalse(target.account in target.manager.getAccountsByType(target.account.type))
             assertFalse(child in target.manager.getAccountsByType(child.type))
+            // Recreate the same exact generation temporarily. Any uncleared status would now be
+            // visible again because SyncStatusStore keys include this creation ID.
+            assertTrue(target.manager.addAccountExplicitly(target.account, null, null))
+            assertTrue(AccountSettings.writeVerified(target.manager, target.account,
+                AccountSettings.KEY_CREATION_ID, target.creationId))
+            assertEquals(SyncStatusStore.Status(),
+                statusStore.status(target.account, SyncStatusStore.Service.CALENDAR))
             assertEquals(
                 Account(expectedReplacement.name, expectedReplacement.type),
                 ActiveAccountManager.getActiveAccount(target.context),

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDrawerSignOutRuntimeTest.kt
@@ -142,10 +142,13 @@ class AccountDrawerSignOutRuntimeTest {
 
     @Test fun adapterRefusesToRemoveSameNameReplacementGeneration() {
         val fixture = Fixture("replacement")
+        var adapter: AndroidCurrentAccountSignOut? = null
         try {
             val oldIdentity = ExactAccountIdentity(fixture.account.type, fixture.account.name, fixture.creationId)
-            val adapter = AndroidCurrentAccountSignOut(fixture.context, fixture.account, fixture.creationId)
+            val retainedAdapter = AndroidCurrentAccountSignOut(fixture.context, fixture.account, fixture.creationId)
+            adapter = retainedAdapter
             removeAccountAndWait(fixture.manager, fixture.account)
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
             val replacementGeneration = "replacement-generation"
             val replacementData = Bundle().apply {
                 putString(AccountSettings.KEY_CREATION_ID, replacementGeneration)
@@ -156,17 +159,19 @@ class AccountDrawerSignOutRuntimeTest {
             assertEquals(replacementGeneration,
                 fixture.manager.getUserData(replacementRow, AccountSettings.KEY_CREATION_ID))
 
+            assertTrue(retainedAdapter.mainGenerationAbsent(oldIdentity))
             val callbackReceived = CountDownLatch(1)
             var callback: Boolean? = null
-            adapter.removeMain(oldIdentity) {
+            retainedAdapter.removeMain(oldIdentity) {
                 callback = it
                 callbackReceived.countDown()
             }
             assertTrue("replacement refusal callback timed out", callbackReceived.await(10, TimeUnit.SECONDS))
             assertEquals(false, callback)
-            assertTrue(adapter.mainGenerationAbsent(oldIdentity))
+            assertTrue(retainedAdapter.mainGenerationAbsent(oldIdentity))
             assertTrue(fixture.account in fixture.manager.getAccountsByType(fixture.account.type))
         } finally {
+            adapter?.close()
             fixture.close()
         }
     }

--- a/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncStatusStore.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/syncadapter/SyncStatusStore.kt
@@ -68,6 +68,9 @@ class SyncStatusStore internal constructor(
 
     fun identity(account: Account): MainIdentity = MainIdentity(mainAccountKey(account))
 
+    internal fun identity(account: Account, creationId: String): MainIdentity =
+        MainIdentity(hashIdentity(account.type, account.name, creationId))
+
     @Synchronized
     fun status(account: Account, service: Service): Status = synchronized(STORE_LOCK) {
         val identity = mainAccountKey(account)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -369,13 +369,10 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
                 ExactAccountIdentity(acc.type, acc.name, it) to acc
             }
         }.sortedWith(compareBy({ it.first.name }, { it.first.creationId }, { it.first.type }))
-        val usedRowIds = mutableSetOf<Int>()
+        val rowIds = accountRowViewIds(ordered.map { it.first })
         for ((identity, acc) in ordered) {
             val row = LayoutInflater.from(this).inflate(R.layout.nav_account_row, container, false)
-            var rowId = accountRowViewId(identity)
-            while (!usedRowIds.add(rowId))
-                rowId = if (rowId == ACCOUNT_ROW_ID_MAX) ACCOUNT_ROW_ID_MIN else rowId + 1
-            row.id = rowId
+            row.id = rowIds.getValue(identity)
             val textView = row.findViewById<TextView>(R.id.nav_account_name)
             val currentIndicator = row.findViewById<View>(R.id.nav_account_current_indicator)
             textView.text = acc.name
@@ -1041,6 +1038,16 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         private const val ACCOUNT_ROW_ID_MAX = 0x02ffffff
         internal fun accountRowViewId(identity: ExactAccountIdentity) =
             ACCOUNT_ROW_ID_MIN or (identity.hashCode() and 0x00ffffff)
+
+        internal fun accountRowViewIds(identities: List<ExactAccountIdentity>): Map<ExactAccountIdentity, Int> {
+            val used = mutableSetOf<Int>()
+            return AccountSwitcherPolicy.ordered(identities).associateWith { identity ->
+                var rowId = accountRowViewId(identity)
+                while (!used.add(rowId))
+                    rowId = if (rowId == ACCOUNT_ROW_ID_MAX) ACCOUNT_ROW_ID_MIN else rowId + 1
+                rowId
+            }
+        }
         fun newIntent(context: Context, account: Account): Intent = Intent(context, AccountActivity::class.java)
             .putExtra(EXTRA_ACCOUNT, account)
             .putExtra(EXTRA_CREATION_ID, AccountManager.get(context).getUserData(account, AccountSettings.KEY_CREATION_ID))

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AccountActivity.kt
@@ -28,10 +28,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.ActionBarDrawerToggle
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
+import androidx.core.view.ViewCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
@@ -43,7 +43,6 @@ import at.bitfire.vcard4android.ContactsStorageException
 import com.etebase.client.CollectionAccessLevel
 import com.etebase.client.CollectionManager
 import com.etebase.client.Utils
-import com.etebase.client.exceptions.EtebaseException
 import io.silentsuite.sync.*
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_ADDRESS_BOOK
 import io.silentsuite.sync.Constants.ETEBASE_TYPE_CALENDAR
@@ -76,6 +75,7 @@ import java.util.logging.Level
 
 class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMenu.OnMenuItemClickListener, Refreshable, NavigationView.OnNavigationItemSelectedListener, SyncStatusObserver {
     private val model: AccountInfoViewModel by viewModels()
+    private val signOutModel: CurrentAccountSignOutViewModel by viewModels()
 
     private lateinit var account: Account
     private lateinit var settings: AccountSettings
@@ -92,11 +92,15 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
     internal val tasksOrgPackage = "org.tasks"
 
     private var syncStatusSnackbar: Snackbar? = null
+    private var signOutErrorSnackbar: Snackbar? = null
     private var syncStatusObserver: Any? = null
     private var syncActiveObserver: Any? = null
     private var swipeRefreshLayout: SwipeRefreshLayout? = null
     private var accountListExpanded = false
     private var pendingExportKind: AndroidExportKind? = null
+    private var signOutOnly = false
+    private var renderedSignOutErrorId = 0L
+    private var signOutCompletionHandled = false
     private lateinit var notificationPermissionFlow: NotificationPermissionFlow
 
     // ActivityResultRegistry keeps this registration across recreation and delivers an outstanding
@@ -144,6 +148,11 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         // An explicit stale/wrong-type parcel is never allowed to fall back to another account.
         val explicit = intent.getParcelableExtra<Account>(EXTRA_ACCOUNT)
         val expectedCreationId = intent.getStringExtra(EXTRA_CREATION_ID)
+        if (explicit != null && !expectedCreationId.isNullOrBlank() &&
+            signOutModel.owns(explicit, expectedCreationId) && signOutModel.hasStarted()) {
+            attachRetainedSignOut()
+            return
+        }
         val resolved = io.silentsuite.sync.ui.setup.ExactAccountRouting.validate(
             explicit, expectedCreationId, App.accountType, accountManager)
             ?: if (explicit == null) ActiveAccountManager.getActiveAccount(this) else null
@@ -174,6 +183,9 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
         title = account.name
         settings = AccountSettings(this, account)
+        val creationId = accountManager.getUserData(account, AccountSettings.KEY_CREATION_ID)
+        if (creationId.isNullOrBlank()) { finish(); return }
+        signOutModel.initialize(account, creationId)
         pendingExportKind = savedInstanceState?.getString(KEY_PENDING_EXPORT_KIND)?.let { name ->
             runCatching { AndroidExportKind.valueOf(name) }.getOrNull()
         }
@@ -213,6 +225,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
         // Setup nav header with account switcher
         setupNavHeader(navigationView)
+        signOutModel.state.observe(this) { renderSignOutState(it) }
 
         // Back press closes drawer first
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
@@ -279,6 +292,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
+        if (signOutOnly) return
         pendingExportKind?.let { outState.putString(KEY_PENDING_EXPORT_KIND, it.name) }
         outState.putBoolean(KEY_NOTIFICATION_PERMISSION_PENDING, notificationPermissionFlow.notificationRequestPending)
         outState.putBoolean(KEY_STARTUP_PERMISSION_FLOW_STARTED, notificationPermissionFlow.runtimePermissionFlowStarted)
@@ -319,20 +333,20 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         val accountManager = AccountManager.get(this)
         val accounts = accountManager.getAccountsByType(App.accountType)
 
-        // Show dropdown arrow only for multi-account users
-        if (accounts.size > 1) {
-            dropdownArrow?.visibility = View.VISIBLE
-
-            accountHeader?.setOnClickListener {
-                accountListExpanded = !accountListExpanded
-                accountListContainer?.visibility = if (accountListExpanded) View.VISIBLE else View.GONE
-                // Rotate arrow
-                dropdownArrow?.rotation = if (accountListExpanded) 180f else 0f
-            }
-
-            // Build account list rows
-            buildAccountList(accountListContainer, accounts)
+        dropdownArrow?.visibility = if (AccountSwitcherPolicy.canExpand(accounts.size)) View.VISIBLE else View.GONE
+        accountHeader?.contentDescription = getString(R.string.account_switcher_description, account.name)
+        fun renderExpansion() {
+            accountListContainer?.visibility = if (accountListExpanded) View.VISIBLE else View.GONE
+            dropdownArrow?.rotation = if (accountListExpanded) 180f else 0f
+            accountHeader?.let { ViewCompat.setStateDescription(it, getString(if (accountListExpanded)
+                R.string.account_switcher_expanded else R.string.account_switcher_collapsed)) }
         }
+        accountHeader?.setOnClickListener {
+            accountListExpanded = !accountListExpanded
+            renderExpansion()
+        }
+        renderExpansion()
+        buildAccountList(accountListContainer, accounts)
 
         // Add account row
         addAccountRow?.setOnClickListener {
@@ -344,35 +358,37 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         if (container == null) return
 
         // Remove any previously added account rows (keep the divider and add-account row)
-        val addAccountRow = container.findViewById<LinearLayout>(R.id.nav_add_account_row)
-        val dividerIndex = 0  // The divider View is at index 0
         // Remove all views except the last two (divider + add account row)
         while (container.childCount > 2) {
             container.removeViewAt(0)
         }
 
-        for (acc in accounts) {
-            val row = LayoutInflater.from(this).inflate(android.R.layout.simple_list_item_1, container, false)
-            val textView = row.findViewById<TextView>(android.R.id.text1)
-            textView.text = acc.name
-            textView.textSize = 14f
-            val textColorAttr = android.R.attr.textColorPrimary
-            val typedValue = android.util.TypedValue()
-            theme.resolveAttribute(textColorAttr, typedValue, true)
-            textView.setTextColor(ContextCompat.getColor(this, typedValue.resourceId))
-            textView.setPadding(
-                resources.getDimensionPixelSize(R.dimen.activity_margin),
-                12, 16, 12
-            )
-
-            // Show checkmark for active account
-            if (acc.name == account.name) {
-                textView.setCompoundDrawablesRelativeWithIntrinsicBounds(
-                    0, 0, android.R.drawable.checkbox_on_background, 0)
+        val manager = AccountManager.get(this)
+        val ordered = accounts.mapNotNull { acc ->
+            manager.getUserData(acc, AccountSettings.KEY_CREATION_ID)?.takeIf(String::isNotBlank)?.let {
+                ExactAccountIdentity(acc.type, acc.name, it) to acc
             }
+        }.sortedWith(compareBy({ it.first.name }, { it.first.creationId }, { it.first.type }))
+        val usedRowIds = mutableSetOf<Int>()
+        for ((identity, acc) in ordered) {
+            val row = LayoutInflater.from(this).inflate(R.layout.nav_account_row, container, false)
+            var rowId = accountRowViewId(identity)
+            while (!usedRowIds.add(rowId))
+                rowId = if (rowId == ACCOUNT_ROW_ID_MAX) ACCOUNT_ROW_ID_MIN else rowId + 1
+            row.id = rowId
+            val textView = row.findViewById<TextView>(R.id.nav_account_name)
+            val currentIndicator = row.findViewById<View>(R.id.nav_account_current_indicator)
+            textView.text = acc.name
+            val isCurrent = identity.type == account.type && identity.name == account.name &&
+                identity.creationId == manager.getUserData(account, AccountSettings.KEY_CREATION_ID)
+            row.isSelected = isCurrent
+            row.contentDescription = getString(R.string.account_switcher_account_description, acc.name)
+            ViewCompat.setStateDescription(row, getString(if (isCurrent)
+                R.string.account_switcher_current else R.string.account_switcher_not_current))
+            currentIndicator.visibility = if (isCurrent) View.VISIBLE else View.INVISIBLE
 
             row.setOnClickListener {
-                if (acc.name != account.name) {
+                if (!isCurrent) {
                     if (!ActiveAccountManager.setActiveAccount(this, acc)) return@setOnClickListener
                     // Recreate activity with new account
                     val intent = newIntent(this, acc)
@@ -389,6 +405,7 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
     override fun onResume() {
         super.onResume()
+        if (signOutOnly) return
         onStatusChanged(SYNC_OBSERVER_TYPE_SETTINGS)
         syncStatusObserver = ContentResolver.addStatusChangeListener(SYNC_OBSERVER_TYPE_SETTINGS, this)
         // Drive the pull-to-refresh spinner from active sync state so it clears
@@ -410,7 +427,11 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        if (signOutOnly) return false
         menuInflater.inflate(R.menu.activity_account, menu)
+        val busy = signOutModel.state.value is CurrentAccountSignOutState.Removing ||
+            signOutModel.state.value is CurrentAccountSignOutState.CleaningUp
+        menu.findItem(R.id.nav_logout)?.isEnabled = !busy
         return true
     }
 
@@ -420,6 +441,8 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
                 requestSync()
                 true
             }
+            R.id.account_show_fingerprint -> { showFingerprintDialog(); true }
+            R.id.account_export_data -> { showExportDialog(); true }
             else -> super.onOptionsItemSelected(item)
         }
     }
@@ -488,29 +511,14 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
         return false
     }
 
-    private fun scrollToSection(sectionId: Int) {
-        val scrollView = findViewById<ScrollView>(R.id.parent) ?: return
-        val section = findViewById<View>(sectionId) ?: return
-        scrollView.post { scrollView.smoothScrollTo(0, section.top) }
-    }
-
     // NavigationView drawer item handling (moved from AccountsActivity)
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.nav_calendar -> scrollToSection(R.id.caldav)
-            R.id.nav_tasks -> scrollToSection(R.id.taskdav)
-            R.id.nav_contacts -> scrollToSection(R.id.carddav)
             R.id.nav_about -> startActivity(Intent(this, AboutActivity::class.java))
             R.id.nav_app_settings -> startActivity(AppSettingsActivity.newIntent(this, account))
             R.id.nav_invitations -> startActivity(InvitationsActivity.newIntent(this, account))
-            R.id.nav_show_fingerprint -> showFingerprintDialog()
-            R.id.nav_export_data -> showExportDialog()
-            R.id.nav_website -> startActivity(Intent(Intent.ACTION_VIEW, Constants.webUri))
-            R.id.nav_webapp -> startActivity(Intent(Intent.ACTION_VIEW, Constants.webAppUri))
-            R.id.nav_guide -> startActivity(Intent(Intent.ACTION_VIEW, Constants.docsUri))
-            R.id.nav_add_account -> startActivity(Intent(this, LoginActivity::class.java))
             R.id.nav_logout -> confirmLogout()
-            R.id.nav_theme -> showThemeDialog()
+            R.id.nav_sync_overview -> Unit
         }
 
         val drawer = findViewById<DrawerLayout>(R.id.drawer_layout)
@@ -583,62 +591,51 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
     }
 
     private fun confirmLogout() {
-        val accountManager = AccountManager.get(this)
-        val accounts = accountManager.getAccountsByType(App.accountType)
-        if (accounts.isEmpty()) {
-            Toast.makeText(this, "No account to log out", Toast.LENGTH_SHORT).show()
-            return
-        }
-
         MaterialAlertDialogBuilder(this)
             .setTitle(R.string.account_delete_confirmation_title)
             .setMessage(R.string.account_delete_confirmation_text)
             .setPositiveButton(R.string.navigation_drawer_logout) { _, _ ->
-                lifecycleScope.launch {
-                    for (acc in accounts) {
-                        try {
-                            teardownAccountState(acc)
-                        } catch (e: Exception) {
-                            if (e is kotlinx.coroutines.CancellationException) throw e
-                            Logger.log.warning("Account teardown failed: ${e.javaClass.name}")
-                        }
-                    }
-                    for (acc in accounts) {
-                        accountManager.removeAccountExplicitly(acc)
-                    }
-                    val intent = Intent(this@AccountActivity, LoginActivity::class.java)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
-                    startActivity(intent)
-                    finish()
-                }
+                signOutModel.begin()
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
     }
 
-    private fun showThemeDialog() {
-        val themes = arrayOf("Light", "Dark", "System default")
-        val prefs = getSharedPreferences("app_settings", MODE_PRIVATE)
-        val currentMode = prefs.getInt("theme_mode", AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
-        val checkedItem = when (currentMode) {
-            AppCompatDelegate.MODE_NIGHT_NO -> 0
-            AppCompatDelegate.MODE_NIGHT_YES -> 1
-            else -> 2
-        }
+    private fun attachRetainedSignOut() {
+        signOutOnly = true
+        setContentView(R.layout.activity_account)
+        signOutModel.state.observe(this) { renderSignOutState(it) }
+    }
 
-        MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.navigation_drawer_theme)
-            .setSingleChoiceItems(themes, checkedItem) { dialog, which ->
-                val mode = when (which) {
-                    0 -> AppCompatDelegate.MODE_NIGHT_NO
-                    1 -> AppCompatDelegate.MODE_NIGHT_YES
-                    else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-                }
-                prefs.edit().putInt("theme_mode", mode).apply()
-                AppCompatDelegate.setDefaultNightMode(mode)
-                dialog.dismiss()
+    private fun renderSignOutState(state: CurrentAccountSignOutState) {
+        invalidateOptionsMenu()
+        findViewById<NavigationView>(R.id.nav_view).menu.findItem(R.id.nav_logout)?.isEnabled =
+            state !is CurrentAccountSignOutState.Removing && state !is CurrentAccountSignOutState.CleaningUp
+        val errorId = when (state) {
+            is CurrentAccountSignOutState.RemovalFailed -> state.errorId
+            is CurrentAccountSignOutState.CleanupFailed -> state.errorId
+            else -> null
+        }
+        if (errorId != null && errorId > renderedSignOutErrorId) {
+            renderedSignOutErrorId = errorId
+            signOutErrorSnackbar?.dismiss()
+            val message = if (state is CurrentAccountSignOutState.CleanupFailed)
+                R.string.account_sign_out_cleanup_failed else R.string.account_sign_out_failed
+            signOutErrorSnackbar = Snackbar.make(findViewById(R.id.coordinator), message, Snackbar.LENGTH_INDEFINITE)
+                .setAction(R.string.retry) { signOutModel.begin() }.also { it.show() }
+        }
+        if (state is CurrentAccountSignOutState.Complete && !signOutCompletionHandled) {
+            signOutCompletionHandled = true
+            signOutErrorSnackbar?.dismiss()
+            val replacement = state.replacement
+            val intent = if (replacement == null) Intent(this, LoginActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+            } else newIntent(this, Account(replacement.name, replacement.type)).apply {
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
             }
-            .show()
+            startActivity(intent)
+            finish()
+        }
     }
 
     /* LOADERS AND LOADED DATA */
@@ -925,34 +922,6 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
     /* USER ACTIONS */
 
-    // Tear down per-account client state before the Android account is removed.
-    // Must run while AccountManager still has the user data, since AccountSettings
-    // (and the etebase session) are read from it. confirmLogout() must call this —
-    // leaving the Etebase FS cache behind causes stale stokens on re-login, which
-    // makes incremental sync miss historical items.
-    private suspend fun teardownAccountState(account: Account) = withContext(Dispatchers.IO) {
-        try {
-            EtebaseLocalCache.clearUserCache(this@AccountActivity, account.name)
-        } catch (e: Throwable) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            Logger.log.warning("Cache clear failed: ${e.javaClass.name}")
-        }
-
-        try {
-            val settings = AccountSettings(this@AccountActivity, account)
-            HttpClient.Builder(this@AccountActivity).build().use { httpClient ->
-                val etebase = EtebaseLocalCache.getEtebase(this@AccountActivity, httpClient.okHttpClient, settings)
-                etebase.logout()
-            }
-        } catch (e: EtebaseException) {
-            Logger.log.warning("Server logout failed: ${e.javaClass.name}")
-        } catch (e: Throwable) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            Logger.log.warning("Account teardown failed: ${e.javaClass.name}")
-        }
-    }
-
-
     private fun requestSync() {
         if (isSyncActive()) return        // don't stack a duplicate concurrent sync
         requestSync(applicationContext, account)
@@ -1063,11 +1032,15 @@ class AccountActivity : BaseActivity(), Toolbar.OnMenuItemClickListener, PopupMe
 
     companion object {
         val EXTRA_ACCOUNT = "account"
-        private const val EXTRA_CREATION_ID = "account_creation_id"
+        internal const val EXTRA_CREATION_ID = "account_creation_id"
         private const val REQUEST_CREATE_EXPORT_DOCUMENT = 7501
         private const val KEY_PENDING_EXPORT_KIND = "pendingExportKind"
         private const val KEY_NOTIFICATION_PERMISSION_PENDING = "notification_permission_pending"
         private const val KEY_STARTUP_PERMISSION_FLOW_STARTED = "startup_permission_flow_started"
+        private const val ACCOUNT_ROW_ID_MIN = 0x02000000
+        private const val ACCOUNT_ROW_ID_MAX = 0x02ffffff
+        internal fun accountRowViewId(identity: ExactAccountIdentity) =
+            ACCOUNT_ROW_ID_MIN or (identity.hashCode() and 0x00ffffff)
         fun newIntent(context: Context, account: Account): Intent = Intent(context, AccountActivity::class.java)
             .putExtra(EXTRA_ACCOUNT, account)
             .putExtra(EXTRA_CREATION_ID, AccountManager.get(context).getUserData(account, AccountSettings.KEY_CREATION_ID))

--- a/android/app/src/main/java/io/silentsuite/sync/ui/ActiveAccountManager.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/ActiveAccountManager.kt
@@ -48,4 +48,29 @@ object ActiveAccountManager {
         return prefs.edit().remove(KEY_NAME).remove(KEY_CREATION_ID).commit() &&
             prefs.getString(KEY_NAME, null) == null && prefs.getString(KEY_CREATION_ID, null) == null
     }
+
+    /** Replace only the exact active generation; a concurrently selected sibling is preserved. */
+    fun replaceIfActive(
+        context: Context,
+        expected: ExactAccountIdentity,
+        replacement: ExactAccountIdentity?
+    ): Boolean {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val decision = ActiveAccountReplacementPolicy.decide(
+            prefs.getString(KEY_NAME, null), prefs.getString(KEY_CREATION_ID, null), expected, replacement)
+        if (decision is ActiveAccountReplacementDecision.Preserve) return true
+        val chosen = (decision as ActiveAccountReplacementDecision.Replace).identity
+        if (chosen != null) {
+            val account = Account(chosen.name, chosen.type)
+            val manager = AccountManager.get(context)
+            if (chosen.type != App.accountType || account !in manager.getAccountsByType(chosen.type) ||
+                manager.getUserData(account, AccountSettings.KEY_CREATION_ID) != chosen.creationId) return false
+        }
+        val edit = prefs.edit()
+        if (chosen == null) edit.remove(KEY_NAME).remove(KEY_CREATION_ID)
+        else edit.putString(KEY_NAME, chosen.name).putString(KEY_CREATION_ID, chosen.creationId)
+        if (!edit.commit()) return false
+        return prefs.getString(KEY_NAME, null) == chosen?.name &&
+            prefs.getString(KEY_CREATION_ID, null) == chosen?.creationId
+    }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
@@ -34,7 +34,7 @@ internal class AndroidCurrentAccountSignOut(
     private val statusCleanup = injectedStatusCleanup ?: run {
         val store = SyncStatusStore(context)
         // Snapshot the opaque generation key while AccountManager still owns the exact row.
-        val statusIdentity = store.identity(account)
+        val statusIdentity = store.identity(account, creationId)
         ExactAccountStatusCleanup { requested -> requested == main && store.clear(statusIdentity) }
     }
 

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
@@ -33,14 +33,18 @@ internal class AndroidCurrentAccountSignOut(
     private val main = ExactAccountIdentity(account.type, account.name, creationId)
     private val statusCleanup = injectedStatusCleanup ?: run {
         val store = SyncStatusStore(context)
-        // Snapshot before AccountManager removal; cleanup retries retain this exact generation key.
+        // Snapshot the opaque generation key while AccountManager still owns the exact row.
         val statusIdentity = store.identity(account)
         ExactAccountStatusCleanup { requested -> requested == main && store.clear(statusIdentity) }
     }
 
+    private fun currentRow(type: String, name: String): Account? =
+        manager.getAccountsByType(type).firstOrNull { it.name == name }
+
     override fun snapshot(): CurrentAccountSignOutSnapshot? {
-        if (creationId.isBlank() || account !in manager.getAccountsByType(account.type) ||
-            manager.getUserData(account, AccountSettings.KEY_CREATION_ID) != creationId) return null
+        val current = currentRow(account.type, account.name) ?: return null
+        if (creationId.isBlank() ||
+            manager.getUserData(current, AccountSettings.KEY_CREATION_ID) != creationId) return null
         val children = manager.getAccountsByType(App.addressBookAccountType).filter { child ->
             manager.getUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_TYPE) == account.type &&
                 manager.getUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_NAME) == account.name
@@ -57,9 +61,8 @@ internal class AndroidCurrentAccountSignOut(
         ContentResolver.cancelSync(Account(identity.second, identity.first), null)
 
     override fun removeMain(main: ExactAccountIdentity, callback: (Boolean) -> Unit) {
-        val row = Account(main.name, main.type)
-        if (row !in manager.getAccountsByType(main.type) ||
-            manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId) {
+        val row = currentRow(main.type, main.name)
+        if (row == null || manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId) {
             callback(false)
             return
         }
@@ -67,14 +70,13 @@ internal class AndroidCurrentAccountSignOut(
     }
 
     override fun mainGenerationAbsent(main: ExactAccountIdentity): Boolean {
-        val row = Account(main.name, main.type)
-        return row !in manager.getAccountsByType(main.type) ||
-            manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId
+        val row = currentRow(main.type, main.name)
+        return row == null || manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId
     }
 
     override fun clearCache(main: ExactAccountIdentity): Boolean {
-        val row = Account(main.name, main.type)
-        if (row in manager.getAccountsByType(main.type)) {
+        val row = currentRow(main.type, main.name)
+        if (row != null) {
             // Cache storage is keyed by account name. A replacement generation owns that name now.
             return manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId
         }
@@ -99,13 +101,13 @@ internal class AndroidCurrentAccountSignOut(
         fun next() {
             if (pending.isEmpty()) { callback(true); return }
             val identity = pending.removeAt(0)
-            val child = Account(identity.second, identity.first)
-            val stillOwned = child in manager.getAccountsByType(identity.first) &&
+            val child = currentRow(identity.first, identity.second)
+            val stillOwned = child != null &&
                 manager.getUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_TYPE) == snapshot.main.type &&
                 manager.getUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_NAME) == snapshot.main.name
             if (!stillOwned) { next(); return }
-            AndroidCompat.removeAccount(manager, child) { confirmed ->
-                if (confirmed && child !in manager.getAccountsByType(identity.first)) next() else callback(false)
+            AndroidCompat.removeAccount(manager, child!!) { confirmed ->
+                if (confirmed && currentRow(identity.first, identity.second) == null) next() else callback(false)
             }
         }
         Handler(Looper.getMainLooper()).post(::next)

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
@@ -1,0 +1,136 @@
+package io.silentsuite.sync.ui
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.app.Application
+import android.content.ContentResolver
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import io.silentsuite.sync.AccountSettings
+import io.silentsuite.sync.App
+import io.silentsuite.sync.EtebaseLocalCache
+import io.silentsuite.sync.resource.LocalAddressBook
+import io.silentsuite.sync.utils.AndroidCompat
+
+/** Slice 10 plugs exact sync-outcome cleanup into this seam; Slice 9 intentionally stores none. */
+fun interface ExactAccountStatusCleanup {
+    fun clear(identity: ExactAccountIdentity): Boolean
+
+    companion object { val NO_OP = ExactAccountStatusCleanup { true } }
+}
+
+internal class AndroidCurrentAccountSignOut(
+    private val context: Context,
+    private val account: Account,
+    private val creationId: String,
+    private val statusCleanup: ExactAccountStatusCleanup = ExactAccountStatusCleanup.NO_OP
+) : CurrentAccountSignOutCoordinator.Seams {
+    private val manager = AccountManager.get(context)
+    private val main = ExactAccountIdentity(account.type, account.name, creationId)
+
+    override fun snapshot(): CurrentAccountSignOutSnapshot? {
+        if (creationId.isBlank() || account !in manager.getAccountsByType(account.type) ||
+            manager.getUserData(account, AccountSettings.KEY_CREATION_ID) != creationId) return null
+        val children = manager.getAccountsByType(App.addressBookAccountType).filter { child ->
+            manager.getUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_TYPE) == account.type &&
+                manager.getUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_NAME) == account.name
+        }.map { it.type to it.name }.distinct().sortedWith(compareBy({ it.second }, { it.first }))
+        val siblings = manager.getAccountsByType(App.accountType).mapNotNull { candidate ->
+            manager.getUserData(candidate, AccountSettings.KEY_CREATION_ID)?.takeIf(String::isNotBlank)?.let {
+                ExactAccountIdentity(candidate.type, candidate.name, it)
+            }
+        }
+        return CurrentAccountSignOutSnapshot(main, children, AccountSwitcherPolicy.ordered(siblings))
+    }
+
+    override fun cancelSync(identity: Pair<String, String>) =
+        ContentResolver.cancelSync(Account(identity.second, identity.first), null)
+
+    override fun removeMain(main: ExactAccountIdentity, callback: (Boolean) -> Unit) {
+        val row = Account(main.name, main.type)
+        if (row !in manager.getAccountsByType(main.type) ||
+            manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId) {
+            callback(false)
+            return
+        }
+        AndroidCompat.removeAccount(manager, row, callback)
+    }
+
+    override fun mainGenerationAbsent(main: ExactAccountIdentity): Boolean {
+        val row = Account(main.name, main.type)
+        return row !in manager.getAccountsByType(main.type) ||
+            manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId
+    }
+
+    override fun clearCache(main: ExactAccountIdentity): Boolean {
+        val row = Account(main.name, main.type)
+        if (row in manager.getAccountsByType(main.type)) {
+            // Cache storage is keyed by account name. A replacement generation owns that name now.
+            return manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId
+        }
+        return runCatching { EtebaseLocalCache.clearUserCache(context, main.name) }.isSuccess
+    }
+
+    override fun clearStatus(main: ExactAccountIdentity) = runCatching { statusCleanup.clear(main) }.getOrDefault(false)
+
+    override fun reconcileActive(main: ExactAccountIdentity, replacement: ExactAccountIdentity?): ActiveAccountReconciliation {
+        if (!ActiveAccountManager.replaceIfActive(context, main, replacement))
+            return ActiveAccountReconciliation(false, null)
+        val active = ActiveAccountManager.getActiveAccount(context)?.let { selected ->
+            manager.getUserData(selected, AccountSettings.KEY_CREATION_ID)?.takeIf(String::isNotBlank)?.let {
+                ExactAccountIdentity(selected.type, selected.name, it)
+            }
+        }
+        return ActiveAccountReconciliation(true, active)
+    }
+
+    override fun removeAndVerifyChildren(snapshot: CurrentAccountSignOutSnapshot, callback: (Boolean) -> Unit) {
+        val pending = snapshot.children.toMutableList()
+        fun next() {
+            if (pending.isEmpty()) { callback(true); return }
+            val identity = pending.removeAt(0)
+            val child = Account(identity.second, identity.first)
+            val stillOwned = child in manager.getAccountsByType(identity.first) &&
+                manager.getUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_TYPE) == snapshot.main.type &&
+                manager.getUserData(child, LocalAddressBook.USER_DATA_MAIN_ACCOUNT_NAME) == snapshot.main.name
+            if (!stillOwned) { next(); return }
+            AndroidCompat.removeAccount(manager, child) { confirmed ->
+                if (confirmed && child !in manager.getAccountsByType(identity.first)) next() else callback(false)
+            }
+        }
+        Handler(Looper.getMainLooper()).post(::next)
+    }
+}
+
+class CurrentAccountSignOutViewModel(application: Application) : AndroidViewModel(application) {
+    companion object {
+        @JvmField internal var seamsFactory: ((Context, Account, String) -> CurrentAccountSignOutCoordinator.Seams)? = null
+    }
+    private val mutableState = MutableLiveData<CurrentAccountSignOutState>()
+    val state: LiveData<CurrentAccountSignOutState> = mutableState
+    private var exactAccount: ExactAccountIdentity? = null
+    private var coordinator: CurrentAccountSignOutCoordinator? = null
+
+    fun initialize(account: Account, creationId: String) {
+        val identity = ExactAccountIdentity(account.type, account.name, creationId)
+        if (exactAccount == identity) return
+        check(exactAccount == null) { "Sign-out owner cannot change exact account" }
+        exactAccount = identity
+        val appContext = getApplication<Application>().applicationContext
+        coordinator = CurrentAccountSignOutCoordinator(
+            seamsFactory?.invoke(appContext, account, creationId)
+                ?: AndroidCurrentAccountSignOut(appContext, account, creationId)
+        ) { mutableState.postValue(it) }
+    }
+
+    fun owns(account: Account, creationId: String) =
+        exactAccount == ExactAccountIdentity(account.type, account.name, creationId)
+
+    fun hasStarted() = coordinator?.state?.let { it !is CurrentAccountSignOutState.Idle } == true
+
+    fun begin() = coordinator?.begin()
+}

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
@@ -2,6 +2,7 @@ package io.silentsuite.sync.ui
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.accounts.OnAccountsUpdateListener
 import android.app.Application
 import android.content.ContentResolver
 import android.content.Context
@@ -16,6 +17,7 @@ import io.silentsuite.sync.EtebaseLocalCache
 import io.silentsuite.sync.resource.LocalAddressBook
 import io.silentsuite.sync.syncadapter.SyncStatusStore
 import io.silentsuite.sync.utils.AndroidCompat
+import java.util.concurrent.atomic.AtomicBoolean
 
 fun interface ExactAccountStatusCleanup {
     fun clear(identity: ExactAccountIdentity): Boolean
@@ -31,6 +33,14 @@ internal class AndroidCurrentAccountSignOut(
 ) : CurrentAccountSignOutCoordinator.Seams {
     private val manager = AccountManager.get(context)
     private val main = ExactAccountIdentity(account.type, account.name, creationId)
+    private val generationInvalidated = AtomicBoolean(false)
+    private val accountListener = OnAccountsUpdateListener { accounts ->
+        val current = accounts.firstOrNull { it.type == main.type && it.name == main.name }
+        if (current == null ||
+            manager.getUserData(current, AccountSettings.KEY_CREATION_ID) != main.creationId) {
+            generationInvalidated.set(true)
+        }
+    }
     private val statusCleanup = injectedStatusCleanup ?: run {
         val store = SyncStatusStore(context)
         // Snapshot the opaque generation key while AccountManager still owns the exact row.
@@ -38,10 +48,15 @@ internal class AndroidCurrentAccountSignOut(
         ExactAccountStatusCleanup { requested -> requested == main && store.clear(statusIdentity) }
     }
 
+    init {
+        manager.addOnAccountsUpdatedListener(accountListener, Handler(Looper.getMainLooper()), true)
+    }
+
     private fun currentRow(type: String, name: String): Account? =
         manager.getAccountsByType(type).firstOrNull { it.name == name }
 
     override fun snapshot(): CurrentAccountSignOutSnapshot? {
+        if (generationInvalidated.get()) return null
         val current = currentRow(account.type, account.name) ?: return null
         if (creationId.isBlank() ||
             manager.getUserData(current, AccountSettings.KEY_CREATION_ID) != creationId) return null
@@ -61,6 +76,10 @@ internal class AndroidCurrentAccountSignOut(
         ContentResolver.cancelSync(Account(identity.second, identity.first), null)
 
     override fun removeMain(main: ExactAccountIdentity, callback: (Boolean) -> Unit) {
+        if (generationInvalidated.get()) {
+            callback(false)
+            return
+        }
         val row = currentRow(main.type, main.name)
         if (row == null || manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId) {
             callback(false)
@@ -70,6 +89,7 @@ internal class AndroidCurrentAccountSignOut(
     }
 
     override fun mainGenerationAbsent(main: ExactAccountIdentity): Boolean {
+        if (generationInvalidated.get()) return true
         val row = currentRow(main.type, main.name)
         return row == null || manager.getUserData(row, AccountSettings.KEY_CREATION_ID) != main.creationId
     }
@@ -84,6 +104,10 @@ internal class AndroidCurrentAccountSignOut(
     }
 
     override fun clearStatus(main: ExactAccountIdentity) = runCatching { statusCleanup.clear(main) }.getOrDefault(false)
+
+    override fun close() {
+        runCatching { manager.removeOnAccountsUpdatedListener(accountListener) }
+    }
 
     override fun reconcileActive(main: ExactAccountIdentity, replacement: ExactAccountIdentity?): ActiveAccountReconciliation {
         if (!ActiveAccountManager.replaceIfActive(context, main, replacement))
@@ -141,4 +165,9 @@ class CurrentAccountSignOutViewModel(application: Application) : AndroidViewMode
     fun hasStarted() = coordinator?.state?.let { it !is CurrentAccountSignOutState.Idle } == true
 
     fun begin() = coordinator?.begin()
+
+    override fun onCleared() {
+        coordinator?.close()
+        super.onCleared()
+    }
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt
@@ -14,9 +14,9 @@ import io.silentsuite.sync.AccountSettings
 import io.silentsuite.sync.App
 import io.silentsuite.sync.EtebaseLocalCache
 import io.silentsuite.sync.resource.LocalAddressBook
+import io.silentsuite.sync.syncadapter.SyncStatusStore
 import io.silentsuite.sync.utils.AndroidCompat
 
-/** Slice 10 plugs exact sync-outcome cleanup into this seam; Slice 9 intentionally stores none. */
 fun interface ExactAccountStatusCleanup {
     fun clear(identity: ExactAccountIdentity): Boolean
 
@@ -27,10 +27,16 @@ internal class AndroidCurrentAccountSignOut(
     private val context: Context,
     private val account: Account,
     private val creationId: String,
-    private val statusCleanup: ExactAccountStatusCleanup = ExactAccountStatusCleanup.NO_OP
+    injectedStatusCleanup: ExactAccountStatusCleanup? = null,
 ) : CurrentAccountSignOutCoordinator.Seams {
     private val manager = AccountManager.get(context)
     private val main = ExactAccountIdentity(account.type, account.name, creationId)
+    private val statusCleanup = injectedStatusCleanup ?: run {
+        val store = SyncStatusStore(context)
+        // Snapshot before AccountManager removal; cleanup retries retain this exact generation key.
+        val statusIdentity = store.identity(account)
+        ExactAccountStatusCleanup { requested -> requested == main && store.clear(statusIdentity) }
+    }
 
     override fun snapshot(): CurrentAccountSignOutSnapshot? {
         if (creationId.isBlank() || account !in manager.getAccountsByType(account.type) ||

--- a/android/app/src/main/java/io/silentsuite/sync/ui/CurrentAccountSignOutCoordinator.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/CurrentAccountSignOutCoordinator.kt
@@ -1,0 +1,133 @@
+package io.silentsuite.sync.ui
+
+/** Non-secret identity used to keep account destructive work exact and framework-independent. */
+data class ExactAccountIdentity(val type: String, val name: String, val creationId: String)
+
+data class CurrentAccountSignOutSnapshot(
+    val main: ExactAccountIdentity,
+    val children: List<Pair<String, String>>,
+    val eligibleSiblings: List<ExactAccountIdentity>
+)
+
+data class ActiveAccountReconciliation(val succeeded: Boolean, val active: ExactAccountIdentity?)
+
+sealed class CurrentAccountSignOutState {
+    object Idle : CurrentAccountSignOutState()
+    object Removing : CurrentAccountSignOutState()
+    object CleaningUp : CurrentAccountSignOutState()
+    data class RemovalFailed(val errorId: Long) : CurrentAccountSignOutState()
+    data class CleanupFailed(val errorId: Long) : CurrentAccountSignOutState()
+    data class Complete(val replacement: ExactAccountIdentity?) : CurrentAccountSignOutState()
+}
+
+/**
+ * Ordered sign-out policy. The snapshot is retained for cleanup-only retry after the main row is
+ * absent; a retry can therefore never broaden ownership or issue the main removal twice.
+ */
+class CurrentAccountSignOutCoordinator(
+    private val seams: Seams,
+    private val onStateChanged: (CurrentAccountSignOutState) -> Unit = {}
+) {
+    interface Seams {
+        fun snapshot(): CurrentAccountSignOutSnapshot?
+        fun cancelSync(identity: Pair<String, String>)
+        fun removeMain(main: ExactAccountIdentity, callback: (Boolean) -> Unit)
+        fun mainGenerationAbsent(main: ExactAccountIdentity): Boolean
+        fun clearCache(main: ExactAccountIdentity): Boolean
+        fun clearStatus(main: ExactAccountIdentity): Boolean
+        fun reconcileActive(main: ExactAccountIdentity, replacement: ExactAccountIdentity?): ActiveAccountReconciliation
+        fun removeAndVerifyChildren(snapshot: CurrentAccountSignOutSnapshot, callback: (Boolean) -> Unit)
+    }
+
+    var state: CurrentAccountSignOutState = CurrentAccountSignOutState.Idle
+        private set
+    private var snapshot: CurrentAccountSignOutSnapshot? = null
+    private var mainRemovalConfirmed = false
+    private var nextErrorId = 1L
+
+    init { onStateChanged(state) }
+
+    fun begin() {
+        if (state is CurrentAccountSignOutState.Removing ||
+            state is CurrentAccountSignOutState.CleaningUp ||
+            state is CurrentAccountSignOutState.Complete) return
+
+        val captured = snapshot ?: runCatching { seams.snapshot() }.getOrNull()?.also { snapshot = it }
+        if (captured == null) {
+            failRemoval()
+            return
+        }
+        if (mainRemovalConfirmed || state is CurrentAccountSignOutState.CleanupFailed) {
+            cleanup(captured)
+            return
+        }
+        if (runCatching { seams.mainGenerationAbsent(captured.main) }.getOrDefault(false)) {
+            mainRemovalConfirmed = true
+            cleanup(captured)
+            return
+        }
+
+        transition(CurrentAccountSignOutState.Removing)
+        try {
+            seams.cancelSync(captured.main.type to captured.main.name)
+            captured.children.forEach(seams::cancelSync)
+            seams.removeMain(captured.main) { confirmed ->
+                if (state !is CurrentAccountSignOutState.Removing) return@removeMain
+                if (confirmed && runCatching { seams.mainGenerationAbsent(captured.main) }.getOrDefault(false)) {
+                    mainRemovalConfirmed = true
+                    cleanup(captured)
+                } else failRemoval()
+            }
+        } catch (_: Exception) {
+            failRemoval()
+        }
+    }
+
+    private fun cleanup(captured: CurrentAccountSignOutSnapshot) {
+        transition(CurrentAccountSignOutState.CleaningUp)
+        val replacement = AccountSwitcherPolicy.replacement(captured.main, captured.eligibleSiblings)
+        val essentialCleanup = runCatching {
+            if (!seams.clearCache(captured.main) || !seams.clearStatus(captured.main)) null
+            else seams.reconcileActive(captured.main, replacement)
+        }.getOrNull()
+        if (essentialCleanup?.succeeded != true) {
+            failCleanup()
+            return
+        }
+        try {
+            seams.removeAndVerifyChildren(captured) { success ->
+                if (state !is CurrentAccountSignOutState.CleaningUp) return@removeAndVerifyChildren
+                if (success) transition(CurrentAccountSignOutState.Complete(essentialCleanup.active)) else failCleanup()
+            }
+        } catch (_: Exception) {
+            failCleanup()
+        }
+    }
+
+    private fun failRemoval() = transition(CurrentAccountSignOutState.RemovalFailed(nextErrorId++))
+    private fun failCleanup() = transition(CurrentAccountSignOutState.CleanupFailed(nextErrorId++))
+    private fun transition(next: CurrentAccountSignOutState) { state = next; onStateChanged(next) }
+}
+
+object AccountSwitcherPolicy {
+    fun ordered(accounts: List<ExactAccountIdentity>): List<ExactAccountIdentity> =
+        accounts.distinct().sortedWith(compareBy<ExactAccountIdentity>({ it.name }, { it.creationId }, { it.type }))
+
+    fun replacement(removed: ExactAccountIdentity, eligible: List<ExactAccountIdentity>): ExactAccountIdentity? =
+        ordered(eligible).firstOrNull { it != removed }
+
+    fun canExpand(accountCount: Int) = accountCount >= 1
+}
+
+sealed class ActiveAccountReplacementDecision {
+    object Preserve : ActiveAccountReplacementDecision()
+    data class Replace(val identity: ExactAccountIdentity?) : ActiveAccountReplacementDecision()
+}
+
+object ActiveAccountReplacementPolicy {
+    fun decide(savedName: String?, savedGeneration: String?, expected: ExactAccountIdentity,
+               replacement: ExactAccountIdentity?): ActiveAccountReplacementDecision =
+        if (savedName == expected.name && savedGeneration == expected.creationId)
+            ActiveAccountReplacementDecision.Replace(replacement)
+        else ActiveAccountReplacementDecision.Preserve
+}

--- a/android/app/src/main/java/io/silentsuite/sync/ui/CurrentAccountSignOutCoordinator.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/CurrentAccountSignOutCoordinator.kt
@@ -37,6 +37,7 @@ class CurrentAccountSignOutCoordinator(
         fun clearStatus(main: ExactAccountIdentity): Boolean
         fun reconcileActive(main: ExactAccountIdentity, replacement: ExactAccountIdentity?): ActiveAccountReconciliation
         fun removeAndVerifyChildren(snapshot: CurrentAccountSignOutSnapshot, callback: (Boolean) -> Unit)
+        fun close() = Unit
     }
 
     var state: CurrentAccountSignOutState = CurrentAccountSignOutState.Idle
@@ -97,7 +98,10 @@ class CurrentAccountSignOutCoordinator(
         try {
             seams.removeAndVerifyChildren(captured) { success ->
                 if (state !is CurrentAccountSignOutState.CleaningUp) return@removeAndVerifyChildren
-                if (success) transition(CurrentAccountSignOutState.Complete(essentialCleanup.active)) else failCleanup()
+                if (success) {
+                    transition(CurrentAccountSignOutState.Complete(essentialCleanup.active))
+                    close()
+                } else failCleanup()
             }
         } catch (_: Exception) {
             failCleanup()
@@ -107,6 +111,7 @@ class CurrentAccountSignOutCoordinator(
     private fun failRemoval() = transition(CurrentAccountSignOutState.RemovalFailed(nextErrorId++))
     private fun failCleanup() = transition(CurrentAccountSignOutState.CleanupFailed(nextErrorId++))
     private fun transition(next: CurrentAccountSignOutState) { state = next; onStateChanged(next) }
+    fun close() { runCatching { seams.close() } }
 }
 
 object AccountSwitcherPolicy {

--- a/android/app/src/main/res/layout/nav_account_row.xml
+++ b/android/app/src/main/res/layout/nav_account_row.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_account_row"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/touch_target_min"
+    android:background="?android:attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="@dimen/spacing_16"
+    android:paddingEnd="@dimen/spacing_16">
+
+    <TextView
+        android:id="@+id/nav_account_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="14sp"
+        tools:text="account@example.com" />
+
+    <ImageView
+        android:id="@+id/nav_account_current_indicator"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:importantForAccessibility="no"
+        android:src="@android:drawable/checkbox_on_background"
+        android:visibility="invisible"
+        tools:ignore="ContentDescription" />
+</LinearLayout>

--- a/android/app/src/main/res/layout/nav_header_accounts.xml
+++ b/android/app/src/main/res/layout/nav_header_accounts.xml
@@ -36,6 +36,8 @@
             android:gravity="center_vertical"
             android:layout_marginTop="8dp"
             android:background="?android:attr/selectableItemBackground"
+            android:clickable="true"
+            android:focusable="true"
             android:minHeight="48dp">
 
             <TextView
@@ -91,11 +93,13 @@
         <LinearLayout
             android:id="@+id/nav_add_account_row"
             android:layout_width="match_parent"
-            android:layout_height="48dp"
+            android:layout_height="@dimen/touch_target_min"
             android:orientation="horizontal"
             android:gravity="center_vertical"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp"
+            android:clickable="true"
+            android:focusable="true"
+            android:paddingStart="@dimen/spacing_16"
+            android:paddingEnd="@dimen/spacing_16"
             android:background="?android:attr/selectableItemBackground">
 
             <ImageView

--- a/android/app/src/main/res/menu/activity_account.xml
+++ b/android/app/src/main/res/menu/activity_account.xml
@@ -15,4 +15,14 @@
           android:title="@string/account_synchronize_now"
           app:showAsAction="always"/>
 
+    <item android:id="@+id/account_show_fingerprint"
+          android:icon="@drawable/ic_fingerprint_dark"
+          android:title="@string/account_show_fingerprint"
+          app:showAsAction="never"/>
+
+    <item android:id="@+id/account_export_data"
+          android:icon="@drawable/ic_import_export_black"
+          android:title="@string/export_data_title"
+          app:showAsAction="never"/>
+
 </menu>

--- a/android/app/src/main/res/menu/activity_accounts_drawer.xml
+++ b/android/app/src/main/res/menu/activity_accounts_drawer.xml
@@ -3,80 +3,30 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <group android:id="@+id/nav_account_group" android:checkableBehavior="none">
+    <group android:id="@+id/nav_destinations_group" android:checkableBehavior="none">
         <item
-            android:id="@+id/nav_add_account"
-            android:icon="@drawable/ic_add_light"
-            android:title="@string/navigation_drawer_add_account"/>
+            android:id="@+id/nav_sync_overview"
+            android:icon="@drawable/ic_sync_light"
+            android:title="@string/navigation_drawer_sync_overview"/>
         <item
-            android:id="@+id/nav_logout"
-            android:icon="@drawable/ic_logout"
-            android:title="@string/navigation_drawer_logout"/>
-    </group>
-
-    <group android:id="@+id/nav_sync_group" android:checkableBehavior="none">
-        <item
-            android:id="@+id/nav_calendar"
-            android:icon="@drawable/ic_event_light"
-            android:title="@string/navigation_drawer_calendar"/>
-        <item
-            android:id="@+id/nav_tasks"
-            android:icon="@drawable/ic_task_light"
-            android:title="@string/navigation_drawer_tasks"/>
-        <item
-            android:id="@+id/nav_contacts"
-            android:icon="@drawable/ic_account_dark"
-            android:title="@string/navigation_drawer_contacts"/>
-    </group>
-
-    <group android:id="@+id/nav_account_tools_group" android:checkableBehavior="none">
+            android:id="@+id/nav_invitations"
+            android:icon="@drawable/ic_people_light"
+            android:title="@string/invitations_title"/>
         <item
             android:id="@+id/nav_app_settings"
             android:icon="@drawable/ic_settings_dark"
             android:title="@string/navigation_drawer_settings"/>
         <item
-            android:id="@+id/nav_invitations"
-            android:icon="@drawable/ic_people_light"
-            android:title="@string/invitations_title"/>
-    </group>
-
-    <group android:id="@+id/nav_security_group" android:checkableBehavior="none">
-        <item
-            android:id="@+id/nav_show_fingerprint"
-            android:icon="@drawable/ic_fingerprint_dark"
-            android:title="@string/account_show_fingerprint"/>
-        <item
-            android:id="@+id/nav_export_data"
-            android:icon="@drawable/ic_import_export_black"
-            android:title="@string/export_data_title"/>
-    </group>
-
-    <group android:id="@+id/nav_app_group" android:checkableBehavior="none">
-        <item
-            android:id="@+id/nav_theme"
-            android:icon="@drawable/ic_palette"
-            android:title="@string/navigation_drawer_theme"/>
-        <item
             android:id="@+id/nav_about"
             android:icon="@drawable/ic_info_dark"
-            android:title="@string/navigation_drawer_about"/>
+            android:title="@string/navigation_drawer_help_about"/>
     </group>
 
-    <item android:title="@string/navigation_drawer_external_links">
-        <menu>
-            <item
-                android:id="@+id/nav_website"
-                android:icon="@drawable/ic_language"
-                android:title="@string/navigation_drawer_website_label"/>
-            <item
-                android:id="@+id/nav_webapp"
-                android:icon="@drawable/ic_devices"
-                android:title="@string/navigation_drawer_webapp_label"/>
-            <item
-                android:id="@+id/nav_guide"
-                android:icon="@drawable/ic_menu_book"
-                android:title="@string/navigation_drawer_guide_label"/>
-        </menu>
-    </item>
+    <group android:id="@+id/nav_sign_out_group" android:checkableBehavior="none">
+        <item
+            android:id="@+id/nav_logout"
+            android:icon="@drawable/ic_logout"
+            android:title="@string/navigation_drawer_logout"/>
+    </group>
 
 </menu>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -77,7 +77,15 @@
     <string name="navigation_drawer_webapp_label">Web App</string>
     <string name="navigation_drawer_guide_label">Documentation</string>
     <string name="navigation_drawer_add_account">Add account</string>
-    <string name="navigation_drawer_logout">Log out</string>
+    <string name="navigation_drawer_logout">Sign out</string>
+    <string name="navigation_drawer_sync_overview">Sync overview</string>
+    <string name="navigation_drawer_help_about">Help &amp; about</string>
+    <string name="account_switcher_description">Account switcher for %1$s</string>
+    <string name="account_switcher_expanded">Expanded</string>
+    <string name="account_switcher_collapsed">Collapsed</string>
+    <string name="account_switcher_account_description">Account %1$s</string>
+    <string name="account_switcher_current">Current account</string>
+    <string name="account_switcher_not_current">Not current</string>
     <string name="navigation_drawer_theme">Theme</string>
     <string name="navigation_drawer_faq">FAQ</string>
     <string name="navigation_drawer_report_issue">Report issue</string>
@@ -144,6 +152,8 @@
     <string name="account_show_fingerprint">Verify encryption fingerprint</string>
     <string name="account_delete_confirmation_title">Sign out?</string>
     <string name="account_delete_confirmation_text">Local copies of your contacts, calendars and tasks will be removed from this device. Your data on the server is safe.</string>
+    <string name="account_sign_out_failed">Couldn’t sign out. Your account and local data were preserved.</string>
+    <string name="account_sign_out_cleanup_failed">The account was signed out, but local cleanup didn’t finish.</string>
     <string name="account_delete_collection_last_title">Can\'t delete last collection</string>
     <string name="account_delete_collection_last_text">Deleting the last collection is not allowed, please create a new one if you\'d like to delete this one.</string>
     <string name="account_showcase_view_collection">Tap a collection to view recent sync activity, import data, or manage members.</string>

--- a/android/app/src/test/java/io/silentsuite/sync/ui/AccountDrawerContractTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/AccountDrawerContractTest.kt
@@ -1,0 +1,40 @@
+package io.silentsuite.sync.ui
+
+import java.io.File
+import org.junit.Assert.*
+import org.junit.Test
+
+class AccountDrawerContractTest {
+    private val main = File("src/main")
+
+    @Test fun `drawer contains only real destinations and one separated sign out`() {
+        val drawer = File(main, "res/menu/activity_accounts_drawer.xml").readText()
+        listOf("nav_calendar", "nav_contacts", "nav_tasks", "nav_add_account", "nav_theme",
+            "nav_show_fingerprint", "nav_export_data", "nav_website", "nav_external", "nav_privacy")
+            .forEach { assertFalse(it, drawer.contains(it)) }
+        listOf("nav_sync_overview", "nav_invitations", "nav_app_settings", "nav_about", "nav_logout")
+            .forEach { assertTrue(it, drawer.contains(it)) }
+        assertEquals(1, Regex("nav_logout").findAll(drawer).count())
+        assertTrue(drawer.contains("nav_sign_out_group"))
+    }
+
+    @Test fun `switcher and dashboard actions retain stable resource contracts`() {
+        val header = File(main, "res/layout/nav_header_accounts.xml").readText()
+        val row = File(main, "res/layout/nav_account_row.xml").readText()
+        val toolbar = File(main, "res/menu/activity_account.xml").readText()
+        assertEquals(1, Regex("nav_add_account_row").findAll(header).count())
+        listOf("nav_account_row", "nav_account_name", "nav_account_current_indicator", "@dimen/touch_target_min")
+            .forEach { assertTrue(it, row.contains(it)) }
+        assertTrue(toolbar.contains("account_show_fingerprint")); assertTrue(toolbar.contains("account_export_data"))
+        val activity = File(main, "java/io/silentsuite/sync/ui/AccountActivity.kt").readText()
+        val signOut = File(main, "java/io/silentsuite/sync/ui/AndroidCurrentAccountSignOut.kt").readText()
+        listOf("R.id.caldav", "R.id.carddav", "R.id.taskdav").forEach { assertTrue(it, activity.contains(it)) }
+        assertTrue(activity.contains("AppSettingsActivity.newIntent(this, account)"))
+        assertTrue(activity.contains("row.id = rowId"))
+        assertTrue(activity.contains("accountRowViewId(identity)"))
+        assertTrue(activity.indexOf("attachRetainedSignOut()") < activity.indexOf("ExactAccountRouting.validate"))
+        assertTrue(signOut.contains("KEY_CREATION_ID) != main.creationId"))
+        assertTrue(signOut.contains("mainGenerationAbsent"))
+        assertFalse(activity.contains("etebase.logout()"))
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/ui/AccountSwitcherPolicyTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/AccountSwitcherPolicyTest.kt
@@ -1,0 +1,34 @@
+package io.silentsuite.sync.ui
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class AccountSwitcherPolicyTest {
+    @Test fun `switcher expands for one account so add remains reachable`() {
+        assertFalse(AccountSwitcherPolicy.canExpand(0))
+        assertTrue(AccountSwitcherPolicy.canExpand(1))
+        assertTrue(AccountSwitcherPolicy.canExpand(2))
+    }
+
+    @Test fun `replacement is deterministic exact and excludes removed generation`() {
+        val removed = ExactAccountIdentity("type", "same", "old")
+        val sameNameNew = ExactAccountIdentity("type", "same", "new")
+        val alice = ExactAccountIdentity("type", "alice", "a")
+        assertEquals(alice, AccountSwitcherPolicy.replacement(removed, listOf(sameNameNew, removed, alice)))
+        assertEquals(sameNameNew, AccountSwitcherPolicy.replacement(removed, listOf(removed, sameNameNew)))
+        assertNull(AccountSwitcherPolicy.replacement(removed, listOf(removed)))
+    }
+
+    @Test fun `active replacement preserves unrelated sibling and replaces only exact generation`() {
+        val removed = ExactAccountIdentity("type", "target", "removed-generation")
+        val sibling = ExactAccountIdentity("type", "sibling", "sibling-generation")
+        assertEquals(ActiveAccountReplacementDecision.Preserve,
+            ActiveAccountReplacementPolicy.decide(sibling.name, sibling.creationId, removed, sibling))
+        assertEquals(ActiveAccountReplacementDecision.Preserve,
+            ActiveAccountReplacementPolicy.decide(removed.name, "new-generation", removed, sibling))
+        assertEquals(ActiveAccountReplacementDecision.Replace(sibling),
+            ActiveAccountReplacementPolicy.decide(removed.name, removed.creationId, removed, sibling))
+        assertEquals(ActiveAccountReplacementDecision.Replace(null),
+            ActiveAccountReplacementPolicy.decide(removed.name, removed.creationId, removed, null))
+    }
+}

--- a/android/app/src/test/java/io/silentsuite/sync/ui/AccountSwitcherPolicyTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/AccountSwitcherPolicyTest.kt
@@ -31,4 +31,17 @@ class AccountSwitcherPolicyTest {
         assertEquals(ActiveAccountReplacementDecision.Replace(null),
             ActiveAccountReplacementPolicy.decide(removed.name, removed.creationId, removed, null))
     }
+
+    @Test fun `colliding account row hashes probe to stable unique ids`() {
+        val first = ExactAccountIdentity("type", "Aa", "generation")
+        val second = ExactAccountIdentity("type", "BB", "generation")
+        assertEquals(first.hashCode(), second.hashCode())
+
+        val forward = AccountActivity.accountRowViewIds(listOf(first, second))
+        val reversed = AccountActivity.accountRowViewIds(listOf(second, first))
+        assertEquals(forward, reversed)
+        assertEquals(2, forward.values.toSet().size)
+        assertEquals(AccountActivity.accountRowViewId(first), forward.getValue(first))
+        assertEquals(AccountActivity.accountRowViewId(first) + 1, forward.getValue(second))
+    }
 }

--- a/android/app/src/test/java/io/silentsuite/sync/ui/CurrentAccountSignOutCoordinatorTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/CurrentAccountSignOutCoordinatorTest.kt
@@ -18,6 +18,7 @@ class CurrentAccountSignOutCoordinatorTest {
         var reconciledActive: ExactAccountIdentity? = sibling
         var children = true
         var removeCalls = 0
+        var closeCalls = 0
         var removeCallback: ((Boolean) -> Unit)? = null
         var childrenCallback: ((Boolean) -> Unit)? = null
         override fun snapshot() = captured.also { events += "snapshot" }
@@ -33,6 +34,7 @@ class CurrentAccountSignOutCoordinatorTest {
         override fun removeAndVerifyChildren(snapshot: CurrentAccountSignOutSnapshot, callback: (Boolean) -> Unit) {
             events += "children"; childrenCallback = callback
         }
+        override fun close() { closeCalls++ }
     }
 
     @Test fun `confirmed removal follows destructive boundary order and routes deterministic sibling`() {
@@ -43,6 +45,7 @@ class CurrentAccountSignOutCoordinatorTest {
         f.absent = true; f.removeCallback!!(true); f.childrenCallback!!(true)
         assertEquals(listOf("cache", "status", "active:a@example.invalid", "children"), f.events.takeLast(4))
         assertEquals(CurrentAccountSignOutState.Complete(sibling), c.state)
+        assertEquals(1, f.closeCalls)
     }
 
     @Test fun `false callback and present row preserve every destructive seam and expose one failure`() {

--- a/android/app/src/test/java/io/silentsuite/sync/ui/CurrentAccountSignOutCoordinatorTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/CurrentAccountSignOutCoordinatorTest.kt
@@ -1,0 +1,138 @@
+package io.silentsuite.sync.ui
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class CurrentAccountSignOutCoordinatorTest {
+    private val target = ExactAccountIdentity("main", "z@example.invalid", "target-generation")
+    private val sibling = ExactAccountIdentity("main", "a@example.invalid", "sibling-generation")
+
+    private inner class Fake : CurrentAccountSignOutCoordinator.Seams {
+        val events = mutableListOf<String>()
+        var captured: CurrentAccountSignOutSnapshot? = CurrentAccountSignOutSnapshot(
+            target, listOf("child" to "book"), listOf(target, sibling))
+        var absent = false
+        var cache = true
+        var status = true
+        var active = true
+        var reconciledActive: ExactAccountIdentity? = sibling
+        var children = true
+        var removeCalls = 0
+        var removeCallback: ((Boolean) -> Unit)? = null
+        var childrenCallback: ((Boolean) -> Unit)? = null
+        override fun snapshot() = captured.also { events += "snapshot" }
+        override fun cancelSync(identity: Pair<String, String>) { events += "cancel:${identity.first}:${identity.second}" }
+        override fun removeMain(main: ExactAccountIdentity, callback: (Boolean) -> Unit) {
+            events += "remove"; removeCalls++; removeCallback = callback
+        }
+        override fun mainGenerationAbsent(main: ExactAccountIdentity) = absent.also { events += "absent:$it" }
+        override fun clearCache(main: ExactAccountIdentity) = cache.also { events += "cache" }
+        override fun clearStatus(main: ExactAccountIdentity) = status.also { events += "status" }
+        override fun reconcileActive(main: ExactAccountIdentity, replacement: ExactAccountIdentity?) =
+            ActiveAccountReconciliation(active, reconciledActive).also { events += "active:${replacement?.name}" }
+        override fun removeAndVerifyChildren(snapshot: CurrentAccountSignOutSnapshot, callback: (Boolean) -> Unit) {
+            events += "children"; childrenCallback = callback
+        }
+    }
+
+    @Test fun `confirmed removal follows destructive boundary order and routes deterministic sibling`() {
+        val f = Fake(); val c = CurrentAccountSignOutCoordinator(f)
+        c.begin()
+        assertEquals(listOf("snapshot", "absent:false", "cancel:main:z@example.invalid", "cancel:child:book", "remove"), f.events)
+        assertTrue(c.state is CurrentAccountSignOutState.Removing)
+        f.absent = true; f.removeCallback!!(true); f.childrenCallback!!(true)
+        assertEquals(listOf("cache", "status", "active:a@example.invalid", "children"), f.events.takeLast(4))
+        assertEquals(CurrentAccountSignOutState.Complete(sibling), c.state)
+    }
+
+    @Test fun `false callback and present row preserve every destructive seam and expose one failure`() {
+        val f = Fake(); val states = mutableListOf<CurrentAccountSignOutState>()
+        val c = CurrentAccountSignOutCoordinator(f) { states += it }
+        c.begin(); f.removeCallback!!(false)
+        assertTrue(c.state is CurrentAccountSignOutState.RemovalFailed)
+        assertFalse(f.events.any { it in setOf("cache", "status", "children") || it.startsWith("active:") })
+        assertEquals(1, states.filterIsInstance<CurrentAccountSignOutState.RemovalFailed>().size)
+
+        val present = Fake(); val other = CurrentAccountSignOutCoordinator(present)
+        other.begin(); present.removeCallback!!(true)
+        assertTrue(other.state is CurrentAccountSignOutState.RemovalFailed)
+        assertFalse(present.events.contains("cache"))
+    }
+
+    @Test fun `delayed callback retains pending state and repeated tap cannot remove twice`() {
+        val f = Fake(); val c = CurrentAccountSignOutCoordinator(f)
+        c.begin(); c.begin()
+        assertEquals(1, f.removeCalls)
+        assertTrue(c.state is CurrentAccountSignOutState.Removing)
+    }
+
+    @Test fun `cleanup failure retries cleanup only and never repeats absent main removal`() {
+        val f = Fake().apply { absent = true; children = false }
+        val c = CurrentAccountSignOutCoordinator(f)
+        c.begin(); f.childrenCallback!!(false)
+        assertTrue(c.state is CurrentAccountSignOutState.CleanupFailed)
+        assertEquals(0, f.removeCalls)
+        f.childrenCallback = null
+        c.begin(); f.childrenCallback!!(true)
+        assertEquals(0, f.removeCalls)
+        assertTrue(c.state is CurrentAccountSignOutState.Complete)
+    }
+
+    @Test fun `replacement generation before retry cannot trigger another main removal`() {
+        val f = Fake()
+        val c = CurrentAccountSignOutCoordinator(f)
+        c.begin()
+        f.removeCallback!!(false)
+        assertEquals(1, f.removeCalls)
+
+        // The exact old generation is absent; a same-name replacement may own the platform row.
+        f.absent = true
+        c.begin()
+        f.childrenCallback!!(true)
+        assertEquals(1, f.removeCalls)
+        assertTrue(c.state is CurrentAccountSignOutState.Complete)
+    }
+
+    @Test fun `confirmed removal remains cleanup only even if presence later changes`() {
+        val f = Fake()
+        val c = CurrentAccountSignOutCoordinator(f)
+        c.begin()
+        f.absent = true
+        f.removeCallback!!(true)
+        f.childrenCallback!!(false)
+        assertTrue(c.state is CurrentAccountSignOutState.CleanupFailed)
+
+        f.absent = false
+        c.begin()
+        f.childrenCallback!!(true)
+        assertEquals(1, f.removeCalls)
+        assertTrue(c.state is CurrentAccountSignOutState.Complete)
+    }
+
+    @Test fun `cache status and active failures stop child cleanup and remain cleanup-only retryable`() {
+        listOf("cache", "status", "active").forEach { failed ->
+            val f = Fake().apply {
+                absent = true; cache = failed != "cache"; status = failed != "status"; active = failed != "active"
+            }
+            val c = CurrentAccountSignOutCoordinator(f); c.begin()
+            assertTrue(c.state is CurrentAccountSignOutState.CleanupFailed)
+            assertFalse(f.events.contains("children")); assertEquals(0, f.removeCalls)
+        }
+    }
+
+    @Test fun `last account completes with login destination`() {
+        val f = Fake().apply {
+            captured = CurrentAccountSignOutSnapshot(target, emptyList(), listOf(target)); reconciledActive = null
+        }
+        val c = CurrentAccountSignOutCoordinator(f); c.begin(); f.absent = true; f.removeCallback!!(true); f.childrenCallback!!(true)
+        assertEquals(CurrentAccountSignOutState.Complete(null), c.state)
+    }
+
+    @Test fun `concurrently active unrelated sibling is preserved as route`() {
+        val other = ExactAccountIdentity("main", "b@example.invalid", "other-generation")
+        val f = Fake().apply { reconciledActive = other }
+        val c = CurrentAccountSignOutCoordinator(f); c.begin(); f.absent = true
+        f.removeCallback!!(true); f.childrenCallback!!(true)
+        assertEquals(CurrentAccountSignOutState.Complete(other), c.state)
+    }
+}


### PR DESCRIPTION
## Summary

- simplify the drawer to real destinations and move service modules to the sync overview
- add an accessible exact-generation account switcher with one Add account action
- implement current-account-only sign-out with confirmed-removal cleanup, sibling activation, retry safety, and truthful-status cleanup
- add deterministic account-row IDs and API 21/API 35 runtime coverage for success, failure, replacement, recreation, and last-account behavior

## Verification

- substantive GPT-5.6 Sol review: GREEN
- focused exact-generation, recreation, status-cleanup, and row-ID collision reviews: GREEN
- `git diff --check`
- Android build, JVM, lint, and API 21/API 35 instrumentation are CI-only per repository policy

No server, wire protocol, encrypted item format, or cryptographic behavior changes.