### PR TITLE
fix(ci): require push event for signed Android releases

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -471,7 +471,7 @@ jobs:
   build-release:
     name: Build (signed, tag release)
     needs: signing-policy
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     environment: android-release
     permissions:

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -27,7 +27,7 @@ ROOT_WORKFLOW = Path(".github/workflows/build-android.yml")
 ANDROID_SIBLING_WORKFLOW = Path("android/.github/workflows/build.yml")
 ALLOWED_JOB = "build-release"
 POLICY_JOB = "signing-policy"
-TAG_GUARD = "startsWith(github.ref, 'refs/tags/v')"
+TAG_GUARD = "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
 ENVIRONMENT_NAME = "android-release"
 SHA_PIN = re.compile(r"^[0-9a-f]{40}$")
 UNSAFE_SECRET_EXPRESSION = re.compile(
@@ -89,7 +89,7 @@ EXPECTED_SECRET_STEP_SHA256 = {
         "0df837fe9af54e6cfb08d657238cd5eec036757c69e7dd216e76bc5904411652"
     ),
 }
-EXPECTED_RELEASE_JOB_SHA256 = "2c76d2e950e84fbd90263cbcc791b2c6274aa425f40c6bc9adfda370cbb3f849"
+EXPECTED_RELEASE_JOB_SHA256 = "2f77c370952a2819564dda7ad18d8ab83e7d55c787126dd41f32bb074c612e84"
 ALLOWED_RELEASE_JOB_KEYS = {
     "name",
     "needs",
@@ -358,7 +358,7 @@ def check(root: Path) -> list[str]:
     if missing_refs:
         violations.append(f"{ALLOWED_JOB} is missing signing references: {', '.join(sorted(missing_refs))}")
     if release.get("if") != TAG_GUARD:
-        violations.append(f"{ALLOWED_JOB} must use the exact semantic version-tag guard")
+        violations.append(f"{ALLOWED_JOB} must use the exact push-triggered version-tag guard")
     if release.get("needs") != POLICY_JOB:
         violations.append(f"{ALLOWED_JOB} must require successful {POLICY_JOB}")
     if release.get("environment") != ENVIRONMENT_NAME:

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -337,11 +337,26 @@ def test_misleading_guard_text_does_not_replace_semantic_guard(tmp_path: Path) -
     workflow = root / ROOT_WORKFLOW
     mutate(
         workflow,
-        "    if: startsWith(github.ref, 'refs/tags/v')\n",
+        "    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n",
         "    if: ${{ true }}\n    env:\n      DOCUMENTED_GUARD: \"startsWith(github.ref, 'refs/tags/v')\"\n",
     )
 
-    assert_rejected(run_checker(root), "must use the exact semantic version-tag guard")
+    assert_rejected(run_checker(root), "must use the exact push-triggered version-tag guard")
+
+
+def test_release_guard_requires_a_push_event(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    workflow = root / ROOT_WORKFLOW
+    text = workflow.read_text(encoding="utf-8")
+    workflow.write_text(
+        text.replace(
+            "    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n",
+            "    if: startsWith(github.ref, 'refs/tags/v')\n",
+        ),
+        encoding="utf-8",
+    )
+
+    assert_rejected(run_checker(root), "must use the exact push-triggered version-tag guard")
 
 
 def test_workflow_level_write_all_is_rejected(tmp_path: Path) -> None:
@@ -758,8 +773,8 @@ def test_release_job_cannot_invoke_local_action(tmp_path: Path) -> None:
     workflow = root / ROOT_WORKFLOW
     mutate(
         workflow,
-        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Set up JDK 17\n",
-        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Local release action\n        uses: ./malicious-action\n\n      - name: Set up JDK 17\n",
+        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Set up JDK 17\n",
+        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Local release action\n        uses: ./malicious-action\n\n      - name: Set up JDK 17\n",
     )
 
     assert_rejected(run_checker(root), "build-release must not invoke local actions")


### PR DESCRIPTION
## Summary

- require the signed Android release job to originate from a `push` event as well as a `v*` tag
- update the semantic signing-boundary checker and whole-job digest
- add an adversarial mutation proving a tag-scoped `workflow_dispatch` cannot satisfy the release guard

## Surface & sibling-path impact

- `.github/workflows/build-android.yml`: release guard only
- `scripts/check-android-signing-boundary.py`: exact semantic guard and reviewed job digest
- `tests/test_android_signing_boundary_static.py`: push-event downgrade mutation
- `android/.github/workflows/build.yml`: inspected, unchanged
- historical tag workflows: unchanged; collaborator permission or environment approval is still required before secret migration

## Verification

- `python3 scripts/check-android-signing-boundary.py`
- `python3 -m pytest tests/test_android_signing_boundary_static.py -q` (53 passed)
- `python3 -m pytest tests/test_android_*.py -q` (134 passed, 26 subtests passed)
- exact CPython 3.12/PyYAML policy environment passed
- `git diff --check`
- Python compilation

Related to #577. This does not close the issue because historical workflow reruns and live secret migration remain outstanding.
