### PR TITLE
fix(bridge): redact packaged Radicale identifiers

### DIFF
--- a/bridge/src/silentsuite_bridge/radicale/application.py
+++ b/bridge/src/silentsuite_bridge/radicale/application.py
@@ -10,7 +10,7 @@ class _DavDiagnosticRedactionFilter(logging.Filter):
 
     def filter(self, record):
         template = str(record.msg)
-        normalized_path = str(record.pathname).replace("\\", "/")
+        normalized_path = "/" + str(record.pathname).replace("\\", "/").lstrip("/")
         if "/radicale/server.py" in normalized_path:
             record.msg = "Radicale server request failed"
             record.args = ()

--- a/bridge/tests/test_radicale_application_privacy.py
+++ b/bridge/tests/test_radicale_application_privacy.py
@@ -1,0 +1,22 @@
+import logging
+
+from silentsuite_bridge.radicale import application as bridge_application
+
+
+def test_radicale_filter_redacts_packaged_relative_app_diagnostics():
+    private_identifier = "private-account@example.invalid"
+    record = logging.LogRecord(
+        name="radicale",
+        level=logging.INFO,
+        pathname="radicale/app/__init__.py",
+        lineno=254,
+        msg="Successful login: %r",
+        args=(private_identifier,),
+        exc_info=None,
+    )
+
+    bridge_application._DavDiagnosticRedactionFilter().filter(record)
+
+    assert record.msg == "Radicale diagnostic suppressed"
+    assert record.args == ()
+    assert private_identifier not in record.getMessage()


### PR DESCRIPTION
## Summary
- normalize Radicale diagnostic source paths before privacy filtering so PyInstaller-relative paths are covered
- add a regression for the packaged `radicale/app/__init__.py` login diagnostic
- preserve existing identifier/payload/token/exception redaction behavior

## Root cause
Source tests used absolute `record.pathname` values such as `/site-packages/radicale/app/...`, while the packaged binary emits relative paths such as `radicale/app/...`. The filter required a leading slash, so the packaged successful-login diagnostic bypassed the app-level redaction branch and logged the authenticated identifier.

Refs #579. This fixes the validated packaged-log blocker; the broader issue remains open pending rebuilt-artifact and DAV convergence evidence.

## TDD
- RED: packaged-relative login diagnostic retained `Successful login: %r` and its identifier
- GREEN: focused regression passed after path canonicalization

## Verification
- `PYTHONPATH=bridge/src .venv/bin/python -m pytest --noconftest -q bridge/tests/test_radicale_application_privacy.py` (1 passed)
- `ruff check bridge/src/silentsuite_bridge/radicale/application.py bridge/tests/test_radicale_application_privacy.py`
- `git diff --check`
- full Bridge suite and rebuilt packaged privacy probe required in exact-head CI/artifact evidence