### PR TITLE
Clarify Android download choices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           pnpm --filter @silentsuite/web build
           SILENTSUITE_HOSTED_DOCS_ANALYTICS=1 pnpm --filter @silentsuite/docs exec vitepress build --outDir .vitepress/dist-hosted
           pnpm --filter @silentsuite/docs exec vitepress build --outDir .vitepress/dist-self
+      - name: Test Android distribution documentation
+        run: pnpm --filter @silentsuite/docs test:android-distribution
       - name: Enforce source and bundle analytics boundary
         run: pnpm run check:public-analytics
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test Android distribution documentation
+        run: pnpm --filter @silentsuite/docs test:android-distribution
+
       - name: Build docs
         run: pnpm run build --filter=@silentsuite/docs
         env:

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Test Android distribution documentation
+        run: pnpm --filter @silentsuite/docs test:android-distribution
+
       - name: Build docs
         run: pnpm run build --filter=@silentsuite/docs
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Open-source, zero-knowledge sync. Plaintext stays off the server; encryption key
 
 <br />
 
-[**Get started for free**](https://app.silentsuite.io/signup) · [Download Android and Bridge](https://github.com/silent-suite/silentsuite/releases/latest) · [Self-host](#self-host) · [Read the security model](https://silentsuite.io/security)
+[**Get started for free**](https://app.silentsuite.io/signup) · [Get SilentSuite for Android](https://docs.silentsuite.io/user-guide/apps/android) · [Download the Bridge](https://github.com/silent-suite/silentsuite/releases/latest) · [Self-host](#self-host) · [Read the security model](https://silentsuite.io/security)
 
 7 days without a card, or 30 days with a card. No charge during the trial.
 
@@ -75,8 +75,8 @@ See the [latest public beta release](https://github.com/silent-suite/silentsuite
 
 | Status | Details |
 |---|---|
-| **Available now** | Hosted web app, self-hosting, signed Android APK, desktop Bridge binaries, import/export, GitHub Releases, and Zapstore |
-| **In progress** | Google Play update, official F-Droid review, broader Android testing, and more DAV compatibility reports |
+| **Available now** | Hosted web app, self-hosting, Google Play, Obtainium, Zapstore, signed Android APK, desktop Bridge binaries, import/export, and GitHub Releases |
+| **In progress** | Official F-Droid inclusion, broader Android testing, and more DAV compatibility reports |
 | **Not in this beta** | Native iOS app, push notifications, shared or multiple collections, first-class encrypted notes, and OAuth-based Google/iCloud import |
 
 The source is public for inspection, but SilentSuite has not yet completed an independent third-party security audit. See the [security page](https://silentsuite.io/security) for the threat model, limitations, and disclosure route.
@@ -89,7 +89,12 @@ The source is public for inspection, but SilentSuite has not yet completed an in
 
 ### Android and desktop Bridge
 
-Download signed Android and Bridge binaries with checksums from [GitHub Releases](https://github.com/silent-suite/silentsuite/releases/latest).
+Install SilentSuite for Android through Google Play, Obtainium, Zapstore, or a
+signed APK. The [Android installation guide](https://docs.silentsuite.io/user-guide/apps/android)
+explains each channel and its update behavior. Official F-Droid inclusion is pending.
+
+Download Bridge binaries and signed Android APKs with checksums from
+[GitHub Releases](https://github.com/silent-suite/silentsuite/releases/latest).
 
 - [Android setup](https://docs.silentsuite.io/user-guide/apps/android)
 - [DAV Bridge setup](https://docs.silentsuite.io/user-guide/apps/dav-bridge)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build",
-    "preview": "vitepress preview"
+    "preview": "vitepress preview",
+    "test:android-distribution": "node --test scripts/android-distribution.test.mjs"
   },
   "devDependencies": {
     "vitepress": "^1.6.3",

--- a/apps/docs/scripts/android-distribution.test.mjs
+++ b/apps/docs/scripts/android-distribution.test.mjs
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict'
+import { readFileSync, readdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import test from 'node:test'
+
+const docsRoot = process.cwd()
+const repoRoot = resolve(docsRoot, '../..')
+
+function read(path) {
+  return readFileSync(path, 'utf8')
+}
+
+const hostedAndroid = read(resolve(docsRoot, 'user-guide/apps/android.md'))
+const hostedFaq = read(resolve(docsRoot, 'user-guide/faq.md'))
+const siblingFaq = read(resolve(repoRoot, 'docs/user-guide/faq.md'))
+const siblingGettingStarted = read(resolve(repoRoot, 'docs/user-guide/getting-started.md'))
+const siblingGuideIndex = read(resolve(repoRoot, 'docs/user-guide/README.md'))
+const rootReadme = read(resolve(repoRoot, 'README.md'))
+
+function markdownInventory(root) {
+  return readdirSync(root, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => resolve(entry.parentPath, entry.name))
+}
+
+const inventory = [
+  resolve(repoRoot, 'README.md'),
+  ...markdownInventory(resolve(docsRoot, 'user-guide')),
+  ...markdownInventory(resolve(repoRoot, 'docs/user-guide')),
+]
+
+const falseFdroidAvailabilityPatterns = [
+  /\b(?:SilentSuite|the (?:SilentSuite )?(?:Android )?app)\s+(?:is\s+|can be\s+)?(?:currently\s+|now\s+)?(?:available|downloadable|installable|downloaded|installed)\s+(?:on|from|through|via)\s+(?:the official\s+)?F-Droid\b/i,
+  /\b(?:download|install|get|obtain)\s+(?:SilentSuite|the (?:SilentSuite )?(?:Android )?app)\s+(?:on|from|through|via)\s+(?:the official\s+)?F-Droid\b/i,
+  /\bavailable\s+(?:now\s+)?(?:on|from|through|via)\b[^.\n]*\bF-Droid\b/i,
+  /\bF-Droid\b\s*(?:[-—:|]\s*)?(?:is\s+)?(?:available(?:\s+now)?|download(?:\s+now)?|install(?:\s+now)?)(?:\b|$)/i,
+  /\b(?:available|download|installation)\s+channels?\b[^.\n]*\bF-Droid\b/i,
+  /\bchannels?\b[^.\n]*\binclude(?:s|d)?\b[^.\n]*\bF-Droid\b/i,
+]
+
+const falseQrTargetPatterns = [
+  /\bQR(?:[- ]code)?\s+download\b/i,
+  /\bQR(?:[- ]code)?\s+(?:that\s+)?(?:downloads?|links?|points?|opens?)\s+(?:directly\s+)?(?:to\s+)?[^,;.\n]*\b(?:APK|GitHub (?:APK|Releases?))\b/i,
+  /\b(?:use|scan)\s+(?:the\s+)?QR(?:[- ]code)?\s+(?:to|for)\s+(?:download|get|open|install)\b[^,;.\n]*\b(?:APK|GitHub (?:APK|Releases?))\b/i,
+  /\b(?:use|scan)\s+(?:the\s+)?QR(?:[- ]code)?\s+for\s+(?:the\s+)?(?:latest\s+)?(?:signed\s+)?(?:APK|GitHub (?:APK|Releases?))\b/i,
+  /\bQR(?:[- ]code)?\s+(?:takes? you|lets? you)\s+(?:directly\s+)?(?:to\s+|download\s+|get\s+|open\s+)?[^,;.\n]*\b(?:APK|GitHub (?:APK|Releases?))\b/i,
+]
+
+function sentences(content) {
+  const blocks = []
+  let current = ''
+  let currentKind = ''
+  let fenceMarker = ''
+
+  const flush = () => {
+    if (current) blocks.push(current)
+    current = ''
+    currentKind = ''
+  }
+
+  const append = (line, kind) => {
+    if (currentKind && currentKind !== kind) flush()
+    current = current ? `${current} ${line}` : line
+    currentKind = kind
+  }
+
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+
+    const fence = line.match(/^(`{3,}|~{3,})/)
+    if (fence) {
+      flush()
+      const marker = fence[1][0]
+      if (!fenceMarker) fenceMarker = marker
+      else if (fenceMarker === marker) fenceMarker = ''
+      continue
+    }
+    if (fenceMarker) continue
+
+    if (!line) {
+      flush()
+      continue
+    }
+
+    if (/^#{1,6}\s/.test(line) || /^:::/.test(line) || /^\|/.test(line)) {
+      flush()
+      blocks.push(line)
+      continue
+    }
+
+    if (/^>/.test(line)) {
+      const quoteLine = line.replace(/^>+\s*/, '')
+      if (!quoteLine) flush()
+      else append(quoteLine, 'quote')
+      continue
+    }
+
+    if (/^(?:[-*+] |\d+\. )/.test(line)) {
+      flush()
+      append(line, 'list')
+      continue
+    }
+
+    append(line, currentKind || 'paragraph')
+  }
+  flush()
+
+  return blocks
+    .flatMap((block) => block.split(/[.!?](?:[)"']?)\s+/))
+    .map((sentence) => sentence.trim())
+    .filter(Boolean)
+}
+
+function claimClauses(sentence) {
+  const subject = '(?:SilentSuite|the (?:SilentSuite )?(?:Android )?app)\\b|F-Droid\\s+(?:is|will|would|can|has|offers|provides|supports)\\b'
+  const separator = new RegExp(
+    `(?:;\\s*|,\\s*(?:and|but|however)\\s+(?=(?:${subject}))|\\s+(?:and|but|however)\\s+(?=(?:${subject})))`,
+    'i',
+  )
+
+  return sentence.split(separator).map((clause) => clause.trim()).filter(Boolean)
+}
+
+function isTruthfulFdroidContext(sentence) {
+  return (
+    /\b(?:official\s+)?F-Droid\b[^.\n]*\b(?:inclusion|publication|distribution)\b[^.\n]*\b(?:pending|planned|coming soon)\b/i.test(sentence) ||
+    /\b(?:inclusion|publication|distribution)\b[^.\n]*\b(?:pending|planned|coming soon)\b[^.\n]*\b(?:official\s+)?F-Droid\b/i.test(sentence) ||
+    /\bfuture\s+(?:reproducible\s+|developer-signed\s+)?F-Droid\s+builds?\b/i.test(sentence) ||
+    /\b(?:SilentSuite|the (?:SilentSuite )?(?:Android )?app)\s+(?:is|are)\s+not\s+(?:yet\s+|currently\s+)?available\b[^.\n]*\bF-Droid\b/i.test(sentence) ||
+    /\bF-Droid\b\s+(?:is|are)\s+not\s+(?:yet\s+|currently\s+)?available\b/i.test(sentence) ||
+    /\b(?:do|does|will|would)\s+not\s+(?:currently\s+)?include\s+(?:(?:Google Play|Zapstore|GitHub Releases|Obtainium)\s*(?:,|or|and)\s*)*F-Droid\b/i.test(sentence) ||
+    /\bF-Droid\b\s+(?:is|was|will be|would be)\s+not\s+(?:currently\s+)?included\b/i.test(sentence) ||
+    /\b(?:when|once|after)\b[^,;.\n]*\bF-Droid\b[^,;.\n]*\b(?:available|published|included|approved)\b/i.test(sentence) ||
+    /\bwhen\s+available\b[^,;.\n]*\b(?:include|support|publish)\b[^,;.\n]*\bF-Droid\b/i.test(sentence) ||
+    /\b(?:will|would)\s+(?:eventually\s+)?(?:include|support|publish)\b[^,;.\n]*\bF-Droid\b/i.test(sentence) ||
+    /\b(?:install|download|get)\s+(?:Obtainium|Tasks\.org|Etar|Simple Calendar)\b[^\n]*\bfrom\b[^\n]*\bF-Droid\b/i.test(sentence) ||
+    /\b(?:Obtainium|Tasks\.org|Etar|Simple Calendar)\b\s+(?:is|are)\s+available\s+from\s+F-Droid\b/i.test(sentence) ||
+    /\boriginal EteSync app\b[^\n]*\bfrom\b[^\n]*\bF-Droid\b/i.test(sentence)
+  )
+}
+
+function findFalseFdroidAvailabilityClaim(content) {
+  return sentences(content)
+    .flatMap(claimClauses)
+    .find(
+      (clause) =>
+        /\bF-Droid\b/i.test(clause) &&
+        !isTruthfulFdroidContext(clause) &&
+        falseFdroidAvailabilityPatterns.some((pattern) => pattern.test(clause)),
+    )
+}
+
+function findFalseQrTargetClaim(content) {
+  return sentences(content).find((sentence) =>
+    falseQrTargetPatterns.some((pattern) => pattern.test(sentence)),
+  )
+}
+
+function hasFalseFdroidAvailabilityClaim(content) {
+  return findFalseFdroidAvailabilityClaim(content) !== undefined
+}
+
+function hasFalseQrTargetClaim(content) {
+  return findFalseQrTargetClaim(content) !== undefined
+}
+
+test('all Android documentation states that official F-Droid inclusion is pending', () => {
+  assert.match(hostedAndroid, /Official F-Droid publication is pending inclusion\./)
+  assert.match(hostedFaq, /Official F-Droid inclusion is pending\./)
+  assert.match(siblingFaq, /Official F-Droid inclusion is pending\./)
+  assert.match(siblingGettingStarted, /Official F-Droid inclusion is pending\./)
+  assert.match(siblingGuideIndex, /Official F-Droid inclusion is pending\./)
+  assert.match(rootReadme, /Official F-Droid inclusion is pending\./)
+})
+
+test('F-Droid availability classifier rejects false claims and permits truthful context', () => {
+  const rejected = [
+    'SilentSuite is available on F-Droid.',
+    'The Android app is available from the official F-Droid repository.',
+    'SilentSuite can be downloaded from F-Droid.',
+    'Download SilentSuite from F-Droid.',
+    'Install SilentSuite via F-Droid.',
+    'Get the Android app through F-Droid.',
+    'F-Droid — available now',
+    'F-Droid is available now.',
+    'F-Droid: download now',
+    'F-Droid: install now',
+    'Available on Google Play, Zapstore, and F-Droid.',
+    'Available channels: Google Play, Zapstore, and F-Droid.',
+    'Download channels include GitHub Releases and F-Droid.',
+    'Installation channels include Google Play and F-Droid.',
+    'Our Android channels include F-Droid.',
+    '> SilentSuite can be downloaded\n> from F-Droid.',
+    '### Future F-Droid\nSilentSuite is available on F-Droid.',
+    'SilentSuite does not include ads and is available on F-Droid.',
+    '> Future F-Droid\n>\n> SilentSuite is available on F-Droid.',
+    'Future updates improve privacy, and SilentSuite is available on F-Droid.',
+    'Obtainium is useful, and SilentSuite is available on F-Droid.',
+    'Install Obtainium from F-Droid, and SilentSuite is available on F-Droid.',
+    'Official F-Droid inclusion is pending, but SilentSuite is available on F-Droid.',
+    'Future reproducible F-Droid builds use one certificate, and SilentSuite is available on F-Droid.',
+    'Google Play is not available, and SilentSuite is available on F-Droid.',
+    'Official F-Droid inclusion is pending and SilentSuite is available on F-Droid.',
+    'Install Obtainium from F-Droid and SilentSuite is available on F-Droid.',
+    'Future reproducible F-Droid builds use one certificate and SilentSuite is available on F-Droid.',
+    'Official F-Droid inclusion is pending and F-Droid is available now.',
+  ]
+  const accepted = [
+    'SilentSuite is not yet available from the official F-Droid package index.',
+    'Official F-Droid inclusion is pending.',
+    'When F-Droid distribution becomes available, keep updates on that channel.',
+    'When available, installation channels will include F-Droid.',
+    'Install Obtainium from F-Droid.',
+    'Tasks.org is available from F-Droid.',
+    'Future reproducible F-Droid builds use the developer-signed certificate.',
+    'SilentSuite is not available from Google Play or F-Droid.',
+    'Available channels do not include F-Droid.',
+    '~~~text\nSilentSuite is available on F-Droid.\n~~~',
+    '```text\nSilentSuite is available on F-Droid.\n```',
+  ]
+
+  for (const content of rejected) {
+    assert.equal(hasFalseFdroidAvailabilityClaim(content), true, content)
+  }
+  for (const content of accepted) {
+    assert.equal(hasFalseFdroidAvailabilityClaim(content), false, content)
+  }
+})
+
+test('documentation inventory contains no false F-Droid availability claims', () => {
+  for (const path of inventory) {
+    const content = read(path)
+    assert.equal(findFalseFdroidAvailabilityClaim(content), undefined, path)
+  }
+})
+
+test('QR target classifier rejects APK claims and permits guide plus separate APK wording', () => {
+  const rejected = [
+    'The QR code downloads the signed APK.',
+    'Use the QR-code download in Settings.',
+    'The QR code that links to the latest signed APK is in Settings.',
+    'The QR code points directly to the GitHub Release.',
+    'The QR code points directly to GitHub Releases.',
+    'Scan the QR code to download the latest APK.',
+    'Use the QR code to download the signed APK.',
+    'The QR code takes you to GitHub Releases.',
+    'The QR code lets you download the signed APK.',
+    'Scan the QR code for the GitHub APK.',
+    'The QR downloads the signed APK.',
+    'Scan QR for the GitHub APK.',
+  ]
+  const accepted = [
+    'The QR code opens the Android installation guide.',
+    'The QR code opens the guide, while a separate APK link opens GitHub Releases.',
+    'Scan the QR code to compare every Android installation option.',
+  ]
+
+  for (const content of rejected) assert.equal(hasFalseQrTargetClaim(content), true, content)
+  for (const content of accepted) assert.equal(hasFalseQrTargetClaim(content), false, content)
+})
+
+test('Settings QR descriptions use the canonical guide and never claim an APK target', () => {
+  for (const content of [siblingFaq, siblingGettingStarted, siblingGuideIndex]) {
+    assert.match(content, /https:\/\/docs\.silentsuite\.io\/user-guide\/apps\/android/)
+  }
+
+  for (const path of inventory) {
+    const content = read(path)
+    assert.equal(findFalseQrTargetClaim(content), undefined, path)
+  }
+})

--- a/apps/docs/user-guide/apps/android.md
+++ b/apps/docs/user-guide/apps/android.md
@@ -8,17 +8,15 @@ Once set up, your SilentSuite data syncs directly into Android's system calendar
 
 ## Install
 
-Choose the install channel you want to keep using for updates.
+Choose the install channel you want to keep using for updates. Google Play is
+the simplest option for most people, while Obtainium, Zapstore, and direct APK
+downloads keep independent distribution paths available.
 
 ### Option 1: Google Play
 
 [Download SilentSuite from Google Play](https://play.google.com/store/apps/details?id=io.silentsuite.android) if you want Play-managed installation and updates. If you installed SilentSuite from Google Play, keep updating it from Google Play.
 
-### Option 2: Zapstore
-
-[Download SilentSuite from Zapstore](https://zapstore.dev/apps/io.silentsuite.android) if you prefer an open app store that installs the signed APK and manages updates outside Google Play.
-
-### Option 3: Obtainium
+### Option 2: Obtainium
 
 [Obtainium](https://github.com/ImranR98/Obtainium) is an open-source Android app that installs and auto-updates apps directly from GitHub releases -- no Google Play, no tracking, no account needed.
 
@@ -29,6 +27,10 @@ Choose the install channel you want to keep using for updates.
    ```
 3. Obtainium will detect the latest SilentSuite release and install the APK. It will notify you whenever a new release is published.
 
+### Option 3: Zapstore
+
+[Download SilentSuite from Zapstore](https://zapstore.dev/apps/io.silentsuite.android) if you prefer an open app store that installs the signed APK and manages updates outside Google Play. Release timing can differ from GitHub Releases, so check the version shown before installing.
+
 ### Option 4: Direct APK download
 
 Grab the latest APK directly from GitHub Releases:
@@ -37,16 +39,22 @@ Grab the latest APK directly from GitHub Releases:
 
 Look for the asset named `silentsuite-android-vX.Y.Z-beta.apk` and install it. You'll need to allow installation from unknown sources the first time.
 
+### F-Droid status
+
+Official F-Droid publication is pending inclusion. SilentSuite is not yet
+available from the official F-Droid package index. Until that changes, use one
+of the available installation channels above.
+
 ### Certificate hashes and channel switching
 
-Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the developer-signed APK distributed through GitHub Releases, Zapstore, or a future F-Droid build.
 
 SilentSuite's known Android signing certificate SHA-256 hashes are:
 
 - **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
-- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+- **Developer-signed release certificate for GitHub Releases, Zapstore, and future reproducible F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
 
-If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching between Google Play and direct APK channels may require uninstalling and reinstalling the app. A certificate mismatch warning in that situation is expected and does not by itself indicate a compromised build.
+If you installed from Google Play, update through Google Play. If you installed from GitHub Releases or Zapstore, update through that same direct APK channel. When official F-Droid distribution becomes available, keep F-Droid installations on that channel. Switching between Google Play and developer-signed APK channels may require uninstalling and reinstalling the app. A certificate mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 
 ::: tip
 The SilentSuite Android app is a fork of the [EteSync Android app](https://github.com/etesync/android) with SilentSuite branding and `server.silentsuite.io` pre-configured as the default server. If you prefer, the original EteSync app from [Google Play](https://play.google.com/store/apps/details?id=com.etesync.syncadapter) or [F-Droid](https://f-droid.org/packages/com.etesync.syncadapter/) also works -- just enter the server URL manually.

--- a/apps/docs/user-guide/faq.md
+++ b/apps/docs/user-guide/faq.md
@@ -15,7 +15,7 @@ SilentSuite offers a hosted service with paid plans to fund development. Self-ho
 SilentSuite works across all major platforms:
 
 - **Web:** The web app is live at [app.silentsuite.io](https://app.silentsuite.io).
-- **Android:** A dedicated Android sync adapter is available from Google Play and direct APK channels such as [GitHub Releases](https://github.com/silent-suite/silentsuite/releases), Zapstore, and F-Droid.
+- **Android:** A dedicated Android sync adapter is available from Google Play, Obtainium, Zapstore, and [GitHub Releases](https://github.com/silent-suite/silentsuite/releases). Official F-Droid inclusion is pending.
 - **iOS:** Use the third-party [EteSync for iOS](https://apps.apple.com/app/etesync/id1489574285) app from the App Store. Enter your server URL during setup.
 - **Desktop:** Use the [SilentSuite Bridge](./apps/dav-bridge.md) with any CalDAV/CardDAV app (Thunderbird, macOS Calendar, GNOME Calendar, and more).
 
@@ -37,14 +37,14 @@ No. Your encryption keys are derived from your password, and the server never ha
 
 ### Why do I see a certificate mismatch when switching Android install channels?
 
-Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the developer-signed APK distributed through GitHub Releases, Zapstore, or a future F-Droid build.
 
 SilentSuite's known Android signing certificate SHA-256 hashes are:
 
 - **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
-- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+- **Developer-signed release certificate for GitHub Releases, Zapstore, and future reproducible F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
 
-If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching channels may require uninstalling and reinstalling the app. A certificate mismatch warning in that situation is expected and does not by itself indicate a compromised build.
+If you installed from Google Play, update through Google Play. If you installed from GitHub Releases or Zapstore, update through that same direct APK channel. When official F-Droid distribution becomes available, keep F-Droid installations on that channel. Switching channels may require uninstalling and reinstalling the app. A certificate mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 
 ## Self-Hosting
 

--- a/apps/web/app/(app)/settings/mobile/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/mobile/__tests__/page.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import MobileSettingsPage from '../page'
+
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value, className }: { value: string; className?: string }) => (
+    <svg data-testid="android-download-qr" data-value={value} className={className} />
+  ),
+}))
+
+describe('MobileSettingsPage Android download choices', () => {
+  it('offers active channels, a pending F-Droid state, and direct APK access', () => {
+    render(<MobileSettingsPage />)
+
+    expect(screen.getByRole('link', { name: /Google Play/i })).toHaveAttribute(
+      'href',
+      'https://play.google.com/store/apps/details?id=io.silentsuite.android',
+    )
+    expect(screen.getByRole('link', { name: /Obtainium/i })).toHaveAttribute(
+      'href',
+      'https://docs.silentsuite.io/user-guide/apps/android',
+    )
+    expect(screen.getByRole('link', { name: /Zapstore/i })).toHaveAttribute(
+      'href',
+      'https://zapstore.dev/apps/io.silentsuite.android',
+    )
+    expect(screen.getByText(/release timing may differ by channel/i)).toBeInTheDocument()
+    expect(screen.queryByText(/work the same across every channel/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /F-Droid/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('group', {
+      name: 'F-Droid, soon. Pending official inclusion',
+    })).toBeInTheDocument()
+    expect(screen.getByText('Soon')).toBeInTheDocument()
+    expect(screen.getByText(/Pending official inclusion/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Download the signed APK/i })).toHaveAttribute(
+      'href',
+      'https://github.com/silent-suite/silentsuite/releases/latest',
+    )
+  })
+
+  it('keeps one responsive QR code pointed at the canonical Android guide', () => {
+    render(<MobileSettingsPage />)
+
+    const qr = screen.getByTestId('android-download-qr')
+    expect(qr).toHaveAttribute('data-value', 'https://docs.silentsuite.io/user-guide/apps/android')
+    expect(qr.closest('[data-android-download-qr]')).toHaveClass('hidden', 'md:block')
+  })
+})

--- a/apps/web/app/(app)/settings/mobile/page.tsx
+++ b/apps/web/app/(app)/settings/mobile/page.tsx
@@ -1,85 +1,129 @@
 'use client'
 
-import { Smartphone, ExternalLink, Monitor } from 'lucide-react'
+import { Download, ExternalLink, Monitor, PackageCheck, RefreshCw, Store } from 'lucide-react'
 import Link from 'next/link'
 import { QRCodeSVG } from 'qrcode.react'
 
 const INSTALL_DOCS_URL = 'https://docs.silentsuite.io/user-guide/apps/android'
+const GOOGLE_PLAY_URL = 'https://play.google.com/store/apps/details?id=io.silentsuite.android'
+const ZAPSTORE_URL = 'https://zapstore.dev/apps/io.silentsuite.android'
 const RELEASES_URL = 'https://github.com/silent-suite/silentsuite/releases/latest'
+
+const activeChannels = [
+  {
+    name: 'Google Play',
+    detail: 'Install and update through Google Play',
+    href: GOOGLE_PLAY_URL,
+    icon: PackageCheck,
+  },
+  {
+    name: 'Obtainium',
+    detail: 'Receive updates from GitHub Releases',
+    href: INSTALL_DOCS_URL,
+    icon: RefreshCw,
+  },
+  {
+    name: 'Zapstore',
+    detail: 'Open app store; releases may arrive later',
+    href: ZAPSTORE_URL,
+    icon: Store,
+  },
+]
 
 export default function MobileSettingsPage() {
   return (
     <div className="space-y-6">
       <div className="space-y-2">
         <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">
-          Connect Mobile
+          Get SilentSuite for Android
         </h2>
         <p className="text-sm text-[rgb(var(--muted))]">
-          Access your encrypted calendar, tasks, and contacts on your phone.
+          Choose how you install and receive updates. Every option uses
+          SilentSuite&apos;s encrypted sync model, but release timing may differ by channel.
         </p>
       </div>
 
-      {/* QR Code section */}
-      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-6">
-        <div className="flex flex-col items-center gap-4">
-          <div className="flex h-48 w-48 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-white p-3">
-            <QRCodeSVG
-              value={INSTALL_DOCS_URL}
-              size={168}
-              level="M"
-              marginSize={0}
-              aria-label="QR code linking to the Android install guide"
-            />
-          </div>
-          <p className="text-sm text-[rgb(var(--foreground))] font-medium">
-            Scan with your phone camera
-          </p>
-          <p className="text-xs text-[rgb(var(--muted))] text-center">
-            The QR code opens the install guide with options for Obtainium (auto-updates) or a direct APK download.
-          </p>
-          <a
-            href={RELEASES_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-[rgb(var(--primary))] hover:underline"
+      <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_13rem] md:items-center">
+        <div className="grid gap-3 sm:grid-cols-2">
+          {activeChannels.map(({ name, detail, href, icon: Icon }) => (
+            <a
+              key={name}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex min-h-28 items-center gap-3 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 transition-colors hover:border-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700 dark:hover:border-emerald-300 dark:focus-visible:ring-emerald-300"
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-700 text-white dark:bg-emerald-400 dark:text-slate-950">
+                <Icon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-semibold text-[rgb(var(--foreground))]">{name}</span>
+                <span className="mt-1 block text-xs leading-relaxed text-[rgb(var(--muted))]">{detail}</span>
+              </span>
+              <ExternalLink className="h-4 w-4 shrink-0 text-[rgb(var(--muted))] group-hover:text-emerald-700 dark:group-hover:text-emerald-300" aria-hidden="true" />
+            </a>
+          ))}
+
+          <div
+            role="group"
+            aria-disabled="true"
+            aria-label="F-Droid, soon. Pending official inclusion"
+            className="flex min-h-28 items-center gap-3 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4"
           >
-            Or jump straight to GitHub Releases
-          </a>
-        </div>
-      </div>
-
-      {/* Manual setup */}
-      <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-4">
-        <div className="flex items-center gap-3">
-          <Smartphone className="h-5 w-5 text-[rgb(var(--primary))]" />
-          <div>
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Manual setup</p>
-            <p className="text-xs text-[rgb(var(--muted))]">
-              Follow the documentation to set up the mobile app manually
-            </p>
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] text-[rgb(var(--muted))]">
+              <Download className="h-5 w-5" aria-hidden="true" />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-semibold text-[rgb(var(--muted))]">F-Droid</span>
+                <span className="rounded-full bg-[rgb(var(--border))] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[rgb(var(--foreground))]">Soon</span>
+              </span>
+              <span className="mt-1 block text-xs leading-relaxed text-[rgb(var(--muted))]">Pending official inclusion</span>
+            </span>
           </div>
         </div>
 
-        <div className="flex flex-col gap-2">
+        <div data-android-download-qr className="hidden md:block">
           <a
             href={INSTALL_DOCS_URL}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center justify-center gap-2 rounded-lg bg-[rgb(var(--primary))] px-4 py-2.5 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors"
+            className="block rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 text-center transition-colors hover:border-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700 dark:hover:border-emerald-300 dark:focus-visible:ring-emerald-300"
+            aria-label="Open Android installation options"
           >
-            <ExternalLink className="h-4 w-4" />
-            View setup instructions
-          </a>
-          <a
-            href="https://docs.silentsuite.io"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center gap-2 rounded-lg border border-[rgb(var(--border))] px-4 py-2.5 text-sm font-medium text-[rgb(var(--foreground))] hover:bg-[rgb(var(--surface))] transition-colors"
-          >
-            Read the full documentation
+            <span className="mx-auto flex w-fit rounded-lg bg-white p-2">
+              <QRCodeSVG
+                value={INSTALL_DOCS_URL}
+                size={144}
+                level="M"
+                marginSize={0}
+                aria-label="QR code linking to Android installation options"
+              />
+            </span>
+            <span className="mt-3 block text-xs font-medium text-[rgb(var(--foreground))]">Scan for every option</span>
           </a>
         </div>
       </div>
+
+      <p className="text-sm text-[rgb(var(--muted))]">
+        <span className="font-medium text-[rgb(var(--foreground))]">Prefer a manual install?</span>{' '}
+        <a
+          href={RELEASES_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-emerald-700 hover:underline dark:text-emerald-300"
+        >
+          Download the signed APK from GitHub Releases.
+        </a>{' '}
+        <a
+          href={INSTALL_DOCS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="whitespace-nowrap text-[rgb(var(--foreground))] hover:underline"
+        >
+          Installation help
+        </a>
+      </p>
 
       {/* Supported platforms */}
       <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 space-y-3">
@@ -87,7 +131,7 @@ export default function MobileSettingsPage() {
         <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
           <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3 text-center">
             <p className="text-sm font-medium text-[rgb(var(--foreground))]">Android</p>
-            <p className="text-xs text-[rgb(var(--primary))]">Available now</p>
+            <p className="text-xs font-medium text-emerald-700 dark:text-emerald-300">Available now</p>
           </div>
           <div className="rounded-md border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3 text-left space-y-1">
             <p className="text-sm font-medium text-[rgb(var(--foreground))] text-center">iOS</p>

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,6 +1,6 @@
 # User Guide
 
-How to use SilentSuite — your end-to-end encrypted sync for calendar, contacts, and tasks. Everything in this guide is grounded in what's actually shipped in [v0.1.0-beta](https://github.com/silent-suite/silentsuite/releases/tag/v0.1.0-beta).
+How to use SilentSuite: your end-to-end encrypted sync for calendar, contacts, and tasks. Everything in this guide is grounded in the current beta. See the [latest release](https://github.com/silent-suite/silentsuite/releases/latest) for version-specific details.
 
 ---
 
@@ -32,6 +32,6 @@ Your Device          SilentSuite Server          Your Other Device
 ## Where to Use SilentSuite
 
 - **Web** — [app.silentsuite.io](https://app.silentsuite.io) (offline-first PWA, installable to any desktop or mobile home screen)
-- **Android** — signed APK, sideloadable. QR-code download in *Settings → Mobile* once you're signed in
+- **Android:** Install through Google Play, Obtainium, Zapstore, or a signed APK from GitHub Releases. In *Settings → Mobile*, the QR code opens the [Android installation guide](https://docs.silentsuite.io/user-guide/apps/android), and a separate link opens the latest signed APK. Official F-Droid inclusion is pending.
 - **Desktop (CalDAV / CardDAV)** — the SilentSuite bridge runs a local DAV daemon for Thunderbird, Apple Calendar, Evolution, GNOME Calendar, etc. Install commands in *Settings → Desktop*
 - **iOS** — no native app yet; the [EteSync iOS app](https://www.etesync.com/) works against your silentsuite.io or self-hosted account in the meantime

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -8,10 +8,10 @@ A privacy-focused, end-to-end encrypted sync service for calendar, contacts, and
 
 ### What's available right now?
 
-The v0.1.0-beta release covers:
+The current beta covers:
 
 - **Web app** at [app.silentsuite.io](https://app.silentsuite.io) — calendar, contacts, tasks, import/export, settings, admin
-- **Android** — Google Play plus signed APK channels such as GitHub Releases, Zapstore, and F-Droid
+- **Android** — Google Play, Obtainium, Zapstore, and signed APKs from GitHub Releases. Official F-Droid inclusion is pending.
 - **Desktop bridge** — CalDAV/CardDAV bridge for Thunderbird, Apple Calendar, Evolution, etc., on Linux / macOS / Windows
 - **Self-hosting** — two-container Docker stack (PostgreSQL + SilentSuite server)
 
@@ -72,16 +72,16 @@ No — an account belongs to a single server. Pick one when you sign up. To migr
 Use the same channel for install and updates:
 
 - **Google Play** - recommended if you installed from Play and want Play-managed updates.
-- **GitHub Releases / Zapstore / F-Droid** - direct APK channels for sideloading and open app-store distribution. To get the direct APK, sign in to [app.silentsuite.io](https://app.silentsuite.io) on a device with a screen, open *Settings → Mobile*, and either scan the QR code or use the direct download link to the latest GitHub Release.
+- **Obtainium / Zapstore / GitHub Releases** - independent channels for open app-store installation, GitHub-managed updates, or direct APK downloads. In *Settings → Mobile*, the QR code opens the [Android installation guide](https://docs.silentsuite.io/user-guide/apps/android), while the separate APK link opens the latest GitHub Release. Official F-Droid inclusion is pending.
 
 ### Why do I see a certificate mismatch when switching Android install channels?
 
-Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the direct APK published through GitHub Releases, Zapstore, or F-Droid.
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. Google Play uses Play App Signing, so the APK installed from Play can have a different certificate than the developer-signed APK distributed through GitHub Releases, Zapstore, or a future F-Droid build.
 
 SilentSuite's known Android signing certificate SHA-256 hashes are:
 
 - **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
-- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+- **Developer-signed release certificate for GitHub Releases, Zapstore, and future reproducible F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
 
 If you installed from Google Play, update through Google Play. If you installed from a direct APK channel, update through that same channel. Switching channels may require uninstalling and reinstalling the app. A mismatch warning in that situation is expected and does not by itself indicate a compromised build.
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -38,14 +38,14 @@ Open [app.silentsuite.io](https://app.silentsuite.io/login) on the second device
 Install SilentSuite from the channel you want to keep using for updates:
 
 - **Google Play** - use the Play listing if you installed from Play or want Play-managed updates.
-- **GitHub Releases / Zapstore / F-Droid** - use these direct APK channels if you prefer sideloading or open app-store distribution. In **Settings → Mobile** there is a QR code that links to the latest signed APK on GitHub Releases.
+- **Obtainium / Zapstore / GitHub Releases** - use these independent channels if you prefer GitHub-managed updates, open app-store distribution, or a direct APK. In **Settings → Mobile**, the QR code opens the [Android installation guide](https://docs.silentsuite.io/user-guide/apps/android), while the separate APK link opens the latest GitHub Release. Official F-Droid inclusion is pending.
 
-Android only allows an app update when the installed app and the update APK are signed with the same certificate. If you installed from Google Play, update through Google Play. If you installed from GitHub Releases, Zapstore, or F-Droid, update through that same direct APK channel. Switching between Google Play and direct APK channels may require uninstalling and reinstalling the app.
+Android only allows an app update when the installed app and the update APK are signed with the same certificate. If you installed from Google Play, update through Google Play. If you installed from GitHub Releases or Zapstore, update through that same developer-signed APK channel. When official F-Droid distribution becomes available, keep F-Droid installations on that channel. Switching between Google Play and developer-signed APK channels may require uninstalling and reinstalling the app.
 
 SilentSuite's known Android signing certificate SHA-256 hashes are:
 
 - **Google Play app signing certificate:** `2e10d9ef90276e755bddf086391d7e0c933589c6d36e4e43fae59a7babcb8a49`
-- **Direct APK release certificate for GitHub Releases, Zapstore, and reproducible/developer-signed F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
+- **Developer-signed release certificate for GitHub Releases, Zapstore, and future reproducible F-Droid builds:** `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`
 
 A certificate mismatch warning while switching install channels is expected and does not by itself indicate a compromised build. The Android app supports a custom server URL in advanced settings if you self-host.
 


### PR DESCRIPTION
## Summary

- present Google Play, Obtainium, Zapstore, pending F-Droid, and direct signed APK choices consistently in Settings → Mobile
- update README and hosted/sibling Android documentation with accurate channel status, signing behavior, Zapstore timing caveat, and canonical QR destination
- add rendered Settings coverage plus an inventory-wide Android distribution documentation contract
- enforce the documentation contract in CI and docs preview/deploy workflows

## Channel truth

- Google Play: available
- Obtainium: available through the canonical Android guide
- Zapstore: linked with an explicit note that releases may arrive later
- F-Droid: visible as pending official inclusion, never presented as currently installable
- Direct APK: latest signed APK from GitHub Releases
- QR: opens the canonical Android installation guide, not a store or APK directly

## Verification

- `pnpm run test 'app/(app)/settings/mobile/__tests__/page.test.tsx'` (2/2)
- full web suite (734/734)
- web typecheck and production build
- `pnpm run test:android-distribution` (5/5 mutation and recursive-inventory contracts)
- docs VitePress build
- workflow YAML parse
- `git diff --check`
- all active destinations returned HTTP 200; official F-Droid package API returned 404

## Review

Independent substantive review: **APPROVE** on commit `76680f26ae7b58d3d3fc927f121d3fcb7b6c1b17` after resolving cross-channel parity, stale sibling documentation, QR-target, and documentation-contract findings.

## Merge order

Recommended to merge this public docs/settings PR before companion landing PR https://github.com/silent-suite/silentsuite-internal/pull/304 so the canonical guide is truthful before the landing page promotes it.
