### PR TITLE
ci(android): enforce protected signing boundary

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -9,17 +9,39 @@ on:
       - 'android/**'
       - 'tests/test_android_*.py'
       - 'scripts/check-android-signing-boundary.py'
-      - '.github/workflows/build-android.yml'
+      - '.github/workflows/**'
+      - 'android/.github/workflows/**'
   pull_request:
     branches: [dev]
     paths:
       - 'android/**'
       - 'tests/test_android_*.py'
       - 'scripts/check-android-signing-boundary.py'
-      - '.github/workflows/build-android.yml'
+      - '.github/workflows/**'
+      - 'android/.github/workflows/**'
   workflow_dispatch:
 
 jobs:
+  signing-policy:
+    name: Enforce Android signing boundary
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.x'
+
+      - name: Install signing policy dependency
+        run: python -m pip install --disable-pip-version-check PyYAML==6.0.3
+
+      - name: Enforce Android signing boundary
+        run: python scripts/check-android-signing-boundary.py
+
   # ─────────────────────────────────────────────────────────────────────
   # PR / dev / main builds — unsigned, no signing secrets accessible.
   # Validates that the Android project compiles and assembles.
@@ -49,13 +71,12 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Enforce Android signing boundary
-        run: python3 ../scripts/check-android-signing-boundary.py
+      - name: Install Android static contract dependencies
+        run: |
+          python -m pip install --disable-pip-version-check pytest PyYAML==6.0.3
 
       - name: Run Android static Python contracts
-        run: |
-          python -m pip install --disable-pip-version-check pytest
-          python -m pytest ../tests/test_android_*.py -q
+        run: python -m pytest ../tests/test_android_*.py -q
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@67ef31d5b988238dd797d409d6f9574278e20537 # master
@@ -391,6 +412,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   build-release:
     name: Build (signed, tag release)
+    needs: signing-policy
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: android-release
@@ -403,9 +425,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Enforce Android signing boundary
-        run: python3 ../scripts/check-android-signing-boundary.py
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -28,19 +28,24 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install signing policy dependency
-        run: python -m pip install --disable-pip-version-check PyYAML==6.0.3
+        run: |
+          printf '%s\n' 'PyYAML==6.0.3 --hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc' > "$RUNNER_TEMP/android-signing-policy-requirements.txt"
+          python -m pip install --disable-pip-version-check --only-binary=:all: --require-hashes -r "$RUNNER_TEMP/android-signing-policy-requirements.txt"
+
+      - name: Checkout policy source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          clean: true
+          persist-credentials: false
 
       - name: Enforce Android signing boundary
-        run: python scripts/check-android-signing-boundary.py
+        run: python "$GITHUB_WORKSPACE/scripts/check-android-signing-boundary.py"
 
   # ─────────────────────────────────────────────────────────────────────
   # PR / dev / main builds — unsigned, no signing secrets accessible.

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - 'android/**'
       - 'tests/test_android_*.py'
+      - 'scripts/check-android-signing-boundary.py'
       - '.github/workflows/build-android.yml'
   pull_request:
     branches: [dev]
     paths:
       - 'android/**'
       - 'tests/test_android_*.py'
+      - 'scripts/check-android-signing-boundary.py'
       - '.github/workflows/build-android.yml'
   workflow_dispatch:
 
@@ -34,18 +36,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Set up Python for static Android contracts
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
+
+      - name: Enforce Android signing boundary
+        run: python3 ../scripts/check-android-signing-boundary.py
 
       - name: Run Android static Python contracts
         run: |
@@ -68,7 +73,7 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.gradle/caches
@@ -188,7 +193,7 @@ jobs:
           retention-days: 14
 
       - name: Upload debug APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: silentsuite-debug-${{ github.sha }}
           path: |
@@ -398,6 +403,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Enforce Android signing boundary
+        run: python3 ../scripts/check-android-signing-boundary.py
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4

--- a/android/.github/workflows/build.yml
+++ b/android/.github/workflows/build.yml
@@ -10,21 +10,21 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         submodules: recursive
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v3
+      uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
 
     - name: Cache Gradle packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: |
           ~/.gradle/caches

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Fail closed when Android signing escapes the protected release job."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+SIGNING_SECRETS = {
+    "ANDROID_KEYSTORE_BASE64",
+    "ANDROID_KEYSTORE_PASSWORD",
+    "ANDROID_KEY_ALIAS",
+}
+ALLOWED_WORKFLOW = "build-android.yml"
+ALLOWED_JOB = "build-release"
+TAG_GUARD = "if: startsWith(github.ref, 'refs/tags/v')"
+ENVIRONMENT_GUARD = "environment: android-release"
+SHA_PIN = re.compile(r"^[0-9a-f]{40}$")
+JOB_HEADER = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
+USES_LINE = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)")
+SECRET_REFERENCE = re.compile(r"secrets\.([A-Z0-9_]+)")
+
+
+def job_sections(workflow: str) -> dict[str, str]:
+    """Return top-level job bodies from a GitHub Actions workflow."""
+    lines = workflow.splitlines()
+    try:
+        jobs_index = next(i for i, line in enumerate(lines) if line == "jobs:")
+    except StopIteration:
+        return {}
+
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in lines[jobs_index + 1 :]:
+        if line and not line.startswith(" "):
+            break
+        match = JOB_HEADER.match(line)
+        if match:
+            current = match.group(1)
+            sections[current] = [line]
+        elif current is not None:
+            sections[current].append(line)
+    return {name: "\n".join(body) for name, body in sections.items()}
+
+
+def signing_references(body: str) -> set[str]:
+    return SIGNING_SECRETS & set(SECRET_REFERENCE.findall(body))
+
+
+def action_ref(target: str) -> str | None:
+    if target.startswith("./"):
+        return None
+    if "@" not in target:
+        return ""
+    return target.rsplit("@", 1)[1]
+
+
+def check(root: Path) -> list[str]:
+    workflow_dir = root / ".github" / "workflows"
+    violations: list[str] = []
+    allowed_path = workflow_dir / ALLOWED_WORKFLOW
+
+    if not allowed_path.is_file():
+        return [f"missing required workflow: {allowed_path}"]
+
+    workflow_paths = sorted((*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")))
+    for path in workflow_paths:
+        body = path.read_text(encoding="utf-8")
+        sections = job_sections(body)
+        for job, section in sections.items():
+            references = signing_references(section)
+            if references and (path.name != ALLOWED_WORKFLOW or job != ALLOWED_JOB):
+                violations.append(
+                    f"{path.relative_to(root)} job {job} references Android signing secrets: "
+                    f"{', '.join(sorted(references))}"
+                )
+            if (
+                path.name == ALLOWED_WORKFLOW
+                and "contents: write" in section
+                and job != ALLOWED_JOB
+            ):
+                violations.append(
+                    f"{path.relative_to(root)} job {job} has contents: write outside the Android release job"
+                )
+
+    allowed_body = allowed_path.read_text(encoding="utf-8")
+    sections = job_sections(allowed_body)
+    release = sections.get(ALLOWED_JOB)
+    if release is None:
+        violations.append(f"{allowed_path.relative_to(root)} is missing job {ALLOWED_JOB}")
+        return violations
+
+    missing = SIGNING_SECRETS - signing_references(release)
+    if missing:
+        violations.append(f"{ALLOWED_JOB} is missing signing references: {', '.join(sorted(missing))}")
+    if TAG_GUARD not in release:
+        violations.append(f"{ALLOWED_JOB} must use the exact version-tag guard")
+    if ENVIRONMENT_GUARD not in release:
+        violations.append(f"{ALLOWED_JOB} must bind the android-release environment")
+    if "permissions:\n      contents: write" not in release:
+        violations.append(f"{ALLOWED_JOB} must declare only the required contents: write permission")
+
+    for line_number, line in enumerate(allowed_body.splitlines(), start=1):
+        match = USES_LINE.match(line)
+        if not match:
+            continue
+        target = match.group(1)
+        ref = action_ref(target)
+        if ref is not None and not SHA_PIN.fullmatch(ref):
+            violations.append(
+                f"{allowed_path.relative_to(root)}:{line_number} action must be pinned to a full commit SHA: {target}"
+            )
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    args = parser.parse_args()
+
+    violations = check(args.root.resolve())
+    if violations:
+        print("Android signing boundary check failed:")
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+
+    print("Android signing boundary check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -13,7 +13,7 @@ import yaml
 from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode
 from yaml.resolver import BaseResolver
-from yaml.tokens import AliasToken, AnchorToken
+from yaml.tokens import AliasToken, AnchorToken, TagToken
 
 
 SIGNING_SECRETS = {
@@ -28,11 +28,43 @@ POLICY_JOB = "signing-policy"
 TAG_GUARD = "startsWith(github.ref, 'refs/tags/v')"
 ENVIRONMENT_NAME = "android-release"
 SHA_PIN = re.compile(r"^[0-9a-f]{40}$")
-POLICY_COMMAND = re.compile(r"^\s*python(?:3)?\s+scripts/check-android-signing-boundary\.py\s*$")
 UNSAFE_SECRET_EXPRESSION = re.compile(
-    r"\bsecrets\s*\[|\btojson\s*\(\s*secrets\s*\)",
+    r"\bsecrets\s*\[|\bsecrets\s*\.\s*\*|\btojson\s*\(\s*secrets\s*\)",
     re.IGNORECASE,
 )
+CHECKOUT_ACTION = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+SETUP_PYTHON_ACTION = "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
+EXPECTED_POLICY_JOB: dict[str, Any] = {
+    "name": "Enforce Android signing boundary",
+    "runs-on": "ubuntu-latest",
+    "permissions": {"contents": "read"},
+    "steps": [
+        {
+            "name": "Set up Python",
+            "uses": SETUP_PYTHON_ACTION,
+            "with": {"python-version": "3.12"},
+        },
+        {
+            "name": "Install signing policy dependency",
+            "run": (
+                "printf '%s\\n' 'PyYAML==6.0.3 "
+                "--hash=sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc' "
+                '> "$RUNNER_TEMP/android-signing-policy-requirements.txt"\n'
+                "python -m pip install --disable-pip-version-check --only-binary=:all: "
+                '--require-hashes -r "$RUNNER_TEMP/android-signing-policy-requirements.txt"\n'
+            ),
+        },
+        {
+            "name": "Checkout policy source",
+            "uses": CHECKOUT_ACTION,
+            "with": {"clean": "true", "persist-credentials": "false"},
+        },
+        {
+            "name": "Enforce Android signing boundary",
+            "run": 'python "$GITHUB_WORKSPACE/scripts/check-android-signing-boundary.py"',
+        },
+    ],
+}
 REQUIRED_TRIGGER_PATHS = {
     ".github/workflows/**",
     "android/.github/workflows/**",
@@ -79,8 +111,8 @@ StrictBaseLoader.add_constructor(BaseResolver.DEFAULT_MAPPING_TAG, construct_uni
 def load_workflow(path: Path) -> dict[str, Any]:
     try:
         text = path.read_text(encoding="utf-8")
-        if any(isinstance(token, (AnchorToken, AliasToken)) for token in yaml.scan(text)):
-            raise ValueError("YAML anchors and aliases are not allowed")
+        if any(isinstance(token, (AnchorToken, AliasToken, TagToken)) for token in yaml.scan(text)):
+            raise ValueError("YAML anchors, aliases, and explicit tags are not allowed")
         parsed = yaml.load(text, Loader=StrictBaseLoader)
     except ValueError:
         raise
@@ -181,17 +213,17 @@ def as_mapping(value: Any, label: str, violations: list[str]) -> dict[str, Any]:
     return value
 
 
-def trigger_paths(workflow: Mapping[str, Any], event: str) -> set[str]:
+def trigger_paths(workflow: Mapping[str, Any], event: str) -> list[str]:
     events = workflow.get("on")
     if not isinstance(events, Mapping):
-        return set()
+        return []
     config = events.get(event)
     if not isinstance(config, Mapping):
-        return set()
+        return []
     paths = config.get("paths")
     if not isinstance(paths, Sequence) or isinstance(paths, (str, bytes)):
-        return set()
-    return {item for item in paths if isinstance(item, str)}
+        return []
+    return [item for item in paths if isinstance(item, str)]
 
 
 def check(root: Path) -> list[str]:
@@ -242,7 +274,7 @@ def check(root: Path) -> list[str]:
                     f"{relative} job {job_name} references Android signing secrets: "
                     f"{', '.join(sorted(refs))}"
                 )
-            if env == ENVIRONMENT_NAME and not is_allowed:
+            if env and env.casefold() == ENVIRONMENT_NAME.casefold() and not is_allowed:
                 violations.append(f"{relative} job {job_name} binds {ENVIRONMENT_NAME} outside {ALLOWED_JOB}")
             if env and "${{" in env and not is_allowed:
                 violations.append(f"{relative} job {job_name} uses a dynamic environment outside {ALLOWED_JOB}")
@@ -278,27 +310,8 @@ def check(root: Path) -> list[str]:
                 f"{ROOT_WORKFLOW} job {job_name} has dynamic or write permissions outside {ALLOWED_JOB}"
             )
 
-    if policy.get("permissions") != {"contents": "read"}:
-        violations.append(f"{POLICY_JOB} permissions must be exactly contents: read")
-    if "if" in policy:
-        violations.append(f"{POLICY_JOB} must not be conditional")
-    if "continue-on-error" in policy:
-        violations.append(f"{POLICY_JOB} must not continue on error")
-    policy_steps = policy.get("steps")
-    if not isinstance(policy_steps, list):
-        violations.append(f"{POLICY_JOB} steps must be a sequence")
-    else:
-        checker_steps = [
-            step
-            for step in policy_steps
-            if isinstance(step, Mapping)
-            and isinstance(step.get("run"), str)
-            and POLICY_COMMAND.fullmatch(step["run"])
-        ]
-        if len(checker_steps) != 1:
-            violations.append(f"{POLICY_JOB} must execute the exact signing-boundary checker command once")
-        elif "if" in checker_steps[0] or "continue-on-error" in checker_steps[0]:
-            violations.append(f"{POLICY_JOB} checker step must be unconditional and fail closed")
+    if policy != EXPECTED_POLICY_JOB:
+        violations.append(f"{POLICY_JOB} must match the exact fail-closed job specification")
 
     missing_refs = SIGNING_SECRETS - signing_references(release)
     if missing_refs:
@@ -311,16 +324,21 @@ def check(root: Path) -> list[str]:
         violations.append(f"{ALLOWED_JOB} must bind the {ENVIRONMENT_NAME} environment")
     if "uses" in release:
         violations.append(f"{ALLOWED_JOB} must not delegate to a reusable workflow")
+    if any(target.startswith("./") for target in action_uses(release)):
+        violations.append(f"{ALLOWED_JOB} must not invoke local actions")
 
     if not isinstance(release.get("steps"), list):
         violations.append(f"{ALLOWED_JOB} steps must be a sequence")
 
     for event in ("push", "pull_request"):
-        missing_paths = REQUIRED_TRIGGER_PATHS - trigger_paths(root_workflow, event)
+        paths = trigger_paths(root_workflow, event)
+        missing_paths = REQUIRED_TRIGGER_PATHS - set(paths)
         if missing_paths:
             violations.append(
                 f"{ROOT_WORKFLOW} {event}.paths is missing: {', '.join(sorted(missing_paths))}"
             )
+        if any(path.startswith("!") for path in paths):
+            violations.append(f"{ROOT_WORKFLOW} {event}.paths must not contain negative patterns")
 
     for relative in (ROOT_WORKFLOW, ANDROID_SIBLING_WORKFLOW):
         path = root / relative

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import re
 from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
@@ -80,6 +82,14 @@ EXPECTED_RELEASE_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
         "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
     },
 }
+EXPECTED_SECRET_STEP_SHA256 = {
+    "Decode release keystore": "44c1231395b5f7347980a05fa641b0e7d866451e10ddb88958e61459f649ffba",
+    "Build signed release APK and AAB": "07a1049b765ab5e0005e943a165dd5399b83741fc38cc91fa7919bd360873d94",
+    "Capture release dependency graph and generate signed-release splits": (
+        "0df837fe9af54e6cfb08d657238cd5eec036757c69e7dd216e76bc5904411652"
+    ),
+}
+EXPECTED_RELEASE_JOB_SHA256 = "2c76d2e950e84fbd90263cbcc791b2c6274aa425f40c6bc9adfda370cbb3f849"
 ALLOWED_RELEASE_JOB_KEYS = {
     "name",
     "needs",
@@ -201,6 +211,16 @@ def permissions_read_only(value: Any) -> bool:
     if value == "read-all":
         return True
     return isinstance(value, Mapping) and all(level in {"read", "none"} for level in value.values())
+
+
+def semantic_sha256(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
 
 
 def action_uses(value: Any) -> Iterator[str]:
@@ -347,6 +367,8 @@ def check(root: Path) -> list[str]:
         violations.append(f"{ALLOWED_JOB} must run exactly on GitHub-hosted ubuntu-latest")
     if release.get("defaults") != {"run": {"working-directory": "android"}}:
         violations.append(f"{ALLOWED_JOB} must use the exact Android working-directory defaults")
+    if semantic_sha256(release) != EXPECTED_RELEASE_JOB_SHA256:
+        violations.append(f"{ALLOWED_JOB} must match the exact reviewed release-job specification")
     for forbidden_key in ("container", "services", "strategy", "env", "continue-on-error"):
         if forbidden_key in release:
             violations.append(f"{ALLOWED_JOB} must not define job-level {forbidden_key}")
@@ -399,6 +421,10 @@ def check(root: Path) -> list[str]:
             if len(matching_steps) != 1 or matching_steps[0].get("env") != expected_env:
                 violations.append(
                     f"{ALLOWED_JOB} must contain exactly one {step_name!r} step with reviewed environment"
+                )
+            elif semantic_sha256(matching_steps[0]) != EXPECTED_SECRET_STEP_SHA256[step_name]:
+                violations.append(
+                    f"{ALLOWED_JOB} step {step_name!r} must match its exact reviewed execution"
                 )
         release_without_step_env = dict(release)
         release_without_step_env["steps"] = [

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -65,6 +65,32 @@ EXPECTED_POLICY_JOB: dict[str, Any] = {
         },
     ],
 }
+EXPECTED_RELEASE_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
+    "Decode release keystore": {
+        "KEYSTORE_BASE64": "${{ secrets.ANDROID_KEYSTORE_BASE64 }}",
+    },
+    "Build signed release APK and AAB": {
+        "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
+        "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
+    },
+    "Capture release dependency graph and generate signed-release splits": {
+        "BUNDLETOOL_VERSION": "1.18.1",
+        "BUNDLETOOL_SHA256": "675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c",
+        "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
+        "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
+    },
+}
+ALLOWED_RELEASE_JOB_KEYS = {
+    "name",
+    "needs",
+    "if",
+    "runs-on",
+    "environment",
+    "permissions",
+    "defaults",
+    "steps",
+}
+ALLOWED_RELEASE_STEP_KEYS = {"name", "uses", "with", "run", "env", "if"}
 REQUIRED_TRIGGER_PATHS = {
     ".github/workflows/**",
     "android/.github/workflows/**",
@@ -175,16 +201,6 @@ def permissions_read_only(value: Any) -> bool:
     if value == "read-all":
         return True
     return isinstance(value, Mapping) and all(level in {"read", "none"} for level in value.values())
-
-
-def needs_job(value: Any, job_name: str) -> bool:
-    if value == job_name:
-        return True
-    return (
-        isinstance(value, Sequence)
-        and not isinstance(value, (str, bytes))
-        and job_name in value
-    )
 
 
 def action_uses(value: Any) -> Iterator[str]:
@@ -323,17 +339,80 @@ def check(root: Path) -> list[str]:
         violations.append(f"{ALLOWED_JOB} is missing signing references: {', '.join(sorted(missing_refs))}")
     if release.get("if") != TAG_GUARD:
         violations.append(f"{ALLOWED_JOB} must use the exact semantic version-tag guard")
-    if not needs_job(release.get("needs"), POLICY_JOB):
+    if release.get("needs") != POLICY_JOB:
         violations.append(f"{ALLOWED_JOB} must require successful {POLICY_JOB}")
-    if environment_name(release) != ENVIRONMENT_NAME:
+    if release.get("environment") != ENVIRONMENT_NAME:
         violations.append(f"{ALLOWED_JOB} must bind the {ENVIRONMENT_NAME} environment")
+    if release.get("runs-on") != "ubuntu-latest":
+        violations.append(f"{ALLOWED_JOB} must run exactly on GitHub-hosted ubuntu-latest")
+    if release.get("defaults") != {"run": {"working-directory": "android"}}:
+        violations.append(f"{ALLOWED_JOB} must use the exact Android working-directory defaults")
+    for forbidden_key in ("container", "services", "strategy", "env", "continue-on-error"):
+        if forbidden_key in release:
+            violations.append(f"{ALLOWED_JOB} must not define job-level {forbidden_key}")
+    unexpected_job_keys = set(release) - ALLOWED_RELEASE_JOB_KEYS
+    if unexpected_job_keys:
+        violations.append(
+            f"{ALLOWED_JOB} has unreviewed job keys: {', '.join(sorted(unexpected_job_keys))}"
+        )
     if "uses" in release:
         violations.append(f"{ALLOWED_JOB} must not delegate to a reusable workflow")
     if any(target.startswith("./") for target in action_uses(release)):
         violations.append(f"{ALLOWED_JOB} must not invoke local actions")
 
-    if not isinstance(release.get("steps"), list):
+    release_steps = release.get("steps")
+    if not isinstance(release_steps, list):
         violations.append(f"{ALLOWED_JOB} steps must be a sequence")
+    else:
+        for step in release_steps:
+            if not isinstance(step, Mapping):
+                violations.append(f"{ALLOWED_JOB} steps must contain only mappings")
+                continue
+            step_name = step.get("name")
+            unexpected_step_keys = set(step) - ALLOWED_RELEASE_STEP_KEYS
+            if unexpected_step_keys:
+                violations.append(
+                    f"{ALLOWED_JOB} step {step_name!r} has unreviewed keys: "
+                    f"{', '.join(sorted(unexpected_step_keys))}"
+                )
+            if ("run" in step) == ("uses" in step):
+                violations.append(
+                    f"{ALLOWED_JOB} step {step_name!r} must define exactly one of run or uses"
+                )
+            for forbidden_key in ("shell", "working-directory", "continue-on-error"):
+                if forbidden_key in step:
+                    violations.append(
+                        f"{ALLOWED_JOB} step {step_name!r} must not define {forbidden_key}"
+                    )
+            if "env" in step:
+                expected_env = EXPECTED_RELEASE_STEP_ENVIRONMENTS.get(str(step_name))
+                if step.get("env") != expected_env:
+                    violations.append(
+                        f"{ALLOWED_JOB} step {step_name!r} must use its exact reviewed environment"
+                    )
+        for step_name, expected_env in EXPECTED_RELEASE_STEP_ENVIRONMENTS.items():
+            matching_steps = [
+                step
+                for step in release_steps
+                if isinstance(step, Mapping) and step.get("name") == step_name
+            ]
+            if len(matching_steps) != 1 or matching_steps[0].get("env") != expected_env:
+                violations.append(
+                    f"{ALLOWED_JOB} must contain exactly one {step_name!r} step with reviewed environment"
+                )
+        release_without_step_env = dict(release)
+        release_without_step_env["steps"] = [
+            {key: value for key, value in step.items() if key != "env"}
+            if isinstance(step, Mapping)
+            else step
+            for step in release_steps
+        ]
+        refs_outside_reviewed_env = signing_references(release_without_step_env)
+        if refs_outside_reviewed_env:
+            violations.append(
+                f"{ALLOWED_JOB} references signing secrets outside reviewed step environments: "
+                f"{', '.join(sorted(refs_outside_reviewed_env))}"
+            )
 
     for event in ("push", "pull_request"):
         paths = trigger_paths(root_workflow, event)

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -5,7 +5,15 @@ from __future__ import annotations
 
 import argparse
 import re
+from collections.abc import Iterator, Mapping, Sequence
 from pathlib import Path
+from typing import Any
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode
+from yaml.resolver import BaseResolver
+from yaml.tokens import AliasToken, AnchorToken
 
 
 SIGNING_SECRETS = {
@@ -13,105 +21,316 @@ SIGNING_SECRETS = {
     "ANDROID_KEYSTORE_PASSWORD",
     "ANDROID_KEY_ALIAS",
 }
-ALLOWED_WORKFLOW = "build-android.yml"
+ROOT_WORKFLOW = Path(".github/workflows/build-android.yml")
+ANDROID_SIBLING_WORKFLOW = Path("android/.github/workflows/build.yml")
 ALLOWED_JOB = "build-release"
-TAG_GUARD = "if: startsWith(github.ref, 'refs/tags/v')"
-ENVIRONMENT_GUARD = "environment: android-release"
+POLICY_JOB = "signing-policy"
+TAG_GUARD = "startsWith(github.ref, 'refs/tags/v')"
+ENVIRONMENT_NAME = "android-release"
 SHA_PIN = re.compile(r"^[0-9a-f]{40}$")
-JOB_HEADER = re.compile(r"^  ([A-Za-z0-9_-]+):\s*$")
-USES_LINE = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)")
-SECRET_REFERENCE = re.compile(r"secrets\.([A-Z0-9_]+)")
+POLICY_COMMAND = re.compile(r"^\s*python(?:3)?\s+scripts/check-android-signing-boundary\.py\s*$")
+UNSAFE_SECRET_EXPRESSION = re.compile(
+    r"\bsecrets\s*\[|\btojson\s*\(\s*secrets\s*\)",
+    re.IGNORECASE,
+)
+REQUIRED_TRIGGER_PATHS = {
+    ".github/workflows/**",
+    "android/.github/workflows/**",
+    "scripts/check-android-signing-boundary.py",
+    "tests/test_android_*.py",
+}
 
 
-def job_sections(workflow: str) -> dict[str, str]:
-    """Return top-level job bodies from a GitHub Actions workflow."""
-    lines = workflow.splitlines()
+class StrictBaseLoader(yaml.BaseLoader):
+    """BaseLoader with parser-differential features rejected."""
+
+
+def construct_unique_mapping(
+    loader: StrictBaseLoader,
+    node: MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as exc:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable key",
+                key_node.start_mark,
+            ) from exc
+        if duplicate:
+            raise ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+StrictBaseLoader.add_constructor(BaseResolver.DEFAULT_MAPPING_TAG, construct_unique_mapping)
+
+
+def load_workflow(path: Path) -> dict[str, Any]:
     try:
-        jobs_index = next(i for i, line in enumerate(lines) if line == "jobs:")
-    except StopIteration:
-        return {}
-
-    sections: dict[str, list[str]] = {}
-    current: str | None = None
-    for line in lines[jobs_index + 1 :]:
-        if line and not line.startswith(" "):
-            break
-        match = JOB_HEADER.match(line)
-        if match:
-            current = match.group(1)
-            sections[current] = [line]
-        elif current is not None:
-            sections[current].append(line)
-    return {name: "\n".join(body) for name, body in sections.items()}
+        text = path.read_text(encoding="utf-8")
+        if any(isinstance(token, (AnchorToken, AliasToken)) for token in yaml.scan(text)):
+            raise ValueError("YAML anchors and aliases are not allowed")
+        parsed = yaml.load(text, Loader=StrictBaseLoader)
+    except ValueError:
+        raise
+    except yaml.YAMLError as exc:
+        raise ValueError(f"invalid YAML: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("workflow root must be a mapping")
+    return parsed
 
 
-def signing_references(body: str) -> set[str]:
-    return SIGNING_SECRETS & set(SECRET_REFERENCE.findall(body))
+def walk(value: Any) -> Iterator[Any]:
+    yield value
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            yield from walk(key)
+            yield from walk(item)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for item in value:
+            yield from walk(item)
 
 
-def action_ref(target: str) -> str | None:
+def strings(value: Any) -> Iterator[str]:
+    for item in walk(value):
+        if isinstance(item, str):
+            yield item
+
+
+def signing_references(value: Any) -> set[str]:
+    body = "\n".join(strings(value))
+    return {name for name in SIGNING_SECRETS if name in body}
+
+
+def contains_unsafe_secret_expression(value: Any) -> bool:
+    return any(UNSAFE_SECRET_EXPRESSION.search(item) for item in strings(value))
+
+
+def contains_secret_inheritance(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if key == "secrets" and item == "inherit":
+                return True
+            if contains_secret_inheritance(item):
+                return True
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return any(contains_secret_inheritance(item) for item in value)
+    return False
+
+
+def environment_name(job: Mapping[str, Any]) -> str | None:
+    value = job.get("environment")
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        name = value.get("name")
+        return name if isinstance(name, str) else None
+    return None
+
+
+def permissions_read_only(value: Any) -> bool:
+    if value == "read-all":
+        return True
+    return isinstance(value, Mapping) and all(level in {"read", "none"} for level in value.values())
+
+
+def needs_job(value: Any, job_name: str) -> bool:
+    if value == job_name:
+        return True
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+        and job_name in value
+    )
+
+
+def action_uses(value: Any) -> Iterator[str]:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if key == "uses" and isinstance(item, str):
+                yield item
+            yield from action_uses(item)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for item in value:
+            yield from action_uses(item)
+
+
+def unpinned_action(target: str) -> bool:
     if target.startswith("./"):
-        return None
+        return False
     if "@" not in target:
-        return ""
-    return target.rsplit("@", 1)[1]
+        return True
+    return not SHA_PIN.fullmatch(target.rsplit("@", 1)[1])
+
+
+def as_mapping(value: Any, label: str, violations: list[str]) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        violations.append(f"{label} must be a mapping")
+        return {}
+    return value
+
+
+def trigger_paths(workflow: Mapping[str, Any], event: str) -> set[str]:
+    events = workflow.get("on")
+    if not isinstance(events, Mapping):
+        return set()
+    config = events.get(event)
+    if not isinstance(config, Mapping):
+        return set()
+    paths = config.get("paths")
+    if not isinstance(paths, Sequence) or isinstance(paths, (str, bytes)):
+        return set()
+    return {item for item in paths if isinstance(item, str)}
 
 
 def check(root: Path) -> list[str]:
     workflow_dir = root / ".github" / "workflows"
     violations: list[str] = []
-    allowed_path = workflow_dir / ALLOWED_WORKFLOW
+    root_path = root / ROOT_WORKFLOW
+    sibling_path = root / ANDROID_SIBLING_WORKFLOW
 
-    if not allowed_path.is_file():
-        return [f"missing required workflow: {allowed_path}"]
+    if not root_path.is_file():
+        return [f"missing required workflow: {ROOT_WORKFLOW}"]
+    if not sibling_path.is_file():
+        return [f"missing Android sibling workflow: {ANDROID_SIBLING_WORKFLOW}"]
 
+    loaded: dict[Path, dict[str, Any]] = {}
     workflow_paths = sorted((*workflow_dir.glob("*.yml"), *workflow_dir.glob("*.yaml")))
     for path in workflow_paths:
-        body = path.read_text(encoding="utf-8")
-        sections = job_sections(body)
-        for job, section in sections.items():
-            references = signing_references(section)
-            if references and (path.name != ALLOWED_WORKFLOW or job != ALLOWED_JOB):
-                violations.append(
-                    f"{path.relative_to(root)} job {job} references Android signing secrets: "
-                    f"{', '.join(sorted(references))}"
-                )
-            if (
-                path.name == ALLOWED_WORKFLOW
-                and "contents: write" in section
-                and job != ALLOWED_JOB
-            ):
-                violations.append(
-                    f"{path.relative_to(root)} job {job} has contents: write outside the Android release job"
-                )
+        relative = path.relative_to(root)
+        try:
+            workflow = load_workflow(path)
+        except ValueError as exc:
+            violations.append(f"{relative}: {exc}")
+            continue
+        loaded[relative] = workflow
+        jobs = as_mapping(workflow.get("jobs"), f"{relative} jobs", violations)
+        workflow_scope = {key: value for key, value in workflow.items() if key != "jobs"}
 
-    allowed_body = allowed_path.read_text(encoding="utf-8")
-    sections = job_sections(allowed_body)
-    release = sections.get(ALLOWED_JOB)
-    if release is None:
-        violations.append(f"{allowed_path.relative_to(root)} is missing job {ALLOWED_JOB}")
+        scope_refs = signing_references(workflow_scope)
+        if scope_refs:
+            violations.append(
+                f"{relative} references Android signing secrets outside a job: "
+                f"{', '.join(sorted(scope_refs))}"
+            )
+
+        if contains_secret_inheritance(workflow):
+            violations.append(f"{relative} must not use reusable-workflow secrets: inherit")
+        if contains_unsafe_secret_expression(workflow):
+            violations.append(f"{relative} must not use dynamic or whole-context secret expressions")
+
+        for job_name, raw_job in jobs.items():
+            if not isinstance(raw_job, Mapping):
+                violations.append(f"{relative} job {job_name} must be a mapping")
+                continue
+            refs = signing_references(raw_job)
+            env = environment_name(raw_job)
+            is_allowed = relative == ROOT_WORKFLOW and job_name == ALLOWED_JOB
+            if refs and not is_allowed:
+                violations.append(
+                    f"{relative} job {job_name} references Android signing secrets: "
+                    f"{', '.join(sorted(refs))}"
+                )
+            if env == ENVIRONMENT_NAME and not is_allowed:
+                violations.append(f"{relative} job {job_name} binds {ENVIRONMENT_NAME} outside {ALLOWED_JOB}")
+            if env and "${{" in env and not is_allowed:
+                violations.append(f"{relative} job {job_name} uses a dynamic environment outside {ALLOWED_JOB}")
+
+    root_workflow = loaded.get(ROOT_WORKFLOW)
+    if root_workflow is None:
+        return violations
+    jobs = as_mapping(root_workflow.get("jobs"), f"{ROOT_WORKFLOW} jobs", violations)
+    policy = jobs.get(POLICY_JOB)
+    if not isinstance(policy, Mapping):
+        violations.append(f"{ROOT_WORKFLOW} is missing mapping job {POLICY_JOB}")
+        return violations
+    release = jobs.get(ALLOWED_JOB)
+    if not isinstance(release, Mapping):
+        violations.append(f"{ROOT_WORKFLOW} is missing mapping job {ALLOWED_JOB}")
         return violations
 
-    missing = SIGNING_SECRETS - signing_references(release)
-    if missing:
-        violations.append(f"{ALLOWED_JOB} is missing signing references: {', '.join(sorted(missing))}")
-    if TAG_GUARD not in release:
-        violations.append(f"{ALLOWED_JOB} must use the exact version-tag guard")
-    if ENVIRONMENT_GUARD not in release:
-        violations.append(f"{ALLOWED_JOB} must bind the android-release environment")
-    if "permissions:\n      contents: write" not in release:
-        violations.append(f"{ALLOWED_JOB} must declare only the required contents: write permission")
+    top_permissions = root_workflow.get("permissions")
+    if top_permissions is not None and not permissions_read_only(top_permissions):
+        violations.append(f"{ROOT_WORKFLOW} must not grant dynamic or write permissions at workflow scope")
 
-    for line_number, line in enumerate(allowed_body.splitlines(), start=1):
-        match = USES_LINE.match(line)
-        if not match:
+    for job_name, raw_job in jobs.items():
+        if not isinstance(raw_job, Mapping):
             continue
-        target = match.group(1)
-        ref = action_ref(target)
-        if ref is not None and not SHA_PIN.fullmatch(ref):
+        permissions = raw_job.get("permissions")
+        if job_name == ALLOWED_JOB:
+            if permissions != {"contents": "write"}:
+                violations.append(f"{ALLOWED_JOB} permissions must be exactly contents: write")
+        elif permissions is None:
+            violations.append(f"{ROOT_WORKFLOW} job {job_name} must declare explicit read-only permissions")
+        elif not permissions_read_only(permissions):
             violations.append(
-                f"{allowed_path.relative_to(root)}:{line_number} action must be pinned to a full commit SHA: {target}"
+                f"{ROOT_WORKFLOW} job {job_name} has dynamic or write permissions outside {ALLOWED_JOB}"
             )
+
+    if policy.get("permissions") != {"contents": "read"}:
+        violations.append(f"{POLICY_JOB} permissions must be exactly contents: read")
+    if "if" in policy:
+        violations.append(f"{POLICY_JOB} must not be conditional")
+    if "continue-on-error" in policy:
+        violations.append(f"{POLICY_JOB} must not continue on error")
+    policy_steps = policy.get("steps")
+    if not isinstance(policy_steps, list):
+        violations.append(f"{POLICY_JOB} steps must be a sequence")
+    else:
+        checker_steps = [
+            step
+            for step in policy_steps
+            if isinstance(step, Mapping)
+            and isinstance(step.get("run"), str)
+            and POLICY_COMMAND.fullmatch(step["run"])
+        ]
+        if len(checker_steps) != 1:
+            violations.append(f"{POLICY_JOB} must execute the exact signing-boundary checker command once")
+        elif "if" in checker_steps[0] or "continue-on-error" in checker_steps[0]:
+            violations.append(f"{POLICY_JOB} checker step must be unconditional and fail closed")
+
+    missing_refs = SIGNING_SECRETS - signing_references(release)
+    if missing_refs:
+        violations.append(f"{ALLOWED_JOB} is missing signing references: {', '.join(sorted(missing_refs))}")
+    if release.get("if") != TAG_GUARD:
+        violations.append(f"{ALLOWED_JOB} must use the exact semantic version-tag guard")
+    if not needs_job(release.get("needs"), POLICY_JOB):
+        violations.append(f"{ALLOWED_JOB} must require successful {POLICY_JOB}")
+    if environment_name(release) != ENVIRONMENT_NAME:
+        violations.append(f"{ALLOWED_JOB} must bind the {ENVIRONMENT_NAME} environment")
+    if "uses" in release:
+        violations.append(f"{ALLOWED_JOB} must not delegate to a reusable workflow")
+
+    if not isinstance(release.get("steps"), list):
+        violations.append(f"{ALLOWED_JOB} steps must be a sequence")
+
+    for event in ("push", "pull_request"):
+        missing_paths = REQUIRED_TRIGGER_PATHS - trigger_paths(root_workflow, event)
+        if missing_paths:
+            violations.append(
+                f"{ROOT_WORKFLOW} {event}.paths is missing: {', '.join(sorted(missing_paths))}"
+            )
+
+    for relative in (ROOT_WORKFLOW, ANDROID_SIBLING_WORKFLOW):
+        path = root / relative
+        try:
+            workflow = load_workflow(path)
+        except ValueError:
+            continue
+        for target in action_uses(workflow):
+            if unpinned_action(target):
+                violations.append(f"{relative} action must be pinned to a full commit SHA: {target}")
 
     return violations
 
@@ -124,7 +343,7 @@ def main() -> int:
     violations = check(args.root.resolve())
     if violations:
         print("Android signing boundary check failed:")
-        for violation in violations:
+        for violation in sorted(set(violations)):
             print(f"- {violation}")
         return 1
 

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -141,8 +141,8 @@ def strings(value: Any) -> Iterator[str]:
 
 
 def signing_references(value: Any) -> set[str]:
-    body = "\n".join(strings(value))
-    return {name for name in SIGNING_SECRETS if name in body}
+    body = "\n".join(strings(value)).casefold()
+    return {name for name in SIGNING_SECRETS if name.casefold() in body}
 
 
 def contains_unsafe_secret_expression(value: Any) -> bool:
@@ -295,6 +295,11 @@ def check(root: Path) -> list[str]:
     top_permissions = root_workflow.get("permissions")
     if top_permissions is not None and not permissions_read_only(top_permissions):
         violations.append(f"{ROOT_WORKFLOW} must not grant dynamic or write permissions at workflow scope")
+    for inherited_key in ("defaults", "env"):
+        if inherited_key in root_workflow:
+            violations.append(
+                f"{ROOT_WORKFLOW} must not define workflow-level {inherited_key} that can alter {POLICY_JOB}"
+            )
 
     for job_name, raw_job in jobs.items():
         if not isinstance(raw_job, Mapping):

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -691,6 +691,56 @@ def test_release_step_environment_is_exact(tmp_path: Path) -> None:
     assert_rejected(run_checker(root), "must use its exact reviewed environment")
 
 
+def test_secret_bearing_step_cannot_be_replaced_by_pinned_action(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        """      - name: Build signed release APK and AAB
+        env:
+          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          ./gradlew assembleRelease bundleRelease --no-daemon \\
+            -PrequireEtebase16Kb=true \\
+            -PsigningStoreLocation="$KEYSTORE_PATH" \\
+            -PsigningKeyAlias="$KEY_ALIAS"
+""",
+        """      - name: Build signed release APK and AAB
+        env:
+          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        uses: attacker/release-secret-recorder@0123456789012345678901234567890123456789
+""",
+    )
+
+    assert_rejected(run_checker(root), "must match its exact reviewed execution")
+
+
+def test_secret_bearing_step_command_is_immutable(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "            -PsigningKeyAlias=\"$KEY_ALIAS\"\n",
+        "            -PsigningKeyAlias=\"$KEY_ALIAS\"\n          curl https://attacker.invalid/\n",
+    )
+
+    assert_rejected(run_checker(root), "must match its exact reviewed execution")
+
+
+def test_earlier_release_step_cannot_poison_secret_execution_environment(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate_last(
+        workflow,
+        "      - name: Make gradlew executable\n        run: chmod +x gradlew\n",
+        "      - name: Make gradlew executable\n        run: |\n          chmod +x gradlew\n          echo 'BASH_ENV=attacker' >> \"$GITHUB_ENV\"\n",
+    )
+
+    assert_rejected(run_checker(root), "must match the exact reviewed release-job specification")
+
+
 def test_release_secret_cannot_move_into_action_input(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     workflow = root / ROOT_WORKFLOW

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -1,4 +1,4 @@
-"""Executable policy contracts for the Android release signing boundary."""
+"""Adversarial policy contracts for the Android release signing boundary."""
 
 from pathlib import Path
 import shutil
@@ -7,112 +7,384 @@ import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]
-CHECKER = ROOT / "scripts/check-android-signing-boundary.py"
-WORKFLOW = Path(".github/workflows/build-android.yml")
+CHECKER = ROOT / "scripts" / "check-android-signing-boundary.py"
+ROOT_WORKFLOW = Path(".github/workflows/build-android.yml")
+SIBLING_WORKFLOW = Path("android/.github/workflows/build.yml")
+POLICY_STEP = """      - name: Enforce Android signing boundary
+        run: python scripts/check-android-signing-boundary.py
+
+"""
 
 
 def run_checker(root: Path) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(CHECKER), "--root", str(root)],
-        capture_output=True,
         check=False,
+        capture_output=True,
         text=True,
     )
 
 
 def fixture_root(tmp_path: Path) -> Path:
-    target = tmp_path / "repo"
-    shutil.copytree(ROOT / ".github", target / ".github")
-    return target
+    root = tmp_path / "repo"
+    shutil.copytree(ROOT / ".github", root / ".github")
+    (root / SIBLING_WORKFLOW).parent.mkdir(parents=True)
+    shutil.copy2(ROOT / SIBLING_WORKFLOW, root / SIBLING_WORKFLOW)
+    return root
 
 
-def mutate(root: Path, old: str, new: str) -> None:
-    path = root / WORKFLOW
-    body = path.read_text(encoding="utf-8")
-    assert old in body
-    path.write_text(body.replace(old, new, 1), encoding="utf-8")
+def mutate(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    assert old in text
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
 
 
-def test_current_android_signing_boundary_passes():
+def assert_rejected(result: subprocess.CompletedProcess[str], needle: str) -> None:
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert needle in result.stdout
+
+
+def test_repository_workflows_satisfy_android_signing_boundary() -> None:
     result = run_checker(ROOT)
-
     assert result.returncode == 0, result.stdout + result.stderr
     assert "Android signing boundary check passed" in result.stdout
 
 
-def test_signing_reference_outside_release_job_fails(tmp_path):
+def test_quoted_job_with_bracket_secret_reference_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
-    mutate(
-        root,
-        "  build-pr:\n",
-        "  signing-leak:\n"
-        "    runs-on: ubuntu-latest\n"
-        "    env:\n"
-        "      LEAK: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n"
-        "    steps:\n"
-        "      - run: test -n \"$LEAK\"\n\n"
-        "  build-pr:\n",
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: bypass
+on: pull_request
+jobs:
+  "quoted-leak":
+    runs-on: ubuntu-latest
+    env:
+      LEAK: ${{ secrets['ANDROID_KEYSTORE_BASE64'] }}
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
     )
 
-    result = run_checker(root)
-
-    assert result.returncode == 1
-    assert "job signing-leak references Android signing secrets" in result.stdout
+    assert_rejected(run_checker(root), "job quoted-leak references Android signing secrets")
 
 
-def test_release_job_without_environment_fails(tmp_path):
+def test_computed_secret_index_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
-    mutate(root, "    environment: android-release\n", "")
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: dynamic bypass
+on: pull_request
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    env:
+      LEAK: ${{ secrets[format('ANDROID_{0}', 'KEYSTORE_BASE64')] }}
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
 
-    result = run_checker(root)
-
-    assert result.returncode == 1
-    assert "must bind the android-release environment" in result.stdout
+    assert_rejected(run_checker(root), "must not use dynamic or whole-context secret expressions")
 
 
-def test_release_job_without_exact_tag_guard_fails(tmp_path):
+def test_whole_secrets_context_serialization_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: whole context bypass
+on: pull_request
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    env:
+      ALL_SECRETS: ${{ toJSON(secrets) }}
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "must not use dynamic or whole-context secret expressions")
+
+
+def test_workflow_scope_signing_reference_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: workflow scope bypass
+on: pull_request
+env:
+  LEAK: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+jobs:
+  harmless:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "references Android signing secrets outside a job")
+
+
+def test_duplicate_yaml_keys_are_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: duplicate key bypass
+on: pull_request
+jobs:
+  duplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+  duplicate:
+    runs-on: ubuntu-latest
+    env:
+      LEAK: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "found duplicate key 'duplicate'")
+
+
+def test_yaml_anchors_and_aliases_are_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: anchor bypass
+on: pull_request
+defaults: &shared
+  runs-on: ubuntu-latest
+  steps:
+    - run: 'true'
+jobs:
+  alias: *shared
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "YAML anchors and aliases are not allowed")
+
+
+def test_reusable_workflow_secret_inheritance_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: reusable bypass
+on: pull_request
+jobs:
+  delegate:
+    uses: owner/repo/.github/workflows/release.yml@0123456789012345678901234567890123456789
+    secrets: inherit
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "must not use reusable-workflow secrets: inherit")
+
+
+def test_reusable_workflow_signing_secret_alias_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: reusable alias bypass
+on: pull_request
+jobs:
+  delegate:
+    uses: owner/repo/.github/workflows/release.yml@0123456789012345678901234567890123456789
+    secrets:
+      SIGNING_BLOB: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "job delegate references Android signing secrets")
+
+
+def test_android_environment_in_another_workflow_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: environment bypass
+on: pull_request
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    environment:
+      name: android-release
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "binds android-release outside build-release")
+
+
+def test_dynamic_environment_outside_release_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: dynamic environment bypass
+on: pull_request
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "uses a dynamic environment outside build-release")
+
+
+def test_misleading_guard_text_does_not_replace_semantic_guard(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
     mutate(
-        root,
+        workflow,
         "    if: startsWith(github.ref, 'refs/tags/v')\n",
-        "    if: github.event_name == 'push'\n",
+        "    if: ${{ true }}\n    env:\n      DOCUMENTED_GUARD: \"startsWith(github.ref, 'refs/tags/v')\"\n",
     )
 
-    result = run_checker(root)
-
-    assert result.returncode == 1
-    assert "must use the exact version-tag guard" in result.stdout
+    assert_rejected(run_checker(root), "must use the exact semantic version-tag guard")
 
 
-def test_mutable_action_reference_fails(tmp_path):
+def test_workflow_level_write_all_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
-    mutate(
-        root,
-        "uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
-        "uses: actions/checkout@v4",
-    )
+    workflow = root / ROOT_WORKFLOW
+    mutate(workflow, "jobs:\n", "permissions: write-all\n\njobs:\n")
 
-    result = run_checker(root)
-
-    assert result.returncode == 1
-    assert "action must be pinned to a full commit SHA" in result.stdout
+    assert_rejected(run_checker(root), "must not grant dynamic or write permissions at workflow scope")
 
 
-def test_contents_write_outside_release_job_fails(tmp_path):
+def test_nonrelease_job_write_permission_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
     mutate(
-        root,
-        "  build-pr:\n",
-        "  publishing-leak:\n"
-        "    runs-on: ubuntu-latest\n"
-        "    permissions:\n"
-        "      contents: write\n"
-        "    steps:\n"
-        "      - run: true\n\n"
-        "  build-pr:\n",
+        workflow,
+        "  build-pr:\n    name: Build (unsigned, PR/dev/main)\n    if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n",
+        "  build-pr:\n    name: Build (unsigned, PR/dev/main)\n    if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    permissions: write-all\n",
+    )
+
+    assert_rejected(
+        run_checker(root),
+        "job build-pr has dynamic or write permissions outside build-release",
+    )
+
+
+def test_release_job_extra_write_permission_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    permissions:\n      contents: write\n",
+        "    permissions:\n      contents: write\n      packages: write\n",
+    )
+
+    assert_rejected(run_checker(root), "permissions must be exactly contents: write")
+
+
+def test_release_requires_successful_policy_job(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(workflow, "    needs: signing-policy\n", "")
+
+    assert_rejected(run_checker(root), "build-release must require successful signing-policy")
+
+
+def test_policy_job_cannot_be_conditional(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "  signing-policy:\n    name: Enforce Android signing boundary\n",
+        "  signing-policy:\n    name: Enforce Android signing boundary\n    if: ${{ false }}\n",
+    )
+
+    assert_rejected(run_checker(root), "signing-policy must not be conditional")
+
+
+def test_policy_checker_step_cannot_continue_on_error(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        POLICY_STEP,
+        POLICY_STEP.rstrip() + "\n        continue-on-error: true\n\n",
+    )
+
+    assert_rejected(run_checker(root), "checker step must be unconditional and fail closed")
+
+
+def test_misleading_checker_command_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "        run: python scripts/check-android-signing-boundary.py\n",
+        "        run: echo python scripts/check-android-signing-boundary.py\n",
+    )
+
+    assert_rejected(run_checker(root), "must execute the exact signing-boundary checker command once")
+
+
+def test_all_root_workflow_changes_must_trigger_policy(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    text = workflow.read_text(encoding="utf-8")
+    workflow.write_text(text.replace("      - '.github/workflows/**'\n", ""), encoding="utf-8")
+
+    result = run_checker(root)
+    assert_rejected(result, "pull_request.paths is missing: .github/workflows/**")
+    assert "push.paths is missing: .github/workflows/**" in result.stdout
+
+
+def test_android_sibling_workflow_changes_must_trigger_policy(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    text = workflow.read_text(encoding="utf-8")
+    workflow.write_text(
+        text.replace("      - 'android/.github/workflows/**'\n", ""),
+        encoding="utf-8",
     )
 
     result = run_checker(root)
+    assert_rejected(result, "pull_request.paths is missing: android/.github/workflows/**")
+    assert "push.paths is missing: android/.github/workflows/**" in result.stdout
 
-    assert result.returncode == 1
-    assert "contents: write outside the Android release job" in result.stdout
+
+def test_mutable_action_in_root_workflow_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
+        "actions/checkout@v4",
+    )
+
+    assert_rejected(run_checker(root), "action must be pinned to a full commit SHA: actions/checkout@v4")
+
+
+def test_mutable_action_in_android_sibling_workflow_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / SIBLING_WORKFLOW
+    mutate(
+        workflow,
+        "android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407",
+        "android-actions/setup-android@v3",
+    )
+
+    assert_rejected(
+        run_checker(root),
+        "android/.github/workflows/build.yml action must be pinned to a full commit SHA",
+    )

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -39,6 +39,13 @@ def mutate(path: Path, old: str, new: str) -> None:
     path.write_text(text.replace(old, new, 1), encoding="utf-8")
 
 
+def mutate_last(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    before, separator, after = text.rpartition(old)
+    assert separator
+    path.write_text(before + new + after, encoding="utf-8")
+
+
 def assert_rejected(result: subprocess.CompletedProcess[str], needle: str) -> None:
     assert result.returncode == 1, result.stdout + result.stderr
     assert needle in result.stdout
@@ -404,6 +411,18 @@ def test_release_requires_successful_policy_job(tmp_path: Path) -> None:
     assert_rejected(run_checker(root), "build-release must require successful signing-policy")
 
 
+def test_release_needs_must_be_exact(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    needs: signing-policy\n",
+        "    needs: [signing-policy, attacker]\n",
+    )
+
+    assert_rejected(run_checker(root), "build-release must require successful signing-policy")
+
+
 def test_policy_job_cannot_be_conditional(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     workflow = root / ROOT_WORKFLOW
@@ -536,6 +555,152 @@ def test_policy_dependency_hash_pin_is_immutable(tmp_path: Path) -> None:
     )
 
     assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
+
+
+def test_release_job_must_use_github_hosted_runner(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    runs-on: ubuntu-latest\n    environment: android-release\n",
+        "    runs-on: self-hosted\n    environment: android-release\n",
+    )
+
+    assert_rejected(run_checker(root), "must run exactly on GitHub-hosted ubuntu-latest")
+
+
+def test_release_job_cannot_use_container(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    runs-on: ubuntu-latest\n    environment: android-release\n",
+        "    runs-on: ubuntu-latest\n    container: attacker/image:latest\n    environment: android-release\n",
+    )
+
+    assert_rejected(run_checker(root), "must not define job-level container")
+
+
+def test_release_job_cannot_use_services(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    runs-on: ubuntu-latest\n    environment: android-release\n",
+        "    runs-on: ubuntu-latest\n    services:\n      attacker:\n        image: attacker/image:latest\n    environment: android-release\n",
+    )
+
+    assert_rejected(run_checker(root), "must not define job-level services")
+
+
+def test_release_job_cannot_use_strategy(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    runs-on: ubuntu-latest\n    environment: android-release\n",
+        "    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        runner: [ubuntu-latest]\n    environment: android-release\n",
+    )
+
+    assert_rejected(run_checker(root), "must not define job-level strategy")
+
+
+def test_release_job_cannot_define_environment(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    runs-on: ubuntu-latest\n    environment: android-release\n",
+        "    runs-on: ubuntu-latest\n    env:\n      BASH_ENV: attacker\n    environment: android-release\n",
+    )
+
+    assert_rejected(run_checker(root), "must not define job-level env")
+
+
+def test_release_job_cannot_override_default_shell(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate_last(
+        workflow,
+        "      run:\n        working-directory: android\n",
+        "      run:\n        working-directory: android\n        shell: bash -c 'exit 0' {0}\n",
+    )
+
+    assert_rejected(run_checker(root), "must use the exact Android working-directory defaults")
+
+
+def test_release_job_cannot_continue_on_error(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    runs-on: ubuntu-latest\n    environment: android-release\n",
+        "    runs-on: ubuntu-latest\n    continue-on-error: true\n    environment: android-release\n",
+    )
+
+    assert_rejected(run_checker(root), "must not define job-level continue-on-error")
+
+
+def test_release_job_environment_must_be_exact_scalar(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    environment: android-release\n",
+        "    environment:\n      name: android-release\n      url: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+    )
+
+    result = run_checker(root)
+    assert_rejected(result, "must bind the android-release environment")
+    assert "references signing secrets outside reviewed step environments" in result.stdout
+
+
+def test_release_job_rejects_unreviewed_job_keys(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "    runs-on: ubuntu-latest\n    environment: android-release\n",
+        "    runs-on: ubuntu-latest\n    timeout-minutes: 30\n    environment: android-release\n",
+    )
+
+    assert_rejected(run_checker(root), "has unreviewed job keys: timeout-minutes")
+
+
+def test_release_step_cannot_override_shell(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "      - name: Decode release keystore\n        env:\n",
+        "      - name: Decode release keystore\n        shell: bash -c 'exit 0' {0}\n        env:\n",
+    )
+
+    assert_rejected(run_checker(root), "step 'Decode release keystore' must not define shell")
+
+
+def test_release_step_environment_is_exact(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "      - name: Decode release keystore\n        env:\n          KEYSTORE_BASE64:",
+        "      - name: Decode release keystore\n        env:\n          PATH: attacker\n          KEYSTORE_BASE64:",
+    )
+
+    assert_rejected(run_checker(root), "must use its exact reviewed environment")
+
+
+def test_release_secret_cannot_move_into_action_input(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate_last(
+        workflow,
+        "      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Set up JDK 17\n",
+        "      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n        with:\n          token: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n\n      - name: Set up JDK 17\n",
+    )
+
+    assert_rejected(run_checker(root), "references signing secrets outside reviewed step environments")
 
 
 def test_release_job_cannot_invoke_local_action(tmp_path: Path) -> None:

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -70,6 +70,26 @@ jobs:
     assert_rejected(run_checker(root), "job quoted-leak references Android signing secrets")
 
 
+def test_secret_name_comparison_is_case_insensitive(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: case bypass
+on: pull_request
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    env:
+      LEAK: ${{ secrets.android_keystore_base64 }}
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "job leak references Android signing secrets")
+
+
 def test_computed_secret_index_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     workflow = root / ".github" / "workflows" / "ci.yml"
@@ -323,6 +343,30 @@ def test_workflow_level_write_all_is_rejected(tmp_path: Path) -> None:
     mutate(workflow, "jobs:\n", "permissions: write-all\n\njobs:\n")
 
     assert_rejected(run_checker(root), "must not grant dynamic or write permissions at workflow scope")
+
+
+def test_workflow_level_run_defaults_are_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "jobs:\n",
+        "defaults:\n  run:\n    shell: bash -c 'exit 0' {0}\n\njobs:\n",
+    )
+
+    assert_rejected(run_checker(root), "must not define workflow-level defaults")
+
+
+def test_workflow_level_environment_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "jobs:\n",
+        "env:\n  PATH: attacker\n  BASH_ENV: attacker\n\njobs:\n",
+    )
+
+    assert_rejected(run_checker(root), "must not define workflow-level env")
 
 
 def test_nonrelease_job_write_permission_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -1,0 +1,118 @@
+"""Executable policy contracts for the Android release signing boundary."""
+
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts/check-android-signing-boundary.py"
+WORKFLOW = Path(".github/workflows/build-android.yml")
+
+
+def run_checker(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), "--root", str(root)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def fixture_root(tmp_path: Path) -> Path:
+    target = tmp_path / "repo"
+    shutil.copytree(ROOT / ".github", target / ".github")
+    return target
+
+
+def mutate(root: Path, old: str, new: str) -> None:
+    path = root / WORKFLOW
+    body = path.read_text(encoding="utf-8")
+    assert old in body
+    path.write_text(body.replace(old, new, 1), encoding="utf-8")
+
+
+def test_current_android_signing_boundary_passes():
+    result = run_checker(ROOT)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Android signing boundary check passed" in result.stdout
+
+
+def test_signing_reference_outside_release_job_fails(tmp_path):
+    root = fixture_root(tmp_path)
+    mutate(
+        root,
+        "  build-pr:\n",
+        "  signing-leak:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    env:\n"
+        "      LEAK: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n"
+        "    steps:\n"
+        "      - run: test -n \"$LEAK\"\n\n"
+        "  build-pr:\n",
+    )
+
+    result = run_checker(root)
+
+    assert result.returncode == 1
+    assert "job signing-leak references Android signing secrets" in result.stdout
+
+
+def test_release_job_without_environment_fails(tmp_path):
+    root = fixture_root(tmp_path)
+    mutate(root, "    environment: android-release\n", "")
+
+    result = run_checker(root)
+
+    assert result.returncode == 1
+    assert "must bind the android-release environment" in result.stdout
+
+
+def test_release_job_without_exact_tag_guard_fails(tmp_path):
+    root = fixture_root(tmp_path)
+    mutate(
+        root,
+        "    if: startsWith(github.ref, 'refs/tags/v')\n",
+        "    if: github.event_name == 'push'\n",
+    )
+
+    result = run_checker(root)
+
+    assert result.returncode == 1
+    assert "must use the exact version-tag guard" in result.stdout
+
+
+def test_mutable_action_reference_fails(tmp_path):
+    root = fixture_root(tmp_path)
+    mutate(
+        root,
+        "uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4",
+        "uses: actions/checkout@v4",
+    )
+
+    result = run_checker(root)
+
+    assert result.returncode == 1
+    assert "action must be pinned to a full commit SHA" in result.stdout
+
+
+def test_contents_write_outside_release_job_fails(tmp_path):
+    root = fixture_root(tmp_path)
+    mutate(
+        root,
+        "  build-pr:\n",
+        "  publishing-leak:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    permissions:\n"
+        "      contents: write\n"
+        "    steps:\n"
+        "      - run: true\n\n"
+        "  build-pr:\n",
+    )
+
+    result = run_checker(root)
+
+    assert result.returncode == 1
+    assert "contents: write outside the Android release job" in result.stdout

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -11,7 +11,7 @@ CHECKER = ROOT / "scripts" / "check-android-signing-boundary.py"
 ROOT_WORKFLOW = Path(".github/workflows/build-android.yml")
 SIBLING_WORKFLOW = Path("android/.github/workflows/build.yml")
 POLICY_STEP = """      - name: Enforce Android signing boundary
-        run: python scripts/check-android-signing-boundary.py
+        run: python "$GITHUB_WORKSPACE/scripts/check-android-signing-boundary.py"
 
 """
 
@@ -110,6 +110,27 @@ jobs:
     assert_rejected(run_checker(root), "must not use dynamic or whole-context secret expressions")
 
 
+def test_secret_object_filter_serialization_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: object filter bypass
+on: pull_request
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    env:
+      ALL_SECRETS: ${{ toJSON(secrets.*) }}
+      JOINED_SECRETS: ${{ join(secrets.*, ',') }}
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "must not use dynamic or whole-context secret expressions")
+
+
 def test_workflow_scope_signing_reference_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     workflow = root / ".github" / "workflows" / "ci.yml"
@@ -170,7 +191,25 @@ jobs:
         encoding="utf-8",
     )
 
-    assert_rejected(run_checker(root), "YAML anchors and aliases are not allowed")
+    assert_rejected(run_checker(root), "YAML anchors, aliases, and explicit tags are not allowed")
+
+
+def test_explicit_yaml_tags_are_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: tag bypass
+on: pull_request
+jobs: !!map
+  safe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "YAML anchors, aliases, and explicit tags are not allowed")
 
 
 def test_reusable_workflow_secret_inheritance_is_rejected(tmp_path: Path) -> None:
@@ -219,6 +258,25 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: android-release
+    steps:
+      - run: 'true'
+""",
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "binds android-release outside build-release")
+
+
+def test_android_environment_comparison_is_case_insensitive(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ".github" / "workflows" / "ci.yml"
+    workflow.write_text(
+        """name: case bypass
+on: pull_request
+jobs:
+  leak:
+    runs-on: ubuntu-latest
+    environment: ANDROID-RELEASE
     steps:
       - run: 'true'
 """,
@@ -311,7 +369,7 @@ def test_policy_job_cannot_be_conditional(tmp_path: Path) -> None:
         "  signing-policy:\n    name: Enforce Android signing boundary\n    if: ${{ false }}\n",
     )
 
-    assert_rejected(run_checker(root), "signing-policy must not be conditional")
+    assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
 
 
 def test_policy_checker_step_cannot_continue_on_error(tmp_path: Path) -> None:
@@ -323,7 +381,7 @@ def test_policy_checker_step_cannot_continue_on_error(tmp_path: Path) -> None:
         POLICY_STEP.rstrip() + "\n        continue-on-error: true\n\n",
     )
 
-    assert_rejected(run_checker(root), "checker step must be unconditional and fail closed")
+    assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
 
 
 def test_misleading_checker_command_is_rejected(tmp_path: Path) -> None:
@@ -331,11 +389,60 @@ def test_misleading_checker_command_is_rejected(tmp_path: Path) -> None:
     workflow = root / ROOT_WORKFLOW
     mutate(
         workflow,
-        "        run: python scripts/check-android-signing-boundary.py\n",
-        "        run: echo python scripts/check-android-signing-boundary.py\n",
+        "        run: python \"$GITHUB_WORKSPACE/scripts/check-android-signing-boundary.py\"\n",
+        "        run: echo python \"$GITHUB_WORKSPACE/scripts/check-android-signing-boundary.py\"\n",
     )
 
-    assert_rejected(run_checker(root), "must execute the exact signing-boundary checker command once")
+    assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
+
+
+def test_policy_checker_cannot_use_working_directory(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        POLICY_STEP,
+        POLICY_STEP.rstrip() + "\n        working-directory: attacker\n\n",
+    )
+
+    assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
+
+
+def test_policy_checker_cannot_use_custom_shell(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        POLICY_STEP,
+        POLICY_STEP.rstrip() + "\n        shell: attacker-shell {0}\n\n",
+    )
+
+    assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
+
+
+def test_policy_checker_cannot_override_path(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        POLICY_STEP,
+        POLICY_STEP.rstrip() + "\n        env:\n          PATH: attacker\n\n",
+    )
+
+    assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
+
+
+def test_policy_job_cannot_add_preceding_workspace_mutation(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        POLICY_STEP,
+        "      - name: Replace checker\n        run: cp attacker.py scripts/check-android-signing-boundary.py\n\n"
+        + POLICY_STEP,
+    )
+
+    assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
 
 
 def test_all_root_workflow_changes_must_trigger_policy(tmp_path: Path) -> None:
@@ -361,6 +468,42 @@ def test_android_sibling_workflow_changes_must_trigger_policy(tmp_path: Path) ->
     result = run_checker(root)
     assert_rejected(result, "pull_request.paths is missing: android/.github/workflows/**")
     assert "push.paths is missing: android/.github/workflows/**" in result.stdout
+
+
+def test_later_negative_path_pattern_cannot_disable_policy_trigger(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "      - 'android/.github/workflows/**'\n  workflow_dispatch:\n",
+        "      - 'android/.github/workflows/**'\n      - '!.github/workflows/**'\n  workflow_dispatch:\n",
+    )
+
+    assert_rejected(run_checker(root), "pull_request.paths must not contain negative patterns")
+
+
+def test_policy_dependency_hash_pin_is_immutable(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc",
+        "0000000000000000000000000000000000000000000000000000000000000000",
+    )
+
+    assert_rejected(run_checker(root), "signing-policy must match the exact fail-closed job specification")
+
+
+def test_release_job_cannot_invoke_local_action(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    mutate(
+        workflow,
+        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Set up JDK 17\n",
+        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Local release action\n        uses: ./malicious-action\n\n      - name: Set up JDK 17\n",
+    )
+
+    assert_rejected(run_checker(root), "build-release must not invoke local actions")
 
 
 def test_mutable_action_in_root_workflow_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- adds an executable policy that confines Android signing references to the protected release job
- mutation-tests secret placement, tag/environment guards, permissions, and immutable action references
- pins the remaining mutable third-party actions in the Android workflow
- runs the policy in unsigned CI and before release signing steps

## Surface and sibling paths

- `.github/workflows/build-android.yml`
- all repository workflows containing Android signing references
- unsigned PR/dev/main builds
- protected `build-release` tag job
- third-party action references in the Android workflow

Live environment secrets, reviewers, bypass policy, and tag rulesets are intentionally not changed by this PR. Those require a separate owner-approved configuration checkpoint.

## Verification

- [x] `python3 scripts/check-android-signing-boundary.py`
- [x] `python3 -m pytest tests/test_android_signing_boundary_static.py -q` (6 passed)
- [x] `python3 -m pytest tests/test_android_*.py -q` (81 passed, 26 subtests)
- [x] `git diff --check`

Closes #577