### PR TITLE
fix(web): improve light mode banner contrast

### DIFF
--- a/apps/web/app/components/EmailVerificationBanner.tsx
+++ b/apps/web/app/components/EmailVerificationBanner.tsx
@@ -127,7 +127,7 @@ export function EmailVerificationBanner() {
   return (
     <div className="border-b border-amber-500/20 bg-amber-500/10 px-4 py-2 text-sm text-amber-800 dark:text-amber-200">
       <div role="alert" className="flex items-center gap-3">
-        <MailWarning className="w-4 h-4 text-amber-400 shrink-0" />
+        <MailWarning className="w-4 h-4 text-amber-700 dark:text-amber-400 shrink-0" />
         <span className="flex-1 text-xs">
           {changeSuccess
             ? changeSuccess
@@ -139,7 +139,7 @@ export function EmailVerificationBanner() {
           <button
             onClick={handleResend}
             disabled={resending}
-            className="shrink-0 text-xs font-medium text-amber-400 hover:text-amber-300 underline underline-offset-2 disabled:opacity-50"
+            className="shrink-0 text-xs font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900 disabled:opacity-50 dark:text-amber-300 dark:hover:text-amber-200"
           >
             {resending ? (
               <Loader2 className="w-3 h-3 animate-spin" />
@@ -154,7 +154,7 @@ export function EmailVerificationBanner() {
             setError(null)
             setChangeSuccess(null)
           }}
-          className="shrink-0 text-xs font-medium text-amber-400 hover:text-amber-300 underline underline-offset-2"
+          className="shrink-0 text-xs font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-200"
         >
           Change email
         </button>

--- a/apps/web/app/components/EmailVerificationBanner.tsx
+++ b/apps/web/app/components/EmailVerificationBanner.tsx
@@ -200,14 +200,14 @@ export function EmailVerificationBanner() {
             <button
               type="button"
               onClick={() => setShowChangeEmail(false)}
-              className="text-xs font-medium text-amber-700 underline underline-offset-2 hover:text-amber-600 dark:text-amber-300 dark:hover:text-amber-200"
+              className="text-xs font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900 dark:text-amber-300 dark:hover:text-amber-200"
             >
               Cancel
             </button>
           </div>
         </form>
       )}
-      {error && <p className="mt-2 text-xs text-red-500 dark:text-red-400">{error}</p>}
+      {error && <p className="mt-2 text-xs text-red-700 dark:text-red-400">{error}</p>}
     </div>
   )
 }

--- a/apps/web/app/components/PendingSyncBanner.tsx
+++ b/apps/web/app/components/PendingSyncBanner.tsx
@@ -70,8 +70,8 @@ export function PendingSyncBanner() {
   return (
     <div className="mx-3 mt-2 space-y-2 md:mx-4">
       {/* Main pending/failed banner */}
-      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">
-        <CloudOff className="h-4 w-4 shrink-0 text-amber-400" />
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200">
+        <CloudOff className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
 
         <span className="flex-1">
           {pendingCount > 0 && (
@@ -81,7 +81,7 @@ export function PendingSyncBanner() {
           )}
           {pendingCount > 0 && failedCount > 0 && <span className="mx-1">&middot;</span>}
           {failedCount > 0 && (
-            <span className="text-red-400">
+            <span className="text-red-700 dark:text-red-400">
               {failedCount} failed
             </span>
           )}
@@ -91,14 +91,14 @@ export function PendingSyncBanner() {
           <div className="flex items-center gap-1">
             <button
               onClick={handleRetryFailed}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-amber-300 transition-colors hover:bg-amber-500/20"
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/20 dark:text-amber-300"
             >
               <RefreshCw className="h-3 w-3" />
               Retry
             </button>
             <button
               onClick={handleDiscardFailed}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-500/20 dark:text-red-400"
             >
               <Trash2 className="h-3 w-3" />
               Discard
@@ -109,16 +109,16 @@ export function PendingSyncBanner() {
 
       {/* Stale queue warning */}
       {hasStaleEntries && (
-        <div className="flex items-center gap-2 rounded-lg border border-orange-500/30 bg-orange-500/10 px-3 py-2 text-sm text-orange-200">
-          <AlertTriangle className="h-4 w-4 shrink-0 text-orange-400" />
+        <div className="flex items-center gap-2 rounded-lg border border-orange-500/30 bg-orange-500/10 px-3 py-2 text-sm text-orange-800 dark:text-orange-200">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-orange-600 dark:text-orange-400" />
           <span>Some changes have been pending for over 24 hours. Please check your internet connection.</span>
         </div>
       )}
 
       {/* Queue size limit warning */}
       {isQueueNearLimit && (
-        <div className="flex items-center gap-2 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-200">
-          <AlertTriangle className="h-4 w-4 shrink-0 text-red-400" />
+        <div className="flex items-center gap-2 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-800 dark:text-red-200">
+          <AlertTriangle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
           <span>Offline queue is full ({MAX_QUEUE_SIZE} changes). Connect to the internet to sync your changes.</span>
         </div>
       )}

--- a/apps/web/app/components/PendingSyncBanner.tsx
+++ b/apps/web/app/components/PendingSyncBanner.tsx
@@ -91,14 +91,14 @@ export function PendingSyncBanner() {
           <div className="flex items-center gap-1">
             <button
               onClick={handleRetryFailed}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-amber-700 transition-colors hover:bg-amber-500/20 dark:text-amber-300"
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-amber-800 transition-colors hover:bg-amber-500/20 dark:text-amber-300"
             >
               <RefreshCw className="h-3 w-3" />
               Retry
             </button>
             <button
               onClick={handleDiscardFailed}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-red-700 transition-colors hover:bg-red-500/20 dark:text-red-400"
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-red-800 transition-colors hover:bg-red-500/20 dark:text-red-400"
             >
               <Trash2 className="h-3 w-3" />
               Discard

--- a/apps/web/app/components/__tests__/EmailVerificationBanner.test.tsx
+++ b/apps/web/app/components/__tests__/EmailVerificationBanner.test.tsx
@@ -65,6 +65,12 @@ describe('EmailVerificationBanner', () => {
     expect(screen.getByLabelText('New email')).toBeInTheDocument()
     expect(screen.getByLabelText('Confirm new email')).toBeInTheDocument()
     expect(screen.getByText('This changes the email we use for account and billing messages. Your current login email may stay the same for now.')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toHaveClass(
+      'text-amber-800',
+      'hover:text-amber-900',
+      'dark:text-amber-300',
+      'dark:hover:text-amber-200',
+    )
   })
 
   it('submits normalized contact email changes to billing and refreshes the session', async () => {
@@ -115,7 +121,10 @@ describe('EmailVerificationBanner', () => {
     fireEvent.change(screen.getByLabelText('Confirm new email'), { target: { value: 'two@example.com' } })
     fireEvent.click(screen.getByText('Save email'))
 
-    expect(screen.getByText('Email addresses do not match.')).toBeInTheDocument()
+    expect(screen.getByText('Email addresses do not match.')).toHaveClass(
+      'text-red-700',
+      'dark:text-red-400',
+    )
     expect(fetch).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/app/components/__tests__/EmailVerificationBanner.test.tsx
+++ b/apps/web/app/components/__tests__/EmailVerificationBanner.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/app/lib/self-hosted', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
-  MailWarning: () => <svg data-testid="mail-warning-icon" />,
+  MailWarning: ({ className }: { className?: string }) => <svg data-testid="mail-warning-icon" className={className} />,
   Loader2: () => <svg data-testid="loader-icon" />,
 }))
 
@@ -37,6 +37,24 @@ describe('EmailVerificationBanner', () => {
     expect(screen.getByText('Please verify your email so you can receive account and billing messages.')).toBeInTheDocument()
     expect(screen.getByText('Resend email')).toBeInTheDocument()
     expect(screen.getByText('Change email')).toBeInTheDocument()
+  })
+
+  it('uses contrasting light and dark colours for the icon and recovery actions', () => {
+    render(<EmailVerificationBanner />)
+
+    expect(screen.getByTestId('mail-warning-icon')).toHaveClass(
+      'text-amber-700',
+      'dark:text-amber-400',
+    )
+
+    for (const name of [/resend email/i, /change email/i]) {
+      expect(screen.getByRole('button', { name })).toHaveClass(
+        'text-amber-800',
+        'hover:text-amber-900',
+        'dark:text-amber-300',
+        'dark:hover:text-amber-200',
+      )
+    }
   })
 
   it('opens a change email form with confirmation and careful contact-email copy', () => {

--- a/apps/web/app/components/__tests__/PendingSyncBanner.test.tsx
+++ b/apps/web/app/components/__tests__/PendingSyncBanner.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { PendingSyncBanner } from '../PendingSyncBanner'
+
+const syncState = {
+  pendingQueueCount: 2,
+  failedQueueCount: 1,
+  isOnline: true,
+  replayOfflineQueue: vi.fn(),
+}
+
+const etebaseState = {
+  account: {},
+  accountFingerprint: 'account-fingerprint',
+}
+
+vi.mock('@/app/stores/use-sync-store', () => ({
+  useSyncStore: (selector: (state: typeof syncState) => unknown) => selector(syncState),
+}))
+
+vi.mock('@/app/stores/use-etebase-store', () => ({
+  useEtebaseStore: (selector: (state: typeof etebaseState) => unknown) => selector(etebaseState),
+}))
+
+vi.mock('@/app/lib/offline-queue', () => ({
+  MAX_QUEUE_SIZE: 2,
+  clearFailed: vi.fn(),
+  retryFailed: vi.fn(),
+  getStaleEntries: vi.fn().mockResolvedValue([{}]),
+}))
+
+vi.mock('@/app/lib/account-epoch', () => ({
+  AccountBoundaryChangedError: class AccountBoundaryChangedError extends Error {},
+  getAccountEpoch: () => 1,
+}))
+
+describe('PendingSyncBanner', () => {
+  it('uses contrasting foregrounds for every light and dark warning state', async () => {
+    const { container } = render(<PendingSyncBanner />)
+
+    const mainBanner = container.firstElementChild?.firstElementChild
+    expect(mainBanner).toHaveClass('text-amber-800', 'dark:text-amber-200')
+    expect(screen.getByRole('button', { name: /retry/i })).toHaveClass(
+      'text-amber-800',
+      'dark:text-amber-300',
+    )
+    expect(screen.getByRole('button', { name: /discard/i })).toHaveClass(
+      'text-red-800',
+      'dark:text-red-400',
+    )
+
+    expect(screen.getByText(/Offline queue is full/i).parentElement).toHaveClass(
+      'text-red-800',
+      'dark:text-red-200',
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/pending for over 24 hours/i).parentElement).toHaveClass(
+        'text-orange-800',
+        'dark:text-orange-200',
+      )
+    })
+  })
+})

--- a/apps/web/app/components/__tests__/partial-load-banner.test.tsx
+++ b/apps/web/app/components/__tests__/partial-load-banner.test.tsx
@@ -78,6 +78,22 @@ describe('PartialLoadBanner', () => {
     expect(syncState.simulateSyncCycle).toHaveBeenCalledTimes(1)
   })
 
+  it('uses contrasting foregrounds in both light and dark modes', () => {
+    authState.isAuthenticated = true
+    syncState.partialLoad = true
+
+    render(<PartialLoadBanner />)
+
+    expect(screen.getByText(/Some of your data could not be loaded/i)).toHaveClass(
+      'text-amber-800',
+      'dark:text-amber-100',
+    )
+    expect(screen.getByRole('button', { name: /retry sync/i })).toHaveClass(
+      'text-amber-800',
+      'dark:text-amber-100',
+    )
+  })
+
   it('disables retry while syncing or offline', () => {
     authState.isAuthenticated = true
     syncState.partialLoad = true

--- a/apps/web/app/components/__tests__/read-only-overlay.test.tsx
+++ b/apps/web/app/components/__tests__/read-only-overlay.test.tsx
@@ -64,6 +64,11 @@ describe('ReadOnlyBanner', () => {
     // Should be a banner-style element
     expect(root.className).toContain('rounded-lg')
   })
+
+  it('uses contrasting foregrounds in both light and dark modes', () => {
+    const { container } = render(<ReadOnlyBanner />)
+    expect(container.firstElementChild).toHaveClass('text-amber-800', 'dark:text-amber-200')
+  })
 })
 
 describe('DegradedModeBanner', () => {
@@ -93,5 +98,10 @@ describe('DegradedModeBanner', () => {
     expect(root.className).not.toContain('fixed')
     expect(root.className).not.toContain('inset-0')
     expect(root.className).toContain('rounded-lg')
+  })
+
+  it('uses contrasting foregrounds in both light and dark modes', () => {
+    const { container } = render(<DegradedModeBanner />)
+    expect(container.firstElementChild).toHaveClass('text-blue-800', 'dark:text-blue-200')
   })
 })

--- a/apps/web/app/components/__tests__/read-only-overlay.test.tsx
+++ b/apps/web/app/components/__tests__/read-only-overlay.test.tsx
@@ -68,6 +68,12 @@ describe('ReadOnlyBanner', () => {
   it('uses contrasting foregrounds in both light and dark modes', () => {
     const { container } = render(<ReadOnlyBanner />)
     expect(container.firstElementChild).toHaveClass('text-amber-800', 'dark:text-amber-200')
+    expect(screen.getByText('Choose a plan').closest('a')).toHaveClass(
+      'bg-amber-700',
+      'hover:bg-amber-800',
+      'dark:bg-amber-400',
+      'dark:hover:bg-amber-300',
+    )
   })
 })
 
@@ -103,5 +109,9 @@ describe('DegradedModeBanner', () => {
   it('uses contrasting foregrounds in both light and dark modes', () => {
     const { container } = render(<DegradedModeBanner />)
     expect(container.firstElementChild).toHaveClass('text-blue-800', 'dark:text-blue-200')
+    expect(screen.getByRole('button', { name: /retry/i })).toHaveClass(
+      'text-blue-700',
+      'dark:text-blue-300',
+    )
   })
 })

--- a/apps/web/app/components/__tests__/restore-blocked-banner.test.tsx
+++ b/apps/web/app/components/__tests__/restore-blocked-banner.test.tsx
@@ -55,6 +55,18 @@ describe('RestoreBlockedBanner', () => {
     expect(link).toHaveAttribute('href', '/login?reason=unlock&returnTo=%2Fcalendar')
   })
 
+  it('uses contrasting foregrounds in both light and dark modes', () => {
+    etebaseState.restoreBlocked = true
+    authState.isAuthenticated = true
+    const { container } = render(<RestoreBlockedBanner />)
+
+    expect(container.firstElementChild).toHaveClass('text-emerald-800', 'dark:text-emerald-200')
+    expect(screen.getByRole('link', { name: /unlock now/i })).toHaveClass(
+      'bg-emerald-700',
+      'dark:bg-emerald-400',
+    )
+  })
+
   it('renders reassuring copy that contains no error/failure/phase wording', () => {
     etebaseState.restoreBlocked = true
     authState.isAuthenticated = true

--- a/apps/web/app/components/__tests__/restore-blocked-banner.test.tsx
+++ b/apps/web/app/components/__tests__/restore-blocked-banner.test.tsx
@@ -63,7 +63,9 @@ describe('RestoreBlockedBanner', () => {
     expect(container.firstElementChild).toHaveClass('text-emerald-800', 'dark:text-emerald-200')
     expect(screen.getByRole('link', { name: /unlock now/i })).toHaveClass(
       'bg-emerald-700',
+      'hover:bg-emerald-800',
       'dark:bg-emerald-400',
+      'dark:hover:bg-emerald-300',
     )
   })
 

--- a/apps/web/app/components/partial-load-banner.tsx
+++ b/apps/web/app/components/partial-load-banner.tsx
@@ -18,15 +18,15 @@ export function PartialLoadBanner() {
 
   return (
     <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm md:mx-4">
-      <TriangleAlert className="h-4 w-4 flex-none text-amber-300" aria-hidden="true" />
-      <p className="min-w-0 flex-1 text-amber-100">
+      <TriangleAlert className="h-4 w-4 flex-none text-amber-600 dark:text-amber-300" aria-hidden="true" />
+      <p className="min-w-0 flex-1 text-amber-800 dark:text-amber-100">
         Some of your data could not be loaded and is not shown right now. Your information is safe. Retry to load it again.
       </p>
       <button
         type="button"
         onClick={() => simulateSyncCycle()}
         disabled={disabled}
-        className="rounded-md border border-amber-300/40 px-2.5 py-1 text-xs font-medium text-amber-100 transition-colors hover:border-amber-200 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded-md border border-amber-600/40 px-2.5 py-1 text-xs font-medium text-amber-700 transition-colors hover:border-amber-700 hover:text-amber-800 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-300/40 dark:text-amber-100 dark:hover:border-amber-200 dark:hover:text-white"
       >
         Retry sync
       </button>

--- a/apps/web/app/components/partial-load-banner.tsx
+++ b/apps/web/app/components/partial-load-banner.tsx
@@ -26,7 +26,7 @@ export function PartialLoadBanner() {
         type="button"
         onClick={() => simulateSyncCycle()}
         disabled={disabled}
-        className="rounded-md border border-amber-600/40 px-2.5 py-1 text-xs font-medium text-amber-700 transition-colors hover:border-amber-700 hover:text-amber-800 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-300/40 dark:text-amber-100 dark:hover:border-amber-200 dark:hover:text-white"
+        className="rounded-md border border-amber-600/40 px-2.5 py-1 text-xs font-medium text-amber-800 transition-colors hover:border-amber-700 disabled:cursor-not-allowed disabled:opacity-50 dark:border-amber-300/40 dark:text-amber-100 dark:hover:border-amber-200 dark:hover:text-white"
       >
         Retry sync
       </button>

--- a/apps/web/app/components/read-only-overlay.tsx
+++ b/apps/web/app/components/read-only-overlay.tsx
@@ -18,15 +18,15 @@ export function ReadOnlyBanner() {
       : 'Your subscription has ended.'
 
   return (
-    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200 md:mx-4">
-      <Lock className="h-4 w-4 shrink-0 text-amber-400" />
+    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800 dark:text-amber-200 md:mx-4">
+      <Lock className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
       <span className="flex-1">
         {title} Your data is safe and read-only.
       </span>
       <div className="flex items-center gap-3">
         <Link
           href="/settings/subscription"
-          className="inline-flex items-center gap-1.5 rounded-lg bg-amber-500 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-amber-700 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:bg-amber-400 dark:text-amber-950 dark:hover:bg-amber-300"
         >
           Choose a plan
           <ExternalLink className="h-3.5 w-3.5" />
@@ -60,15 +60,15 @@ export function DegradedModeBanner() {
   }
 
   return (
-    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-sm text-blue-200 md:mx-4">
-      <WifiOff className="h-4 w-4 shrink-0 text-blue-400" />
+    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/10 px-3 py-2 text-sm text-blue-800 dark:text-blue-200 md:mx-4">
+      <WifiOff className="h-4 w-4 shrink-0 text-blue-600 dark:text-blue-400" />
       <span className="flex-1">
         Billing service temporarily unavailable. Your data is safe.
       </span>
       <button
         onClick={handleRetry}
         disabled={isRetrying}
-        className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-blue-300 transition-colors hover:bg-blue-500/20 disabled:opacity-50"
+        className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-500/20 disabled:opacity-50 dark:text-blue-300"
       >
         <RefreshCw className={`h-3 w-3 ${isRetrying ? 'animate-spin' : ''}`} />
         {isRetrying ? 'Retrying…' : 'Retry'}

--- a/apps/web/app/components/read-only-overlay.tsx
+++ b/apps/web/app/components/read-only-overlay.tsx
@@ -26,7 +26,7 @@ export function ReadOnlyBanner() {
       <div className="flex items-center gap-3">
         <Link
           href="/settings/subscription"
-          className="inline-flex items-center gap-1.5 rounded-lg bg-amber-700 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:bg-amber-400 dark:text-amber-950 dark:hover:bg-amber-300"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-amber-700 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-amber-800 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:bg-amber-400 dark:text-amber-950 dark:hover:bg-amber-300"
         >
           Choose a plan
           <ExternalLink className="h-3.5 w-3.5" />

--- a/apps/web/app/components/restore-blocked-banner.tsx
+++ b/apps/web/app/components/restore-blocked-banner.tsx
@@ -25,14 +25,14 @@ export function RestoreBlockedBanner() {
   const href = `/login?reason=unlock&returnTo=${encodeURIComponent(returnTo)}`
 
   return (
-    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-200 md:mx-4">
-      <KeyRound className="h-4 w-4 shrink-0 text-emerald-400" />
+    <div className="mx-3 mt-2 flex flex-wrap items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-800 dark:text-emerald-200 md:mx-4">
+      <KeyRound className="h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
       <span className="flex-1">
         Your data is encrypted and safe on the server. This browser needs to unlock it again.
       </span>
       <Link
         href={href}
-        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2"
+        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:bg-emerald-400 dark:text-emerald-950 dark:hover:bg-emerald-300"
       >
         Unlock now
       </Link>

--- a/apps/web/app/components/restore-blocked-banner.tsx
+++ b/apps/web/app/components/restore-blocked-banner.tsx
@@ -32,7 +32,7 @@ export function RestoreBlockedBanner() {
       </span>
       <Link
         href={href}
-        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:bg-emerald-400 dark:text-emerald-950 dark:hover:bg-emerald-300"
+        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-700 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:bg-emerald-400 dark:text-emerald-950 dark:hover:bg-emerald-300"
       >
         Unlock now
       </Link>


### PR DESCRIPTION
## Summary
- give the restore-blocked banner explicit high-contrast light-mode text and icon colours while preserving dark-mode colours
- apply the same light/dark pairing to sibling app-shell read-only, degraded, partial-load, and pending-sync banners
- keep default and hover CTA/action states above WCAG AA contrast and add regression assertions across every touched banner state

## Surface & Sibling-Path Map
- **Web app shell banners:** affected and fixed
- **Restore/unlock behavior:** visual styles only; route and recovery behavior unchanged
- **Calendar/tasks/contacts data paths:** unchanged
- **Server, Android, bridge, billing contracts:** not affected
- **Sibling paths:** restore-blocked, read-only, degraded, partial-load, pending/failed/stale queue states audited and updated; email verification already had explicit light/dark colours; dark-background toasts are unaffected

## Verification
- `pnpm --filter @silentsuite/web test` (55 files, 699 tests passed)
- focused banner suite (4 files, 21 tests passed)
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web lint` (passes with pre-existing warnings)
- `git diff --check`
- computed light-mode contrast: body/action text 5.72:1 or higher across updated palette; CTA hover states 7.09:1 and 7.68:1

## Review follow-up
The first substantive review requested changes for hover-state contrast and incomplete widened-surface coverage. Commit `13ccf99` addressed both findings. A fresh substantive review of immutable head `13ccf99f0bb8117d677fe95137d94c2780fcc822` returned **APPROVE** with no blocking findings.

## Environment note
The configured `ss@xl` SSH route rejected authentication, so this branch was created from current `origin/dev` in a clean isolated clone rather than touching the dirty synced workspace.