### PR TITLE
fix(web): preserve paid signup recovery identity

### DIFF
--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -108,6 +108,10 @@ function paidSignupRequestBody(callIndex = 0) {
   return JSON.parse(init?.body as string) as Record<string, unknown>
 }
 
+function currentPaidSignupRecoverySecret() {
+  return paidSignupRequestBody(vi.mocked(fetch).mock.calls.length - 1).recoverySecret as string
+}
+
 function persistedPaidSignupIdentities() {
   const raw = sessionStorage.getItem('silentsuite-paid-signup-recovery')
   if (!raw) return []
@@ -254,7 +258,7 @@ describe('useAuthStore', () => {
         cryptoCheckoutUrl: null,
         cryptoInvoiceId: null,
         cryptoInvoiceLookupToken: null,
-        paymentSessionToken: 'signup-session-token',
+        paymentSessionToken: currentPaidSignupRecoverySecret(),
       }),
     } as Response)
 
@@ -274,8 +278,8 @@ describe('useAuthStore', () => {
       requestKey: expect.any(String),
       recoverySecret: expect.any(String),
     })
-    expect(result.paymentSessionToken).toBe('signup-session-token')
-    expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe('signup-session-token')
+    expect(result.paymentSessionToken).toBe(currentPaidSignupRecoverySecret())
+    expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe(currentPaidSignupRecoverySecret())
     expect(useAuthStore.getState().pendingSignup?.etebaseAuthToken).toBeUndefined()
   })
 
@@ -284,7 +288,7 @@ describe('useAuthStore', () => {
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
       status: 200,
-      json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret() }),
     } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day'))
@@ -306,10 +310,45 @@ describe('useAuthStore', () => {
     } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day'))
-      .rejects.toThrow('missing its recovery token')
+      .rejects.toThrow('invalid recovery token')
 
     expect(persistedPaidSignupIdentities()).toHaveLength(1)
     expect(paidSignupRequestBody().requestKey).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+  })
+
+  it('retains the real recovery identity when a successful response returns a different nonempty token', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ paymentSessionToken: 'different-nonempty-token', clientSecret: 'seti_complete' }),
+    } as Response)
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day'))
+      .rejects.toThrow('invalid recovery token')
+
+    expect(persistedPaidSignupIdentities()).toHaveLength(1)
+    expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBeUndefined()
+  })
+
+  it('retains the real Bitcoin recovery identity when the invoice lookup token is mismatched', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'crypto@example.com' } })
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        paymentSessionToken: currentPaidSignupRecoverySecret(),
+        cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/inv-mismatch',
+        cryptoInvoiceId: 'inv-mismatch',
+        cryptoInvoiceLookupToken: 'different-nonempty-token',
+      }),
+    } as Response)
+
+    await expect(useAuthStore.getState().signup('early_annual', 'crypto_annual'))
+      .rejects.toThrow('invalid invoice recovery token')
+
+    expect(persistedPaidSignupIdentities()).toHaveLength(1)
+    expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBeUndefined()
   })
 
   it('reuses paid-signup recovery identity after ambiguous transport loss and a reload-like store reset', async () => {
@@ -319,7 +358,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
@@ -341,10 +380,10 @@ describe('useAuthStore', () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+      json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
     } as Response)
 
-    await Promise.all([
+    const results = await Promise.allSettled([
       useAuthStore.getState().signup('early_monthly', '30day'),
       useAuthStore.getState().signup('early_monthly', '30day'),
     ])
@@ -353,7 +392,63 @@ describe('useAuthStore', () => {
     const concurrent = paidSignupRequestBody(1)
     expect(concurrent.requestKey).toBe(first.requestKey)
     expect(concurrent.recoverySecret).toBe(first.recoverySecret)
+    expect(results.map((result) => result.status).sort()).toEqual(['fulfilled', 'rejected'])
+    const rejected = results.find((result) => result.status === 'rejected')
+    expect(rejected).toMatchObject({ reason: expect.objectContaining({ message: 'Paid signup request was superseded' }) })
   })
+
+  it.each([
+    ['30day', 'crypto_annual', 'first'],
+    ['30day', 'crypto_annual', 'second'],
+    ['crypto_annual', '30day', 'first'],
+    ['crypto_annual', '30day', 'second'],
+  ] as const)(
+    'publishes only the latest %s → %s attempt when the %s response resolves first',
+    async (firstTrialPath, secondTrialPath, firstResolution) => {
+      useAuthStore.setState({ pendingSignup: { email: 'race@example.com' } })
+      const pendingResponses = new Map<string, { secret: string, resolve: (response: Response) => void }>()
+      vi.mocked(fetch).mockImplementation(async (_url, init) => {
+        const body = JSON.parse(init?.body as string) as { trialPath: string, recoverySecret: string }
+        return await new Promise<Response>((resolve) => {
+          pendingResponses.set(body.trialPath, { secret: body.recoverySecret, resolve })
+        })
+      })
+
+      const first = useAuthStore.getState().signup('early_annual', firstTrialPath)
+      const second = useAuthStore.getState().signup('early_annual', secondTrialPath)
+      const responseFor = (trialPath: string) => {
+        const pendingResponse = pendingResponses.get(trialPath)!
+        return {
+          ok: true,
+          status: 200,
+          json: async () => trialPath === '30day'
+            ? { paymentSessionToken: pendingResponse.secret, clientSecret: `seti_${trialPath}` }
+            : {
+                paymentSessionToken: pendingResponse.secret,
+                cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/inv-race',
+                cryptoInvoiceId: 'inv-race',
+                cryptoInvoiceLookupToken: pendingResponse.secret,
+              },
+        } as Response
+      }
+      const firstPending = pendingResponses.get(firstTrialPath)!
+      const secondPending = pendingResponses.get(secondTrialPath)!
+      if (firstResolution === 'first') {
+        firstPending.resolve(responseFor(firstTrialPath))
+        await Promise.resolve()
+        secondPending.resolve(responseFor(secondTrialPath))
+      } else {
+        secondPending.resolve(responseFor(secondTrialPath))
+        await Promise.resolve()
+        firstPending.resolve(responseFor(firstTrialPath))
+      }
+
+      const results = await Promise.allSettled([first, second])
+      expect(results[0]).toMatchObject({ status: 'rejected', reason: expect.objectContaining({ message: 'Paid signup request was superseded' }) })
+      expect(results[1].status).toBe('fulfilled')
+      expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe(secondPending.secret)
+    },
+  )
 
   it('rotates paid-signup recovery identity after a definitive rejection', async () => {
     useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
@@ -366,7 +461,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Invalid signup')
@@ -385,12 +480,12 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
       } as Response)
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'recovered-first-session', clientSecret: 'seti_recovered_first' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_recovered_first' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
@@ -415,7 +510,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'opt-out-session', clientSecret: 'seti_opt_out' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_opt_out' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
@@ -443,7 +538,7 @@ describe('useAuthStore', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+          json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
         } as Response)
 
       await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Retry later')
@@ -468,7 +563,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
       } as Response)
 
     try {
@@ -494,7 +589,7 @@ describe('useAuthStore', () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+      json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
     } as Response)
 
     try {
@@ -515,7 +610,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'new-session-token', clientSecret: 'seti_new_session' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_new_session' }),
       } as Response)
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
     const ambiguous = paidSignupRequestBody(0)
@@ -556,7 +651,7 @@ describe('useAuthStore', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+          json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
         } as Response)
 
       await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Terminal conflict')
@@ -578,7 +673,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Retry later')
@@ -600,10 +695,10 @@ describe('useAuthStore', () => {
         ok: true,
         status: 200,
         json: async () => ({
-          paymentSessionToken: 'crypto-session-token',
+          paymentSessionToken: currentPaidSignupRecoverySecret(),
           cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/inv-123',
           cryptoInvoiceId: 'inv-123',
-          cryptoInvoiceLookupToken: 'lookup-token',
+          cryptoInvoiceLookupToken: currentPaidSignupRecoverySecret(),
         }),
       } as Response)
 
@@ -626,7 +721,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
+        json: async () => ({ paymentSessionToken: currentPaidSignupRecoverySecret(), clientSecret: 'seti_complete' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Temporarily unavailable')

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -297,6 +297,21 @@ describe('useAuthStore', () => {
     expect(persistedPaidSignupIdentities()).toHaveLength(1)
   })
 
+  it('retains paid-signup recovery identity when a successful response has a non-string session token', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ paymentSessionToken: 123, clientSecret: 'seti_complete' }),
+    } as Response)
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day'))
+      .rejects.toThrow('missing its recovery token')
+
+    expect(persistedPaidSignupIdentities()).toHaveLength(1)
+    expect(paidSignupRequestBody().requestKey).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+  })
+
   it('reuses paid-signup recovery identity after ambiguous transport loss and a reload-like store reset', async () => {
     useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
     vi.mocked(fetch)

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useAuthStore } from '../use-auth-store'
 import { secureClear } from '@/app/lib/secure-storage'
+import { logger } from '@/app/lib/logger'
 
 // Mock fetch globally
 vi.stubGlobal('fetch', vi.fn())
@@ -100,6 +101,18 @@ function resetStore() {
     pendingSignup: null,
     subscriptionStatus: null,
   })
+}
+
+function paidSignupRequestBody(callIndex = 0) {
+  const [, init] = vi.mocked(fetch).mock.calls[callIndex]
+  return JSON.parse(init?.body as string) as Record<string, unknown>
+}
+
+function persistedPaidSignupIdentities() {
+  const raw = sessionStorage.getItem('silentsuite-paid-signup-recovery')
+  if (!raw) return []
+  const registry = JSON.parse(raw) as { identities?: Record<string, Record<string, unknown>> }
+  return Object.values(registry.identities ?? {})
 }
 
 describe('useAuthStore', () => {
@@ -249,21 +262,366 @@ describe('useAuthStore', () => {
 
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('/auth/signup/payment-session'),
-      expect.objectContaining({
-        method: 'POST',
-        body: JSON.stringify({
-          email: 'paid@example.com',
-          planId: 'early_monthly',
-          trialPath: '30day',
-          promoCode: 'BETA196',
-          wantsProductUpdates: false,
-          rememberDevice: false,
-        }),
-      }),
+      expect.objectContaining({ method: 'POST' }),
     )
+    expect(paidSignupRequestBody()).toMatchObject({
+      email: 'paid@example.com',
+      planId: 'early_monthly',
+      trialPath: '30day',
+      promoCode: 'BETA196',
+      wantsProductUpdates: false,
+      rememberDevice: false,
+      requestKey: expect.any(String),
+      recoverySecret: expect.any(String),
+    })
     expect(result.paymentSessionToken).toBe('signup-session-token')
     expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe('signup-session-token')
     expect(useAuthStore.getState().pendingSignup?.etebaseAuthToken).toBeUndefined()
+  })
+
+  it('creates a UUID request key and a high-entropy recovery secret for paid signup', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+    } as Response)
+
+    await useAuthStore.getState().signup('early_monthly', '30day')
+
+    const body = paidSignupRequestBody()
+    expect(body.requestKey).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+    expect(body.recoverySecret).toMatch(/^[A-Za-z0-9_-]{43,}$/)
+    expect(body.recoverySecret).not.toBe(body.requestKey)
+    expect(sessionStorage.getItem('silentsuite-paid-signup-recovery')).toBeNull()
+  })
+
+  it('reuses paid-signup recovery identity after ambiguous transport loss and a reload-like store reset', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      } as Response)
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
+    const [persisted] = persistedPaidSignupIdentities()
+    expect(persisted.requestKey).toBe(paidSignupRequestBody(0).requestKey)
+    expect(persisted.recoverySecret).toBe(paidSignupRequestBody(0).recoverySecret)
+    resetStore()
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    await useAuthStore.getState().signup('early_monthly', '30day')
+
+    const first = paidSignupRequestBody(0)
+    const retry = paidSignupRequestBody(1)
+    expect(retry.requestKey).toBe(first.requestKey)
+    expect(retry.recoverySecret).toBe(first.recoverySecret)
+  })
+
+  it('uses one recovery identity for concurrent paid-signup calls', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+    } as Response)
+
+    await Promise.all([
+      useAuthStore.getState().signup('early_monthly', '30day'),
+      useAuthStore.getState().signup('early_monthly', '30day'),
+    ])
+
+    const first = paidSignupRequestBody(0)
+    const concurrent = paidSignupRequestBody(1)
+    expect(concurrent.requestKey).toBe(first.requestKey)
+    expect(concurrent.recoverySecret).toBe(first.recoverySecret)
+  })
+
+  it('rotates paid-signup recovery identity after a definitive rejection', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ detail: 'Invalid signup' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      } as Response)
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Invalid signup')
+    await useAuthStore.getState().signup('early_monthly', '30day')
+
+    const rejected = paidSignupRequestBody(0)
+    const next = paidSignupRequestBody(1)
+    expect(next.requestKey).not.toBe(rejected.requestKey)
+    expect(next.recoverySecret).not.toBe(rejected.recoverySecret)
+  })
+
+  it('retains an ambiguous scope while a different signup draft uses its own identity', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'first@example.com' } })
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'recovered-first-session' }),
+      } as Response)
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
+    useAuthStore.getState().prepareSignupDraft('second@example.com')
+    await useAuthStore.getState().signup('early_monthly', '30day')
+    useAuthStore.getState().prepareSignupDraft('first@example.com')
+    await useAuthStore.getState().signup('early_monthly', '30day')
+
+    const first = paidSignupRequestBody(0)
+    const next = paidSignupRequestBody(1)
+    const recovered = paidSignupRequestBody(2)
+    expect(next.requestKey).not.toBe(first.requestKey)
+    expect(next.recoverySecret).not.toBe(first.recoverySecret)
+    expect(recovered.requestKey).toBe(first.requestKey)
+    expect(recovered.recoverySecret).toBe(first.recoverySecret)
+  })
+
+  it.each(['signup-in-progress', 'payment-reconciliation-required', 'bitcoin-invoice-active'])(
+    'retains paid-signup recovery identity for ambiguous 409 problem %s',
+    async (problemCode) => {
+      useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 409,
+          json: async () => ({ type: `https://api.silentsuite.io/problems/${problemCode}`, detail: 'Retry later' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+        } as Response)
+
+      await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Retry later')
+      await useAuthStore.getState().signup('early_monthly', '30day')
+
+      expect(paidSignupRequestBody(1).requestKey).toBe(paidSignupRequestBody(0).requestKey)
+      expect(paidSignupRequestBody(1).recoverySecret).toBe(paidSignupRequestBody(0).recoverySecret)
+    },
+  )
+
+  it('retains paid-signup recovery identity when sessionStorage writes fail', async () => {
+    const originalSetItem = Storage.prototype.setItem
+    const storageSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (key, value) {
+      if (this === sessionStorage && key === 'silentsuite-paid-signup-recovery') {
+        throw new DOMException('quota exceeded', 'QuotaExceededError')
+      }
+      return originalSetItem.call(this, key, value)
+    })
+    useAuthStore.setState({ pendingSignup: { email: 'storage-failure@example.com' } })
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      } as Response)
+
+    try {
+      await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
+      await useAuthStore.getState().signup('early_monthly', '30day')
+    } finally {
+      storageSpy.mockRestore()
+    }
+
+    expect(paidSignupRequestBody(1).requestKey).toBe(paidSignupRequestBody(0).requestKey)
+    expect(paidSignupRequestBody(1).recoverySecret).toBe(paidSignupRequestBody(0).recoverySecret)
+  })
+
+  it('does not resurrect a cleared recovery identity when sessionStorage removal fails', async () => {
+    const originalRemoveItem = Storage.prototype.removeItem
+    const storageSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function (key) {
+      if (this === sessionStorage && key === 'silentsuite-paid-signup-recovery') {
+        throw new DOMException('storage unavailable', 'SecurityError')
+      }
+      return originalRemoveItem.call(this, key)
+    })
+    useAuthStore.setState({ pendingSignup: { email: 'removal-failure@example.com' } })
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+    } as Response)
+
+    try {
+      await useAuthStore.getState().signup('early_monthly', '30day')
+      await useAuthStore.getState().signup('early_monthly', '30day')
+    } finally {
+      storageSpy.mockRestore()
+    }
+
+    expect(paidSignupRequestBody(1).requestKey).not.toBe(paidSignupRequestBody(0).requestKey)
+    expect(paidSignupRequestBody(1).recoverySecret).not.toBe(paidSignupRequestBody(0).recoverySecret)
+  })
+
+  it('clears recovery authority before storage-wide removal failures during signup completion', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'completed@example.com' } })
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'new-session-token' }),
+      } as Response)
+    await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
+    const ambiguous = paidSignupRequestBody(0)
+    useAuthStore.setState({
+      pendingSignup: {
+        email: 'completed@example.com',
+        provisionedUser: { id: 'user-1', planId: 'early_monthly', isAdmin: false },
+        provisionedSubscriptionStatus: 'active',
+      },
+    })
+    const storageSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(function () {
+      if (this === sessionStorage) throw new DOMException('storage unavailable', 'SecurityError')
+    })
+
+    try {
+      expect(() => useAuthStore.getState().completeSignup()).not.toThrow()
+      useAuthStore.setState({ pendingSignup: { email: 'completed@example.com' } })
+      await useAuthStore.getState().signup('early_monthly', '30day')
+    } finally {
+      storageSpy.mockRestore()
+    }
+
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+    expect(paidSignupRequestBody(1).requestKey).not.toBe(ambiguous.requestKey)
+    expect(paidSignupRequestBody(1).recoverySecret).not.toBe(ambiguous.recoverySecret)
+  })
+
+  it.each(['account-exists', 'payment-intent-conflict', 'payment-already-confirmed'])(
+    'clears paid-signup recovery identity for definitive 409 problem %s',
+    async (problemCode) => {
+      useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+      vi.mocked(fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 409,
+          json: async () => ({ type: `https://api.silentsuite.io/problems/${problemCode}`, detail: 'Terminal conflict' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+        } as Response)
+
+      await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Terminal conflict')
+      await useAuthStore.getState().signup('early_monthly', '30day')
+
+      expect(paidSignupRequestBody(1).requestKey).not.toBe(paidSignupRequestBody(0).requestKey)
+      expect(paidSignupRequestBody(1).recoverySecret).not.toBe(paidSignupRequestBody(0).recoverySecret)
+    },
+  )
+
+  it('preserves paid-signup recovery identity for an unknown 409 problem', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({ type: 'https://api.silentsuite.io/problems/future-reconciliation-state', detail: 'Retry later' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      } as Response)
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Retry later')
+    await useAuthStore.getState().signup('early_monthly', '30day')
+
+    expect(paidSignupRequestBody(1).requestKey).toBe(paidSignupRequestBody(0).requestKey)
+    expect(paidSignupRequestBody(1).recoverySecret).toBe(paidSignupRequestBody(0).recoverySecret)
+  })
+
+  it('uses the same recovery identity for pre-account BTCPay after an ambiguous failure', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'crypto@example.com' } })
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ detail: 'Provider response uncertain' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          paymentSessionToken: 'crypto-session-token',
+          cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/inv-123',
+          cryptoInvoiceId: 'inv-123',
+          cryptoInvoiceLookupToken: 'lookup-token',
+        }),
+      } as Response)
+
+    await expect(useAuthStore.getState().signup('early_annual', 'crypto_annual')).rejects.toThrow('Provider response uncertain')
+    const recovered = await useAuthStore.getState().signup('early_annual', 'crypto_annual')
+
+    expect(paidSignupRequestBody(1).requestKey).toBe(paidSignupRequestBody(0).requestKey)
+    expect(paidSignupRequestBody(1).recoverySecret).toBe(paidSignupRequestBody(0).recoverySecret)
+    expect(recovered.cryptoInvoiceId).toBe('inv-123')
+  })
+
+  it('retains paid-signup recovery identity after an ambiguous server failure', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ detail: 'Temporarily unavailable' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      } as Response)
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Temporarily unavailable')
+    await useAuthStore.getState().signup('early_monthly', '30day')
+
+    const first = paidSignupRequestBody(0)
+    const retry = paidSignupRequestBody(1)
+    expect(retry.requestKey).toBe(first.requestKey)
+    expect(retry.recoverySecret).toBe(first.recoverySecret)
+  })
+
+  it('keeps paid-signup recovery capability out of Zustand, redirect state, localStorage, and logs', async () => {
+    const loggerSpies = [
+      vi.spyOn(logger, 'debug'),
+      vi.spyOn(logger, 'log'),
+      vi.spyOn(logger, 'warn'),
+      vi.spyOn(logger, 'error'),
+    ]
+    useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
+    vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
+    const body = paidSignupRequestBody()
+    useAuthStore.getState().saveSignupStateForRedirect('monthly')
+
+    expect(JSON.stringify(useAuthStore.getState())).not.toContain(body.recoverySecret as string)
+    expect(JSON.stringify(useAuthStore.getState())).not.toContain(body.requestKey as string)
+    expect(sessionStorage.getItem('silentsuite-signup-redirect-state')).not.toContain(body.recoverySecret as string)
+    expect(sessionStorage.getItem('silentsuite-signup-redirect-state')).not.toContain(body.requestKey as string)
+    expect(localStorage.getItem('silentsuite-paid-signup-recovery')).toBeNull()
+    expect(JSON.stringify(loggerSpies.flatMap((spy) => spy.mock.calls))).not.toContain(body.recoverySecret as string)
+    expect(JSON.stringify(loggerSpies.flatMap((spy) => spy.mock.calls))).not.toContain(body.requestKey as string)
+    loggerSpies.forEach((spy) => spy.mockRestore())
   })
 
   it('clears stale payment state when the signup draft email changes', () => {

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -279,7 +279,7 @@ describe('useAuthStore', () => {
     expect(useAuthStore.getState().pendingSignup?.etebaseAuthToken).toBeUndefined()
   })
 
-  it('creates a UUID request key and a high-entropy recovery secret for paid signup', async () => {
+  it('retains a UUID request key and high-entropy recovery secret after an incomplete successful response', async () => {
     useAuthStore.setState({ pendingSignup: { email: 'paid@example.com' } })
     vi.mocked(fetch).mockResolvedValueOnce({
       ok: true,
@@ -287,13 +287,14 @@ describe('useAuthStore', () => {
       json: async () => ({ paymentSessionToken: 'signup-session-token' }),
     } as Response)
 
-    await useAuthStore.getState().signup('early_monthly', '30day')
+    await expect(useAuthStore.getState().signup('early_monthly', '30day'))
+      .rejects.toThrow('incomplete provider continuation')
 
     const body = paidSignupRequestBody()
     expect(body.requestKey).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
     expect(body.recoverySecret).toMatch(/^[A-Za-z0-9_-]{43,}$/)
     expect(body.recoverySecret).not.toBe(body.requestKey)
-    expect(sessionStorage.getItem('silentsuite-paid-signup-recovery')).toBeNull()
+    expect(persistedPaidSignupIdentities()).toHaveLength(1)
   })
 
   it('reuses paid-signup recovery identity after ambiguous transport loss and a reload-like store reset', async () => {
@@ -303,7 +304,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
@@ -325,7 +326,7 @@ describe('useAuthStore', () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
     } as Response)
 
     await Promise.all([
@@ -350,7 +351,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Invalid signup')
@@ -369,12 +370,12 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
       } as Response)
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'recovered-first-session' }),
+        json: async () => ({ paymentSessionToken: 'recovered-first-session', clientSecret: 'seti_recovered_first' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
@@ -392,6 +393,28 @@ describe('useAuthStore', () => {
     expect(recovered.recoverySecret).toBe(first.recoverySecret)
   })
 
+  it('does not reuse default marketing opt-in authority for an explicit opt-out retry', async () => {
+    useAuthStore.setState({ pendingSignup: { email: 'preferences@example.com' } })
+    vi.mocked(fetch)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ paymentSessionToken: 'opt-out-session', clientSecret: 'seti_opt_out' }),
+      } as Response)
+
+    await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
+    useAuthStore.setState({ pendingSignup: { email: 'preferences@example.com', wantsProductUpdates: false } })
+    await useAuthStore.getState().signup('early_monthly', '30day')
+
+    const defaultOptIn = paidSignupRequestBody(0)
+    const explicitOptOut = paidSignupRequestBody(1)
+    expect(defaultOptIn.wantsProductUpdates).toBe(true)
+    expect(explicitOptOut.wantsProductUpdates).toBe(false)
+    expect(explicitOptOut.requestKey).not.toBe(defaultOptIn.requestKey)
+    expect(explicitOptOut.recoverySecret).not.toBe(defaultOptIn.recoverySecret)
+  })
+
   it.each(['signup-in-progress', 'payment-reconciliation-required', 'bitcoin-invoice-active'])(
     'retains paid-signup recovery identity for ambiguous 409 problem %s',
     async (problemCode) => {
@@ -405,7 +428,7 @@ describe('useAuthStore', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+          json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
         } as Response)
 
       await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Retry later')
@@ -430,7 +453,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
       } as Response)
 
     try {
@@ -456,7 +479,7 @@ describe('useAuthStore', () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       status: 200,
-      json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+      json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
     } as Response)
 
     try {
@@ -477,7 +500,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'new-session-token' }),
+        json: async () => ({ paymentSessionToken: 'new-session-token', clientSecret: 'seti_new_session' }),
       } as Response)
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Failed to fetch')
     const ambiguous = paidSignupRequestBody(0)
@@ -518,7 +541,7 @@ describe('useAuthStore', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+          json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
         } as Response)
 
       await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Terminal conflict')
@@ -540,7 +563,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Retry later')
@@ -588,7 +611,7 @@ describe('useAuthStore', () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ paymentSessionToken: 'signup-session-token' }),
+        json: async () => ({ paymentSessionToken: 'signup-session-token', clientSecret: 'seti_complete' }),
       } as Response)
 
     await expect(useAuthStore.getState().signup('early_monthly', '30day')).rejects.toThrow('Temporarily unavailable')

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -124,6 +124,161 @@ const AUTH_RATE_LIMIT_MESSAGE =
 const AUTH_TEMPORARY_UNAVAILABLE_MESSAGE =
   'Sign-in is temporarily unavailable. Please wait a minute and try again. Your encrypted data is safe.'
 
+const PAID_SIGNUP_RECOVERY_KEY = 'silentsuite-paid-signup-recovery'
+const RECOVERY_SECRET_BYTES = 32
+
+interface PaidSignupRecoveryIdentity {
+  scope: string
+  requestKey: string
+  recoverySecret: string
+}
+
+interface PaidSignupRecoveryRegistry {
+  version: 1
+  identities: Record<string, PaidSignupRecoveryIdentity>
+}
+
+let inMemoryPaidSignupRecoveryRegistry: PaidSignupRecoveryRegistry = { version: 1, identities: {} }
+let paidSignupStorageWriteUnavailable = false
+
+function paidSignupRecoveryScope(
+  email: string,
+  planId: string,
+  trialPath: string,
+  promoCode?: string,
+  wantsProductUpdates?: boolean,
+  rememberDevice?: boolean,
+): string {
+  return JSON.stringify({
+    email: email.trim().toLowerCase(),
+    planId,
+    trialPath,
+    promoCode: promoCode?.trim() || null,
+    wantsProductUpdates: wantsProductUpdates === true,
+    rememberDevice: rememberDevice === true,
+  })
+}
+
+function isPaidSignupRecoveryIdentity(
+  value: unknown,
+  scope: string,
+): value is PaidSignupRecoveryIdentity {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Partial<PaidSignupRecoveryIdentity>
+  return candidate.scope === scope
+    && typeof candidate.requestKey === 'string'
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(candidate.requestKey)
+    && typeof candidate.recoverySecret === 'string'
+    && /^[A-Za-z0-9_-]{43}$/.test(candidate.recoverySecret)
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = ''
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index])
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function readPaidSignupRecoveryRegistry(): PaidSignupRecoveryRegistry {
+  if (typeof window === 'undefined') return inMemoryPaidSignupRecoveryRegistry
+  try {
+    const raw = sessionStorage.getItem(PAID_SIGNUP_RECOVERY_KEY)
+    if (!raw) {
+      if (paidSignupStorageWriteUnavailable) return inMemoryPaidSignupRecoveryRegistry
+      inMemoryPaidSignupRecoveryRegistry = { version: 1, identities: {} }
+      return inMemoryPaidSignupRecoveryRegistry
+    }
+    // A failed write means persisted data may be stale in either direction:
+    // it may lack a newly created capability or retain one that was cleared.
+    // The complete desired in-memory registry is authoritative until a later
+    // write succeeds.
+    if (paidSignupStorageWriteUnavailable) return inMemoryPaidSignupRecoveryRegistry
+    const parsed = JSON.parse(raw) as Partial<PaidSignupRecoveryRegistry>
+    if (parsed.version !== 1 || !parsed.identities || typeof parsed.identities !== 'object') {
+      sessionStorage.removeItem(PAID_SIGNUP_RECOVERY_KEY)
+      return { version: 1, identities: {} }
+    }
+    const persistedIdentities = Object.fromEntries(
+      Object.entries(parsed.identities).filter(([scope, identity]) => isPaidSignupRecoveryIdentity(identity, scope)),
+    )
+    const identities = persistedIdentities
+    return { version: 1, identities }
+  } catch {
+    return inMemoryPaidSignupRecoveryRegistry
+  }
+}
+
+function writePaidSignupRecoveryRegistry(registry: PaidSignupRecoveryRegistry) {
+  inMemoryPaidSignupRecoveryRegistry = registry
+  if (typeof window === 'undefined') return
+  try {
+    if (Object.keys(registry.identities).length === 0) {
+      sessionStorage.removeItem(PAID_SIGNUP_RECOVERY_KEY)
+    } else {
+      sessionStorage.setItem(PAID_SIGNUP_RECOVERY_KEY, JSON.stringify(registry))
+    }
+    paidSignupStorageWriteUnavailable = false
+  } catch {
+    paidSignupStorageWriteUnavailable = true
+    // The in-memory registry still coordinates retries during this page load.
+  }
+}
+
+function getOrCreatePaidSignupRecoveryIdentity(scope: string): PaidSignupRecoveryIdentity {
+  const registry = readPaidSignupRecoveryRegistry()
+  const stored = registry.identities[scope]
+  if (isPaidSignupRecoveryIdentity(stored, scope)) return stored
+
+  const randomBytes = new Uint8Array(RECOVERY_SECRET_BYTES)
+  crypto.getRandomValues(randomBytes)
+  const identity: PaidSignupRecoveryIdentity = {
+    scope,
+    requestKey: crypto.randomUUID(),
+    recoverySecret: encodeBase64Url(randomBytes),
+  }
+  registry.identities[scope] = identity
+  // Capabilities survive same-tab reloads and scope changes after response
+  // loss, but never receive localStorage's cross-tab or long-lived persistence.
+  writePaidSignupRecoveryRegistry(registry)
+  return identity
+}
+
+function clearPaidSignupRecoveryIdentity(expectedRequestKey?: string) {
+  if (!expectedRequestKey) {
+    writePaidSignupRecoveryRegistry({ version: 1, identities: {} })
+    return
+  }
+  const registry = readPaidSignupRecoveryRegistry()
+  for (const [scope, identity] of Object.entries(registry.identities)) {
+    if (identity.requestKey === expectedRequestKey) delete registry.identities[scope]
+  }
+  writePaidSignupRecoveryRegistry(registry)
+}
+
+const DEFINITIVE_PAID_SIGNUP_CONFLICTS = new Set([
+  'account-exists',
+  'payment-intent-conflict',
+  'payment-already-confirmed',
+])
+
+function paidSignupProblemCode(problem: unknown): string | null {
+  if (!problem || typeof problem !== 'object') return null
+  const candidate = problem as { code?: unknown, type?: unknown }
+  if (typeof candidate.code === 'string') return candidate.code
+  if (typeof candidate.type !== 'string') return null
+  return candidate.type.split('/').filter(Boolean).at(-1) ?? null
+}
+
+function isDefinitivePaidSignupFailure(status: number, problem: unknown): boolean {
+  if (status === 408 || status === 429 || status >= 500) return false
+  if (status === 409) {
+    const code = paidSignupProblemCode(problem)
+    return code !== null && DEFINITIVE_PAID_SIGNUP_CONFLICTS.has(code)
+  }
+  return status >= 400 && status < 500
+}
+
 let hostedActiveTabHeartbeat: number | null = null
 let hostedActiveTabUnloadHooked = false
 
@@ -439,9 +594,15 @@ async function clearLocalAuthMaterial(reason: 'logout' | 'invalid-hosted-auth') 
     logger.warn(`[auth-store] Failed to clear offline queue during ${reason}:`, err)
   }
 
+  clearPaidSignupRecoveryIdentity()
   if (typeof window !== 'undefined') {
-    sessionStorage.removeItem('silentsuite-signup-in-progress')
-    sessionStorage.removeItem('silentsuite-signup-redirect-state')
+    for (const key of ['silentsuite-signup-in-progress', 'silentsuite-signup-redirect-state']) {
+      try {
+        sessionStorage.removeItem(key)
+      } catch {
+        // Recovery capability clearing above remains authoritative in memory.
+      }
+    }
   }
 
   try {
@@ -628,6 +789,16 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
     const isPaidSignupDraft = (trialPath === '30day' || trialPath === 'crypto_annual') && !pending.etebaseAuthToken
     if (isPaidSignupDraft) {
+      const recoveryIdentity = getOrCreatePaidSignupRecoveryIdentity(
+        paidSignupRecoveryScope(
+          pending.email,
+          planId,
+          trialPath,
+          promoCode,
+          pending.wantsProductUpdates,
+          pending.rememberDevice,
+        ),
+      )
       set({ isLoading: true, error: null })
       try {
         const res = await fetch(`${BILLING_API_URL}/auth/signup/payment-session`, {
@@ -637,6 +808,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
             email: pending.email,
             planId,
             trialPath,
+            requestKey: recoveryIdentity.requestKey,
+            recoverySecret: recoveryIdentity.recoverySecret,
             ...(promoCode?.trim() ? { promoCode: promoCode.trim() } : {}),
             wantsProductUpdates: pending.wantsProductUpdates,
             rememberDevice: pending.rememberDevice === true,
@@ -645,11 +818,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         })
         if (!res.ok) {
           const errData = await res.json().catch(() => null)
+          if (isDefinitivePaidSignupFailure(res.status, errData)) {
+            clearPaidSignupRecoveryIdentity(recoveryIdentity.requestKey)
+          }
           throw new Error(errData?.detail ?? 'Payment setup failed')
         }
         const data = await res.json()
         const paymentSessionToken = (data.paymentSessionToken as string | null) ?? null
         if (!paymentSessionToken) throw new Error('Payment setup did not return a session token')
+        clearPaidSignupRecoveryIdentity(recoveryIdentity.requestKey)
         set({
           pendingSignup: {
             ...pending,
@@ -774,8 +951,13 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       return
     }
     // Clear the signup-in-progress flag so restoreSession works normally
+    clearPaidSignupRecoveryIdentity()
     if (typeof window !== 'undefined') {
-      sessionStorage.removeItem('silentsuite-signup-in-progress')
+      try {
+        sessionStorage.removeItem('silentsuite-signup-in-progress')
+      } catch {
+        // Signup completion must not be interrupted by unavailable tab storage.
+      }
     }
     // Sync admin cookie so middleware allows /admin access
     syncAdminCookie(pending.provisionedUser.isAdmin, pending.rememberDevice === true)

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -824,8 +824,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           throw new Error(errData?.detail ?? 'Payment setup failed')
         }
         const data = await res.json()
-        const paymentSessionToken = (data.paymentSessionToken as string | null) ?? null
-        if (!paymentSessionToken) throw new Error('Payment setup did not return a session token')
+        const paymentSessionToken = data.paymentSessionToken
+        if (typeof paymentSessionToken !== 'string' || paymentSessionToken.trim().length === 0) {
+          throw new Error('Paid signup response is missing its recovery token')
+        }
         const clientSecret = (data.clientSecret as string | null) ?? null
         const cryptoCheckoutUrl = (data.cryptoCheckoutUrl as string | null) ?? null
         const cryptoInvoiceId = (data.cryptoInvoiceId as string | null) ?? null

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -34,6 +34,7 @@ interface PendingSignup {
   earlyAdopter?: boolean
   wantsProductUpdates?: boolean
   rememberDevice?: boolean
+  paidSignupAttemptId?: string
   /** Provisioned user data — stored here until the entire signup flow completes. */
   provisionedUser?: {
     id: string
@@ -799,7 +800,32 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           pending.rememberDevice,
         ),
       )
-      set({ isLoading: true, error: null })
+      const attemptId = crypto.randomUUID()
+      const isActiveAttempt = () => {
+        const current = get().pendingSignup
+        if (!current || current.paidSignupAttemptId !== attemptId) return false
+        const currentScope = paidSignupRecoveryScope(
+          current.email,
+          planId,
+          trialPath,
+          promoCode,
+          current.wantsProductUpdates,
+          current.rememberDevice,
+        )
+        if (currentScope !== recoveryIdentity.scope) return false
+        const currentIdentity = readPaidSignupRecoveryRegistry().identities[recoveryIdentity.scope]
+        return isPaidSignupRecoveryIdentity(currentIdentity, recoveryIdentity.scope)
+          && currentIdentity.requestKey === recoveryIdentity.requestKey
+          && currentIdentity.recoverySecret === recoveryIdentity.recoverySecret
+      }
+      set({
+        pendingSignup: {
+          ...pending,
+          paidSignupAttemptId: attemptId,
+        },
+        isLoading: true,
+        error: null,
+      })
       try {
         const res = await fetch(`${BILLING_API_URL}/auth/signup/payment-session`, {
           method: 'POST',
@@ -818,15 +844,16 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         })
         if (!res.ok) {
           const errData = await res.json().catch(() => null)
-          if (isDefinitivePaidSignupFailure(res.status, errData)) {
+          if (isActiveAttempt() && isDefinitivePaidSignupFailure(res.status, errData)) {
             clearPaidSignupRecoveryIdentity(recoveryIdentity.requestKey)
           }
           throw new Error(errData?.detail ?? 'Payment setup failed')
         }
         const data = await res.json()
+        if (!isActiveAttempt()) throw new Error('Paid signup request was superseded')
         const paymentSessionToken = data.paymentSessionToken
-        if (typeof paymentSessionToken !== 'string' || paymentSessionToken.trim().length === 0) {
-          throw new Error('Paid signup response is missing its recovery token')
+        if (paymentSessionToken !== recoveryIdentity.recoverySecret) {
+          throw new Error('Paid signup response has an invalid recovery token')
         }
         const clientSecret = (data.clientSecret as string | null) ?? null
         const cryptoCheckoutUrl = (data.cryptoCheckoutUrl as string | null) ?? null
@@ -840,11 +867,20 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         if (!completeProviderContinuation) {
           throw new Error('Payment setup returned an incomplete provider continuation')
         }
+        if (trialPath === 'crypto_annual' && cryptoInvoiceLookupToken !== recoveryIdentity.recoverySecret) {
+          throw new Error('Paid signup response has an invalid invoice recovery token')
+        }
+        if (!isActiveAttempt()) throw new Error('Paid signup request was superseded')
         clearPaidSignupRecoveryIdentity(recoveryIdentity.requestKey)
+        const currentPending = get().pendingSignup
+        if (!currentPending || currentPending.paidSignupAttemptId !== attemptId) {
+          throw new Error('Paid signup request was superseded')
+        }
         set({
           pendingSignup: {
-            ...pending,
+            ...currentPending,
             paymentSessionToken,
+            paidSignupAttemptId: undefined,
           },
           isLoading: false,
         })
@@ -857,7 +893,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Payment setup failed'
-        set({ error: message, isLoading: false })
+        if (get().pendingSignup?.paidSignupAttemptId === attemptId) {
+          set({ error: message, isLoading: false })
+        }
         throw err
       }
     }

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -154,7 +154,7 @@ function paidSignupRecoveryScope(
     planId,
     trialPath,
     promoCode: promoCode?.trim() || null,
-    wantsProductUpdates: wantsProductUpdates === true,
+    wantsProductUpdates: wantsProductUpdates !== false,
     rememberDevice: rememberDevice === true,
   })
 }
@@ -811,7 +811,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
             requestKey: recoveryIdentity.requestKey,
             recoverySecret: recoveryIdentity.recoverySecret,
             ...(promoCode?.trim() ? { promoCode: promoCode.trim() } : {}),
-            wantsProductUpdates: pending.wantsProductUpdates,
+            wantsProductUpdates: pending.wantsProductUpdates !== false,
             rememberDevice: pending.rememberDevice === true,
           }),
           credentials: 'include',
@@ -826,6 +826,18 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         const data = await res.json()
         const paymentSessionToken = (data.paymentSessionToken as string | null) ?? null
         if (!paymentSessionToken) throw new Error('Payment setup did not return a session token')
+        const clientSecret = (data.clientSecret as string | null) ?? null
+        const cryptoCheckoutUrl = (data.cryptoCheckoutUrl as string | null) ?? null
+        const cryptoInvoiceId = (data.cryptoInvoiceId as string | null) ?? null
+        const cryptoInvoiceLookupToken = (data.cryptoInvoiceLookupToken as string | null) ?? null
+        const completeProviderContinuation = trialPath === '30day'
+          ? typeof clientSecret === 'string' && clientSecret.length > 0
+          : typeof cryptoCheckoutUrl === 'string' && cryptoCheckoutUrl.length > 0
+            && typeof cryptoInvoiceId === 'string' && cryptoInvoiceId.length > 0
+            && typeof cryptoInvoiceLookupToken === 'string' && cryptoInvoiceLookupToken.length > 0
+        if (!completeProviderContinuation) {
+          throw new Error('Payment setup returned an incomplete provider continuation')
+        }
         clearPaidSignupRecoveryIdentity(recoveryIdentity.requestKey)
         set({
           pendingSignup: {
@@ -835,10 +847,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           isLoading: false,
         })
         return {
-          clientSecret: (data.clientSecret as string | null) ?? null,
-          cryptoCheckoutUrl: (data.cryptoCheckoutUrl as string | null) ?? null,
-          cryptoInvoiceId: (data.cryptoInvoiceId as string | null) ?? null,
-          cryptoInvoiceLookupToken: (data.cryptoInvoiceLookupToken as string | null) ?? null,
+          clientSecret,
+          cryptoCheckoutUrl,
+          cryptoInvoiceId,
+          cryptoInvoiceLookupToken,
           paymentSessionToken,
         }
       } catch (err) {


### PR DESCRIPTION
1|## Summary
2|- generate cryptographically strong request and recovery credentials for pre-account paid signup
3|- preserve ambiguous attempts per tab and semantic signup scope across retries and reloads
4|- normalize marketing preference defaults so explicit opt-out uses a distinct recovery identity
5|- retain recovery identity until a successful response contains a runtime-valid session token and complete flow-specific provider continuation
6|- cover card and Bitcoin signup recovery, malformed responses, structured conflicts, concurrency, and storage failures
7|
8|## Coordination
9|- Companion to internal Billing issue #280
10|- Do not deploy the client contract before the internal API change is merged and promoted
11|
12|## Verification
13|- 92 focused auth-store tests passed
14|- 713 full web tests passed before the final focused malformed-token regression was added
15|- web TypeScript type-check passed
16|- GitHub CI, dependency audit, public analytics guard, preview build, and production web build passed
17|- final substantive coordinated security/privacy review pending the internal immutable patch
18|