### PR TITLE
docs: add Apps & Integrations to the homepage

### DIFF
--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -28,4 +28,8 @@ features:
     title: Contributing
     details: Set up a development environment, understand the architecture, and contribute to SilentSuite.
     link: /contributing/dev-setup
+  - icon: 🔌
+    title: Apps & Integrations
+    details: Set up Android, iOS, desktop apps, Tasks.org, and DAV bridge clients.
+    link: /user-guide/apps/
 ---


### PR DESCRIPTION
## Summary

- add an Apps & Integrations card to the docs homepage
- link the card to the existing app and integration setup index
- preserve the existing User Guide, Self-Hosting, and Contributing cards

## Verification

- `vitepress build apps/docs`
- verified the generated homepage contains the card text and `/user-guide/apps/` link
- verified the destination route generates as `user-guide/apps/index.html`

Closes #432
