### PR TITLE
fix(bridge): require verified Unix installer downloads

### DIFF
--- a/bridge/install.sh
+++ b/bridge/install.sh
@@ -17,7 +17,12 @@
 
 set -e
 
-cleanup() { rm -f "$TMP_FILE"; }
+TMP_FILE=""
+TMP_CHECKSUM=""
+cleanup() {
+    [ -z "$TMP_FILE" ] || rm -f "$TMP_FILE"
+    [ -z "$TMP_CHECKSUM" ] || rm -f "$TMP_CHECKSUM"
+}
 trap cleanup EXIT
 
 # --- Configuration ---
@@ -122,33 +127,56 @@ install_binary() {
         wget -qO "$TMP_FILE" "$DOWNLOAD_URL"
     fi
 
-    # Verify checksum if available
+    # Verification is mandatory. Never install a binary when the verifier or
+    # release sidecar is unavailable, ambiguous, malformed, or mismatched.
     CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
     if command -v sha256sum >/dev/null 2>&1; then
         SHA256CMD="sha256sum"
     elif command -v shasum >/dev/null 2>&1; then
         SHA256CMD="shasum -a 256"
     else
-        SHA256CMD=""
+        error "No supported SHA-256 verifier found. Install sha256sum or shasum and retry."
     fi
 
-    if [ -n "$SHA256CMD" ]; then
-        if command -v curl >/dev/null 2>&1; then
-            EXPECTED_HASH=$(curl -fsSL "$CHECKSUM_URL" 2>/dev/null | awk '{print $1}' || true)
-        else
-            EXPECTED_HASH=$(wget -qO- "$CHECKSUM_URL" 2>/dev/null | awk '{print $1}' || true)
-        fi
-        if [ -n "$EXPECTED_HASH" ]; then
-            ACTUAL_HASH=$($SHA256CMD "$TMP_FILE" | awk '{print $1}')
-            if [ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]; then
-                rm -f "$TMP_FILE"
-                error "Checksum mismatch! Download may be corrupted."
-            fi
-            info "Checksum verified"
-        fi
+    TMP_CHECKSUM=$(mktemp)
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$CHECKSUM_URL" -o "$TMP_CHECKSUM" || error "Could not download the release checksum; refusing to install an unverified binary."
+    else
+        wget -qO "$TMP_CHECKSUM" "$CHECKSUM_URL" || error "Could not download the release checksum; refusing to install an unverified binary."
     fi
+
+    if [ "$(tail -c 1 "$TMP_CHECKSUM" | wc -l | tr -d '[:space:]')" != "1" ]; then
+        error "Invalid checksum content; expected a newline-terminated checksum line."
+    fi
+
+    EXPECTED_HASH=$(awk -v expected_name="$ASSET_NAME" '
+        {
+            lines += 1
+            if (
+                NF == 2
+                && length($1) == 64
+                && $1 ~ /^[0-9A-Fa-f]+$/
+                && $2 == expected_name
+                && $0 == $1 "  " expected_name
+            ) hash = tolower($1)
+            else invalid = 1
+        }
+        END {
+            if (lines == 1 && !invalid && hash != "") print hash
+        }
+    ' "$TMP_CHECKSUM")
+    if [ -z "$EXPECTED_HASH" ]; then
+        error "Invalid checksum content; expected one SHA-256 checksum line."
+    fi
+
+    ACTUAL_HASH=$($SHA256CMD "$TMP_FILE" | awk 'NR == 1 { print tolower($1) }')
+    if [ -z "$ACTUAL_HASH" ] || [ "$EXPECTED_HASH" != "$ACTUAL_HASH" ]; then
+        error "Checksum mismatch! Download may be corrupted."
+    fi
+    info "Checksum verified"
 
     mv "$TMP_FILE" "${INSTALL_DIR}/${BINARY_NAME}"
+    TMP_FILE=""
     chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
 
     # macOS: remove quarantine flag so Gatekeeper doesn't block the binary

--- a/bridge/install.sh
+++ b/bridge/install.sh
@@ -152,13 +152,7 @@ install_binary() {
     EXPECTED_HASH=$(awk -v expected_name="$ASSET_NAME" '
         {
             lines += 1
-            if (
-                NF == 2
-                && length($1) == 64
-                && $1 ~ /^[0-9A-Fa-f]+$/
-                && $2 == expected_name
-                && $0 == $1 "  " expected_name
-            ) hash = tolower($1)
+            if (NF == 2 && length($1) == 64 && $1 ~ /^[0-9A-Fa-f]+$/ && $2 == expected_name && $0 == $1 "  " expected_name) hash = tolower($1)
             else invalid = 1
         }
         END {

--- a/bridge/tests/test_unix_installer.py
+++ b/bridge/tests/test_unix_installer.py
@@ -45,7 +45,7 @@ while [ "$#" -gt 0 ]; do
 done
 case "$url" in
     *api.github.com*/releases*)
-        printf '%s\n' '[{"assets":[{"browser_download_url":"https://download.test/silentsuite-bridge-linux-x86_64"}]}]'
+        printf '%s\n' '[' '  "browser_download_url": "https://download.test/silentsuite-bridge-linux-x86_64"' ']'
         ;;
     https://download.test/*)
         case "$url" in

--- a/bridge/tests/test_unix_installer.py
+++ b/bridge/tests/test_unix_installer.py
@@ -33,6 +33,7 @@ def installer_path(tmp_path: Path, *, verifier: str | None) -> Path:
     executable(
         fake_bin / "curl",
         """#!/bin/sh
+raw_args=$*
 url=''
 out=''
 while [ "$#" -gt 0 ]; do
@@ -55,7 +56,7 @@ case "$url" in
             *) printf '%s' "$BINARY_BODY" > "$out" ;;
         esac
         ;;
-    *) printf 'unexpected test URL: %s\n' "$url" >&2; exit 22 ;;
+    *) printf 'unexpected test URL: %s (args: %s)\n' "$url" "$raw_args" >&2; exit 22 ;;
 esac
 exit 0
 """,

--- a/bridge/tests/test_unix_installer.py
+++ b/bridge/tests/test_unix_installer.py
@@ -1,0 +1,132 @@
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = ROOT / "bridge" / "install.sh"
+BINARY_BODY = "#!/bin/sh\nexit 0\n"
+BINARY_HASH = hashlib.sha256(BINARY_BODY.encode()).hexdigest()
+
+
+def executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def installer_path(tmp_path: Path, *, verifier: str | None) -> Path:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    for command in ("awk", "chmod", "cut", "grep", "head", "mkdir", "mktemp", "mv", "rm", "sleep", "tail", "tr", "wc"):
+        target = Path("/usr/bin") / command
+        if not target.exists():
+            target = Path("/bin") / command
+        (fake_bin / command).symlink_to(target)
+    if verifier:
+        target = Path("/usr/bin") / verifier
+        if not target.exists():
+            target = Path("/bin") / verifier
+        (fake_bin / verifier).symlink_to(target)
+    executable(fake_bin / "uname", "#!/bin/sh\n[ \"${1:-}\" = \"-s\" ] && echo Linux || echo x86_64\n")
+    executable(
+        fake_bin / "curl",
+        """#!/bin/sh
+url=''
+out=''
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) out=$2; shift 2 ;;
+        http*) url=$1; shift ;;
+        *) shift ;;
+    esac
+done
+case "$url" in
+    *api.github.com*/releases*)
+        printf '%s\n' '[{"assets":[{"browser_download_url":"https://download.test/silentsuite-bridge-linux-x86_64"}]}]'
+        ;;
+    https://download.test/*)
+        case "$url" in
+            *.sha256)
+                [ "${CHECKSUM_CASE:-}" != "fetch-failure" ] || exit 22
+                if [ -n "$out" ]; then printf '%s' "${CHECKSUM_BODY:-}" > "$out"; else printf '%s' "${CHECKSUM_BODY:-}"; fi
+                ;;
+            *) printf '%s' "$BINARY_BODY" > "$out" ;;
+        esac
+        ;;
+    *) printf 'unexpected test URL: %s\n' "$url" >&2; exit 22 ;;
+esac
+exit 0
+""",
+    )
+    return fake_bin
+
+
+def run_installer(tmp_path: Path, checksum_case: str, checksum_body: str, verifier: str | None = "sha256sum"):
+    fake_bin = installer_path(tmp_path, verifier=verifier)
+    install_dir = tmp_path / "install"
+    env = {
+        **os.environ,
+        "PATH": str(fake_bin),
+        "HOME": str(tmp_path / "home"),
+        "SILENTSUITE_INSTALL_DIR": str(install_dir),
+        "CHECKSUM_CASE": checksum_case,
+        "CHECKSUM_BODY": checksum_body,
+        "BINARY_BODY": BINARY_BODY,
+        "TMPDIR": str(tmp_path),
+    }
+    (tmp_path / "home").mkdir()
+    result = subprocess.run(
+        ["/bin/sh", str(INSTALLER)],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+    leftovers = sorted(path.name for path in tmp_path.glob("tmp.*"))
+    return result, install_dir / "silentsuite-bridge", leftovers
+
+
+@pytest.mark.parametrize(
+    ("checksum_case", "checksum_body", "verifier"),
+    [
+        ("valid", "", None),
+        ("fetch-failure", "", "sha256sum"),
+        ("valid", "", "sha256sum"),
+        ("valid", "not-a-checksum\n", "sha256sum"),
+        ("valid", f"{'0' * 64}  silentsuite-bridge-linux-x86_64\n", "sha256sum"),
+        ("valid", f"{'0' * 64}  one\n{'1' * 64}  two\n", "sha256sum"),
+        ("valid", f"{'0' * 64}  silentsuite-bridge-linux-x86_64 extra\n", "sha256sum"),
+        ("valid", f"{'0' * 64}  wrong-artifact\n", "sha256sum"),
+        ("valid", f"\n{'0' * 64}  silentsuite-bridge-linux-x86_64\nextra\n", "sha256sum"),
+        ("valid", f"\n{BINARY_HASH}  silentsuite-bridge-linux-x86_64\n", "sha256sum"),
+        ("valid", f"{BINARY_HASH}  silentsuite-bridge-linux-x86_64\n\n", "sha256sum"),
+        ("valid", f"{BINARY_HASH}  silentsuite-bridge-linux-x86_64", "sha256sum"),
+    ],
+)
+def test_unix_installer_fails_closed_and_removes_downloads(
+    tmp_path: Path,
+    checksum_case: str,
+    checksum_body: str,
+    verifier: str | None,
+):
+    result, installed, leftovers = run_installer(tmp_path, checksum_case, checksum_body, verifier)
+
+    assert result.returncode != 0
+    assert not installed.exists()
+    assert leftovers == []
+
+
+def test_unix_installer_accepts_one_exact_matching_checksum(tmp_path: Path):
+    result, installed, leftovers = run_installer(
+        tmp_path,
+        "valid",
+        f"{BINARY_HASH}  silentsuite-bridge-linux-x86_64\n",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert installed.read_text(encoding="utf-8") == BINARY_BODY
+    assert os.access(installed, os.X_OK)
+    assert leftovers == []


### PR DESCRIPTION
## Summary
- fail closed when no SHA-256 verifier is available
- require one canonical, newline-terminated checksum record for the exact release asset
- reject missing, empty, malformed, ambiguous, wrong-name, and mismatched sidecars
- clean downloaded binary and sidecar files on every failure path
- add a shell-executed regression matrix under the Bridge test suite

## Verification
- POSIX shell syntax check passes
- branch diff check passes
- repository policy defers Python test execution to CI

Closes #580