### PR TITLE
Docs: correct iOS sidebar label

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -54,7 +54,7 @@ export default defineConfig({
           items: [
             { text: 'Overview', link: '/user-guide/apps/' },
             { text: 'Android', link: '/user-guide/apps/android' },
-            { text: 'iOS (EteSync)', link: '/user-guide/apps/ios' },
+            { text: 'iOS', link: '/user-guide/apps/ios' },
             { text: 'Tasks.org', link: '/user-guide/apps/tasks-org' },
             { text: 'GNOME Evolution', link: '/user-guide/apps/evolution' },
             { text: 'KDE Kontact', link: '/user-guide/apps/kde' },


### PR DESCRIPTION
## Summary

- rename the docs sidebar entry from `iOS (EteSync)` to `iOS`
- align deployed navigation with the corrected iOS status page from #590

## Verification

- `cd apps/docs && pnpm run build`
- exact stale sidebar-label search
- `git diff --check`
- deployed-preview inspection identified this remaining label

Follow-up for #490.
