### PR TITLE
fix(auth): replace Billing bearer handoff with one-time proofs

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -12,7 +12,10 @@ on:
 
 concurrency:
   group: deploy-server-production
-  cancel-in-progress: true
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/silent-suite/silentsuite-server
 
 jobs:
   build-and-push:
@@ -22,10 +25,23 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Assert this is the live main commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          LIVE_MAIN_SHA=$(git rev-parse origin/main)
+          if [ "$GITHUB_REF" != "refs/heads/main" ] || [ "$GITHUB_SHA" != "$LIVE_MAIN_SHA" ]; then
+            echo "Refusing deploy: workflow commit is not the live main head"
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -38,14 +54,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push server image
+        id: build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: Dockerfile.server
           push: true
-          tags: |
-            ghcr.io/silent-suite/silentsuite-server:latest
-            ghcr.io/silent-suite/silentsuite-server:${{ github.sha }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          build-args: VCS_REF=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -54,19 +70,104 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Re-assert live main immediately before deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          LIVE_MAIN_SHA=$(git rev-parse origin/main)
+          if [ "$GITHUB_REF" != "refs/heads/main" ] || [ "$GITHUB_SHA" != "$LIVE_MAIN_SHA" ]; then
+            echo "Refusing deploy: workflow commit is no longer the live main head"
+            exit 1
+          fi
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DEPLOY_SHA: ${{ github.sha }}
+          IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image-digest }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: IMAGE_NAME,DEPLOY_SHA,IMAGE_DIGEST
           script: |
-            docker pull ghcr.io/silent-suite/silentsuite-server:latest
+            bash -se <<'BASH'
+            set -euo pipefail
+            if ! echo "${DEPLOY_SHA:-}" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "Deploy configuration error: DEPLOY_SHA is not an immutable commit SHA"
+              exit 1
+            fi
+            if ! echo "${IMAGE_DIGEST:-}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+              echo "Deploy configuration error: IMAGE_DIGEST is not immutable"
+              exit 1
+            fi
             cd ~/etebase
-            docker compose up -d --force-recreate silentsuite-server
+            PREVIOUS_CONTAINER=$(docker compose ps -q silentsuite-server)
+            PREVIOUS_IMAGE_ID=$(docker inspect "$PREVIOUS_CONTAINER" --format '{{.Image}}')
+            if ! echo "$PREVIOUS_IMAGE_ID" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+              echo "Deploy configuration error: running server image identity is unavailable"
+              exit 1
+            fi
+            DEPLOY_OVERRIDE=$(mktemp)
+            ROLLBACK_OVERRIDE=$(mktemp)
+            cleanup() { rm -f "$DEPLOY_OVERRIDE" "$ROLLBACK_OVERRIDE"; }
+            trap cleanup EXIT
+            docker pull "${IMAGE_NAME}@${IMAGE_DIGEST}"
+            PULLED_REVISION=$(docker inspect "${IMAGE_NAME}@${IMAGE_DIGEST}" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')
+            if [ "$PULLED_REVISION" != "$DEPLOY_SHA" ]; then
+              echo "Deploy integrity error: image revision label does not match live main"
+              exit 1
+            fi
+            docker tag "$PREVIOUS_IMAGE_ID" "${IMAGE_NAME}:rollback-${DEPLOY_SHA}"
+            cat > "$DEPLOY_OVERRIDE" <<EOF
+            services:
+              silentsuite-server:
+                image: ${IMAGE_NAME}@${IMAGE_DIGEST}
+            EOF
+            cat > "$ROLLBACK_OVERRIDE" <<EOF
+            services:
+              silentsuite-server:
+                image: ${IMAGE_NAME}:rollback-${DEPLOY_SHA}
+            EOF
+            docker compose -f docker-compose.yml -f "$DEPLOY_OVERRIDE" run --rm --no-deps silentsuite-server python manage.py migrate --noinput
+            wait_for_server() {
+              for i in 1 2 3 4 5 6; do
+                curl -sf https://server.silentsuite.io/ >/dev/null && return 0
+                sleep 10
+              done
+              return 1
+            }
+            rollback() {
+              failure_status=$?
+              trap - ERR
+              set +e
+              echo "Server deploy failed; restoring the previously running image"
+              docker compose -f docker-compose.yml -f "$ROLLBACK_OVERRIDE" up -d --force-recreate --no-deps --no-build silentsuite-server
+              ROLLED_BACK_ID=$(docker inspect "$(docker compose ps -q silentsuite-server)" --format '{{.Image}}' 2>/dev/null || echo "")
+              [ "$ROLLED_BACK_ID" = "$PREVIOUS_IMAGE_ID" ] && wait_for_server || echo "Automatic server rollback failed; operator intervention is required"
+              exit "$failure_status"
+            }
+            trap rollback ERR
+            docker compose -f docker-compose.yml -f "$DEPLOY_OVERRIDE" up -d --force-recreate --no-deps --no-build silentsuite-server
+            PULLED_IMAGE_ID=$(docker inspect "${IMAGE_NAME}@${IMAGE_DIGEST}" --format '{{.Id}}')
+            RUNNING_CONTAINER=$(docker compose ps -q silentsuite-server)
+            RUNNING_IMAGE_ID=$(docker inspect "$RUNNING_CONTAINER" --format '{{.Image}}')
+            RUNNING_REVISION=$(docker inspect "$RUNNING_CONTAINER" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')
+            [ "$RUNNING_IMAGE_ID" = "$PULLED_IMAGE_ID" ]
+            [ "$RUNNING_REVISION" = "$DEPLOY_SHA" ]
+            wait_for_server
+            trap - ERR
             echo "SilentSuite server deployed successfully"
+            BASH
 
       - name: Post-deploy health check
         run: |

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -13,7 +13,10 @@ on:
 
 concurrency:
   group: deploy-web-production
-  cancel-in-progress: true
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: ghcr.io/silent-suite/silentsuite-web
 
 jobs:
   build-and-push:
@@ -23,10 +26,23 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image-digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Assert this is the live main commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          LIVE_MAIN_SHA=$(git rev-parse origin/main)
+          if [ "$GITHUB_REF" != "refs/heads/main" ] || [ "$GITHUB_SHA" != "$LIVE_MAIN_SHA" ]; then
+            echo "Refusing deploy: workflow commit is not the live main head"
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -39,20 +55,20 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push web image
+        id: build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: Dockerfile.web
           push: true
-          tags: |
-            ghcr.io/silent-suite/silentsuite-web:latest
-            ghcr.io/silent-suite/silentsuite-web:${{ github.sha }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }}
           build-args: |
             NEXT_PUBLIC_ETEBASE_SERVER_URL=https://server.silentsuite.io
             NEXT_PUBLIC_BILLING_API_URL=https://api.silentsuite.io
             NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
             NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED=true
             NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=true
+            VCS_REF=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -61,20 +77,106 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Re-assert live main immediately before deployment
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          LIVE_MAIN_SHA=$(git rev-parse origin/main)
+          if [ "$GITHUB_REF" != "refs/heads/main" ] || [ "$GITHUB_SHA" != "$LIVE_MAIN_SHA" ]; then
+            echo "Refusing deploy: workflow commit is no longer the live main head"
+            exit 1
+          fi
+
+      - name: Require the non-bearer Billing handoff before web cutover
+        run: curl --fail --silent --show-error https://api.silentsuite.io/health/link-proof
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          DEPLOY_SHA: ${{ github.sha }}
+          IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image-digest }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          envs: IMAGE_NAME,DEPLOY_SHA,IMAGE_DIGEST
           script: |
-            docker pull ghcr.io/silent-suite/silentsuite-web:latest
-            docker tag ghcr.io/silent-suite/silentsuite-web:latest etebase-web:latest
+            bash -se <<'BASH'
+            set -euo pipefail
+            if ! echo "${DEPLOY_SHA:-}" | grep -Eq '^[0-9a-f]{40}$'; then
+              echo "Deploy configuration error: DEPLOY_SHA is not an immutable commit SHA"
+              exit 1
+            fi
+            if ! echo "${IMAGE_DIGEST:-}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+              echo "Deploy configuration error: IMAGE_DIGEST is not immutable"
+              exit 1
+            fi
             cd ~/etebase
-            docker compose up -d --force-recreate web
+            PREVIOUS_CONTAINER=$(docker compose ps -q web)
+            PREVIOUS_IMAGE_ID=$(docker inspect "$PREVIOUS_CONTAINER" --format '{{.Image}}')
+            if ! echo "$PREVIOUS_IMAGE_ID" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+              echo "Deploy configuration error: running web image identity is unavailable"
+              exit 1
+            fi
+            DEPLOY_OVERRIDE=$(mktemp)
+            ROLLBACK_OVERRIDE=$(mktemp)
+            cleanup() { rm -f "$DEPLOY_OVERRIDE" "$ROLLBACK_OVERRIDE"; }
+            trap cleanup EXIT
+            docker pull "${IMAGE_NAME}@${IMAGE_DIGEST}"
+            PULLED_REVISION=$(docker inspect "${IMAGE_NAME}@${IMAGE_DIGEST}" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')
+            if [ "$PULLED_REVISION" != "$DEPLOY_SHA" ]; then
+              echo "Deploy integrity error: image revision label does not match live main"
+              exit 1
+            fi
+            docker tag "$PREVIOUS_IMAGE_ID" "${IMAGE_NAME}:rollback-${DEPLOY_SHA}"
+            cat > "$DEPLOY_OVERRIDE" <<EOF
+            services:
+              web:
+                image: ${IMAGE_NAME}@${IMAGE_DIGEST}
+            EOF
+            cat > "$ROLLBACK_OVERRIDE" <<EOF
+            services:
+              web:
+                image: ${IMAGE_NAME}:rollback-${DEPLOY_SHA}
+            EOF
+            wait_for_web() {
+              for i in 1 2 3 4 5 6; do
+                curl -sf https://app.silentsuite.io/ >/dev/null && return 0
+                sleep 10
+              done
+              return 1
+            }
+            rollback() {
+              failure_status=$?
+              trap - ERR
+              set +e
+              echo "Web deploy failed; restoring the previously running image"
+              docker compose -f docker-compose.yml -f "$ROLLBACK_OVERRIDE" up -d --force-recreate --no-deps --no-build web
+              ROLLED_BACK_ID=$(docker inspect "$(docker compose ps -q web)" --format '{{.Image}}' 2>/dev/null || echo "")
+              [ "$ROLLED_BACK_ID" = "$PREVIOUS_IMAGE_ID" ] && wait_for_web || echo "Automatic web rollback failed; operator intervention is required"
+              exit "$failure_status"
+            }
+            trap rollback ERR
+            docker compose -f docker-compose.yml -f "$DEPLOY_OVERRIDE" up -d --force-recreate --no-deps --no-build web
+            PULLED_IMAGE_ID=$(docker inspect "${IMAGE_NAME}@${IMAGE_DIGEST}" --format '{{.Id}}')
+            RUNNING_CONTAINER=$(docker compose ps -q web)
+            RUNNING_IMAGE_ID=$(docker inspect "$RUNNING_CONTAINER" --format '{{.Image}}')
+            RUNNING_REVISION=$(docker inspect "$RUNNING_CONTAINER" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')
+            [ "$RUNNING_IMAGE_ID" = "$PULLED_IMAGE_ID" ]
+            [ "$RUNNING_REVISION" = "$DEPLOY_SHA" ]
+            wait_for_web
+            trap - ERR
             echo "Web app deployed successfully"
+            BASH
 
       - name: Post-deploy health check
         run: |

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -14,6 +14,9 @@ RUN pip install --no-cache-dir -r /requirements.txt
 # --- Production stage ---
 FROM python:3.12-alpine
 
+ARG VCS_REF
+LABEL org.opencontainers.image.revision=$VCS_REF
+
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PYTHONUNBUFFERED=1
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -48,6 +48,9 @@ FROM node:22-alpine AS runner
 
 WORKDIR /app
 
+ARG VCS_REF
+LABEL org.opencontainers.image.revision=$VCS_REF
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 

--- a/apps/web/app/lib/__tests__/production-deploy-workflows.test.ts
+++ b/apps/web/app/lib/__tests__/production-deploy-workflows.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function workflow(name: string): string {
+  return readFileSync(resolve(process.cwd(), `../../.github/workflows/${name}`), 'utf8')
+}
+
+describe('production deployment workflow integrity', () => {
+  it.each(['deploy-web.yml', 'deploy-server.yml'])('%s deploys only an exact live-main image', (name) => {
+    const source = workflow(name)
+
+    expect(source).toContain('git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main')
+    expect(source.match(/GITHUB_SHA.*LIVE_MAIN_SHA/g)).toHaveLength(2)
+    expect(source).toContain('IMAGE_NAME }}:${{ github.sha }}')
+    expect(source).toContain('DEPLOY_SHA: ${{ github.sha }}')
+    expect(source).toContain('IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image-digest }}')
+    expect(source).toContain('image: ${IMAGE_NAME}@${IMAGE_DIGEST}')
+    expect(source).toContain('org.opencontainers.image.revision')
+    expect(source).toContain("bash -se <<'BASH'")
+    expect(source).not.toMatch(/silentsuite-(?:web|server):latest/)
+  })
+
+  it('blocks the web cutover until Billing proves the non-bearer handoff is ready', () => {
+    const source = workflow('deploy-web.yml')
+    const gate = source.indexOf('https://api.silentsuite.io/health/link-proof')
+    const deploy = source.indexOf('name: Deploy via SSH')
+
+    expect(gate).toBeGreaterThan(-1)
+    expect(deploy).toBeGreaterThan(gate)
+  })
+
+  it('runs server migrations from the exact image before replacing the server', () => {
+    const source = workflow('deploy-server.yml')
+    const migration = source.indexOf('run --rm --no-deps silentsuite-server python manage.py migrate --noinput')
+    const replacement = source.indexOf('up -d --force-recreate --no-deps --no-build silentsuite-server')
+
+    expect(migration).toBeGreaterThan(-1)
+    expect(replacement).toBeGreaterThan(migration)
+  })
+
+  it.each([
+    ['deploy-web.yml', 'web'],
+    ['deploy-server.yml', 'server'],
+  ])('%s verifies the running image and rolls back failed replacements', (name, component) => {
+    const source = workflow(name)
+
+    expect(source).toContain('PREVIOUS_IMAGE_ID=')
+    expect(source).toContain('RUNNING_IMAGE_ID=')
+    expect(source).toContain('RUNNING_REVISION=')
+    expect(source).toContain('rollback()')
+    expect(source).toContain(`Automatic ${component} rollback failed`)
+  })
+})

--- a/apps/web/app/lib/etebase-auth.ts
+++ b/apps/web/app/lib/etebase-auth.ts
@@ -5,6 +5,20 @@ interface EtebaseAuthResult {
   savedSession: string
 }
 
+/** Mint immediately before a Billing request. The proof is never persisted. */
+export async function issueBillingLinkProof(savedSession: string, serverUrl?: string): Promise<string> {
+  const { restoreSession } = await import('@silentsuite/core')
+  const account = await restoreSession(serverUrl || ETEBASE_SERVER_URL, savedSession)
+  const authToken = (account as any).authToken as string
+  const response = await fetch(`${(serverUrl || ETEBASE_SERVER_URL).replace(/\/$/, '')}/api/v1/billing/link-proof/`, {
+    method: 'POST', headers: { Authorization: `Token ${authToken}` },
+  })
+  if (!response.ok) throw new Error('Could not establish billing identity')
+  const value = await response.json() as { etebaseLinkProof?: unknown }
+  if (typeof value.etebaseLinkProof !== 'string') throw new Error('Could not establish billing identity')
+  return value.etebaseLinkProof
+}
+
 export async function etebaseSignUp(
   email: string,
   password: string,

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -56,16 +56,21 @@ vi.mock('@/app/lib/secure-storage', () => ({
 
 // Mock etebase-auth (dynamically imported by login)
 vi.mock('@/app/lib/etebase-auth', () => ({
+  etebaseSignUp: vi.fn().mockResolvedValue({
+    authToken: 'mock-auth-token',
+    savedSession: 'mock-saved-session',
+  }),
   etebaseLogIn: vi.fn().mockResolvedValue({
     authToken: 'mock-auth-token',
     savedSession: 'mock-saved-session',
   }),
+  issueBillingLinkProof: vi.fn().mockResolvedValue('mock-link-proof-value-with-at-least-43-characters'),
 }))
 
 // Mock self-hosted checks
 vi.mock('@/app/lib/self-hosted', () => ({
   isSelfHosted: false,
-  isCustomServer: () => false,
+  isCustomServer: (serverUrl?: string) => Boolean(serverUrl && serverUrl !== 'https://server.silentsuite.io'),
 }))
 
 // Mock etebase store (used by logout)
@@ -158,6 +163,13 @@ describe('useAuthStore', () => {
     expect(state.user).not.toBeNull()
     expect(state.user!.email).toBe('test@example.com')
     expect(state.isLoading).toBe(false)
+    const [, init] = vi.mocked(fetch).mock.calls[0]
+    expect(JSON.parse(init?.body as string)).toEqual({
+      etebaseLinkProof: 'mock-link-proof-value-with-at-least-43-characters',
+      rememberDevice: false,
+    })
+    expect(init?.body).not.toContain('authToken')
+    expect(init?.body).not.toContain('savedSession')
   })
 
   it('unlockEtebaseSession restores only the local session for the signed-in account', async () => {
@@ -187,11 +199,51 @@ describe('useAuthStore', () => {
     expect(useAuthStore.getState().error).toMatch(/already signed in/i)
   })
 
+  it('keeps custom-server signup and finalization out of hosted Billing', async () => {
+    const customServerUrl = 'https://sync.example.test'
+    const { issueBillingLinkProof } = await import('@/app/lib/etebase-auth')
+    vi.mocked(issueBillingLinkProof).mockClear()
+
+    useAuthStore.getState().prepareSignupDraft('custom@example.com', false)
+    await useAuthStore.getState().createEtebaseAccount(
+      'custom@example.com',
+      'password123',
+      customServerUrl,
+    )
+    const result = await useAuthStore.getState().signup('early_monthly', '7day')
+
+    expect(result).toEqual({
+      clientSecret: null,
+      cryptoCheckoutUrl: null,
+      cryptoInvoiceId: null,
+      cryptoInvoiceLookupToken: null,
+      paymentSessionToken: null,
+    })
+    expect(fetch).not.toHaveBeenCalled()
+    expect(issueBillingLinkProof).not.toHaveBeenCalled()
+    expect(localStorage.getItem('silentsuite-server-url')).toBe(customServerUrl)
+    expect(useAuthStore.getState().pendingSignup).toMatchObject({
+      serverUrl: customServerUrl,
+      provisionedUser: { id: 'self-hosted', planId: 'self-hosted', isAdmin: true },
+    })
+
+    useAuthStore.setState({
+      pendingSignup: {
+        ...useAuthStore.getState().pendingSignup!,
+        paymentSessionToken: 'must-not-be-sent',
+      },
+    })
+    await expect(useAuthStore.getState().finalizePaidSignup())
+      .rejects.toThrow('Paid signup is not available for custom servers')
+    expect(fetch).not.toHaveBeenCalled()
+    expect(issueBillingLinkProof).not.toHaveBeenCalled()
+  })
+
   it('signup sends a trimmed promo code when provided', async () => {
+    secureStore.etebase_session = 'mock-saved-session'
     useAuthStore.setState({
       pendingSignup: {
         email: 'promo@example.com',
-        etebaseAuthToken: 'etebase-token',
         wantsProductUpdates: true,
       },
     })
@@ -208,7 +260,7 @@ describe('useAuthStore', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
-          etebaseSessionToken: 'etebase-token',
+          etebaseLinkProof: 'mock-link-proof-value-with-at-least-43-characters',
           planId: 'early_monthly',
           trialPath: '30day',
           promoCode: 'beta196',
@@ -220,10 +272,10 @@ describe('useAuthStore', () => {
   })
 
   it('signup omits an empty promo code', async () => {
+    secureStore.etebase_session = 'mock-saved-session'
     useAuthStore.setState({
       pendingSignup: {
         email: 'promo@example.com',
-        etebaseAuthToken: 'etebase-token',
       },
     })
 
@@ -236,7 +288,7 @@ describe('useAuthStore', () => {
 
     const [, init] = vi.mocked(fetch).mock.calls[0]
     expect(JSON.parse(init?.body as string)).toEqual({
-      etebaseSessionToken: 'etebase-token',
+      etebaseLinkProof: 'mock-link-proof-value-with-at-least-43-characters',
       planId: 'early_monthly',
       trialPath: '30day',
       rememberDevice: false,
@@ -280,7 +332,7 @@ describe('useAuthStore', () => {
     })
     expect(result.paymentSessionToken).toBe(currentPaidSignupRecoverySecret())
     expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe(currentPaidSignupRecoverySecret())
-    expect(useAuthStore.getState().pendingSignup?.etebaseAuthToken).toBeUndefined()
+    expect(JSON.stringify(useAuthStore.getState().pendingSignup)).not.toContain('etebaseAuthToken')
   })
 
   it('retains a UUID request key and high-entropy recovery secret after an incomplete successful response', async () => {
@@ -416,6 +468,7 @@ describe('useAuthStore', () => {
 
       const first = useAuthStore.getState().signup('early_annual', firstTrialPath)
       const second = useAuthStore.getState().signup('early_annual', secondTrialPath)
+      await vi.waitFor(() => expect(pendingResponses.size).toBe(2))
       const responseFor = (trialPath: string) => {
         const pendingResponse = pendingResponses.get(trialPath)!
         return {
@@ -761,7 +814,6 @@ describe('useAuthStore', () => {
     useAuthStore.setState({
       pendingSignup: {
         email: 'old@example.com',
-        etebaseAuthToken: 'old-etebase-token',
         paymentSessionToken: 'old-payment-token',
       },
     })
@@ -776,10 +828,10 @@ describe('useAuthStore', () => {
   })
 
   it('finalizes a paid signup payment session after Etebase signup completes', async () => {
+    secureStore.etebase_session = 'mock-saved-session'
     useAuthStore.setState({
       pendingSignup: {
         email: 'paid@example.com',
-        etebaseAuthToken: 'etebase-token',
         paymentSessionToken: 'payment-session-token',
       },
     })
@@ -809,7 +861,7 @@ describe('useAuthStore', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
-          etebaseSessionToken: 'etebase-token',
+          etebaseLinkProof: 'mock-link-proof-value-with-at-least-43-characters',
           paymentSessionToken: 'payment-session-token',
         }),
       }),
@@ -827,7 +879,6 @@ describe('useAuthStore', () => {
     useAuthStore.setState({
       pendingSignup: {
         email: 'paid@example.com',
-        etebaseAuthToken: 'etebase-token',
       },
     })
 
@@ -836,10 +887,10 @@ describe('useAuthStore', () => {
   })
 
   it('signup returns crypto checkout details without authenticating', async () => {
+    secureStore.etebase_session = 'mock-saved-session'
     useAuthStore.setState({
       pendingSignup: {
         email: 'crypto@example.com',
-        etebaseAuthToken: 'etebase-token',
       },
     })
 
@@ -1083,7 +1134,6 @@ describe('useAuthStore', () => {
       useAuthStore.setState({
         pendingSignup: {
           email: 'new@user.com',
-          etebaseAuthToken: 'tok',
           provisionedUser: { id: 'new-1', planId: 'pro', isAdmin: false },
           provisionedSubscriptionStatus: 'trialing',
         },
@@ -1703,7 +1753,7 @@ describe('useAuthStore', () => {
   describe('signup redirect state storage', () => {
     const pending = {
       email: 'user@example.com',
-      etebaseAuthToken: 'auth-token-abc',
+      paymentSessionToken: 'payment-session-token',
     }
 
     it('saves redirect state to sessionStorage, not localStorage', () => {

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -29,7 +29,7 @@ export interface User {
 
 interface PendingSignup {
   email: string
-  etebaseAuthToken?: string
+  serverUrl?: string
   paymentSessionToken?: string
   earlyAdopter?: boolean
   wantsProductUpdates?: boolean
@@ -95,7 +95,7 @@ interface AuthState {
    * Persist pendingSignup + billing interval to sessionStorage so the signup
    * flow survives a full-page Stripe 3DS redirect. sessionStorage is scoped to
    * the tab and cleared on close, which is a tighter blast radius than
-   * localStorage for the etebaseAuthToken this blob carries. The data is also
+   * localStorage. The data is also
    * cleared on first read and rejected if older than 2 hours.
    */
   saveSignupStateForRedirect: (selectedInterval: 'monthly' | 'annual') => void
@@ -705,9 +705,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         // Recover legacy abandoned signups where Etebase was created before payment.
         authResult = await etebaseLogIn(email, password, serverUrl)
       }
-      const { authToken, savedSession } = authResult
+      const { savedSession } = authResult
       if (!isSelfHosted && !isCustomServer(serverUrl)) clearHostedValidationMarkers()
       await secureSet('etebase_session', savedSession)
+      if (isCustomServer(serverUrl) && serverUrl) {
+        localStorage.setItem('silentsuite-server-url', serverUrl)
+      }
 
       let earlyAdopter = false
       if (!isSelfHosted && !isCustomServer(serverUrl)) {
@@ -732,7 +735,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const pending = get().pendingSignup
       const reusablePending = pending?.email.toLowerCase() === email.toLowerCase() ? pending : null
       set({
-        pendingSignup: { ...(reusablePending ?? {}), email, etebaseAuthToken: authToken, earlyAdopter },
+        pendingSignup: { ...(reusablePending ?? {}), email, serverUrl, earlyAdopter },
         isLoading: false,
       })
     } catch (err) {
@@ -753,12 +756,13 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   signup: async (planId: string, trialPath: string, promoCode?: string) => {
-    if (isSelfHosted || planId === 'self-hosted') {
-      const pending = get().pendingSignup
-      if (!pending) throw new Error('No pending signup')
+    const pending = get().pendingSignup
+    if (!pending) throw new Error('No pending signup')
+    const isLocalServerSignup = isSelfHosted || isCustomServer(pending.serverUrl) || planId === 'self-hosted'
+    if (isLocalServerSignup) {
 
       // Self-hosted: if user opted in, subscribe to newsletter on the SilentSuite API
-      if (pending.wantsProductUpdates) {
+      if (isSelfHosted && pending.wantsProductUpdates) {
         try {
           const res = await fetch(`${BILLING_API_URL}/newsletter/subscribe`, {
             method: 'POST',
@@ -784,11 +788,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       return { clientSecret: null, cryptoCheckoutUrl: null, cryptoInvoiceId: null, cryptoInvoiceLookupToken: null, paymentSessionToken: null }
     }
 
-    const pending = get().pendingSignup
-    if (!pending?.email) {
+    if (!pending.email) {
       throw new Error('No pending signup')
     }
-    const isPaidSignupDraft = (trialPath === '30day' || trialPath === 'crypto_annual') && !pending.etebaseAuthToken
+    const savedEtebaseSession = await secureGet('etebase_session')
+    const isPaidSignupDraft = (trialPath === '30day' || trialPath === 'crypto_annual') && !savedEtebaseSession
     if (isPaidSignupDraft) {
       const recoveryIdentity = getOrCreatePaidSignupRecoveryIdentity(
         paidSignupRecoveryScope(
@@ -900,17 +904,19 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       }
     }
 
-    if (!pending.etebaseAuthToken) {
+    if (!savedEtebaseSession) {
       throw new Error('No Etebase session. Please start signup again.')
     }
     set({ isLoading: true, error: null })
 
     try {
+      const { issueBillingLinkProof } = await import('@/app/lib/etebase-auth')
+      const etebaseLinkProof = await issueBillingLinkProof(savedEtebaseSession)
       const res = await fetch(`${BILLING_API_URL}/auth/provision`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({
-          etebaseSessionToken: pending.etebaseAuthToken,
+          etebaseLinkProof,
           planId,
           trialPath,
           ...(promoCode?.trim() ? { promoCode: promoCode.trim() } : {}),
@@ -953,16 +959,22 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   finalizePaidSignup: async () => {
     const pending = get().pendingSignup
-    if (!pending?.etebaseAuthToken || !pending.paymentSessionToken) {
+    if (isCustomServer(pending?.serverUrl)) {
+      throw new Error('Paid signup is not available for custom servers.')
+    }
+    const savedEtebaseSession = await secureGet('etebase_session')
+    if (!pending || !savedEtebaseSession || !pending.paymentSessionToken) {
       throw new Error('No completed payment session. Please start signup again.')
     }
     set({ isLoading: true, error: null })
     try {
+      const { issueBillingLinkProof } = await import('@/app/lib/etebase-auth')
+      const etebaseLinkProof = await issueBillingLinkProof(savedEtebaseSession)
       const res = await fetch(`${BILLING_API_URL}/auth/signup/finalize-payment`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({
-          etebaseSessionToken: pending.etebaseAuthToken,
+          etebaseLinkProof,
           paymentSessionToken: pending.paymentSessionToken,
         }),
         credentials: 'include',
@@ -1013,7 +1025,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
     // Sync admin cookie so middleware allows /admin access
     syncAdminCookie(pending.provisionedUser.isAdmin, pending.rememberDevice === true)
-    if (!isSelfHosted) markHostedValidation(pending.provisionedUser.id, pending.rememberDevice === true)
+    if (!isSelfHosted && !isCustomServer(pending.serverUrl)) {
+      markHostedValidation(pending.provisionedUser.id, pending.rememberDevice === true)
+    }
     set({
       user: {
         id: pending.provisionedUser.id,
@@ -1035,7 +1049,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     set({ isLoading: true, error: null })
     try {
       const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
-      const { authToken, savedSession } = await etebaseLogIn(email, password, serverUrl)
+      const { savedSession } = await etebaseLogIn(email, password, serverUrl)
       // A successful Etebase login may be an account switch in the same browser
       // profile. The offline queue can contain item UIDs/collection UIDs and,
       // in future encrypted-cache mode, mutation content. Clear it after the
@@ -1075,10 +1089,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // Logging in to the default server — clear any stale self-hosted URL
       localStorage.removeItem('silentsuite-server-url')
 
+      const { issueBillingLinkProof } = await import('@/app/lib/etebase-auth')
+      const etebaseLinkProof = await issueBillingLinkProof(savedSession, serverUrl)
       const res = await fetch(`${BILLING_API_URL}/auth/token-exchange`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
-        body: JSON.stringify({ etebaseSessionToken: authToken, rememberDevice: rememberDevice === true }),
+        body: JSON.stringify({ etebaseLinkProof, rememberDevice: rememberDevice === true }),
         credentials: 'include',
       })
 
@@ -1452,7 +1468,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       sessionStorage.removeItem('silentsuite-signup-redirect-state')
       const data = JSON.parse(raw) as RedirectSignupState
       // Basic shape validation — guard against corrupted or tampered storage data
-      if (!data.pendingSignup?.email || (!data.pendingSignup?.etebaseAuthToken && !data.pendingSignup?.paymentSessionToken)) {
+      if (!data.pendingSignup?.email || !data.pendingSignup?.paymentSessionToken) {
         logger.warn('[auth-store] Redirect signup state is malformed, discarding')
         return null
       }

--- a/docs/operator-billing-link-proof-rollout.md
+++ b/docs/operator-billing-link-proof-rollout.md
@@ -1,0 +1,12 @@
+# Billing link-proof rollout
+
+This is a bounded, staged cutover. Do not put any secret values in source control or tickets.
+
+1. Provision the same dedicated `ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY` on the hosted Etebase server and Billing. Configure Billing's `ETEBASE_SERVER_URL` with its HTTPS URL. Temporarily set `ETEBASE_LEGACY_BEARER_IDENTITY_ROLLOUT_ENABLED=true` on the Etebase server, but do not yet deploy the proof-producing web image.
+2. Promote the public commit. Let the exact-SHA Etebase server image deploy first. The web deployment gate must remain closed because the old Billing service has no `/health/link-proof` readiness endpoint; the existing web container remains active.
+3. Deploy Billing with `ETEBASE_LEGACY_BEARER_ROLLOUT_ENABLED=true`. This temporary mode verifies a legacy bearer only by calling Etebase's authenticated identity endpoint; it never restores Billing database access to Etebase token tables. Confirm `https://api.silentsuite.io/health/link-proof` returns `200`.
+4. Rerun the failed web deploy job for the same immutable public commit. Its readiness gate must pass before the exact-SHA web image replaces the old container. Confirm hosted signup provisioning, paid-signup finalization, and fresh login all use link proofs. Confirm self-host/custom-server journeys make no hosted Billing proof calls.
+5. Disable both temporary flags: unset `ETEBASE_LEGACY_BEARER_ROLLOUT_ENABLED` in Billing and `ETEBASE_LEGACY_BEARER_IDENTITY_ROLLOUT_ENABLED` on Etebase. Restart the affected services and verify requests containing legacy bearers are rejected.
+6. Confirm migration `0025_remove_etebase_session_verifier.sql` has removed the old verifier function and any dependent Billing privilege. Remove the temporary Etebase identity path in the next source cleanup after the cutover window.
+
+Missing machine-key configuration intentionally makes proof consumption fail closed; it does not prevent a self-hosted Etebase server from starting.

--- a/server/etebase_server/django/migrations/0038_billing_link_proof.py
+++ b/server/etebase_server/django/migrations/0038_billing_link_proof.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("django_etebase", "0037_auto_20210127_1237")]
+
+    operations = [
+        migrations.CreateModel(
+            name="BillingLinkProof",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("proof_hash", models.CharField(db_index=True, max_length=64, unique=True)),
+                ("audience", models.CharField(default="billing", max_length=32)),
+                ("expires_at", models.DateTimeField(db_index=True)),
+                ("consumed_at", models.DateTimeField(blank=True, null=True)),
+                ("user", models.ForeignKey(on_delete=models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/server/etebase_server/django/models.py
+++ b/server/etebase_server/django/models.py
@@ -12,6 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import hashlib
 import typing as t
 from pathlib import Path
 
@@ -20,6 +21,7 @@ from django.core.validators import RegexValidator
 from django.db import models, transaction
 from django.db.models import Max, Value as Val
 from django.db.models.functions import Coalesce, Greatest
+from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.functional import cached_property
 
@@ -148,6 +150,27 @@ class Stoken(models.Model):
     )
 
     objects: models.manager.BaseManager["Stoken"]
+
+
+class BillingLinkProof(models.Model):
+    """One-time, opaque link from an authenticated Etebase account to Billing.
+
+    The bearer value is deliberately never stored.  A SHA-256 digest is enough
+    for lookup because the value has 256 bits of entropy.
+    """
+
+    proof_hash = models.CharField(max_length=64, unique=True, db_index=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    audience = models.CharField(max_length=32, default="billing")
+    expires_at = models.DateTimeField(db_index=True)
+    consumed_at = models.DateTimeField(null=True, blank=True)
+
+    @staticmethod
+    def digest(proof: str) -> str:
+        return hashlib.sha256(proof.encode("utf-8")).hexdigest()
+
+    def is_usable(self) -> bool:
+        return self.audience == "billing" and self.consumed_at is None and self.expires_at > timezone.now()
 
 
 class CollectionItemRevision(models.Model):

--- a/server/etebase_server/fastapi/main.py
+++ b/server/etebase_server/fastapi/main.py
@@ -13,6 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from .exceptions import CustomHttpException
 from .msgpack import MsgpackResponse
 from .routers.authentication import authentication_router
+from .routers.billing_link import billing_link_router
 from .routers.collection import collection_router, item_router
 from .routers.invitation import invitation_incoming_router, invitation_outgoing_router
 from .routers.member import member_router
@@ -36,6 +37,7 @@ def create_application(prefix="", middlewares=[]):
     BASE_PATH = f"{prefix}/api/{VERSION}"  # noqa: N806
     COLLECTION_UID_MARKER = "{collection_uid}"  # noqa: N806
     app.include_router(authentication_router, prefix=f"{BASE_PATH}/authentication", tags=["authentication"])
+    app.include_router(billing_link_router, prefix=f"{BASE_PATH}/billing", tags=["billing"])
     app.include_router(collection_router, prefix=f"{BASE_PATH}/collection", tags=["collection"])
     app.include_router(item_router, prefix=f"{BASE_PATH}/collection/{COLLECTION_UID_MARKER}", tags=["item"])
     app.include_router(member_router, prefix=f"{BASE_PATH}/collection/{COLLECTION_UID_MARKER}", tags=["member"])

--- a/server/etebase_server/fastapi/routers/billing_link.py
+++ b/server/etebase_server/fastapi/routers/billing_link.py
@@ -1,0 +1,89 @@
+"""Narrow Billing linkage endpoints.  Remove the legacy identity route after cutover."""
+import hmac
+import os
+import secrets
+from datetime import timedelta
+
+from django.db import transaction
+from django.utils import timezone
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import Field
+
+from etebase_server.django.models import BillingLinkProof
+from etebase_server.myauth.models import UserType
+
+from ..db_hack import django_db_cleanup_decorator
+from ..dependencies import get_authenticated_user
+from ..utils import BaseModel
+
+billing_link_router = APIRouter()
+PROOF_TTL_SECONDS = 120
+
+
+class ProofOut(BaseModel):
+    etebaseLinkProof: str = Field(min_length=43, max_length=256)
+
+
+class ConsumeIn(BaseModel):
+    etebaseLinkProof: str = Field(min_length=43, max_length=256)
+
+
+class IdentityOut(BaseModel):
+    username: str
+    email: str
+
+
+def forbidden() -> None:
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication failed")
+
+
+@billing_link_router.post("/link-proof/", response_model=ProofOut)
+@django_db_cleanup_decorator
+def issue_proof(user: UserType = Depends(get_authenticated_user)):
+    proof = secrets.token_urlsafe(32)
+    BillingLinkProof.objects.create(
+        proof_hash=BillingLinkProof.digest(proof), user=user, audience="billing",
+        expires_at=timezone.now() + timedelta(seconds=PROOF_TTL_SECONDS),
+    )
+    return ProofOut(etebaseLinkProof=proof)
+
+
+@billing_link_router.post("/link-proof/consume/", response_model=IdentityOut)
+@django_db_cleanup_decorator
+def consume_proof(payload: ConsumeIn, x_etebase_billing_key: str | None = Header(default=None)):
+    configured = os.environ.get("ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY")
+    if not configured or not x_etebase_billing_key or not hmac.compare_digest(configured, x_etebase_billing_key):
+        forbidden()
+    digest = BillingLinkProof.digest(payload.etebaseLinkProof)
+    consumed_at = timezone.now()
+    with transaction.atomic():
+        claimed = BillingLinkProof.objects.filter(
+            proof_hash=digest,
+            audience="billing",
+            consumed_at__isnull=True,
+            expires_at__gt=consumed_at,
+        ).update(consumed_at=consumed_at)
+        if claimed != 1:
+            forbidden()
+        try:
+            proof = BillingLinkProof.objects.select_related("user").get(proof_hash=digest)
+        except BillingLinkProof.DoesNotExist:
+            forbidden()
+        return IdentityOut(username=proof.user.username, email=proof.user.email)
+
+
+@billing_link_router.get("/link-proof/ready/")
+def proof_ready(x_etebase_billing_key: str | None = Header(default=None)):
+    configured = os.environ.get("ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY")
+    if not configured or not x_etebase_billing_key or not hmac.compare_digest(configured, x_etebase_billing_key):
+        forbidden()
+    return {"ready": True}
+
+
+@billing_link_router.get("/billing-identity/", response_model=IdentityOut)
+@django_db_cleanup_decorator
+def legacy_identity(user: UserType = Depends(get_authenticated_user)):
+    # Temporary production rollout escape hatch.  It is intentionally opt-in.
+    if os.environ.get("ETEBASE_LEGACY_BEARER_IDENTITY_ROLLOUT_ENABLED") != "true":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    return IdentityOut(username=user.username, email=user.email)

--- a/server/etebase_server/fastapi/test_billing_link.py
+++ b/server/etebase_server/fastapi/test_billing_link.py
@@ -1,0 +1,181 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+
+import pytest
+from django.db import connection
+from django.db.migrations.loader import MigrationLoader
+from django.utils import timezone
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from etebase_server.django.models import BillingLinkProof
+
+from .dependencies import get_authenticated_user
+from .routers.billing_link import billing_link_router
+
+pytestmark = pytest.mark.django_db(transaction=True)
+MACHINE_KEY = "test-machine-key"
+
+
+def test_billing_link_migration_extends_the_real_app_graph():
+    loader = MigrationLoader(connection)
+    target = ("django_etebase", "0038_billing_link_proof")
+
+    assert target in loader.graph.nodes
+    assert ("django_etebase", "0037_auto_20210127_1237") in loader.graph.forwards_plan(target)
+
+
+def make_client(user=None):
+    app = FastAPI()
+    app.include_router(billing_link_router, prefix="/api/v1/billing")
+    if user is not None:
+        app.dependency_overrides[get_authenticated_user] = lambda: user
+    return app, TestClient(app, raise_server_exceptions=False)
+
+
+def issue_proof(client):
+    response = client.post("/api/v1/billing/link-proof/")
+    assert response.status_code == 200
+    proof = response.json()["etebaseLinkProof"]
+    assert len(proof) == 43
+    return proof
+
+
+def consume(client, proof, key=MACHINE_KEY):
+    headers = {"X-Etebase-Billing-Key": key} if key is not None else {}
+    return client.post(
+        "/api/v1/billing/link-proof/consume/",
+        json={"etebaseLinkProof": proof},
+        headers=headers,
+    )
+
+
+def test_issue_requires_authenticated_user():
+    _, client = make_client()
+
+    response = client.post("/api/v1/billing/link-proof/")
+
+    assert response.status_code in (401, 403)
+    assert BillingLinkProof.objects.count() == 0
+
+
+def test_issue_stores_only_hash_and_account_binding(user_factory):
+    user = user_factory(username="proof-user", email="proof@example.com")
+    _, client = make_client(user)
+
+    proof = issue_proof(client)
+    stored = BillingLinkProof.objects.get()
+
+    assert stored.user == user
+    assert stored.audience == "billing"
+    assert stored.proof_hash == BillingLinkProof.digest(proof)
+    assert proof not in stored.proof_hash
+    assert stored.consumed_at is None
+    assert stored.expires_at > timezone.now()
+
+
+def test_consume_requires_correct_machine_key_without_burning_proof(user_factory, monkeypatch):
+    monkeypatch.setenv("ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY", MACHINE_KEY)
+    user = user_factory(username="proof-user", email="proof@example.com")
+    _, client = make_client(user)
+    proof = issue_proof(client)
+
+    assert consume(client, proof, key=None).status_code == 401
+    assert consume(client, proof, key="wrong-machine-key").status_code == 401
+
+    response = consume(client, proof)
+    assert response.status_code == 200
+    assert response.json() == {"username": "proof-user", "email": "proof@example.com"}
+
+
+def test_consumption_is_one_time(user_factory, monkeypatch):
+    monkeypatch.setenv("ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY", MACHINE_KEY)
+    user = user_factory(username="proof-user", email="proof@example.com")
+    _, client = make_client(user)
+    proof = issue_proof(client)
+
+    assert consume(client, proof).status_code == 200
+    assert consume(client, proof).status_code == 401
+    assert BillingLinkProof.objects.get().consumed_at is not None
+
+
+def test_concurrent_consumers_have_exactly_one_winner(user_factory, monkeypatch):
+    monkeypatch.setenv("ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY", MACHINE_KEY)
+    user = user_factory(username="proof-user", email="proof@example.com")
+    app, client = make_client(user)
+    proof = issue_proof(client)
+
+    def attempt():
+        with TestClient(app, raise_server_exceptions=False) as concurrent_client:
+            return consume(concurrent_client, proof).status_code
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        statuses = sorted(pool.map(lambda _: attempt(), range(2)))
+
+    assert statuses == [200, 401]
+
+
+def test_expired_and_wrong_audience_proofs_fail_closed(user_factory, monkeypatch):
+    monkeypatch.setenv("ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY", MACHINE_KEY)
+    user = user_factory(username="proof-user", email="proof@example.com")
+    _, client = make_client(user)
+
+    expired = "e" * 43
+    BillingLinkProof.objects.create(
+        user=user,
+        proof_hash=BillingLinkProof.digest(expired),
+        audience="billing",
+        expires_at=timezone.now() - timedelta(seconds=1),
+    )
+    wrong_audience = "a" * 43
+    BillingLinkProof.objects.create(
+        user=user,
+        proof_hash=BillingLinkProof.digest(wrong_audience),
+        audience="another-service",
+        expires_at=timezone.now() + timedelta(minutes=5),
+    )
+
+    assert consume(client, expired).status_code == 401
+    assert consume(client, wrong_audience).status_code == 401
+    assert BillingLinkProof.objects.filter(consumed_at__isnull=False).count() == 0
+
+
+def test_malformed_proof_is_rejected_before_database_lookup(user_factory, monkeypatch):
+    monkeypatch.setenv("ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY", MACHINE_KEY)
+    user = user_factory(username="proof-user", email="proof@example.com")
+    _, client = make_client(user)
+
+    response = consume(client, "too-short")
+
+    assert response.status_code == 422
+    assert BillingLinkProof.objects.count() == 0
+
+
+def test_readiness_requires_machine_key(monkeypatch):
+    monkeypatch.setenv("ETEBASE_BILLING_LINK_PROOF_MACHINE_KEY", MACHINE_KEY)
+    _, client = make_client()
+
+    assert client.get("/api/v1/billing/link-proof/ready/").status_code == 401
+    assert client.get(
+        "/api/v1/billing/link-proof/ready/",
+        headers={"X-Etebase-Billing-Key": MACHINE_KEY},
+    ).json() == {"ready": True}
+
+
+def test_legacy_identity_is_disabled_by_default(user_factory, monkeypatch):
+    monkeypatch.delenv("ETEBASE_LEGACY_BEARER_IDENTITY_ROLLOUT_ENABLED", raising=False)
+    user = user_factory(username="proof-user", email="proof@example.com")
+    _, client = make_client(user)
+
+    assert client.get("/api/v1/billing/billing-identity/").status_code == 404
+
+
+def test_legacy_identity_requires_explicit_rollout_flag(user_factory, monkeypatch):
+    monkeypatch.setenv("ETEBASE_LEGACY_BEARER_IDENTITY_ROLLOUT_ENABLED", "true")
+    user = user_factory(username="proof-user", email="proof@example.com")
+    _, client = make_client(user)
+
+    response = client.get("/api/v1/billing/billing-identity/")
+
+    assert response.status_code == 200
+    assert response.json() == {"username": "proof-user", "email": "proof@example.com"}


### PR DESCRIPTION
## Summary
- issue short-lived, audience-bound, single-use Billing link proofs from the authenticated Etebase server
- stop sending reusable Etebase bearer/session credentials to hosted Billing
- keep custom-server signup and finalization outside hosted Billing
- deploy public server/web images by immutable digest with exact revision verification, migration-before-replacement, and automatic rollback
- document the staged compatibility rollout

## Verification
- web auth and deployment contract tests: 105 passed
- web type-check: passed
- web lint: passed with existing unrelated warnings
- changed Python files: Ruff E/F/I passed
- `git diff --check`: passed
- server migration/runtime tests: CI-only per repository policy
- independent GPT-5.6 Terra review: PUBLIC GREEN; CROSS-REPO ROLLOUT GREEN

## Paired internal PR
https://github.com/silent-suite/silentsuite-internal/pull/314

## Rollout
Merge to `dev` only after both exact heads pass CI. Production promotion remains separately gated and requires the staged order in `docs/operator-billing-link-proof-rollout.md`.