### PR TITLE
Fix fresh-login calendar preference hydration

### DIFF
--- a/apps/web/app/(app)/calendar/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/calendar/__tests__/page.test.tsx
@@ -43,7 +43,9 @@ const storeMock = vi.hoisted(() => ({
   },
   authState: {
     canWrite: vi.fn(() => true),
+    user: { email: 'account-a@example.test' },
   },
+  preferencesSyncState: { status: 'ready' as 'idle' | 'loading' | 'ready' | 'unavailable' | 'failed' },
 }))
 
 vi.mock('@/app/stores/use-calendar-store', () => ({
@@ -56,6 +58,10 @@ vi.mock('@/app/stores/use-calendar-list-store', () => ({
 
 vi.mock('@/app/stores/use-auth-store', () => ({
   useAuthStore: (selector: (state: typeof storeMock.authState) => unknown) => selector(storeMock.authState),
+}))
+
+vi.mock('@/app/stores/use-preferences-sync-store', () => ({
+  usePreferencesSyncStore: (selector: (state: typeof storeMock.preferencesSyncState) => unknown) => selector(storeMock.preferencesSyncState),
 }))
 
 vi.mock('@/app/stores/use-preferences-store', () => ({
@@ -117,6 +123,7 @@ function resetCalendarMocks() {
   storeMock.calendarState.setSearchQuery.mockReset()
   storeMock.authState.canWrite.mockReturnValue(true)
   timingMock.logCalendarPaintTiming.mockReset()
+  storeMock.preferencesSyncState.status = 'ready'
   vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0))
   vi.stubGlobal('cancelAnimationFrame', (handle: number) => window.clearTimeout(handle))
 }
@@ -133,6 +140,31 @@ describe('CalendarPage calendar visibility', () => {
       { id: 'visible-cal', name: 'Visible', color: '#10b981', visible: true },
       { id: 'hidden-cal', name: 'Hidden', color: '#ef4444', visible: false },
     ]
+  })
+
+  it('mounts only the calendar skeleton while preference hydration is pending', () => {
+    storeMock.preferencesSyncState.status = 'loading'
+    renderWithIntl(<CalendarPage />)
+
+    expect(screen.queryByTestId('desktop-grid')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('mobile-agenda')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'New event' })).not.toBeInTheDocument()
+    expect(document.querySelector('.skeleton-shimmer')).toBeInTheDocument()
+  })
+
+  it('resets account-local calendar body state across idle before the next account is ready', () => {
+    const rendered = renderWithIntl(<CalendarPage />)
+    fireEvent.click(screen.getByRole('button', { name: manageCalendars }))
+    expect(screen.getByTestId('collection-sheet')).toBeInTheDocument()
+
+    storeMock.preferencesSyncState.status = 'idle'
+    rendered.rerender(<CalendarPage />)
+    expect(screen.queryByTestId('collection-sheet')).not.toBeInTheDocument()
+
+    storeMock.authState.user.email = 'account-b@example.test'
+    storeMock.preferencesSyncState.status = 'ready'
+    rendered.rerender(<CalendarPage />)
+    expect(screen.queryByTestId('collection-sheet')).not.toBeInTheDocument()
   })
 
   it('keeps hidden calendar events out of desktop grid and mobile agenda', () => {

--- a/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/apps/web/app/(app)/calendar/components/CalendarGrid.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useInsertionEffect, useMemo, useState, useCallback, useRef } from 'react'
+import { useEffect, useInsertionEffect, useLayoutEffect, useMemo, useState, useCallback, useRef } from 'react'
 import { useNextCalendarApp, ScheduleXCalendar } from '@schedule-x/react'
 import {
   createViewWeek,
@@ -447,8 +447,8 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
   // Capture initial view so useNextCalendarApp config doesn't change on view switch
   const initialViewRef = useRef(VIEW_MAP[effectiveView])
   const initialDateRef = useRef(selectedDate)
-  // Capture time format at mount — Schedule-X locale can't change after init
-  const initialLocaleRef = useRef(timeFormat === '24h' ? 'en-GB' : 'en-US')
+  const scheduleXLocale = timeFormat === '24h' ? 'en-GB' : 'en-US'
+  const initialLocaleRef = useRef(scheduleXLocale)
   // Capture initial timezone for Schedule-X config (changes are pushed via signal below)
   const initialTimezoneRef = useRef(userTz)
   // Capture initial first-day-of-week for Schedule-X config (changes pushed via signal below)
@@ -504,6 +504,18 @@ export function CalendarGrid({ events, displayView, onSlotClick, onEventClick }:
       onClickDate: handleClickDate,
     },
   })
+
+  useLayoutEffect(() => {
+    if (!calendar) return
+    try {
+      const localeSignal = (calendar as any).$app?.config?.locale
+      if (localeSignal && localeSignal.value !== scheduleXLocale) {
+        localeSignal.value = scheduleXLocale
+      }
+    } catch {
+      // Schedule-X private configuration is guarded for the pinned integration.
+    }
+  }, [calendar, scheduleXLocale])
 
   // Push timezone changes to the Schedule-X config signal so the grid re-renders
   // when the user updates their preference in Settings without a full page reload.

--- a/apps/web/app/(app)/calendar/components/__tests__/CalendarGrid.schedule-x-contract.test.ts
+++ b/apps/web/app/(app)/calendar/components/__tests__/CalendarGrid.schedule-x-contract.test.ts
@@ -1,0 +1,18 @@
+import 'temporal-polyfill/global'
+import { createCalendar, createViewWeek } from '@schedule-x/calendar'
+import { describe, expect, it } from 'vitest'
+
+describe('pinned Schedule-X locale contract', () => {
+  it('constructs a synchronous mutable locale signal in both directions', () => {
+    const calendar = createCalendar({
+      views: [createViewWeek()],
+      locale: 'en-US',
+    }) as any
+
+    expect(calendar.$app.config.locale.value).toBe('en-US')
+    calendar.$app.config.locale.value = 'en-GB'
+    expect(calendar.$app.config.locale.value).toBe('en-GB')
+    calendar.$app.config.locale.value = 'en-US'
+    expect(calendar.$app.config.locale.value).toBe('en-US')
+  })
+})

--- a/apps/web/app/(app)/calendar/components/__tests__/CalendarGrid.test.tsx
+++ b/apps/web/app/(app)/calendar/components/__tests__/CalendarGrid.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { StrictMode } from 'react'
+import { StrictMode, useSyncExternalStore } from 'react'
 import type { CalendarEvent } from '@silentsuite/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { CalendarGrid } from '../CalendarGrid'
@@ -11,6 +11,10 @@ const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'),
 }
 
 const mocks = vi.hoisted(() => {
+  const preferenceListeners = new Set<() => void>()
+  const localeListeners = new Set<() => void>()
+  const localeAssignments: string[] = []
+  let localeValue = 'en-GB'
   const calendarState = {
     currentView: 'week' as const,
     currentDate: new Date('2026-07-13T12:00:00.000Z'),
@@ -29,6 +33,14 @@ const mocks = vi.hoisted(() => {
   const calendar = {
     $app: {
       config: {
+        locale: {
+          get value() { return localeValue },
+          set value(value: string) {
+            localeAssignments.push(value)
+            localeValue = value
+            localeListeners.forEach((listener) => listener())
+          },
+        },
         timezone: { value: 'UTC' },
         firstDayOfWeek: { value: 1 },
         dayBoundaries: { value: { start: 700, end: 2300 } },
@@ -46,6 +58,11 @@ const mocks = vi.hoisted(() => {
     calendar,
     calendarState,
     preferencesState,
+    preferenceListeners,
+    localeListeners,
+    localeAssignments,
+    getLocale: () => localeValue,
+    setLocale: (value: string) => { localeValue = value },
     latestConfig: undefined as Record<string, any> | undefined,
     setEvents: vi.fn(),
     requestAnimationFrame: vi.fn(),
@@ -69,8 +86,18 @@ vi.mock('@schedule-x/react', () => ({
     mocks.latestConfig = config
     return mocks.calendar
   },
-  ScheduleXCalendar: () => (
+  ScheduleXCalendar: () => {
+    const locale = useSyncExternalStore(
+      (listener) => { mocks.localeListeners.add(listener); return () => mocks.localeListeners.delete(listener) },
+      mocks.getLocale,
+      mocks.getLocale,
+    )
+    const is24h = locale === 'en-GB'
+    return (
     <div className="sx-react-calendar-wrapper" data-testid="schedule-x">
+      <output aria-label={is24h ? '13/07/2026, 18:30' : '7/13/2026, 6:30 PM'}>
+        {is24h ? '18:30 · 13/07/2026' : '6:30 PM · 7/13/2026'}
+      </output>
       <div className="sx__week-grid" data-testid="time-grid">
         <div className="sx__time-grid-day" data-testid="day-column">
           <div
@@ -82,7 +109,8 @@ vi.mock('@schedule-x/react', () => ({
         </div>
       </div>
     </div>
-  ),
+    )
+  },
 }))
 
 vi.mock('next-themes', () => ({ useTheme: () => ({ resolvedTheme: 'light' }) }))
@@ -98,7 +126,11 @@ vi.mock('@/app/stores/use-calendar-store', () => {
 })
 
 vi.mock('@/app/stores/use-preferences-store', () => {
-  const usePreferencesStore = (selector: (state: typeof mocks.preferencesState) => unknown) => selector(mocks.preferencesState)
+  const usePreferencesStore = (selector: (state: typeof mocks.preferencesState) => unknown) => useSyncExternalStore(
+    (listener) => { mocks.preferenceListeners.add(listener); return () => mocks.preferenceListeners.delete(listener) },
+    () => selector(mocks.preferencesState),
+    () => selector(mocks.preferencesState),
+  )
   usePreferencesStore.getState = () => mocks.preferencesState
   return { usePreferencesStore }
 })
@@ -150,6 +182,9 @@ beforeEach(() => {
   mocks.calendarState.currentView = 'week'
   mocks.calendarState.currentDate = new Date('2026-07-13T12:00:00.000Z')
   mocks.preferencesState.defaultTimezone = 'UTC'
+  mocks.preferencesState.timeFormat = '24h'
+  mocks.setLocale('en-GB')
+  mocks.localeAssignments.length = 0
   mocks.calendar.$app.config.dayBoundaries.value = { start: 700, end: 2300 }
   mocks.calendar.$app.config.weekOptions.value = { gridHeight: 900 }
   vi.stubGlobal('ResizeObserver', class {
@@ -188,6 +223,46 @@ function renderGestureHarness(projected: boolean) {
 }
 
 describe('CalendarGrid timed-event integration', () => {
+  it('updates mounted Schedule-X visible date and time output when synced time format changes', async () => {
+    render(<CalendarGrid events={[]} />)
+    expect(screen.getByText('18:30 · 13/07/2026')).toBeInTheDocument()
+
+    act(() => {
+      mocks.preferencesState.timeFormat = '12h'
+      mocks.preferenceListeners.forEach((listener) => listener())
+    })
+
+    expect(await screen.findByText('6:30 PM · 7/13/2026')).toBeInTheDocument()
+    expect(screen.getByLabelText('7/13/2026, 6:30 PM')).toBeInTheDocument()
+  })
+
+  it('updates mounted output from 12-hour back to 24-hour without remounting', async () => {
+    mocks.preferencesState.timeFormat = '12h'
+    mocks.setLocale('en-US')
+    const { container } = render(<CalendarGrid events={[]} />)
+    const instance = container.firstElementChild
+
+    act(() => {
+      mocks.preferencesState.timeFormat = '24h'
+      mocks.preferenceListeners.forEach((listener) => listener())
+    })
+
+    expect(await screen.findByText('18:30 · 13/07/2026')).toBeInTheDocument()
+    expect(container.firstElementChild).toBe(instance)
+  })
+
+  it('does not assign an equal locale during unrelated rerenders', () => {
+    const { rerender } = render(<CalendarGrid events={[]} />)
+    rerender(<CalendarGrid events={[]} />)
+    expect(mocks.localeAssignments).toEqual([])
+  })
+
+  it('fails safely when the pinned locale signal is absent at effect time', () => {
+    const locale = mocks.calendar.$app.config.locale
+    ;(mocks.calendar.$app.config as any).locale = undefined
+    expect(() => render(<CalendarGrid events={[]} />)).not.toThrow()
+    mocks.calendar.$app.config.locale = locale
+  })
   it('pins the Schedule-X versions whose private classifier behavior is relied on', () => {
     expect(packageJson.dependencies['@schedule-x/calendar']).toBe('4.3.1')
     expect(packageJson.dependencies['@schedule-x/events-service']).toBe('4.3.1')

--- a/apps/web/app/(app)/calendar/page.tsx
+++ b/apps/web/app/(app)/calendar/page.tsx
@@ -17,6 +17,7 @@ import { EventDialog } from './components/EventDialog'
 import { FloatingAddButton } from './components/FloatingAddButton'
 import { resolveUserTimezone } from '@/app/lib/tz'
 import { logCalendarPaintTiming } from '@/app/lib/sync-timing'
+import { usePreferencesSyncStore } from '@/app/stores/use-preferences-sync-store'
 
 /** Snap a Date to the nearest 30-minute boundary */
 function snapTo30Min(date: Date): Date {
@@ -137,7 +138,7 @@ interface CreateDialogState {
   allDay: boolean
 }
 
-export default function CalendarPage() {
+function CalendarPageBody() {
   const t = useTranslations('Collections')
   const canWrite = useAuthStore((s) => s.canWrite())
   const events = useCalendarStore((s) => s.events)
@@ -563,4 +564,16 @@ export default function CalendarPage() {
       />
     </div>
   )
+}
+
+export default function CalendarPage() {
+  const preferenceStatus = usePreferencesSyncStore((state) => state.status)
+  const accountKey = useAuthStore((state) => state.user?.email ?? 'no-account')
+  const preferencesTerminal = preferenceStatus === 'ready' || preferenceStatus === 'unavailable' || preferenceStatus === 'failed'
+
+  if (!preferencesTerminal) {
+    return <div className="flex h-full flex-col"><CalendarSkeleton /></div>
+  }
+
+  return <CalendarPageBody key={accountKey} />
 }

--- a/apps/web/app/components/SyncIndicator.tsx
+++ b/apps/web/app/components/SyncIndicator.tsx
@@ -5,6 +5,7 @@ import { RefreshCw } from 'lucide-react'
 import { useSyncStore } from '@/app/stores/use-sync-store'
 import { formatTimeAgo } from '@/app/lib/format-time-ago'
 import type { SyncStatus } from '@silentsuite/core'
+import { usePreferencesSyncStore } from '@/app/stores/use-preferences-sync-store'
 
 const dotStyles: Record<SyncStatus, string> = {
   synced: 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.5)]',
@@ -42,6 +43,7 @@ export function SyncIndicator() {
   const simulateSyncCycle = useSyncStore((s) => s.simulateSyncCycle)
   const pendingQueueCount = useSyncStore((s) => s.pendingQueueCount)
   const partialLoad = useSyncStore((s) => s.partialLoad)
+  const preferenceIntegrity = usePreferencesSyncStore((s) => s.integrity)
   const [showTooltip, setShowTooltip] = useState(false)
   const [tooltipText, setTooltipText] = useState('')
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -88,6 +90,16 @@ export function SyncIndicator() {
       </div>
 
       {/* Error label */}
+      {preferenceIntegrity === 'failed' && (
+        <span
+          role="status"
+          aria-label="Account preferences could not be verified"
+          className="text-xs text-amber-400"
+        >
+          <span aria-hidden="true" className="md:hidden">!</span>
+          <span className="sr-only md:not-sr-only">Preferences need sync</span>
+        </span>
+      )}
       {isError && (
         <button
           onClick={handleSync}

--- a/apps/web/app/components/__tests__/SyncIndicator.test.tsx
+++ b/apps/web/app/components/__tests__/SyncIndicator.test.tsx
@@ -12,9 +12,13 @@ const mockSyncState = {
   partialLoad: false,
   simulateSyncCycle: vi.fn(),
 }
+const mockPreferenceState = { integrity: 'valid' as 'valid' | 'failed' }
 
 vi.mock('@/app/stores/use-sync-store', () => ({
   useSyncStore: (selector: (s: typeof mockSyncState) => unknown) => selector(mockSyncState),
+}))
+vi.mock('@/app/stores/use-preferences-sync-store', () => ({
+  usePreferencesSyncStore: (selector: (s: typeof mockPreferenceState) => unknown) => selector(mockPreferenceState),
 }))
 
 vi.mock('@/app/lib/format-time-ago', () => ({
@@ -29,6 +33,7 @@ describe('SyncIndicator', () => {
     mockSyncState.pendingQueueCount = 0
     mockSyncState.partialLoad = false
     mockSyncState.simulateSyncCycle.mockClear()
+    mockPreferenceState.integrity = 'valid'
     sessionStorage.clear()
   })
 
@@ -97,5 +102,19 @@ describe('SyncIndicator', () => {
     const button = screen.getByRole('button', { name: 'Sync now' })
     fireEvent.click(button)
     expect(mockSyncState.simulateSyncCycle).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a privacy-safe preference warning with the keyboard-accessible retry action', () => {
+    mockPreferenceState.integrity = 'failed'
+    render(<SyncIndicator />)
+
+    const warning = screen.getByRole('status', { name: 'Account preferences could not be verified' })
+    expect(warning).toBeInTheDocument()
+    expect(warning).not.toHaveClass('hidden')
+    expect(screen.getByText('!', { selector: '[aria-hidden="true"]' })).toBeInTheDocument()
+    const retry = screen.getByRole('button', { name: 'Sync now' })
+    retry.focus()
+    expect(retry).toHaveFocus()
+    expect(document.body.textContent).not.toMatch(/item|account-a|24h/i)
   })
 })

--- a/apps/web/app/components/__tests__/sidebar.test.tsx
+++ b/apps/web/app/components/__tests__/sidebar.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Sidebar } from '../sidebar'
+
+const state = vi.hoisted(() => ({ preferenceStatus: 'loading', miniCalendar: vi.fn() }))
+
+vi.mock('next/navigation', () => ({ usePathname: () => '/calendar' }))
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
+vi.mock('@/app/stores/use-sidebar-store', () => ({
+  useSidebarStore: () => ({ isExpanded: true, toggle: vi.fn() }),
+  initializeSidebar: vi.fn(),
+}))
+vi.mock('@/app/stores/use-auth-store', () => ({ useAuthStore: () => false }))
+vi.mock('@/app/lib/self-hosted', () => ({ isSelfHosted: false }))
+vi.mock('@/app/stores/use-preferences-sync-store', () => ({
+  usePreferencesSyncStore: (selector: (value: { status: string }) => unknown) => selector({ status: state.preferenceStatus }),
+}))
+vi.mock('@/app/(app)/calendar/components/MiniCalendar', () => ({
+  MiniCalendar: () => { state.miniCalendar(); return <div>mini calendar</div> },
+}))
+vi.mock('@/app/components/CalendarListPanel', () => ({ CalendarListPanel: () => <div>calendar lists</div> }))
+vi.mock('@/app/components/TaskListPanel', () => ({ TaskListPanel: () => null }))
+vi.mock('@/app/components/ContactListPanel', () => ({ ContactListPanel: () => null }))
+vi.mock('@/app/components/OnboardingChecklist', () => ({ OnboardingChecklist: () => null }))
+
+describe('Sidebar preference readiness', () => {
+  beforeEach(() => { state.preferenceStatus = 'loading'; state.miniCalendar.mockClear() })
+
+  it('keeps navigation and calendar lists visible without mounting MiniCalendar while pending', () => {
+    render(<Sidebar />)
+
+    expect(state.miniCalendar).not.toHaveBeenCalled()
+    expect(screen.getByText('calendar lists')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /calendar/i })).toBeInTheDocument()
+  })
+
+  it.each(['ready', 'unavailable', 'failed'])('mounts MiniCalendar at terminal status %s', (status) => {
+    state.preferenceStatus = status
+    render(<Sidebar />)
+    expect(screen.getByText('mini calendar')).toBeInTheDocument()
+  })
+})

--- a/apps/web/app/components/sidebar.tsx
+++ b/apps/web/app/components/sidebar.tsx
@@ -21,6 +21,7 @@ import { CalendarListPanel } from '@/app/components/CalendarListPanel'
 import { TaskListPanel } from '@/app/components/TaskListPanel'
 import { ContactListPanel } from '@/app/components/ContactListPanel'
 import { OnboardingChecklist } from '@/app/components/OnboardingChecklist'
+import { usePreferencesSyncStore } from '@/app/stores/use-preferences-sync-store'
 
 const navItems = [
   { href: '/calendar', labelKey: 'calendar', icon: CalendarDays },
@@ -33,6 +34,8 @@ export function Sidebar() {
   const { isExpanded, toggle } = useSidebarStore()
   const pathname = usePathname()
   const isAdmin = useAuthStore((s) => s.user?.isAdmin) || isSelfHosted
+  const preferenceStatus = usePreferencesSyncStore((state) => state.status)
+  const preferencesTerminal = preferenceStatus === 'ready' || preferenceStatus === 'unavailable' || preferenceStatus === 'failed'
 
   useEffect(() => {
     initializeSidebar()
@@ -59,7 +62,7 @@ export function Sidebar() {
       {/* Mini calendar (always visible) + context-aware list panel */}
       {isExpanded && (
         <div className="border-t border-b border-[rgb(var(--border))]">
-          <MiniCalendar />
+          {preferencesTerminal && <MiniCalendar />}
           {pathname.startsWith('/calendar') && <CalendarListPanel />}
           {pathname.startsWith('/tasks') && <TaskListPanel />}
           {pathname.startsWith('/contacts') && <ContactListPanel />}

--- a/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
+++ b/apps/web/app/providers/__tests__/sync-provider.timing.test.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from '@testing-library/react'
-import type { ReactNode } from 'react'
+import { StrictMode, type ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SyncProvider } from '../sync-provider'
 import { bumpAccountEpoch } from '@/app/lib/account-epoch'
@@ -76,6 +76,14 @@ const etebaseMock = vi.hoisted(() => {
 const taskStoreMock = vi.hoisted(() => ({ syncFromRemote: vi.fn(() => order.push('syncTasks')) }))
 const contactStoreMock = vi.hoisted(() => ({ syncFromRemote: vi.fn(() => order.push('syncContacts')) }))
 const calendarStoreMock = vi.hoisted(() => ({ syncFromRemote: vi.fn(() => order.push('syncCalendar')) }))
+const preferencesSyncMock = vi.hoisted(() => ({
+  operationGeneration: 7,
+  beginRemoteRead: vi.fn(() => 11),
+  initialize: vi.fn(async () => {}),
+  loadFromRemote: vi.fn(async () => {}),
+  recordRemoteReadFailure: vi.fn(),
+  destroy: vi.fn(),
+}))
 
 const cacheMock = vi.hoisted(() => ({
   getItemsByType: vi.fn(async (type: string) => {
@@ -159,7 +167,7 @@ vi.mock('@/app/stores/use-label-suggestions-store', () => ({
 
 vi.mock('@/app/stores/use-preferences-sync-store', () => ({
   usePreferencesSyncStore: {
-    getState: () => ({ initialize: vi.fn(async () => {}), loadFromRemote: vi.fn(async () => {}), destroy: vi.fn() }),
+    getState: () => preferencesSyncMock,
   },
 }))
 
@@ -204,6 +212,29 @@ describe('SyncProvider timing instrumentation', () => {
     timingMock.logSyncTiming.mockImplementation(() => {})
     timingMock.markSyncTimingStart.mockReturnValue(100)
     timingMock.nowMs.mockReturnValue(100)
+  })
+
+  it('publishes provider-owned preference refresher failures for the captured operation', async () => {
+    etebaseMock.state.refreshCollection.mockRejectedValueOnce(new Error('transport details'))
+    renderProvider()
+    await waitFor(() => expect(etebaseMock.getSyncChangeHandler()).not.toBeNull())
+
+    await etebaseMock.getSyncChangeHandler()?.({
+      collectionType: 'silentsuite.preferences',
+      collectionUid: 'preferences',
+      itemUids: [],
+      changeType: 'update',
+    })
+
+    expect(preferencesSyncMock.recordRemoteReadFailure).toHaveBeenCalledWith(expect.any(Number), 7, 11)
+    expect(preferencesSyncMock.loadFromRemote).not.toHaveBeenCalled()
+  })
+
+  it('does not reset preference readiness during React Strict Mode effect replay', async () => {
+    render(<StrictMode><SyncProvider><div>child</div></SyncProvider></StrictMode>)
+
+    await waitFor(() => expect(preferencesSyncMock.initialize).toHaveBeenCalledTimes(1))
+    expect(preferencesSyncMock.destroy).not.toHaveBeenCalled()
   })
 
   it('loads each domain into its store as the domain callback fires (calendar first)', async () => {

--- a/apps/web/app/providers/sync-provider.tsx
+++ b/apps/web/app/providers/sync-provider.tsx
@@ -402,13 +402,18 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
             logger.warn('[sync-provider] Label suggestions refresh failed', getSafeErrorDetails(err))
           }
         } else if (collectionType === 'silentsuite.preferences') {
+          const preferenceStore = usePreferencesSyncStore.getState()
+          const preferenceGeneration = preferenceStore.operationGeneration
+          const preferenceReadGeneration = preferenceStore.beginRemoteRead(accountEpoch, preferenceGeneration)
+          if (preferenceReadGeneration === null) return
           try {
             const preferenceItems = await refresher('preferences', event.collectionUid)
             assertCurrentAccountEpoch(accountEpoch)
-            await usePreferencesSyncStore.getState().loadFromRemote(preferenceItems)
+            await preferenceStore.loadFromRemote(preferenceItems, accountEpoch, preferenceGeneration, preferenceReadGeneration)
             assertCurrentAccountEpoch(accountEpoch)
           } catch (err) {
             if (err instanceof AccountBoundaryChangedError) return
+            preferenceStore.recordRemoteReadFailure(accountEpoch, preferenceGeneration, preferenceReadGeneration)
             logger.warn('[sync-provider] Preferences refresh failed', getSafeErrorDetails(err))
           }
         }
@@ -437,7 +442,6 @@ export function SyncProvider({ children }: { children: React.ReactNode }) {
     return () => {
       if (unsubChange) unsubChange()
       if (unsubStatus) unsubStatus()
-      usePreferencesSyncStore.getState().destroy()
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-preferences-sync-store.test.ts
@@ -3,7 +3,7 @@ import { createSyncedPreferences, serializePreferences } from '@silentsuite/core
 import { useEtebaseStore } from '../use-etebase-store'
 import { usePreferencesStore } from '../use-preferences-store'
 import { usePreferencesSyncStore } from '../use-preferences-sync-store'
-import { AccountBoundaryChangedError, bumpAccountEpoch } from '@/app/lib/account-epoch'
+import { AccountBoundaryChangedError, bumpAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 
 vi.mock('@/app/stores/use-toast-store', () => ({
   showErrorToast: vi.fn(),
@@ -52,11 +52,28 @@ function mockItem(uid: string, content: string) {
   }
 }
 
+function authorizeWrites() {
+  usePreferencesSyncStore.setState({
+    status: 'ready',
+    integrity: 'valid',
+    operationEpoch: getAccountEpoch(),
+  })
+}
+
 describe('usePreferencesSyncStore', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.clearAllMocks()
     resetStores()
+  })
+
+  it('publishes unavailable when initialization has no restored account', async () => {
+    await usePreferencesSyncStore.getState().initialize()
+
+    expect(usePreferencesSyncStore.getState()).toMatchObject({
+      status: 'unavailable',
+      integrity: 'unavailable',
+    })
   })
 
   it('initializes read-only when no remote preferences collection exists', async () => {
@@ -66,6 +83,7 @@ describe('usePreferencesSyncStore', () => {
       account: { id: 'account' } as any,
       createItem: createItem as any,
       updateItem: updateItem as any,
+      refreshCollection: vi.fn(async () => [{ uid: 'pref-1', content: serializePreferences(remote) }]) as any,
     })
     listCollectionsMock.mockResolvedValue([] as any)
 
@@ -75,6 +93,22 @@ describe('usePreferencesSyncStore', () => {
     expect(createItem).not.toHaveBeenCalled()
     expect(updateItem).not.toHaveBeenCalled()
     expect(usePreferencesSyncStore.getState()).toMatchObject({ isInitialized: true, remoteItemUid: null })
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ status: 'ready', integrity: 'valid' })
+  })
+
+  it('deduplicates concurrent initialization for the current account operation', async () => {
+    let release!: (collections: any[]) => void
+    listCollectionsMock.mockImplementation(() => new Promise((resolve) => { release = resolve }))
+    useEtebaseStore.setState({ account: { id: 'account' } as any })
+
+    const first = usePreferencesSyncStore.getState().initialize()
+    const second = usePreferencesSyncStore.getState().initialize()
+    await vi.waitFor(() => expect(listCollectionsMock).toHaveBeenCalledTimes(1))
+    release([])
+    await Promise.all([first, second])
+
+    expect(listCollectionsMock).toHaveBeenCalledTimes(1)
+    expect(usePreferencesSyncStore.getState().status).toBe('ready')
   })
 
   it('does not publish or track stale preferences collections after an account switch', async () => {
@@ -131,6 +165,7 @@ describe('usePreferencesSyncStore', () => {
       itemTypeMap: new Map([['pref-1', 'preferences']]),
       itemCollectionMap: new Map([['pref-1', 'prefs-col']]),
       updateItem: updateItem as any,
+      refreshCollection: vi.fn(async () => [{ uid: 'pref-1', content: serializePreferences(remote) }]) as any,
     })
 
     await usePreferencesSyncStore.getState().loadFromRemote()
@@ -146,6 +181,185 @@ describe('usePreferencesSyncStore', () => {
     expect(usePreferencesSyncStore.getState().remoteItemUid).toBe('pref-1')
   })
 
+  it('fails integrity for a non-empty all-corrupt remote read without applying values', async () => {
+    usePreferencesStore.setState({ timeFormat: '24h' })
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      syncEngine: { trackCollection: vi.fn(async () => {}) } as any,
+      refreshCollection: vi.fn(async () => [{ uid: 'bad', content: 'not preferences' }]) as any,
+    })
+
+    await usePreferencesSyncStore.getState().initialize()
+
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ status: 'failed', integrity: 'failed' })
+    expect(usePreferencesStore.getState().timeFormat).toBe('24h')
+  })
+
+  it('retries cached collection tracking after failure and records success once', async () => {
+    const trackCollection = vi.fn()
+      .mockRejectedValueOnce(new Error('track failed'))
+      .mockResolvedValue(undefined)
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      syncEngine: { trackCollection } as any,
+      refreshCollection: vi.fn(async () => []) as any,
+    })
+
+    await usePreferencesSyncStore.getState().initialize()
+    expect(usePreferencesSyncStore.getState().status).toBe('failed')
+    await usePreferencesSyncStore.getState().initialize(true)
+
+    expect(trackCollection).toHaveBeenCalledTimes(2)
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ status: 'ready', integrity: 'valid' })
+  })
+
+  it('preserves values and revokes integrity after a later corrupt read, then recovers', async () => {
+    const remote = createSyncedPreferences({ timeFormat: '12h' }, { timeFormat: 20 }, 20)
+    useEtebaseStore.setState({ account: { id: 'account' } as any })
+    await usePreferencesSyncStore.getState().loadFromRemote([{ uid: 'valid', content: serializePreferences(remote) }])
+    const epoch = usePreferencesSyncStore.getState().operationEpoch!
+    const generation = usePreferencesSyncStore.getState().operationGeneration
+
+    await usePreferencesSyncStore.getState().loadFromRemote([{ uid: 'bad', content: 'corrupt' }], epoch, generation)
+    expect(usePreferencesStore.getState().timeFormat).toBe('12h')
+    expect(usePreferencesSyncStore.getState().integrity).toBe('failed')
+
+    await usePreferencesSyncStore.getState().loadFromRemote([{ uid: 'valid', content: serializePreferences(remote) }], epoch, generation)
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ status: 'ready', integrity: 'valid' })
+  })
+
+  it('does not let an older valid refresh overwrite a newer integrity failure', async () => {
+    const older = createSyncedPreferences({ timeFormat: '24h' }, { timeFormat: 10 }, 10)
+    const initialTimeFormat = usePreferencesStore.getState().timeFormat
+    let releaseOlder!: (items: { uid: string; content: string }[]) => void
+    const refreshCollection = vi.fn(() => new Promise<{ uid: string; content: string }[]>((resolve) => {
+      releaseOlder = resolve
+    }))
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      syncEngine: { trackCollection: vi.fn() } as any,
+      refreshCollection: refreshCollection as any,
+    })
+
+    const olderRefresh = usePreferencesSyncStore.getState().loadFromRemote()
+    await vi.waitFor(() => expect(refreshCollection).toHaveBeenCalledTimes(1))
+    await usePreferencesSyncStore.getState().loadFromRemote([{ uid: 'bad', content: 'corrupt' }])
+    releaseOlder([{ uid: 'older', content: serializePreferences(older) }])
+
+    await expect(olderRefresh).rejects.toThrow('Stale preference read')
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ status: 'failed', integrity: 'failed' })
+    expect(usePreferencesStore.getState().timeFormat).toBe(initialTimeFormat)
+  })
+
+  it('rejects stale provider failure publication', () => {
+    usePreferencesSyncStore.setState({ operationEpoch: getAccountEpoch(), operationGeneration: 10, status: 'ready', integrity: 'valid' })
+    usePreferencesSyncStore.getState().recordRemoteReadFailure(getAccountEpoch(), 9)
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ status: 'ready', integrity: 'valid' })
+  })
+
+  it('does not retry or write from unavailable integrity', async () => {
+    const createCollection = vi.fn()
+    const createItem = vi.fn()
+    await usePreferencesSyncStore.getState().initialize()
+    useEtebaseStore.setState({ account: { id: 'restored-too-late' } as any, createCollection: createCollection as any, createItem: createItem as any })
+
+    expect(await usePreferencesSyncStore.getState().pushNow()).toBe(false)
+    expect(listCollectionsMock).not.toHaveBeenCalled()
+    expect(createCollection).not.toHaveBeenCalled()
+    expect(createItem).not.toHaveBeenCalled()
+  })
+
+  it('retries a failed read-only operation and writes only after that operation is ready', async () => {
+    const createCollection = vi.fn(async () => 'prefs-col')
+    const createItem = vi.fn(async () => 'pref-1')
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      createCollection: createCollection as any,
+      createItem: createItem as any,
+    })
+    listCollectionsMock.mockResolvedValue([] as any)
+    usePreferencesSyncStore.setState({
+      status: 'failed',
+      integrity: 'failed',
+      operationEpoch: getAccountEpoch(),
+    })
+
+    expect(await usePreferencesSyncStore.getState().pushNow()).toBe(true)
+    expect(listCollectionsMock).toHaveBeenCalledTimes(2)
+    expect(createCollection).toHaveBeenCalledTimes(1)
+    expect(createItem).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not write when a failed-operation retry remains all-corrupt', async () => {
+    const createItem = vi.fn()
+    const updateItem = vi.fn()
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      refreshCollection: vi.fn(async () => [{ uid: 'bad', content: 'corrupt' }]) as any,
+      createItem: createItem as any,
+      updateItem: updateItem as any,
+    })
+    usePreferencesSyncStore.setState({
+      status: 'failed',
+      integrity: 'failed',
+      operationEpoch: getAccountEpoch(),
+    })
+
+    expect(await usePreferencesSyncStore.getState().pushNow()).toBe(false)
+    expect(createItem).not.toHaveBeenCalled()
+    expect(updateItem).not.toHaveBeenCalled()
+  })
+
+  it('revokes write authorization when the explicit-sync preflight read fails', async () => {
+    const createItem = vi.fn()
+    const updateItem = vi.fn()
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      collections: { calendar: [], tasks: [], contacts: [], preferences: [{ uid: 'prefs-col' }] as any[] },
+      syncEngine: { trackCollection: vi.fn() } as any,
+      refreshCollection: vi.fn(async () => { throw new Error('network unavailable') }) as any,
+      createItem: createItem as any,
+      updateItem: updateItem as any,
+    })
+    authorizeWrites()
+
+    await expect(usePreferencesSyncStore.getState().pushNow()).resolves.toBe(false)
+
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ status: 'failed', integrity: 'failed' })
+    expect(createItem).not.toHaveBeenCalled()
+    expect(updateItem).not.toHaveBeenCalled()
+  })
+
+  it('creates after an empty preflight without performing a fallible post-create reread', async () => {
+    const createCollection = vi.fn(async () => {
+      useEtebaseStore.setState((state) => ({
+        collections: { ...state.collections, preferences: [{ uid: 'new-prefs-col' }] as any[] },
+      }))
+      return 'new-prefs-col'
+    })
+    const createItem = vi.fn(async () => 'new-preference-item')
+    const refreshCollection = vi.fn(async () => { throw new Error('must not run after empty preflight') })
+    useEtebaseStore.setState({
+      account: { id: 'account' } as any,
+      createCollection: createCollection as any,
+      createItem: createItem as any,
+      refreshCollection: refreshCollection as any,
+    })
+    listCollectionsMock.mockResolvedValue([] as any)
+    authorizeWrites()
+
+    await expect(usePreferencesSyncStore.getState().pushNow()).resolves.toBe(true)
+
+    expect(createCollection).toHaveBeenCalledTimes(1)
+    expect(createItem).toHaveBeenCalledTimes(1)
+    expect(refreshCollection).not.toHaveBeenCalled()
+    expect(usePreferencesSyncStore.getState()).toMatchObject({ status: 'ready', integrity: 'valid' })
+  })
+
   it('pushNow creates a preferences collection and item only on explicit action', async () => {
     const createCollection = vi.fn(async () => 'prefs-col')
     const createItem = vi.fn(async () => 'pref-1')
@@ -156,6 +370,7 @@ describe('usePreferencesSyncStore', () => {
       createItem: createItem as any,
     })
     listCollectionsMock.mockResolvedValue([] as any)
+    authorizeWrites()
 
     const pushed = await usePreferencesSyncStore.getState().pushNow()
 
@@ -206,7 +421,9 @@ describe('usePreferencesSyncStore', () => {
       itemTypeMap: new Map([['pref-1', 'preferences']]),
       itemCollectionMap: new Map([['pref-1', 'prefs-col']]),
       updateItem: updateItem as any,
+      refreshCollection: vi.fn(async () => [{ uid: 'pref-1', content: serializePreferences(remote) }]) as any,
     })
+    authorizeWrites()
 
     await usePreferencesSyncStore.getState().pushNow()
 
@@ -244,6 +461,7 @@ describe('usePreferencesSyncStore', () => {
       itemCollectionMap: new Map([['pref-1', 'prefs-col']]),
       updateItem: updateItem as any,
     })
+    authorizeWrites()
 
     const pushed = await usePreferencesSyncStore.getState().pushNow()
 
@@ -264,6 +482,7 @@ describe('usePreferencesSyncStore', () => {
       itemCollectionMap: new Map([['pref-1', 'prefs-col']]),
       updateItem: updateItem as any,
     })
+    authorizeWrites()
 
     const pushed = await usePreferencesSyncStore.getState().pushNow()
 

--- a/apps/web/app/stores/use-preferences-sync-store.ts
+++ b/apps/web/app/stores/use-preferences-sync-store.ts
@@ -10,11 +10,23 @@ import {
 import { logger } from '@/app/lib/logger'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { usePreferencesStore } from '@/app/stores/use-preferences-store'
-import { assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
+import { AccountBoundaryChangedError, assertCurrentAccountEpoch, getAccountEpoch } from '@/app/lib/account-epoch'
 
 const COLLECTION_TYPE_PREFERENCES = 'silentsuite.preferences'
 const PREFERENCES_COLLECTION_NAME = 'Preferences'
 const PREFERENCES_TEMP_ID = 'silentsuite-preferences'
+
+let operationCounter = 0
+let readCounter = 0
+let currentOperation: { epoch: number; generation: number; promise: Promise<void> } | null = null
+const trackedCollections = new WeakMap<object, Set<string>>()
+
+class StalePreferenceReadError extends Error {
+  constructor() {
+    super('Stale preference read')
+    this.name = 'StalePreferenceReadError'
+  }
+}
 
 interface RemotePreferenceItem {
   uid: string
@@ -22,6 +34,11 @@ interface RemotePreferenceItem {
 }
 
 interface PreferencesSyncState {
+  status: 'idle' | 'loading' | 'ready' | 'unavailable' | 'failed'
+  integrity: 'unknown' | 'valid' | 'unavailable' | 'failed'
+  operationEpoch: number | null
+  operationGeneration: number
+  readGeneration: number
   remoteItemUid: string | null
   isInitialized: boolean
   isApplyingRemote: boolean
@@ -29,8 +46,10 @@ interface PreferencesSyncState {
 }
 
 interface PreferencesSyncActions {
-  initialize: () => Promise<void>
-  loadFromRemote: (items?: { uid: string; content: string }[], accountEpoch?: number) => Promise<void>
+  initialize: (force?: boolean) => Promise<void>
+  beginRemoteRead: (accountEpoch?: number, operationGeneration?: number) => number | null
+  loadFromRemote: (items?: { uid: string; content: string }[], accountEpoch?: number, generation?: number, readGeneration?: number) => Promise<void>
+  recordRemoteReadFailure: (accountEpoch?: number, generation?: number, readGeneration?: number) => void
   pushNow: () => Promise<boolean>
   setRemoteItemUid: (uid: string) => void
   destroy: () => void
@@ -58,87 +77,184 @@ function mergeRemoteItems(items: RemotePreferenceItem[]): SyncedPreferencesV1 | 
   return mergeSyncedPreferences(items.map((item) => item.preferences))
 }
 
-async function listPreferencesCollections(accountEpoch: number): Promise<any[]> {
+function assertCurrentOperation(accountEpoch: number, generation: number) {
   assertCurrentAccountEpoch(accountEpoch)
+  const state = usePreferencesSyncStore.getState()
+  if (state.operationEpoch !== accountEpoch || state.operationGeneration !== generation) {
+    throw new AccountBoundaryChangedError()
+  }
+}
+
+function assertCurrentRead(accountEpoch: number, generation: number, readGeneration: number) {
+  assertCurrentOperation(accountEpoch, generation)
+  if (usePreferencesSyncStore.getState().readGeneration !== readGeneration) {
+    throw new StalePreferenceReadError()
+  }
+}
+
+async function trackPreferencesCollection(engine: object | null, uid: string, accountEpoch: number, generation: number) {
+  if (!engine) return
+  assertCurrentOperation(accountEpoch, generation)
+  let tracked = trackedCollections.get(engine)
+  if (tracked?.has(uid)) return
+  await (engine as any).trackCollection(COLLECTION_TYPE_PREFERENCES, uid)
+  assertCurrentOperation(accountEpoch, generation)
+  if (!tracked) {
+    tracked = new Set()
+    trackedCollections.set(engine, tracked)
+  }
+  tracked.add(uid)
+}
+
+async function listPreferencesCollections(accountEpoch: number, generation: number): Promise<any[]> {
+  assertCurrentOperation(accountEpoch, generation)
   const etebase = useEtebaseStore.getState()
   if (!etebase.account) return []
-  if (etebase.collections.preferences.length > 0) return etebase.collections.preferences
+  if (etebase.collections.preferences.length > 0) {
+    for (const collection of etebase.collections.preferences) {
+      await trackPreferencesCollection(etebase.syncEngine, collection.uid, accountEpoch, generation)
+    }
+    return etebase.collections.preferences
+  }
 
   const core = await import('@silentsuite/core')
-  assertCurrentAccountEpoch(accountEpoch)
+  assertCurrentOperation(accountEpoch, generation)
   const collections = await core.listCollections(etebase.account, COLLECTION_TYPE_PREFERENCES)
-  assertCurrentAccountEpoch(accountEpoch)
+  assertCurrentOperation(accountEpoch, generation)
   if (collections.length > 0) {
     const currentEtebase = useEtebaseStore.getState()
     if (currentEtebase.account !== etebase.account || currentEtebase.syncEngine !== etebase.syncEngine) return []
     useEtebaseStore.setState((state) => ({
       collections: { ...state.collections, preferences: collections },
     }))
-    assertCurrentAccountEpoch(accountEpoch)
+    assertCurrentOperation(accountEpoch, generation)
     for (const collection of collections) {
-      assertCurrentAccountEpoch(accountEpoch)
+      assertCurrentOperation(accountEpoch, generation)
       if (useEtebaseStore.getState().syncEngine !== etebase.syncEngine) return []
-      etebase.syncEngine?.trackCollection(COLLECTION_TYPE_PREFERENCES as any, collection.uid)
+      await trackPreferencesCollection(etebase.syncEngine, collection.uid, accountEpoch, generation)
     }
   }
   return collections
 }
 
-async function ensurePreferencesCollection(accountEpoch: number): Promise<string | null> {
-  const existing = await listPreferencesCollections(accountEpoch)
-  assertCurrentAccountEpoch(accountEpoch)
-  if (existing[0]?.uid) return existing[0].uid
-  return useEtebaseStore.getState().createCollection('preferences', PREFERENCES_COLLECTION_NAME)
-}
-
-async function readRemotePreferenceItems(accountEpoch: number): Promise<{ uid: string; content: string }[]> {
-  const collections = await listPreferencesCollections(accountEpoch)
-  assertCurrentAccountEpoch(accountEpoch)
+async function readRemotePreferenceItems(accountEpoch: number, generation: number): Promise<{ uid: string; content: string }[]> {
+  const collections = await listPreferencesCollections(accountEpoch, generation)
+  assertCurrentOperation(accountEpoch, generation)
   if (collections.length === 0) return []
   return useEtebaseStore.getState().refreshCollection('preferences')
 }
 
 export const usePreferencesSyncStore = create<PreferencesSyncState & PreferencesSyncActions>((set, get) => ({
+  status: 'idle',
+  integrity: 'unknown',
+  operationEpoch: null,
+  operationGeneration: 0,
+  readGeneration: 0,
   remoteItemUid: null,
   isInitialized: false,
   isApplyingRemote: false,
   lastSyncedAt: null,
 
-  initialize: async () => {
+  initialize: (force = false) => {
     const epoch = getAccountEpoch()
-    if (get().isInitialized) return
-    if (!useEtebaseStore.getState().account) return
+    if (currentOperation?.epoch === epoch) return currentOperation.promise
+    if (!force && get().status !== 'idle' && get().operationEpoch === epoch) return Promise.resolve()
+    const generation = ++operationCounter
+    if (!useEtebaseStore.getState().account) {
+      set({ status: 'unavailable', integrity: 'unavailable', operationEpoch: epoch, operationGeneration: generation })
+      return Promise.resolve()
+    }
 
-    await get().loadFromRemote(undefined, epoch)
-    assertCurrentAccountEpoch(epoch)
-    set({ isInitialized: true })
+    set({ status: 'loading', integrity: 'unknown', operationEpoch: epoch, operationGeneration: generation })
+    const promise = (async () => {
+      try {
+        await get().loadFromRemote(undefined, epoch, generation)
+        assertCurrentOperation(epoch, generation)
+        if (get().integrity === 'failed') return
+        set({ isInitialized: true, status: 'ready', integrity: 'valid' })
+      } catch (err) {
+        if (err instanceof StalePreferenceReadError) return
+        if (getAccountEpoch() === epoch && get().operationGeneration === generation) {
+          set({ status: 'failed', integrity: 'failed' })
+        }
+        if (err instanceof AccountBoundaryChangedError) throw err
+      } finally {
+        if (currentOperation?.epoch === epoch && currentOperation.generation === generation) currentOperation = null
+      }
+    })()
+    currentOperation = { epoch, generation, promise }
+    return promise
   },
 
-  loadFromRemote: async (itemsFromRefresh, initiatingEpoch) => {
+  beginRemoteRead: (accountEpoch, operationGeneration) => {
+    const epoch = accountEpoch ?? getAccountEpoch()
+    const generation = operationGeneration ?? get().operationGeneration
+    if (getAccountEpoch() !== epoch || get().operationEpoch !== epoch || get().operationGeneration !== generation) return null
+    const readGeneration = ++readCounter
+    set({ readGeneration })
+    return readGeneration
+  },
+
+  loadFromRemote: async (itemsFromRefresh, initiatingEpoch, generation, initiatingReadGeneration) => {
     const epoch = initiatingEpoch ?? getAccountEpoch()
-    assertCurrentAccountEpoch(epoch)
+    let operationGeneration = generation ?? get().operationGeneration
+    if (get().operationEpoch === null && generation === undefined) {
+      operationGeneration = ++operationCounter
+      set({ operationEpoch: epoch, operationGeneration })
+    }
+    const remoteReadGeneration = initiatingReadGeneration ?? get().beginRemoteRead(epoch, operationGeneration)
+    if (remoteReadGeneration === null) throw new AccountBoundaryChangedError()
+    assertCurrentRead(epoch, operationGeneration, remoteReadGeneration)
     const etebase = useEtebaseStore.getState()
     if (!etebase.account) return
 
-    const items = itemsFromRefresh ?? await readRemotePreferenceItems(epoch)
-    assertCurrentAccountEpoch(epoch)
+    let items: { uid: string; content: string }[]
+    try {
+      items = itemsFromRefresh ?? await readRemotePreferenceItems(epoch, operationGeneration)
+      assertCurrentRead(epoch, operationGeneration, remoteReadGeneration)
+    } catch (err) {
+      if (!(err instanceof AccountBoundaryChangedError || err instanceof StalePreferenceReadError)) {
+        get().recordRemoteReadFailure(epoch, operationGeneration, remoteReadGeneration)
+      }
+      throw err
+    }
     const remoteItems = parseRemoteItems(items)
+    if (items.length > 0 && remoteItems.length === 0) {
+      assertCurrentRead(epoch, operationGeneration, remoteReadGeneration)
+      set({ status: 'failed', integrity: 'failed' })
+      return
+    }
     const canonical = chooseCanonical(remoteItems)
     const mergedRemote = mergeRemoteItems(remoteItems)
 
     if (!canonical || !mergedRemote) {
-      set({ remoteItemUid: null, lastSyncedAt: new Date() })
+      assertCurrentRead(epoch, operationGeneration, remoteReadGeneration)
+      set({ remoteItemUid: null, lastSyncedAt: new Date(), isInitialized: true, status: 'ready', integrity: 'valid' })
       return
     }
 
+    assertCurrentRead(epoch, operationGeneration, remoteReadGeneration)
     set({ isApplyingRemote: true, remoteItemUid: canonical.uid })
     try {
-      assertCurrentAccountEpoch(epoch)
+      assertCurrentRead(epoch, operationGeneration, remoteReadGeneration)
       usePreferencesStore.getState().applySyncedPreferences(mergedRemote)
     } finally {
-      assertCurrentAccountEpoch(epoch)
-      set({ isApplyingRemote: false, lastSyncedAt: new Date() })
+      assertCurrentRead(epoch, operationGeneration, remoteReadGeneration)
+      set({ isApplyingRemote: false, lastSyncedAt: new Date(), isInitialized: true, status: 'ready', integrity: 'valid' })
     }
+  },
+
+  recordRemoteReadFailure: (accountEpoch, generation, initiatingReadGeneration) => {
+    const epoch = accountEpoch ?? getAccountEpoch()
+    const operationGeneration = generation ?? get().operationGeneration
+    const remoteReadGeneration = initiatingReadGeneration ?? get().readGeneration
+    if (
+      getAccountEpoch() !== epoch ||
+      get().operationEpoch !== epoch ||
+      get().operationGeneration !== operationGeneration ||
+      get().readGeneration !== remoteReadGeneration
+    ) return
+    set({ status: 'failed', integrity: 'failed' })
   },
 
   pushNow: async () => {
@@ -147,13 +263,29 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
 
     const etebase = useEtebaseStore.getState()
     if (!etebase.account) return false
+    if (get().status === 'unavailable') return false
+    if (get().status === 'failed') await get().initialize(true)
+    const generation = get().operationGeneration
+    if (get().status !== 'ready' || get().integrity !== 'valid' || get().operationEpoch !== epoch) return false
 
-    const collectionUid = await ensurePreferencesCollection(epoch)
-    assertCurrentAccountEpoch(epoch)
-    if (!collectionUid) return false
+    const remoteReadGeneration = get().beginRemoteRead(epoch, generation)
+    if (remoteReadGeneration === null) return false
 
-    const remoteItems = parseRemoteItems(await readRemotePreferenceItems(epoch))
-    assertCurrentAccountEpoch(epoch)
+    let rawRemoteItems: { uid: string; content: string }[]
+    try {
+      rawRemoteItems = await readRemotePreferenceItems(epoch, generation)
+      assertCurrentRead(epoch, generation, remoteReadGeneration)
+    } catch (err) {
+      if (!(err instanceof AccountBoundaryChangedError || err instanceof StalePreferenceReadError)) {
+        get().recordRemoteReadFailure(epoch, generation, remoteReadGeneration)
+      }
+      return false
+    }
+    const remoteItems = parseRemoteItems(rawRemoteItems)
+    if (rawRemoteItems.length > 0 && remoteItems.length === 0) {
+      get().recordRemoteReadFailure(epoch, generation, remoteReadGeneration)
+      return false
+    }
     const mergedRemote = mergeRemoteItems(remoteItems)
     const merged = mergedRemote
       ? mergeSyncedPreferences([mergedRemote, usePreferencesStore.getState().toSyncedPreferences()])
@@ -164,13 +296,14 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
     if (canonical) {
       const canonicalContent = serializePreferences(canonical.preferences)
       if (content === canonicalContent) {
+        assertCurrentRead(epoch, generation, remoteReadGeneration)
         usePreferencesStore.getState().applySyncedPreferences(merged)
         set({ remoteItemUid: canonical.uid, lastSyncedAt: new Date() })
         return true
       }
       const beforeUpdateItem = useEtebaseStore.getState().itemCache.get(canonical.uid)
       await etebase.updateItem('preferences', canonical.uid, content)
-      assertCurrentAccountEpoch(epoch)
+      assertCurrentRead(epoch, generation, remoteReadGeneration)
       const afterUpdateItem = useEtebaseStore.getState().itemCache.get(canonical.uid)
       if (!afterUpdateItem || afterUpdateItem === beforeUpdateItem) {
         return false
@@ -179,8 +312,19 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
       return true
     }
 
+    let collectionUid = useEtebaseStore.getState().collections.preferences[0]?.uid ?? null
+    if (!collectionUid) {
+      try {
+        collectionUid = await useEtebaseStore.getState().createCollection('preferences', PREFERENCES_COLLECTION_NAME)
+        assertCurrentRead(epoch, generation, remoteReadGeneration)
+      } catch {
+        return false
+      }
+    }
+    if (!collectionUid) return false
+
     const itemUid = await etebase.createItem('preferences', content, PREFERENCES_TEMP_ID, collectionUid)
-    assertCurrentAccountEpoch(epoch)
+    assertCurrentRead(epoch, generation, remoteReadGeneration)
     if (itemUid) {
       set({ remoteItemUid: itemUid, lastSyncedAt: new Date() })
       return true
@@ -191,7 +335,14 @@ export const usePreferencesSyncStore = create<PreferencesSyncState & Preferences
   setRemoteItemUid: (uid) => set({ remoteItemUid: uid }),
 
   destroy: () => {
+    currentOperation = null
+    operationCounter += 1
     set({
+      status: 'idle',
+      integrity: 'unknown',
+      operationEpoch: null,
+      operationGeneration: operationCounter,
+      readGeneration: ++readCounter,
       remoteItemUid: null,
       isInitialized: false,
       isApplyingRemote: false,


### PR DESCRIPTION
## Summary
- gate preference-dependent calendar surfaces until encrypted account preference hydration reaches a terminal state
- make mounted Schedule-X calendars react to authoritative time-format changes without remounting
- harden preference initialization, integrity, retry, read ordering, account-boundary, and explicit-write guards
- surface privacy-safe preference integrity failures across desktop and mobile

## Verification
- `pnpm exec vitest run --maxWorkers=2 --reporter=default` (694 tests passed)
- `pnpm run type-check`
- `pnpm run lint` (existing warnings only)
- `git diff --check`
- independent immutable-head review: green

## Privacy
- startup remains read-only
- no passive preference collection/item creation or upload
- no preference schema or server changes

## Manual QA
- authenticated desktop/mobile Cloudflare preview smoke remains required before merge