### PR TITLE
docs: remove private landing app from setup tree

### DIFF
--- a/apps/docs/contributing/dev-setup.md
+++ b/apps/docs/contributing/dev-setup.md
@@ -40,7 +40,6 @@ SilentSuite is a pnpm monorepo managed by Turborepo:
 ```
 silentsuite/
   apps/
-    landing/         # Landing page and blog (Next.js)
     web/             # Main web application (Next.js)
     docs/            # Documentation (you are here)
   android/           # Kotlin Android sync adapter


### PR DESCRIPTION
## Summary

- remove the private landing app from the public monorepo structure example
- preserve the remaining public app and repository paths
- avoid adding private repository paths or internal details

## Verification

- `vitepress build apps/docs`
- verified the rendered development setup page no longer contains `landing/`
- verified the public `web/` and `docs/` entries remain

Closes #434
