### PR TITLE
ci: complete native Node 24 action migration

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -29,7 +29,7 @@ jobs:
       contents: read
     steps:
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.12'
 
@@ -66,13 +66,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Set up Python for static Android contracts
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
 
@@ -99,7 +99,7 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
 
       - name: Cache Gradle
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.gradle/caches
@@ -288,7 +288,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -322,7 +322,7 @@ jobs:
 
       - name: Run focused launcher and setup recreation contracts
         id: focused-runtime
-        uses: ReactiveCircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
+        uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: ${{ matrix.api-level }}
           arch: ${{ matrix.arch }}
@@ -524,7 +524,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -545,7 +545,7 @@ jobs:
           echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.2.13676358" >> "$GITHUB_ENV"
 
       - name: Cache Gradle
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.gradle/caches
@@ -672,7 +672,7 @@ jobs:
             > "silentsuite-android-${{ github.ref_name }}.aab.sha256"
 
       - name: Attach Android artifacts to umbrella GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ github.ref_name }}
           name: SilentSuite ${{ github.ref_name }}

--- a/.github/workflows/build-bridge.yml
+++ b/.github/workflows/build-bridge.yml
@@ -88,7 +88,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Set up QEMU
         if: matrix.qemu
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         with:
           platforms: ${{ matrix.qemu-arch }}
 
@@ -98,7 +98,7 @@ jobs:
       # etebase-py 0.31.5 uses cpython 0.7.x which doesn't support Python 3.12+
       - name: Set up Python 3.10
         if: "!matrix.qemu"
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 
@@ -326,7 +326,7 @@ jobs:
       # run creates the draft release, subsequent runs append assets without
       # clobbering an existing body.
       - name: Attach bridge binaries to umbrella GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: SilentSuite ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,7 +53,7 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -145,7 +145,7 @@ jobs:
           fi
 
       - name: Deploy to production Worker
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -44,7 +44,7 @@ jobs:
 
       - name: Deploy to preview Worker
         id: deploy
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Comment preview URL on PR
         if: github.event_name == 'push'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: prs } = await github.rest.pulls.list({

--- a/.github/workflows/preview-web.yml
+++ b/.github/workflows/preview-web.yml
@@ -57,7 +57,7 @@ jobs:
           cache-from: type=gha
 
       - name: Comment on PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const body = `**Preview build completed**\n\nVPS preview deploy is restricted to \`dev\` pushes. This PR built the web image locally but did not publish the shared preview tag or SSH deploy.\n\nBranch: \`${context.payload.pull_request.head.ref}\``;

--- a/.github/workflows/test-bridge-linux.yml
+++ b/.github/workflows/test-bridge-linux.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 
@@ -53,7 +53,7 @@ jobs:
 
       # etebase-py 0.31.5 uses cpython 0.7.x which doesn't support Python 3.12+
       - name: Set up Python 3.10
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
 

--- a/android/.github/workflows/build.yml
+++ b/android/.github/workflows/build.yml
@@ -10,21 +10,21 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
     - name: Set up JDK 17
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Setup Android SDK
-      uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+      uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
     - name: Cache Gradle packages
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.gradle/caches

--- a/apps/web/app/lib/__tests__/production-deploy-workflows.test.ts
+++ b/apps/web/app/lib/__tests__/production-deploy-workflows.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import { join, resolve } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -86,25 +86,77 @@ const jobContracts: Record<string, Record<string, { steps: string; permissions: 
     deploy: { steps: 'bbd0c9a9415d24b319bf53201011b78485a5a22674d36336b252fa770e19cf4c', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
   },
   'deploy-docs.yml': {
-    build: { steps: '90a5bed17b51f0b60748163cd3d53b9d86c0088f0b2e5904db0a69cb370bd7a9', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
-    deploy: { steps: '9663c351621aa2b85d3afb464e9630039a802f1799205610c2e3e3285ba09c08', permissions: '551b70084a8244c7f3114d8603c3d2ddac6b642093a4b34cd2e3a00b7e4f8ee1' },
+    build: { steps: '91656156d61547951a0d50b9c710a6356288443ac53c935b12c050c730a9215f', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
+    deploy: { steps: '3637fc52acda8299a45cbc10b550f22c958b66ad938757f1c8ea13b8a1f87abb', permissions: '551b70084a8244c7f3114d8603c3d2ddac6b642093a4b34cd2e3a00b7e4f8ee1' },
   },
 }
 
 const workflowContracts: Record<string, string> = {
   'deploy-web.yml': '67fe57e851cfa98a1736c623e070ddb3dc61bbc88f1b05f0f2b32cf8306ee74a',
   'deploy-server.yml': 'ee8015b23a29d0faa6b0ecb0371f049ae9189c37fe4c80591f82f0e844193312',
-  'deploy-docs.yml': '7f768623b8e654b10da26f18e63c5ca021df3e33e24d3e8ceef31611e71c8ed9',
+  'deploy-docs.yml': 'd9f4bbecc94008729bf0d6b3ddc43ace09c420d6959a67263a4c1fd732ecec27',
 }
 
 const approvedNode24ActionPins: Record<string, string> = {
   'actions/checkout': '3d3c42e5aac5ba805825da76410c181273ba90b1',
+  'pnpm/action-setup': '0977fd99725f1db4007ccb2928dbb4e90d06cc86',
+  'actions/setup-python': '5fda3b95a4ea91299a34e894583c3862153e4b97',
+  'actions/setup-java': 'b6effb05e454b25005698d916606bdc6ffcbf961',
+  'actions/cache': '55cc8345863c7cc4c66a329aec7e433d2d1c52a9',
+  'ReactiveCircus/android-emulator-runner': 'a421e43855164a8197daf9d8d40fe71c6996bb0d',
+  'softprops/action-gh-release': '3d0d9888cb7fd7b750713d6e236d1fcb99157228',
+  'actions/github-script': '3a2844b7e9c422d3c10d287c895573f7108da1b3',
+  'cloudflare/wrangler-action': 'ebbaa1584979971c8614a24965b4405ff95890e0',
+  'docker/setup-qemu-action': '96fe6ef7f33517b61c61be40b68a1882f3264fb8',
+  'android-actions/setup-android': '40fd30fb8d7440372e1316f5d1809ec01dcd3699',
   'actions/setup-node': '820762786026740c76f36085b0efc47a31fe5020',
   'actions/upload-artifact': '043fb46d1a93c77aae656e7c1c64a875d1fc6a0a',
   'actions/download-artifact': '3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c',
   'docker/setup-buildx-action': 'bb05f3f5519dd87d3ba754cc423b652a5edd6d2c',
   'docker/login-action': 'dbcb813823bdd20940b903addbd779551569679f',
   'docker/build-push-action': '53b7df96c91f9c12dcc8a07bcb9ccacbed38856a',
+}
+
+function node24PinViolations(root: string): string[] {
+  const seen = new Set<string>()
+  const violations: string[] = []
+
+  for (const relativeDirectory of ['.github/workflows', 'android/.github/workflows']) {
+    const directory = join(root, relativeDirectory)
+    for (const name of readdirSync(directory).filter((entry) => /\.ya?ml$/.test(entry))) {
+      const relativePath = `${relativeDirectory}/${name}`
+      let parsed: ParsedWorkflow
+      try {
+        parsed = parseWorkflow(readFileSync(join(directory, name), 'utf8'))
+      } catch (error) {
+        violations.push(`${relativePath}: invalid workflow YAML: ${String(error)}`)
+        continue
+      }
+
+      for (const job of Object.values(parsed.jobs ?? {})) {
+        for (const step of job.steps ?? []) {
+          if (typeof step.uses !== 'string') continue
+          const separator = step.uses.lastIndexOf('@')
+          const action = separator === -1 ? step.uses : step.uses.slice(0, separator)
+          const canonicalAction = Object.keys(approvedNode24ActionPins)
+            .find((approved) => approved.toLocaleLowerCase('en-US') === action.toLocaleLowerCase('en-US'))
+          if (!canonicalAction) continue
+          seen.add(canonicalAction)
+          const expected = `${canonicalAction}@${approvedNode24ActionPins[canonicalAction]}`
+          if (step.uses !== expected) {
+            violations.push(
+              `${relativePath}: governed action must use exact immutable pin ${expected}; found ${step.uses}`,
+            )
+          }
+        }
+      }
+    }
+  }
+
+  for (const action of Object.keys(approvedNode24ActionPins)) {
+    if (!seen.has(action)) violations.push(`missing governed action: ${action}`)
+  }
+  return violations
 }
 
 function expectAuthorizedJob(job: WorkflowJob, environment: string, approvalVariable: string, authorizationName: string, expectedRunSha256: string) {
@@ -141,23 +193,34 @@ function jobBlock(source: string, name: string): string {
 
 describe('production deployment workflow integrity', () => {
   it('pins migrated JavaScript actions to approved immutable Node 24 releases', () => {
-    const directory = resolve(process.cwd(), '../../.github/workflows')
-    const seen = new Set<string>()
+    expect(node24PinViolations(resolve(process.cwd(), '../..'))).toEqual([])
+  })
 
-    for (const name of readdirSync(directory).filter((entry) => /\.ya?ml$/.test(entry))) {
-      const source = readFileSync(join(directory, name), 'utf8')
-      for (const match of source.matchAll(/^\s*uses:\s*([^\s#]+)/gm)) {
-        const uses = match[1]
-        const separator = uses.lastIndexOf('@')
-        const action = separator === -1 ? uses : uses.slice(0, separator)
-        const approved = approvedNode24ActionPins[action]
-        if (!approved) continue
-        seen.add(action)
-        expect(uses, `${name}: ${action}`).toBe(`${action}@${approved}`)
+  it.each([
+    ['bare step uses key', '.github/workflows/bypass.yml', 'jobs:\n  bypass:\n    steps:\n      - uses: actions/checkout@v7\n', 'actions/checkout@v7'],
+    ['quoted value and spaced key', '.github/workflows/bypass.yml', 'jobs:\n  bypass:\n    steps:\n      - uses : "actions/checkout@v7"\n', 'actions/checkout@v7'],
+    ['action identity case variant', '.github/workflows/bypass.yml', "jobs:\n  bypass:\n    steps:\n      - uses: 'Actions/Checkout@v7'\n", 'Actions/Checkout@v7'],
+    ['Android sibling workflow', 'android/.github/workflows/bypass.yml', 'jobs:\n  bypass:\n    steps:\n      - uses: actions/checkout@v7\n', 'actions/checkout@v7'],
+  ])('rejects mutable governed actions written as %s', (_label, relativePath, source, actualUses) => {
+    const root = mkdtempSync(join(tmpdir(), 'silentsuite-action-pins-'))
+    try {
+      for (const directory of ['.github/workflows', 'android/.github/workflows']) {
+        mkdirSync(join(root, directory), { recursive: true })
       }
-    }
+      for (const [action, pin] of Object.entries(approvedNode24ActionPins)) {
+        writeFileSync(
+          join(root, '.github/workflows', `${action.replaceAll('/', '-')}.yml`),
+          `jobs:\n  control:\n    steps:\n      - name: unchanged control\n        uses: ${action}@${pin}\n`,
+        )
+      }
+      writeFileSync(join(root, relativePath), source)
 
-    expect([...seen].sort()).toEqual(Object.keys(approvedNode24ActionPins).sort())
+      expect(node24PinViolations(root)).toContain(
+        `${relativePath}: governed action must use exact immutable pin actions/checkout@${approvedNode24ActionPins['actions/checkout']}; found ${actualUses}`,
+      )
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 
   it('strict AST rejects attacker checkout, no-op authorization, heredoc decoys, and duplicate keys', () => {

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -35,7 +35,7 @@ UNSAFE_SECRET_EXPRESSION = re.compile(
     re.IGNORECASE,
 )
 CHECKOUT_ACTION = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
-SETUP_PYTHON_ACTION = "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065"
+SETUP_PYTHON_ACTION = "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
 EXPECTED_POLICY_JOB: dict[str, Any] = {
     "name": "Enforce Android signing boundary",
     "runs-on": "ubuntu-latest",
@@ -89,7 +89,7 @@ EXPECTED_SECRET_STEP_SHA256 = {
         "69ded7eab4c4ff48deff2da950aacf8e627da05373ffa507f358fbcc986a7a6a"
     ),
 }
-EXPECTED_RELEASE_JOB_SHA256 = "c346399442d912004eca8a4e7fcc6cec3f67eb72e476a9f9b5b89e1b0ae707fb"
+EXPECTED_RELEASE_JOB_SHA256 = "9f46c62e36525f08aa18d073564ca6867ad1b4d4d332089abf22528249c2c242"
 ALLOWED_RELEASE_JOB_KEYS = {
     "name",
     "needs",

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -797,8 +797,8 @@ def test_mutable_action_in_android_sibling_workflow_is_rejected(tmp_path: Path) 
     workflow = root / SIBLING_WORKFLOW
     mutate(
         workflow,
-        "android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407",
-        "android-actions/setup-android@v3",
+        "android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699",
+        "android-actions/setup-android@v4",
     )
 
     assert_rejected(


### PR DESCRIPTION
Closes #623

## Summary

- migrate every remaining public Node 20 action reference across root and Android sibling workflows to independently verified native Node 24 releases pinned by immutable commit SHA
- cover all eleven remaining/governed families, including missed sibling Checkout, QEMU, and Android setup paths
- replace raw-source action discovery with strict parsed-YAML traversal across both workflow directories
- reject bare `- uses:`, quoted/spaced mappings, case variants, mutable refs, and missing governed families
- verify GitHub Script v9 inline scripts do not use removed `require('@actions/github')` or redeclare `getOctokit`
- mechanically recompute Android signing and production Docs workflow contracts without weakening gates

## Promotion blocker

Exact-head GPT-5.6 Sol review of production promotion PR #624 found the migration incomplete and the pin guard fail-open. This fix is intentionally on `dev`; #624 must be rebuilt after merge.

## Verification

- RED: four adversarial bypass fixtures failed against the old guard
- parsed-YAML guard: 21/21 focused tests green
- web suite: 59 files / 767 tests green
- public Python suite: 164 tests / 26 subtests green
- Android signing boundary: green
- type-check: green
- 102 remote action uses scanned; zero mutable/non-SHA refs
- zero old Node 20 SHAs remain
- effective workflow comparison: action refs/comments only; zero non-action semantic drift
- local `pnpm audit --audit-level high` still reports the pre-existing brace-expansion advisory; the repository's hosted dependency gate remains authoritative

No release, signing, production deployment, Android behavior change, #621 compatibility cleanup, or main merge is included.
