### PR TITLE
release: promote dev to main (2026-08-03)

### DIFF
--- a/.github/workflows/android-network-evidence.yml
+++ b/.github/workflows/android-network-evidence.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: android-network-evidence
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Materialize sanitized evidence only
         env:
           NETWORK_EVIDENCE_JSONL: ${{ secrets.ANDROID_NETWORK_EVIDENCE_JSONL }}
@@ -88,7 +88,7 @@ jobs:
           Path('network-evidence/summary/manual-review.json').write_text(json.dumps(record, indent=2) + '\n')
           PY
       - name: Upload sanitized summary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-network-summary-${{ github.sha }}
           path: network-evidence/summary/

--- a/.github/workflows/android-tracker-quarterly-review.yml
+++ b/.github/workflows/android-tracker-quarterly-review.yml
@@ -13,7 +13,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run positive fixtures and policy checks
         run: |
           python3 -m unittest tests.test_android_tracker_scan -v
@@ -52,7 +52,7 @@ jobs:
               'review_record': baseline['review_record'],
           }, indent=2) + '\n')
           PY
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-tracker-quarterly-review-${{ github.sha }}
           path: android-quarterly-review/

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -39,7 +39,7 @@ jobs:
           python -m pip install --disable-pip-version-check --only-binary=:all: --require-hashes -r "$RUNNER_TEMP/android-signing-policy-requirements.txt"
 
       - name: Checkout policy source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           clean: true
           persist-credentials: false
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload unit test reports and results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-unit-test-results-${{ github.sha }}
           path: |
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload lint reports
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-lint-reports-${{ github.sha }}
           path: |
@@ -236,14 +236,14 @@ jobs:
             app/build/outputs/apk/debug/*.apk
 
       - name: Upload tracker verification evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-tracker-scan-${{ github.sha }}
           path: android/build/privacy-evidence/
           retention-days: 14
 
       - name: Upload debug APK artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: silentsuite-debug-${{ github.sha }}
           path: |
@@ -285,7 +285,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -492,7 +492,7 @@ jobs:
 
       - name: Upload focused androidTest reports and results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: account-recreation-androidTest-api${{ matrix.api-level }}-${{ matrix.arch }}-${{ matrix.shard }}-${{ github.sha }}
           path: |
@@ -521,7 +521,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -627,7 +627,7 @@ jobs:
             build/privacy-evidence/signed-release-splits
 
       - name: Upload signed tracker verification evidence
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: android-tracker-scan-${{ github.sha }}
           path: android/build/privacy-evidence/
@@ -650,7 +650,7 @@ jobs:
         run: jarsigner -verify -certs -verbose app/build/outputs/bundle/release/*.aab
 
       - name: Upload signed release APK and AAB
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: silentsuite-release-${{ github.sha }}
           path: |

--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -81,7 +81,7 @@ jobs:
       # 1. Checkout
       # -----------------------------------------------------------------------
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # -----------------------------------------------------------------------
       # 2. Set up QEMU (arm64 Linux only)
@@ -260,7 +260,7 @@ jobs:
       # 11. Upload artifact (always — for manual inspect even without release)
       # -----------------------------------------------------------------------
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.asset-name }}
           path: |
@@ -284,11 +284,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Download all build artifacts
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: release-assets/
 

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python 3.10
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run tracker scanner and UID network evidence fixtures
         run: python3 -m unittest tests.test_android_tracker_scan -v
 
@@ -27,11 +27,11 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -54,13 +54,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -81,13 +81,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -108,13 +108,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -140,13 +140,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build web Docker image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.web

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout exact approved commit for build
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.expected_sha }}
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload admitted docs artifact
         id: upload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-production-${{ inputs.expected_sha }}
           path: apps/docs/.vitepress/dist
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout exact approved commit for deployment
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.expected_sha }}
           fetch-depth: 0

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout exact approved commit for publication
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.expected_sha }}
           fetch-depth: 0
@@ -57,10 +57,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push server image
         id: build
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.server
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout exact approved commit for deployment
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.expected_sha }}
           fetch-depth: 0

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout exact approved commit for publication
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.expected_sha }}
           fetch-depth: 0
@@ -57,10 +57,10 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Build and push web image
         id: build
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.web
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout exact approved commit for deployment
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.expected_sha }}
           fetch-depth: 0

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -35,13 +35,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build preview image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.web
@@ -99,20 +99,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push preview image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.web

--- a/.github/workflows/test-bridge-linux.yml
+++ b/.github/workflows/test-bridge-linux.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python 3.10
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # etebase-py 0.31.5 uses cpython 0.7.x which doesn't support Python 3.12+
       - name: Set up Python 3.10
@@ -83,7 +83,7 @@ jobs:
           dist/silentsuite-bridge --help
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: silentsuite-bridge-linux-x86_64-test
           path: bridge/dist/silentsuite-bridge

--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python 3.10
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python 3.10
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/apps/web/app/lib/__tests__/production-deploy-workflows.test.ts
+++ b/apps/web/app/lib/__tests__/production-deploy-workflows.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -78,23 +78,33 @@ esac
 
 const jobContracts: Record<string, Record<string, { steps: string; permissions: string }>> = {
   'deploy-web.yml': {
-    'build-and-push': { steps: 'e23e2195d21717e71fe08e47d202b446f858488f65ebbeee6c7dd7abd459fb46', permissions: '005c397eb9ccf2cc53aad524b4ebcad817405ec025bb937a039a8a5ef8c69bca' },
-    deploy: { steps: '72639f5529b592052a55c819853c08d009e3d092c8808ce733a7c64640b7e3ef', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
+    'build-and-push': { steps: '986d2e9862eb81e1d9b3abc028158b3880435f19b52fbb6fc40ba37bdd406733', permissions: '005c397eb9ccf2cc53aad524b4ebcad817405ec025bb937a039a8a5ef8c69bca' },
+    deploy: { steps: '27e085d4e9108ff2e06b8ae1b4b616794c8c7fd3fac65c1a47277cb7717ef828', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
   },
   'deploy-server.yml': {
-    'build-and-push': { steps: '009b1bf33803af9b5210638ee074a4006a4ab332557750e68caab4fa21219a9d', permissions: '005c397eb9ccf2cc53aad524b4ebcad817405ec025bb937a039a8a5ef8c69bca' },
-    deploy: { steps: '4a6af78622256751915bc0d4bcbc5c03a63f40ab1db8388885441f62b19b4625', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
+    'build-and-push': { steps: 'eaaaecf8738fd3b7d25bfb6f383709911df7c00da94dff1cca81014fdb254a62', permissions: '005c397eb9ccf2cc53aad524b4ebcad817405ec025bb937a039a8a5ef8c69bca' },
+    deploy: { steps: 'bbd0c9a9415d24b319bf53201011b78485a5a22674d36336b252fa770e19cf4c', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
   },
   'deploy-docs.yml': {
-    build: { steps: 'bc49bcc31e40e8c2c8564e68efe2dfc09a400c0c0de8bcec9155fadad5760e49', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
-    deploy: { steps: '9324d75996bca253594b92ebbc089d60d833dc39f94853c377ad0be5f9610a2a', permissions: '551b70084a8244c7f3114d8603c3d2ddac6b642093a4b34cd2e3a00b7e4f8ee1' },
+    build: { steps: '90a5bed17b51f0b60748163cd3d53b9d86c0088f0b2e5904db0a69cb370bd7a9', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
+    deploy: { steps: '9663c351621aa2b85d3afb464e9630039a802f1799205610c2e3e3285ba09c08', permissions: '551b70084a8244c7f3114d8603c3d2ddac6b642093a4b34cd2e3a00b7e4f8ee1' },
   },
 }
 
 const workflowContracts: Record<string, string> = {
-  'deploy-web.yml': '3f87487c3d4398cdf5ee851f3497304f1e81221cfb3b51aa53a7f4bb9caa6e5b',
-  'deploy-server.yml': 'ac36934537cbc324464fffe593e0e9b6c7e86b61ca592540bb1568771745c565',
-  'deploy-docs.yml': '083c229f0bb65953a44da47e01f13d870fe85b5df16489c36515d90177e00b62',
+  'deploy-web.yml': '67fe57e851cfa98a1736c623e070ddb3dc61bbc88f1b05f0f2b32cf8306ee74a',
+  'deploy-server.yml': 'ee8015b23a29d0faa6b0ecb0371f049ae9189c37fe4c80591f82f0e844193312',
+  'deploy-docs.yml': '7f768623b8e654b10da26f18e63c5ca021df3e33e24d3e8ceef31611e71c8ed9',
+}
+
+const approvedNode24ActionPins: Record<string, string> = {
+  'actions/checkout': '3d3c42e5aac5ba805825da76410c181273ba90b1',
+  'actions/setup-node': '820762786026740c76f36085b0efc47a31fe5020',
+  'actions/upload-artifact': '043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
+  'actions/download-artifact': '3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c',
+  'docker/setup-buildx-action': 'bb05f3f5519dd87d3ba754cc423b652a5edd6d2c',
+  'docker/login-action': 'dbcb813823bdd20940b903addbd779551569679f',
+  'docker/build-push-action': '53b7df96c91f9c12dcc8a07bcb9ccacbed38856a',
 }
 
 function expectAuthorizedJob(job: WorkflowJob, environment: string, approvalVariable: string, authorizationName: string, expectedRunSha256: string) {
@@ -130,6 +140,26 @@ function jobBlock(source: string, name: string): string {
 }
 
 describe('production deployment workflow integrity', () => {
+  it('pins migrated JavaScript actions to approved immutable Node 24 releases', () => {
+    const directory = resolve(process.cwd(), '../../.github/workflows')
+    const seen = new Set<string>()
+
+    for (const name of readdirSync(directory).filter((entry) => /\.ya?ml$/.test(entry))) {
+      const source = readFileSync(join(directory, name), 'utf8')
+      for (const match of source.matchAll(/^\s*uses:\s*([^\s#]+)/gm)) {
+        const uses = match[1]
+        const separator = uses.lastIndexOf('@')
+        const action = separator === -1 ? uses : uses.slice(0, separator)
+        const approved = approvedNode24ActionPins[action]
+        if (!approved) continue
+        seen.add(action)
+        expect(uses, `${name}: ${action}`).toBe(`${action}@${approved}`)
+      }
+    }
+
+    expect([...seen].sort()).toEqual(Object.keys(approvedNode24ActionPins).sort())
+  })
+
   it('strict AST rejects attacker checkout, no-op authorization, heredoc decoys, and duplicate keys', () => {
     const source = workflow('deploy-web.yml')
     const mutated = source
@@ -171,6 +201,11 @@ describe('production deployment workflow integrity', () => {
     expect(billingLinkRollout).toContain('0025_retain_etebase_session_verifier.sql')
     expect(billingLinkRollout).toContain('rollback-eligible Billing image')
     expect(billingLinkRollout).toContain('later reviewed contract release')
+    expect(billingLinkRollout).toContain('At least 48 hours of clean post-cutover production soak')
+    expect(billingLinkRollout).toContain('owner explicitly closes the previous-image rollback window')
+    expect(billingLinkRollout).toContain('declares the prior Billing image non-restorable')
+    expect(billingLinkRollout).toContain('silent-suite/silentsuite#621')
+    expect(billingLinkRollout).toContain('If any condition is missing, preserve the rollback-compatible code and verifier')
     expect(billingLinkRollout).not.toContain('0025_remove_etebase_session_verifier.sql')
   })
 

--- a/docs/operator-billing-link-proof-rollout.md
+++ b/docs/operator-billing-link-proof-rollout.md
@@ -9,4 +9,20 @@ This is a bounded, staged cutover. Do not put any secret values in source contro
 5. Disable both temporary flags: unset `ETEBASE_LEGACY_BEARER_ROLLOUT_ENABLED` in Billing and `ETEBASE_LEGACY_BEARER_IDENTITY_ROLLOUT_ENABLED` on Etebase. Restart the affected services and verify requests containing legacy bearers are rejected.
 6. Confirm migration `0025_retain_etebase_session_verifier.sql` has retained and validated the old verifier function and its bounded Billing privilege while any rollback-eligible Billing image can still call it. Remove the verifier only in a later reviewed contract release after the rollback window has closed and no rollback-eligible image depends on it. Remove the temporary Etebase identity path in that same or a later reviewed cleanup.
 
+## Rollback-window closure and cleanup admission
+
+Keep the dormant routes, false-by-default flags, verifier function, bounded execute grant, previous Billing image, and rollback configuration intact during the post-cutover soak. Disabled compatibility is not evidence that rollback compatibility is disposable.
+
+Prepare cleanup under issue `silent-suite/silentsuite#621`, but do not merge or deploy the destructive cleanup until all of these conditions are recorded with sanitized evidence:
+
+1. At least 48 hours of clean post-cutover production soak has elapsed.
+2. The current proof-only Web, Server, and Billing path passes immediately before cleanup: proof issue, proof exchange, Billing session read, logout, revoked refresh rejection, and legacy bearer rejection.
+3. The owner explicitly closes the previous-image rollback window and declares the prior Billing image non-restorable.
+4. The public cleanup removes the temporary Etebase identity route and flag without changing the opaque proof contract.
+5. The internal cleanup separately removes the legacy bearer request field/resolver and uses a reviewed migration to remove the retained verifier function and bounded grant.
+6. Both cleanup heads pass exact-head CI and substantive review before promotion; the database migration is exercised under the restricted Billing role.
+7. Only after the proof-only images are healthy in production may the retired image, stale Compose mappings, and rollback backup be removed under a separate operator checkpoint.
+
+If any condition is missing, preserve the rollback-compatible code and verifier. Do not reinterpret elapsed time, disabled flags, or a healthy current image as implicit cleanup approval.
+
 Missing machine-key configuration intentionally makes proof consumption fail closed; it does not prevent a self-hosted Etebase server from starting.

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -34,7 +34,7 @@ UNSAFE_SECRET_EXPRESSION = re.compile(
     r"\bsecrets\s*\[|\bsecrets\s*\.\s*\*|\btojson\s*\(\s*secrets\s*\)",
     re.IGNORECASE,
 )
-CHECKOUT_ACTION = "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5"
+CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
 SETUP_PYTHON_ACTION = "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
 EXPECTED_POLICY_JOB: dict[str, Any] = {
     "name": "Enforce Android signing boundary",
@@ -89,7 +89,7 @@ EXPECTED_SECRET_STEP_SHA256 = {
         "69ded7eab4c4ff48deff2da950aacf8e627da05373ffa507f358fbcc986a7a6a"
     ),
 }
-EXPECTED_RELEASE_JOB_SHA256 = "32b3bd8d5584e1049e4c56003bfe56be379c3204fca8f223a1c19b2e0b3c5402"
+EXPECTED_RELEASE_JOB_SHA256 = "c346399442d912004eca8a4e7fcc6cec3f67eb72e476a9f9b5b89e1b0ae707fb"
 ALLOWED_RELEASE_JOB_KEYS = {
     "name",
     "needs",

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -761,8 +761,8 @@ def test_release_secret_cannot_move_into_action_input(tmp_path: Path) -> None:
     workflow = root / ROOT_WORKFLOW
     mutate_last(
         workflow,
-        "      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Set up JDK 17\n",
-        "      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n        with:\n          token: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n\n      - name: Set up JDK 17\n",
+        "      - name: Checkout\n        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n\n      - name: Set up JDK 17\n",
+        "      - name: Checkout\n        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n        with:\n          token: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n\n      - name: Set up JDK 17\n",
     )
 
     assert_rejected(run_checker(root), "references signing secrets outside reviewed step environments")
@@ -773,8 +773,8 @@ def test_release_job_cannot_invoke_local_action(tmp_path: Path) -> None:
     workflow = root / ROOT_WORKFLOW
     mutate(
         workflow,
-        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Set up JDK 17\n",
-        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4\n\n      - name: Local release action\n        uses: ./malicious-action\n\n      - name: Set up JDK 17\n",
+        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n\n      - name: Set up JDK 17\n",
+        "  build-release:\n    name: Build (signed, tag release)\n    needs: signing-policy\n    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')\n    runs-on: ubuntu-latest\n    environment: android-release\n    permissions:\n      contents: write\n    defaults:\n      run:\n        working-directory: android\n\n    steps:\n      - name: Checkout\n        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n\n      - name: Local release action\n        uses: ./malicious-action\n\n      - name: Set up JDK 17\n",
     )
 
     assert_rejected(run_checker(root), "build-release must not invoke local actions")
@@ -785,11 +785,11 @@ def test_mutable_action_in_root_workflow_is_rejected(tmp_path: Path) -> None:
     workflow = root / ROOT_WORKFLOW
     mutate(
         workflow,
-        "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
-        "actions/checkout@v4",
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "actions/checkout@v7",
     )
 
-    assert_rejected(run_checker(root), "action must be pinned to a full commit SHA: actions/checkout@v4")
+    assert_rejected(run_checker(root), "action must be pinned to a full commit SHA: actions/checkout@v7")
 
 
 def test_mutable_action_in_android_sibling_workflow_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
## Immutable promotion identity

- Production base (`main`): `8d546fe77a79a034a6dae82e463b26e8576ac66b`
- Frozen integration head (`dev`): `a0b6cf2897b67c3ba3f689f54435cb900bbd1365`
- Candidate merge: `67ed72d801aee032a67072168adcecd5282bd79a`
- Ordered parents: `8d546fe77a79a034a6dae82e463b26e8576ac66b a0b6cf2897b67c3ba3f689f54435cb900bbd1365`
- Candidate tree: `b34e5f7e37ee4611ad402182d365fc3b6885dc1c`

## Scope

Promote the frozen public `dev` head containing #622 into `main`. `dev` and `main` had diverged; this candidate is a two-parent merge from current `main` plus current `dev`.

## Composition evidence

- `git merge-tree --write-tree` produced the same candidate tree.
- No merge conflicts.
- Full 1,473-path classification found zero paths differing from both parents.
- `git diff --check main..candidate` passed.
- No conflict-resolution-only behavior.

## Required gates

- exact-head production-target CI
- GPT-5.6 Sol substantive review
- independent strongest-available substantive review
- final revalidation that `main`, frozen `dev`, PR head, parents, and tree have not moved

## Boundaries

Merging advances public `main` and triggers production-branch CI. It does not create a tag or GitHub release and does not authorize any separately dispatched deployment or release workflow.
