### PR TITLE
fix: keep signed APK secondary in Android docs

### DIFF
--- a/apps/docs/.vitepress/theme/custom.css
+++ b/apps/docs/.vitepress/theme/custom.css
@@ -139,6 +139,58 @@
   opacity: 0.72;
 }
 
+.android-channel-secondary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: -0.75rem 0 2rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.875rem;
+}
+
+.android-channel-secondary-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  color: var(--vp-c-text-1) !important;
+  text-decoration: none !important;
+  background: var(--vp-c-bg-soft);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 0.625rem;
+}
+
+.android-channel-secondary-link:hover {
+  border-color: var(--vp-c-brand-3);
+}
+
+.android-channel-secondary-link:focus-visible {
+  outline: 2px solid var(--vp-c-brand-3);
+  outline-offset: 2px;
+}
+
+.dark .android-channel-secondary-link:hover {
+  border-color: var(--vp-c-brand-1);
+}
+
+.dark .android-channel-secondary-link:focus-visible {
+  outline-color: var(--vp-c-brand-1);
+}
+
+.android-channel-secondary .android-channel-logo {
+  width: 2rem;
+  height: 2rem;
+  flex-basis: 2rem;
+  padding: 0.3rem;
+  border-radius: 0.45rem;
+}
+
+.android-channel-secondary .android-channel-logo img {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 .android-channel-status {
   display: inline-flex;
   width: fit-content;

--- a/apps/docs/scripts/android-distribution.test.mjs
+++ b/apps/docs/scripts/android-distribution.test.mjs
@@ -195,6 +195,8 @@ test('hosted Android guide exposes direct logo buttons for every distribution st
   assert.match(hostedAndroid, /href="obtainium:\/\/add\/https:\/\/github\.com\/silent-suite\/silentsuite"/)
   assert.match(hostedAndroid, /href="https:\/\/zapstore\.dev\/apps\/io\.silentsuite\.android"/)
   assert.match(hostedAndroid, /href="https:\/\/github\.com\/silent-suite\/silentsuite\/releases\/latest"/)
+  assert.doesNotMatch(hostedAndroid, /class="android-channel-button"[^>]*href="https:\/\/github\.com\/silent-suite\/silentsuite\/releases\/latest"/)
+  assert.match(hostedAndroid, /class="android-channel-secondary-link"[^>]*href="https:\/\/github\.com\/silent-suite\/silentsuite\/releases\/latest"/)
   assert.match(hostedAndroid, /class="android-channel-button is-pending"[^>]*aria-label="F-Droid, on the roadmap, pending official inclusion"/)
 })
 

--- a/apps/docs/user-guide/apps/android.md
+++ b/apps/docs/user-guide/apps/android.md
@@ -25,14 +25,18 @@ downloads keep independent distribution paths available.
     <span class="android-channel-logo"><img src="/channel-icons/zapstore.png" alt="" aria-hidden="true"></span>
     <span class="android-channel-copy"><strong>Zapstore</strong><small>Independent app-store updates</small></span>
   </a>
-  <a class="android-channel-button" href="https://github.com/silent-suite/silentsuite/releases/latest" target="_blank" rel="noopener noreferrer">
-    <span class="android-channel-logo"><img src="/channel-icons/github.svg" alt="" aria-hidden="true"></span>
-    <span class="android-channel-copy"><strong>Direct signed APK</strong><small>Latest GitHub release</small></span>
-  </a>
   <div class="android-channel-button is-pending" role="group" aria-label="F-Droid, on the roadmap, pending official inclusion">
     <span class="android-channel-logo"><img src="/channel-icons/fdroid.png" alt="" aria-hidden="true"></span>
     <span class="android-channel-copy"><strong>F-Droid</strong><small>Pending official inclusion</small><span class="android-channel-status">On the roadmap</span></span>
   </div>
+</div>
+
+<div class="android-channel-secondary">
+  <span>Prefer a signed APK?</span>
+  <a class="android-channel-secondary-link" href="https://github.com/silent-suite/silentsuite/releases/latest" target="_blank" rel="noopener noreferrer">
+    <span class="android-channel-logo"><img src="/channel-icons/github.svg" alt="" aria-hidden="true"></span>
+    <strong>Direct signed APK</strong>
+  </a>
 </div>
 
 ### Option 1: Google Play


### PR DESCRIPTION
## Summary
- keep managed Android channels in the primary docs grid
- move the logo-backed GitHub signed APK into a compact secondary control
- add hierarchy and focus-state regression coverage

## Verification
- `pnpm test:android-distribution` (8/8)
- `pnpm build`
- `git diff --check origin/dev`

Targets `dev`.