### PR TITLE
test(android): stabilize API 21 account entry runtime

### DIFF
--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/AuthenticatorLifecycleRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/AuthenticatorLifecycleRuntimeTest.kt
@@ -59,69 +59,99 @@ class AuthenticatorLifecycleRuntimeTest {
             val loginIntent = Intent(targetContext, LoginActivity::class.java)
             assertEquals(targetContext.packageName, loginIntent.component?.packageName)
             ActivityScenario.launch<LoginActivity>(loginIntent).use { scenario ->
-                instrumentation.waitForIdleSync()
-                scenario.onActivity { activity ->
-                    activity.findViewById<android.view.View>(R.id.account_choice_sign_in).performClick()
-                    activity.supportFragmentManager.executePendingTransactions()
-                    activity.findViewById<android.view.View>(R.id.show_advanced).performClick()
-                    activity.findViewById<android.widget.EditText>(R.id.custom_server)
-                        .setText("https://custom.example.invalid/")
-                    activity.supportFragmentManager.beginTransaction()
-                        .replace(
-                            android.R.id.content,
-                            CreateAccountFragment(),
-                            LoginActivity.CREATE_ACCOUNT_TAG,
+                var loginActivity: LoginActivity? = null
+                try {
+                    instrumentation.waitForIdleSync()
+                    scenario.onActivity { activity ->
+                        loginActivity = activity
+                        activity.findViewById<android.view.View>(R.id.account_choice_sign_in).performClick()
+                        activity.supportFragmentManager.executePendingTransactions()
+                        activity.findViewById<android.view.View>(R.id.show_advanced).performClick()
+                        activity.findViewById<android.widget.EditText>(R.id.custom_server)
+                            .setText("https://custom.example.invalid/")
+                        activity.findViewById<android.widget.EditText>(R.id.user_name)
+                            .setText("restore@example.invalid")
+                        activity.findViewById<android.widget.EditText>(R.id.login_password)
+                            .setText("process-only-fixture")
+                        val credentials = activity.supportFragmentManager
+                            .findFragmentById(android.R.id.content) as LoginCredentialsFragment
+                        val validate = LoginCredentialsFragment::class.java
+                            .getDeclaredMethod("validateLoginData").apply { isAccessible = true }
+                        val staged = validate.invoke(credentials) as LoginCredentials
+                        val lease = requireNotNull(activity.setupLease())
+                        assertTrue(SetupSecretHolder.setLoginCredentials(lease, staged))
+                        activity.supportFragmentManager.beginTransaction()
+                            .replace(
+                                android.R.id.content,
+                                CreateAccountFragment.newInstance(SetupSecretHolder.reference(lease)),
+                                LoginActivity.CREATE_ACCOUNT_TAG,
+                            )
+                            .addToBackStack(LoginActivity.CREDENTIALS_TO_CREATOR_BACK_STACK)
+                            .commit()
+                    }
+                    instrumentation.waitForIdleSync()
+                    val recoveryDeadline = android.os.SystemClock.elapsedRealtime() + 5_000L
+                    var recoveryReady = false
+                    while (!recoveryReady && android.os.SystemClock.elapsedRealtime() < recoveryDeadline) {
+                        instrumentation.waitForIdleSync()
+                        scenario.onActivity { activity ->
+                            activity.supportFragmentManager.executePendingTransactions()
+                            val retry = activity.supportFragmentManager
+                                .findFragmentByTag(LoginActivity.CREATE_RETRY_ERROR_TAG)
+                            recoveryReady =
+                                activity.supportFragmentManager.findFragmentById(android.R.id.content)
+                                    is LoginCredentialsFragment &&
+                                    retry is androidx.fragment.app.DialogFragment &&
+                                    retry.dialog?.isShowing == true
+                        }
+                        if (!recoveryReady) android.os.SystemClock.sleep(25L)
+                    }
+                    assertTrue("Valid creator failure did not restore credentials with a bounded retry dialog", recoveryReady)
+                    scenario.onActivity { activity ->
+                        org.junit.Assert.assertFalse(activity.isFinishing)
+                        org.junit.Assert.assertNull(
+                            activity.supportFragmentManager.findFragmentByTag(LoginActivity.CREATE_ACCOUNT_TAG),
                         )
-                        .addToBackStack(LoginActivity.CREDENTIALS_TO_CREATOR_BACK_STACK)
-                        .commit()
-                }
-                instrumentation.waitForIdleSync()
-                scenario.onActivity { activity ->
-                    activity.supportFragmentManager.executePendingTransactions()
-                    org.junit.Assert.assertFalse(activity.isFinishing)
-                    val dismissedCreator = activity.supportFragmentManager
-                        .findFragmentByTag(LoginActivity.CREATE_ACCOUNT_TAG) as CreateAccountFragment
-                    org.junit.Assert.assertFalse(dismissedCreator.isAdded)
-                    org.junit.Assert.assertFalse(dismissedCreator.dialog?.isShowing == true)
-                    org.junit.Assert.assertNull(
-                        activity.supportFragmentManager.findFragmentByTag("account_creation_retry_error"),
-                    )
-                    activity.onBackPressedDispatcher.onBackPressed()
-                    activity.supportFragmentManager.executePendingTransactions()
-                    org.junit.Assert.assertNull(
-                        activity.supportFragmentManager.findFragmentByTag(LoginActivity.CREATE_ACCOUNT_TAG),
-                    )
-                }
-                instrumentation.waitForIdleSync()
-                scenario.onActivity { activity ->
-                    val credentials = activity.supportFragmentManager
-                        .findFragmentById(android.R.id.content) as LoginCredentialsFragment
-                    val guard = LoginCredentialsFragment::class.java.getDeclaredField("submissionInProgress")
-                    guard.isAccessible = true
-                    org.junit.Assert.assertFalse(guard.getBoolean(credentials))
-                    val expanded = LoginCredentialsFragment::class.java.getDeclaredField("advancedExpanded")
-                    expanded.isAccessible = true
-                    org.junit.Assert.assertTrue(expanded.getBoolean(credentials))
-                    assertEquals(
-                        "Custom server settings, expanded",
-                        activity.findViewById<android.view.View>(R.id.show_advanced).contentDescription,
-                    )
-                    assertEquals(
-                        "https://custom.example.invalid/",
-                        activity.findViewById<android.widget.EditText>(R.id.custom_server).text.toString(),
-                    )
-                    activity.findViewById<android.widget.EditText>(R.id.user_name)
-                        .setText("restore@example.invalid")
-                    activity.findViewById<android.widget.EditText>(R.id.login_password)
-                        .setText("process-only-fixture")
-                    val validate = LoginCredentialsFragment::class.java
-                        .getDeclaredMethod("validateLoginData")
-                    validate.isAccessible = true
-                    val restored = validate.invoke(credentials) as LoginCredentials
-                    assertEquals(URI("https://custom.example.invalid/"), restored.uri)
-                    org.junit.Assert.assertFalse(activity.isFinishing)
-                    org.junit.Assert.assertEquals(1, delivery.continued)
-                    org.junit.Assert.assertEquals(0, delivery.errors)
+                        val retry = activity.supportFragmentManager
+                            .findFragmentByTag(LoginActivity.CREATE_RETRY_ERROR_TAG) as androidx.fragment.app.DialogFragment
+                        org.junit.Assert.assertTrue(retry.dialog?.isShowing == true)
+                        retry.dismissAllowingStateLoss()
+                        activity.supportFragmentManager.executePendingTransactions()
+                        val credentials = activity.supportFragmentManager
+                            .findFragmentById(android.R.id.content) as LoginCredentialsFragment
+                        val guard = LoginCredentialsFragment::class.java.getDeclaredField("submissionInProgress")
+                        guard.isAccessible = true
+                        org.junit.Assert.assertFalse(guard.getBoolean(credentials))
+                        val expanded = LoginCredentialsFragment::class.java.getDeclaredField("advancedExpanded")
+                        expanded.isAccessible = true
+                        org.junit.Assert.assertTrue(expanded.getBoolean(credentials))
+                        assertEquals(
+                            "Custom server settings, expanded",
+                            activity.findViewById<android.view.View>(R.id.show_advanced).contentDescription,
+                        )
+                        assertEquals(
+                            "https://custom.example.invalid/",
+                            activity.findViewById<android.widget.EditText>(R.id.custom_server).text.toString(),
+                        )
+                        val validate = LoginCredentialsFragment::class.java
+                            .getDeclaredMethod("validateLoginData")
+                        validate.isAccessible = true
+                        val restored = validate.invoke(credentials) as LoginCredentials
+                        assertEquals(URI("https://custom.example.invalid/"), restored.uri)
+                        assertEquals("restore@example.invalid", restored.userName)
+                        assertEquals("process-only-fixture", restored.password)
+                        org.junit.Assert.assertFalse(activity.isFinishing)
+                        org.junit.Assert.assertEquals(1, delivery.continued)
+                        org.junit.Assert.assertEquals(0, delivery.errors)
+                    }
+                } finally {
+                    loginActivity?.let {
+                        finishAndAwaitDestroyed(
+                            instrumentation,
+                            it,
+                            "Recoverable-creation login did not finish before scenario cleanup",
+                        )
+                    }
                 }
             }
             creatorGenerationReplacementRoutesToSettingsResolution()

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/AuthenticatorLifecycleRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/AuthenticatorLifecycleRuntimeTest.kt
@@ -98,9 +98,10 @@ class AuthenticatorLifecycleRuntimeTest {
                             activity.supportFragmentManager.executePendingTransactions()
                             val retry = activity.supportFragmentManager
                                 .findFragmentByTag(LoginActivity.CREATE_RETRY_ERROR_TAG)
+                            val credentials = activity.supportFragmentManager
+                                .findFragmentById(android.R.id.content)
                             recoveryReady =
-                                activity.supportFragmentManager.findFragmentById(android.R.id.content)
-                                    is LoginCredentialsFragment &&
+                                credentials is LoginCredentialsFragment &&
                                     retry is androidx.fragment.app.DialogFragment &&
                                     retry.dialog?.isShowing == true
                         }

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/AuthenticatorLifecycleRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/AuthenticatorLifecycleRuntimeTest.kt
@@ -134,13 +134,20 @@ class AuthenticatorLifecycleRuntimeTest {
                             "https://custom.example.invalid/",
                             activity.findViewById<android.widget.EditText>(R.id.custom_server).text.toString(),
                         )
+                        assertEquals(
+                            "restore@example.invalid",
+                            activity.findViewById<android.widget.EditText>(R.id.user_name).text.toString(),
+                        )
+                        assertEquals(
+                            "",
+                            activity.findViewById<android.widget.EditText>(R.id.login_password).text.toString(),
+                        )
+                        val lease = requireNotNull(activity.setupLease())
+                        org.junit.Assert.assertNull(SetupSecretHolder.getLoginCredentials(lease))
                         val validate = LoginCredentialsFragment::class.java
                             .getDeclaredMethod("validateLoginData")
                         validate.isAccessible = true
-                        val restored = validate.invoke(credentials) as LoginCredentials
-                        assertEquals(URI("https://custom.example.invalid/"), restored.uri)
-                        assertEquals("restore@example.invalid", restored.userName)
-                        assertEquals("process-only-fixture", restored.password)
+                        org.junit.Assert.assertNull(validate.invoke(credentials))
                         org.junit.Assert.assertFalse(activity.isFinishing)
                         org.junit.Assert.assertEquals(1, delivery.continued)
                         org.junit.Assert.assertEquals(0, delivery.errors)

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/FirstRunSignInRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/FirstRunSignInRuntimeTest.kt
@@ -167,42 +167,61 @@ class FirstRunSignInRuntimeTest {
                     })
                 }
 
-                lateinit var releasedAdmission: LoginFlowOwnerRegistry.Admission
-                val admissionField = LoginActivity::class.java.getDeclaredField("admission").apply {
-                    isAccessible = true
-                }
-                scenario.onActivity { activity ->
-                    releasedAdmission = admissionField.get(activity) as LoginFlowOwnerRegistry.Admission
-                    LoginFlowOwnerRegistry.release(
-                        activity,
-                        releasedAdmission.releaseToken,
-                        changingConfigurations = true,
+                val frozenNow = SetupElapsedClock.now()
+                SetupElapsedClock.nowForTest = { frozenNow }
+                var rebindReturn: SignupReturnActivity? = null
+                try {
+                    lateinit var releasedAdmission: LoginFlowOwnerRegistry.Admission
+                    val admissionField = LoginActivity::class.java.getDeclaredField("admission").apply {
+                        isAccessible = true
+                    }
+                    scenario.onActivity { activity ->
+                        releasedAdmission = admissionField.get(activity) as LoginFlowOwnerRegistry.Admission
+                        LoginFlowOwnerRegistry.release(
+                            activity,
+                            releasedAdmission.releaseToken,
+                            changingConfigurations = true,
+                        )
+                    }
+                    val rebindMonitor = monitorSignupReturn()
+                    context.startActivity(
+                        Intent(
+                            Intent.ACTION_VIEW,
+                            android.net.Uri.parse("silentsuite://signup-complete"),
+                            context,
+                            SignupReturnActivity::class.java,
+                        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK),
                     )
+                    val monitoredReturn = instrumentation.waitForMonitorWithTimeout(rebindMonitor, 5_000L)
+                    assertTrue("Tokenless callback did not enter the rebind queue", monitoredReturn is SignupReturnActivity)
+                    val callback = monitoredReturn as SignupReturnActivity
+                    rebindReturn = callback
+                    assertFalse("Rebind-queued callback finished before replacement admission", callback.isFinishing)
+                    scenario.onActivity { activity ->
+                        val rebound = LoginFlowOwnerRegistry.admit(
+                            activity,
+                            releasedAdmission.flowId,
+                            releasedAdmission.generation,
+                        )
+                        admissionField.set(activity, rebound)
+                    }
+                    val rebindFinishDeadline = android.os.SystemClock.elapsedRealtime() + 5_000L
+                    while (!callback.isFinishing && android.os.SystemClock.elapsedRealtime() < rebindFinishDeadline)
+                        android.os.SystemClock.sleep(50L)
+                    assertTrue("Rebind-queued callback did not finish after replacement admission", callback.isFinishing)
+                } finally {
+                    try {
+                        rebindReturn?.let {
+                            finishAndAwaitDestroyed(
+                                instrumentation,
+                                it,
+                                "Rebind callback did not finish before elapsed-clock restoration",
+                            )
+                        }
+                    } finally {
+                        SetupElapsedClock.nowForTest = null
+                    }
                 }
-                val rebindMonitor = monitorSignupReturn()
-                context.startActivity(
-                    Intent(
-                        Intent.ACTION_VIEW,
-                        android.net.Uri.parse("silentsuite://signup-complete"),
-                        context,
-                        SignupReturnActivity::class.java,
-                    ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK),
-                )
-                val rebindReturn = instrumentation.waitForMonitorWithTimeout(rebindMonitor, 5_000L)
-                assertTrue("Tokenless callback did not enter the rebind queue", rebindReturn is SignupReturnActivity)
-                assertFalse("Rebind-queued callback finished before replacement admission", rebindReturn!!.isFinishing)
-                scenario.onActivity { activity ->
-                    val rebound = LoginFlowOwnerRegistry.admit(
-                        activity,
-                        releasedAdmission.flowId,
-                        releasedAdmission.generation,
-                    )
-                    admissionField.set(activity, rebound)
-                }
-                val rebindFinishDeadline = android.os.SystemClock.elapsedRealtime() + 5_000L
-                while (!rebindReturn.isFinishing && android.os.SystemClock.elapsedRealtime() < rebindFinishDeadline)
-                    android.os.SystemClock.sleep(50L)
-                assertTrue("Rebind-queued callback did not finish after replacement admission", rebindReturn.isFinishing)
             }
 
             var deadlineRecoveryMonitor: android.app.Instrumentation.ActivityMonitor? = null
@@ -532,6 +551,7 @@ class FirstRunSignInRuntimeTest {
         LoginActivity.controllerFactory = null
         LoginActivity.browserLauncherForTest = null
         SignupReturnActivity.foregroundExecutorForTest = null
+        SetupElapsedClock.nowForTest = null
         LoginFlowOwnerRegistry.resetForTests()
         SignupContinuationRegistry.resetForTests()
         SetupSecretHolder.resetForTests()

--- a/tests/test_android_security_static.py
+++ b/tests/test_android_security_static.py
@@ -108,6 +108,9 @@ def test_account_entry_lifecycle_security_blockers_have_explicit_fail_closed_con
     continuation = (setup / "SignupContinuationRegistry.kt").read_text(encoding="utf-8")
     detector = (setup / "DetectConfigurationFragment.kt").read_text(encoding="utf-8")
     creator = (setup / "CreateAccountFragment.kt").read_text(encoding="utf-8")
+    credentials_layout = (
+        ROOT / "android/app/src/main/res/layout/login_credentials_fragment.xml"
+    ).read_text(encoding="utf-8")
     credential_change = (setup / "LoginCredentialsChangeFragment.kt").read_text(encoding="utf-8")
     signup_return = (setup / "SignupReturnActivity.kt").read_text(encoding="utf-8")
     first_run_runtime = (ROOT / "android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/FirstRunSignInRuntimeTest.kt").read_text(encoding="utf-8")
@@ -141,6 +144,10 @@ def test_account_entry_lifecycle_security_blockers_have_explicit_fail_closed_con
     assert "check(BuildConfig.DEBUG)" in holder.split("fun now(): Long", 1)[1].split("object SetupSecretHolder", 1)[0]
     assert "if (nextGeneration == Long.MAX_VALUE)" in continuation
 
+    password_view = credentials_layout.split('android:id="@+id/login_password"', 1)[1].split(
+        "/>", 1
+    )[0]
+    assert 'android:saveEnabled="false"' in password_view
     assert "FragmentLifecycleCallbacks" in activity
     assert "onFragmentResumed" in activity
     acknowledgement = activity.split("private fun acknowledgeSignupDestinationIfReady", 1)[1]
@@ -219,6 +226,8 @@ def test_account_entry_lifecycle_security_blockers_have_explicit_fail_closed_con
     assert "CreateAccountFragment.newInstance(SetupSecretHolder.reference(lease))" in recoverable_runtime
     assert "CreateAccountFragment()," not in recoverable_runtime
     assert "Valid creator failure did not restore credentials with a bounded retry dialog" in recoverable_runtime
+    assert "SetupSecretHolder.getLoginCredentials(lease)" in recoverable_runtime
+    assert "assertNull(validate.invoke(credentials))" in recoverable_runtime
     assert recoverable_runtime.index("assertEquals(0, delivery.errors)") < recoverable_runtime.index(
         "finishAndAwaitDestroyed"
     )

--- a/tests/test_android_security_static.py
+++ b/tests/test_android_security_static.py
@@ -111,6 +111,7 @@ def test_account_entry_lifecycle_security_blockers_have_explicit_fail_closed_con
     credential_change = (setup / "LoginCredentialsChangeFragment.kt").read_text(encoding="utf-8")
     signup_return = (setup / "SignupReturnActivity.kt").read_text(encoding="utf-8")
     first_run_runtime = (ROOT / "android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/FirstRunSignInRuntimeTest.kt").read_text(encoding="utf-8")
+    authenticator_runtime = (ROOT / "android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/AuthenticatorLifecycleRuntimeTest.kt").read_text(encoding="utf-8")
 
     detector_failure = detector.split("if (data == null || data.isFailed)", 1)[1].split(
         "dismissAllowingStateLoss()", 1
@@ -198,6 +199,29 @@ def test_account_entry_lifecycle_security_blockers_have_explicit_fail_closed_con
     assert "foregroundExecutorForTest = null" in first_run_runtime
     assert "Tokenless callback did not enter the rebind queue" in first_run_runtime
     assert "Persistent foreground failure did not recover after its deadline" in first_run_runtime
+    rebind_runtime = first_run_runtime.split("val frozenNow = SetupElapsedClock.now()", 1)[1].split(
+        "var deadlineRecoveryMonitor", 1
+    )[0]
+    assert "SetupElapsedClock.nowForTest = { frozenNow }" in rebind_runtime
+    assert rebind_runtime.index("LoginFlowOwnerRegistry.release") < rebind_runtime.index(
+        "LoginFlowOwnerRegistry.admit"
+    )
+    assert rebind_runtime.index("finishAndAwaitDestroyed") < rebind_runtime.index(
+        "SetupElapsedClock.nowForTest = null"
+    )
+    finish_scenario = first_run_runtime.split("private fun finishScenario", 1)[1].split(
+        "private fun assertTestStateEmpty", 1
+    )[0]
+    assert "SetupElapsedClock.nowForTest = null" in finish_scenario
+    recoverable_runtime = authenticator_runtime.split(
+        "fun recoverableCreationFailureRestoresCredentialsWithoutFinishingOrCancelling", 1
+    )[1].split("private fun creatorGenerationReplacementRoutesToSettingsResolution", 1)[0]
+    assert "CreateAccountFragment.newInstance(SetupSecretHolder.reference(lease))" in recoverable_runtime
+    assert "CreateAccountFragment()," not in recoverable_runtime
+    assert "Valid creator failure did not restore credentials with a bounded retry dialog" in recoverable_runtime
+    assert recoverable_runtime.index("assertEquals(0, delivery.errors)") < recoverable_runtime.index(
+        "finishAndAwaitDestroyed"
+    )
     unknown_route = owner.split("val flowId =", 1)[1].split("val exactToken", 1)[0]
     assert "current?.state == State.REBINDING" in unknown_route
     assert "SignupRouteResult.QUEUED_REBIND(current.rebindDeadline)" in unknown_route


### PR DESCRIPTION
## Summary
- freeze the existing debug elapsed-time seam without rewinding monotonic time while manually exercising pre-deadline owner rebind
- explicitly destroy callback and LoginActivity fixtures before clock/scenario teardown
- exercise the valid leased account-creation recovery path, including bounded retry UI and preserved credential fields
- add semantic static guards for cleanup ordering and valid creator authority

## Root cause
The two failures in promotion workflow 30736816475 were test synchronization defects, not production state-machine defects. API 21 monitor delivery exceeded the real two-second rebind lease in one subcase, and ActivityScenario.close timed out while a deliberately live LoginActivity remained PAUSED in the other.

## Verification
- `python3 -m pytest ../tests/test_android_*.py -q` from `android/`: 150 passed, 26 subtests passed
- `git diff --check`
- no `android/app/src/main/**` changes

## Hosted gate
Android build/instrumentation is CI-only. The corrected exact head must pass fresh API 21 remaining/mixed and all other workflow shards. No unchanged-SHA rerun is being used.

Closes no issue.