### PR TITLE
fix(deps): update lodash past security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "fast-uri": "^3.1.2",
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",
       "ws": "^7.5.11",
+      "lodash": "^4.18.0",
       "vitepress>vite": "^6.4.3"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   fast-uri: ^3.1.2
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
   ws: ^7.5.11
+  lodash: ^4.18.0
   vitepress>vite: ^6.4.3
 
 importers:
@@ -4364,8 +4365,8 @@ packages:
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -10217,7 +10218,7 @@ snapshots:
 
   lodash.sortby@4.7.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -11767,7 +11768,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       fs-extra: 9.1.0
       glob: 7.2.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       pretty-bytes: 5.6.0
       rollup: 2.80.0
       source-map: 0.8.0-beta.0
@@ -11810,7 +11811,7 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       fs-extra: 9.1.0
       glob: 7.2.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       pretty-bytes: 5.6.0
       rollup: 2.80.0
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
## Summary
- override transitive lodash to the fixed 4.18.x line
- regenerate the pnpm lockfile at lodash 4.18.1
- keep both Workbox dependency paths on the patched version

## Security
Resolves the CI blocker from GHSA-r5fr-rjxr-66jc. Vulnerable lodash 4.17.23 is no longer present. No audit allowlist changes.

## Surface and sibling-path map
- Surface: root pnpm dependency resolution and security audit
- Sibling paths: workbox-build 7.1.0 and 7.1.1 via next-pwa/workbox-webpack-plugin
- Contract impact: no runtime API or product behavior changes; transitive lodash remains within Workbox declared semver range
- Verification tier: frozen install, dependency audit, module-load compatibility, full PR CI

## Verification
- `corepack pnpm install --lockfile-only`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run audit:security` (0 critical, 0 high)
- loaded workbox-build 7.1.0 and 7.1.1 with lodash 4.18.1
- confirmed lodash 4.17.23 absent
- `git diff --check`

Reviewed GREEN on the exact patch.