### PR TITLE
fix(web): keep Android QR square

### DIFF
--- a/apps/web/app/(app)/settings/mobile/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/mobile/__tests__/page.test.tsx
@@ -77,6 +77,7 @@ describe('MobileSettingsPage Android download choices', () => {
     const qr = screen.getByTestId('android-download-qr')
     expect(qr).toHaveAttribute('data-value', 'https://docs.silentsuite.io/user-guide/apps/android')
     expect(qr).toHaveAttribute('data-size', '144')
+    expect(qr.parentElement).toHaveClass('h-40', 'w-40', 'p-[7px]')
     expect(qr.closest('[data-android-download-qr]')).toHaveClass(
       'hidden',
       'lg:flex',

--- a/apps/web/app/(app)/settings/mobile/page.tsx
+++ b/apps/web/app/(app)/settings/mobile/page.tsx
@@ -116,7 +116,7 @@ export default function MobileSettingsPage() {
             className={`${channelCardClass} w-full flex-col justify-center text-center transition-colors hover:border-emerald-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700 dark:hover:border-emerald-300 dark:focus-visible:ring-emerald-300`}
             aria-label="Open Android installation options"
           >
-            <span className="flex h-40 w-40 shrink-0 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-white p-2">
+            <span className="flex h-40 w-40 shrink-0 items-center justify-center rounded-lg border border-[rgb(var(--border))] bg-white p-[7px]">
               <QRCodeSVG
                 value={INSTALL_DOCS_URL}
                 size={144}


### PR DESCRIPTION
## Summary
- preserve the Settings → Mobile QR SVG at a square rendered 144×144px inside its bordered 160px wrapper
- add a focused regression for the padding geometry

## Browser finding
Post-merge `dev` QA of #601 measured the SVG at 142×144px because the 160px wrapper's border plus 8px padding left only 142px of horizontal content space. Reducing padding to 7px preserves the intended 144px square without changing the card or wrapper dimensions.

## Verification
- RED: focused Settings test failed on `p-2` versus required `p-[7px]`
- GREEN: `pnpm --filter @silentsuite/web exec vitest run 'app/(app)/settings/mobile/__tests__/page.test.tsx'`
- `pnpm --filter @silentsuite/web type-check`
- `pnpm --filter @silentsuite/web build`
- `git diff --check`

Follow-up to #601.
