### PR TITLE
Docs: clarify current iOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SilentSuite encrypts calendar events, contacts, and tasks on your device before 
 | **Android** | Sync through Android's calendar, contacts, and task providers |
 | **Desktop** | Local CalDAV/CardDAV Bridge for compatible calendar and address-book apps |
 | **Self-hosting** | Open-source server deployment on infrastructure you control |
-| **iOS** | EteSync's compatible open-source client while a native SilentSuite app is not available |
+| **iOS** | A native SilentSuite app is in development; EteSync for iOS is not a supported or working SilentSuite client |
 
 Built on the open [Etebase protocol](https://www.etebase.com/) and the EteSync open-source lineage.
 

--- a/apps/docs/user-guide/apps/index.md
+++ b/apps/docs/user-guide/apps/index.md
@@ -1,6 +1,6 @@
 # Apps & Integrations
 
-SilentSuite is built on the [Etebase protocol](https://www.etebase.com/), which means your encrypted data works with a growing ecosystem of compatible apps. You can sync your calendar, contacts, and tasks with native apps on every major platform.
+SilentSuite is built on the [Etebase protocol](https://www.etebase.com/). You can sync your encrypted data with the supported SilentSuite and third-party apps listed below.
 
 ## How It Works
 
@@ -12,6 +12,7 @@ The hosted server at `server.silentsuite.io` (or your self-hosted URL) speaks th
 |---|---|---|
 | [SilentSuite Web](https://app.silentsuite.io) | Browser | Contacts, Calendars, Tasks |
 | [SilentSuite for Android](./android.md) | Android | Contacts, Calendars, Tasks |
+| [SilentSuite for iOS](./ios.md) | iOS | In development |
 
 ## Compatible Third-Party Apps
 
@@ -19,7 +20,6 @@ These apps connect directly to `server.silentsuite.io` or your self-hosted serve
 
 | App | Platform | Syncs |
 |---|---|---|
-| [EteSync for iOS](./ios.md) (third-party) | iOS | Contacts, Calendars, Reminders |
 | [Tasks.org](./tasks-org.md) | Android | Tasks |
 | [GNOME Evolution](./evolution.md) | Linux (GNOME) | Contacts, Calendars, Tasks |
 | [GNOME Calendar, Contacts & To Do](./evolution.md) | Linux (GNOME) | Contacts, Calendars, Tasks |

--- a/apps/docs/user-guide/apps/ios.md
+++ b/apps/docs/user-guide/apps/ios.md
@@ -1,59 +1,9 @@
-# iOS Calendar & Contacts
+# SilentSuite for iOS
 
-Sync your SilentSuite calendar, contacts, and reminders with the native iOS apps.
+A native SilentSuite iOS app is in development. The EteSync iOS app is not currently a supported or working SilentSuite client, so do not use its setup instructions with a hosted or self-hosted SilentSuite account.
 
-## Install
+## What works today
 
-Install the **EteSync** app from the [App Store](https://apps.apple.com/app/etesync/id1489574285).
+You can use the [SilentSuite web app](https://app.silentsuite.io) in a browser on iPhone or iPad. This does not sync SilentSuite data into the native iOS Calendar, Contacts, or Reminders apps.
 
-## Set Up
-
-1. Open the **EteSync** app.
-2. Tap **Advanced Settings** to reveal the server URL field.
-3. Enter your server URL:
-   - Hosted: `https://server.silentsuite.io`
-   - Self-hosted: `https://sync.your-domain.com`
-4. Enter your **username** (email) and **password**.
-5. Tap **Log in**.
-
-## Important: iOS Sync Limitation
-
-iOS does not allow third-party apps to create new calendar or contact accounts directly. To sync with iOS Calendar, Contacts, and Reminders, you need to either:
-
-### Option A: Disable iCloud for these services
-
-1. Go to **Settings > [your name] > iCloud**.
-2. Turn off **Calendars**, **Contacts**, and **Reminders**.
-3. When prompted, choose **Keep on My iPhone**.
-4. Open the EteSync app and sync. Your data will appear in the native apps.
-
-### Option B: Create a local DAV account (workaround)
-
-If you want to keep iCloud enabled alongside EteSync:
-
-1. Go to **Settings > Calendar > Accounts > Add Account > Other**.
-2. Tap **Add CalDAV Account**.
-3. Enter:
-   - Server: `localhost`
-   - Username: `aaaaa`
-   - Password: `aaaaa`
-   - Description: `etesync` (this exact text is required)
-4. Tap **Save** (ignore any SSL/verification errors).
-5. Open the EteSync app and sync.
-
-## Sync History Limit
-
-By default, iOS only syncs calendar events from the last 30 days. To change this:
-
-1. Go to **Settings > Calendar > Sync**.
-2. Select **All Events** (or your preferred range).
-
-## Troubleshooting
-
-### Events not appearing in iOS Calendar
-
-Make sure the EteSync calendars are enabled in iOS Calendar. Open Calendar, tap **Calendars** at the bottom, and check that the EteSync calendars are ticked.
-
-### Contacts not appearing
-
-If using the iCloud workaround (Option B), make sure the local account's contacts are enabled in **Settings > Contacts > Accounts**.
+On a Mac, the [SilentSuite DAV Bridge](./dav-bridge.md) connects supported desktop apps such as Apple Calendar and Contacts. The Bridge is a desktop option and does not run on iPhone or iPad.

--- a/apps/docs/user-guide/faq.md
+++ b/apps/docs/user-guide/faq.md
@@ -12,11 +12,11 @@ SilentSuite offers a hosted service with paid plans to fund development. Self-ho
 
 ### What platforms are supported?
 
-SilentSuite works across all major platforms:
+SilentSuite currently supports these platforms and access paths:
 
 - **Web:** The web app is live at [app.silentsuite.io](https://app.silentsuite.io).
 - **Android:** A dedicated Android sync adapter is available from Google Play, Obtainium, Zapstore, and [GitHub Releases](https://github.com/silent-suite/silentsuite/releases). Official F-Droid inclusion is pending.
-- **iOS:** Use the third-party [EteSync for iOS](https://apps.apple.com/app/etesync/id1489574285) app from the App Store. Enter your server URL during setup.
+- **iOS:** A native SilentSuite app is in development. EteSync for iOS is not a supported or working SilentSuite client. You can use the web app in an iOS browser, but it does not sync with native iOS Calendar, Contacts, or Reminders.
 - **Desktop:** Use the [SilentSuite Bridge](./apps/dav-bridge.md) with any CalDAV/CardDAV app (Thunderbird, macOS Calendar, GNOME Calendar, and more).
 
 ## Privacy & Security

--- a/apps/docs/user-guide/getting-started.md
+++ b/apps/docs/user-guide/getting-started.md
@@ -17,7 +17,7 @@ Your password is used to derive your encryption keys locally on your device. It 
 
 After creating your account, you can use SilentSuite immediately in the web app. Add calendar events, contacts, and tasks right from your browser.
 
-To sync with other apps and devices, see the [Apps & Integrations](./apps/index.md) page for setup guides covering Android, iOS (via EteSync), desktop apps, and more.
+To sync with other apps and devices, see the [Apps & Integrations](./apps/index.md) page for supported Android and desktop setup guides and the current iOS development status.
 
 ## 3. Add Your Data
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -34,4 +34,4 @@ Your Device          SilentSuite Server          Your Other Device
 - **Web** — [app.silentsuite.io](https://app.silentsuite.io) (offline-first PWA, installable to any desktop or mobile home screen)
 - **Android:** Install through Google Play, Obtainium, Zapstore, or a signed APK from GitHub Releases. In *Settings → Mobile*, the QR code opens the [Android installation guide](https://docs.silentsuite.io/user-guide/apps/android), and a separate link opens the latest signed APK. Official F-Droid inclusion is pending.
 - **Desktop (CalDAV / CardDAV)** — the SilentSuite bridge runs a local DAV daemon for Thunderbird, Apple Calendar, Evolution, GNOME Calendar, etc. Install commands in *Settings → Desktop*
-- **iOS** — no native app yet; the [EteSync iOS app](https://www.etesync.com/) works against your silentsuite.io or self-hosted account in the meantime
+- **iOS** — a native SilentSuite app is in development; EteSync for iOS is not a supported or working SilentSuite client

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -21,7 +21,7 @@ See the [v0.1.0-beta release notes](https://github.com/silent-suite/silentsuite/
 
 On the roadmap, not yet shipped:
 
-- Native iOS app (the [EteSync iOS app](https://www.etesync.com/) works against your account in the meantime — same Etebase protocol)
+- Native iOS app. It is in development; EteSync for iOS is not a supported or working SilentSuite client.
 - OAuth-based one-click import from Google / iCloud
 - Push notifications
 - Multiple collections per account ([#88](https://github.com/silent-suite/silentsuite/issues/88))

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -59,7 +59,7 @@ Install commands are in **Settings → Desktop** in the web app.
 
 ### iOS
 
-There's no SilentSuite iOS app yet (on the roadmap). In the meantime, the [EteSync iOS app](https://www.etesync.com/) speaks the same Etebase protocol and works against your silentsuite.io or self-hosted account.
+A native SilentSuite iOS app is in development. EteSync for iOS is not a supported or working SilentSuite client. You can use the SilentSuite web app in an iOS browser, but it does not sync with native iOS Calendar, Contacts, or Reminders.
 
 ## 4. Confirm Sync Works
 


### PR DESCRIPTION
## Summary

- clarify that EteSync for iOS is not a supported or working SilentSuite client
- replace the obsolete EteSync install guide with the current native-app development status
- correct matching iOS claims across the public documentation copies

## Verification

- `cd apps/docs && pnpm run build`
- stale-claim search across `README.md`, `apps/docs/user-guide`, and `docs/user-guide`
- `git diff --check`
- docs-only changed-file check

Closes #490
