### PR TITLE
fix(deps): remediate August dependency advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "i18n:check": "pnpm --filter @silentsuite/web i18n:check",
     "i18n:report": "pnpm --filter @silentsuite/web i18n:report",
     "check:public-analytics": "node scripts/check-public-analytics.mjs && node --experimental-strip-types --test apps/docs/.vitepress/theme/public-analytics.test.mts",
-    "audit:security": "node scripts/audit-high-critical.mjs"
+    "test:dependency-security": "node --test scripts/audit-high-critical.test.mjs scripts/dependency-compatibility-smoke.test.mjs",
+    "audit:security": "pnpm run test:dependency-security && node scripts/audit-high-critical.mjs"
   },
   "devDependencies": {
     "turbo": "^2.4.0"
@@ -33,16 +34,20 @@
       "serialize-javascript": "^7.0.3",
       "flatted": "^3.4.2",
       "picomatch": "^4.0.4",
-      "brace-expansion@<1.1.16": "1.1.16",
-      "brace-expansion@>=2.0.0 <2.1.2": "2.1.2",
-      "brace-expansion@>=3.0.0 <5.0.8": "5.0.8",
-      "fast-uri": "^3.1.4",
+      "undici@>=7.0.0 <7.29.0": "7.29.0",
+      "undici@>=8.0.0 <8.9.0": "8.9.0",
+      "fast-uri@>=2.0.0 <2.4.4": "2.4.4",
+      "fast-uri@>=3.0.0 <3.1.5": "3.1.5",
+      "fast-uri@>=4.0.0 <4.1.2": "4.1.2",
+      "brace-expansion@<1.1.18": "1.1.18",
+      "brace-expansion@>=2.0.0 <2.1.4": "2.1.4",
+      "brace-expansion@>=3.0.0 <3.0.6": "3.0.6",
+      "brace-expansion@>=5.0.0 <5.0.9": "5.0.9",
       "js-yaml": "^4.3.0",
       "postcss": "^8.5.18",
       "sharp": "^0.35.0",
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",
       "ws": "^7.5.11",
-      "lodash": "^4.18.0",
       "vitepress>vite": "^6.4.3"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,16 +8,20 @@ overrides:
   serialize-javascript: ^7.0.3
   flatted: ^3.4.2
   picomatch: ^4.0.4
-  brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
-  fast-uri: ^3.1.4
+  undici@>=7.0.0 <7.29.0: 7.29.0
+  undici@>=8.0.0 <8.9.0: 8.9.0
+  fast-uri@>=2.0.0 <2.4.4: 2.4.4
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  fast-uri@>=4.0.0 <4.1.2: 4.1.2
+  brace-expansion@<1.1.18: 1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: 2.1.4
+  brace-expansion@>=3.0.0 <3.0.6: 3.0.6
+  brace-expansion@>=5.0.0 <5.0.9: 5.0.9
   js-yaml: ^4.3.0
   postcss: ^8.5.18
   sharp: ^0.35.0
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
   ws: ^7.5.11
-  lodash: ^4.18.0
   vitepress>vite: ^6.4.3
 
 importers:
@@ -3304,14 +3308,14 @@ packages:
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -3792,8 +3796,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -5394,8 +5398,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -8738,7 +8742,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8927,16 +8931,16 @@ snapshots:
 
   birpc@2.9.0: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9629,7 +9633,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -10075,7 +10079,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -10300,15 +10304,15 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -11331,7 +11335,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/scripts/audit-high-critical.mjs
+++ b/scripts/audit-high-critical.mjs
@@ -1,92 +1,101 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process'
 
-const ALLOWLIST = [
-  {
-    advisory: 'GHSA-r5fr-rjxr-66jc',
-    module: 'lodash',
-    severity: 'high',
-    expires: '2026-07-14',
-    rationale: 'Transitive via @ducanh2912/next-pwa -> workbox-build. pnpm audit reports patched >=4.18.0, but npm lodash currently has no 4.18.x release to resolve to. Keep visible and fail once expired or if any new high/critical appears.',
-  },
-  {
-    advisory: 'GHSA-gv7w-rqvm-qjhr',
-    module: 'esbuild',
-    severity: 'high',
-    expires: '2026-07-14',
-    rationale: 'Transitive build-tool exposure from Vite/Webpack paths. The patched esbuild 0.28.x line currently breaks VitePress production builds in this workspace, so keep this visible while upstream-compatible patches are evaluated. No runtime browser/server dependency on esbuild is introduced by this allowlist.',
-  },
-  {
-    advisory: 'GHSA-mh99-v99m-4gvg',
-    module: 'brace-expansion',
-    severity: 'high',
-    expires: '2026-08-09',
-    rationale: 'Transitive build-tool exposure through legacy minimatch/glob consumers. Forcing brace-expansion 5.0.8 into minimatch 3.x/5.x breaks brace matching at runtime because v5 exports a named API. Keep the compatible patched 1.1.16/2.1.2 lines visible while upstream consumers migrate; no production request path evaluates attacker-controlled glob patterns.',
-  },
-]
-
-function advisoryId(advisory) {
-  const url = String(advisory.url ?? '')
-  return url.match(/GHSA-[a-z0-9-]+/i)?.[0] ?? String(advisory.id ?? advisory.title ?? 'unknown')
+function isObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
-function isExpired(entry) {
-  return Date.now() > Date.parse(`${entry.expires}T23:59:59Z`)
+function hasAdvisoryIdentity(advisory) {
+  const id = advisory.id
+  if ((typeof id === 'string' && id.trim() !== '') || (Number.isInteger(id) && id > 0)) return true
+
+  return typeof advisory.url === 'string' && /GHSA-[a-z0-9-]+/i.test(advisory.url)
 }
 
-function isAllowed(advisory) {
-  const id = advisoryId(advisory)
-  return ALLOWLIST.some((entry) => {
-    return !isExpired(entry)
-      && entry.advisory === id
-      && entry.module === advisory.module_name
-      && entry.severity === advisory.severity
-  })
-}
-
-const result = spawnSync('pnpm', ['audit', '--audit-level=high', '--json'], {
-  encoding: 'utf8',
-  stdio: ['ignore', 'pipe', 'pipe'],
-})
-
-let report
-try {
-  report = JSON.parse(result.stdout)
-} catch (err) {
-  console.error('Could not parse pnpm audit JSON output.')
-  if (result.stderr) console.error(result.stderr)
-  process.exit(1)
-}
-
-const advisories = Object.values(report.advisories ?? {})
-const highCritical = advisories.filter((advisory) => ['high', 'critical'].includes(advisory.severity))
-const unallowed = highCritical.filter((advisory) => !isAllowed(advisory))
-const allowed = highCritical.filter((advisory) => isAllowed(advisory))
-const counts = report.metadata?.vulnerabilities ?? {}
-
-console.log(`Dependency audit summary: ${counts.critical ?? 0} critical, ${counts.high ?? 0} high, ${counts.moderate ?? 0} moderate, ${counts.low ?? 0} low.`)
-
-if (allowed.length > 0) {
-  console.log('')
-  console.log('Temporarily allowlisted high/critical advisories:')
-  for (const advisory of allowed) {
-    const id = advisoryId(advisory)
-    const entry = ALLOWLIST.find((item) => item.advisory === id && item.module === advisory.module_name)
-    console.log(`- ${advisory.severity}: ${advisory.module_name} ${id}; expires ${entry?.expires}; ${entry?.rationale}`)
+function validateReport(report) {
+  if (!isObject(report) || Object.hasOwn(report, 'error')) return 'Audit returned an error response.'
+  if (!isObject(report.advisories)) return 'Audit report is missing advisory metadata.'
+  if (!isObject(report.metadata) || !isObject(report.metadata.vulnerabilities)) {
+    return 'Audit report is missing vulnerability metadata.'
   }
-}
 
-if (unallowed.length > 0) {
-  console.error('')
-  console.error('Unallowlisted high/critical dependency advisories found:')
-  for (const advisory of unallowed) {
-    console.error(`- ${advisory.severity}: ${advisory.module_name} ${advisoryId(advisory)} — ${advisory.title}`)
+  for (const severity of ['critical', 'high', 'moderate', 'low']) {
+    if (!Number.isInteger(report.metadata.vulnerabilities[severity]) || report.metadata.vulnerabilities[severity] < 0) {
+      return `Audit report has invalid ${severity} vulnerability metadata.`
+    }
   }
-  process.exit(1)
+
+  const advisories = Object.values(report.advisories)
+  for (const advisory of advisories) {
+    if (!isObject(advisory)
+      || !['critical', 'high', 'moderate', 'low'].includes(advisory.severity)
+      || typeof advisory.module_name !== 'string' || advisory.module_name.trim() === ''
+      || typeof advisory.title !== 'string' || advisory.title.trim() === ''
+      || !hasAdvisoryIdentity(advisory)) {
+      return 'Audit report has malformed advisory metadata.'
+    }
+  }
+
+  for (const severity of ['critical', 'high']) {
+    const hasAdvisory = advisories.some((advisory) => advisory.severity === severity)
+    const metadataHasVulnerability = report.metadata.vulnerabilities[severity] > 0
+    if (hasAdvisory !== metadataHasVulnerability) {
+      return `Audit report has contradictory ${severity} vulnerability metadata.`
+    }
+  }
+
+  return undefined
 }
 
-if (highCritical.length === 0) {
-  console.log('No high or critical advisories found.')
-} else {
-  console.log('No unallowlisted high or critical advisories found.')
+export function runAudit({ spawn = spawnSync, log = console.log, error = console.error } = {}) {
+  let result
+  try {
+    result = spawn('pnpm', ['audit', '--audit-level=high', '--json'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+  } catch (cause) {
+    error(`Could not start pnpm audit: ${cause.message}`)
+    return 1
+  }
+
+  if (!result || result.error || result.signal || ![0, 1].includes(result.status)) {
+    error('pnpm audit did not complete with an expected exit status.')
+    if (result?.stderr) error(result.stderr)
+    return 1
+  }
+
+  let report
+  try {
+    if (typeof result.stdout !== 'string' || result.stdout.trim() === '') throw new Error('empty output')
+    report = JSON.parse(result.stdout)
+  } catch {
+    error('Could not parse pnpm audit JSON output.')
+    if (result.stderr) error(result.stderr)
+    return 1
+  }
+
+  const validationError = validateReport(report)
+  if (validationError) {
+    error(validationError)
+    return 1
+  }
+
+  const advisories = Object.values(report.advisories)
+  const highCritical = advisories.filter((advisory) => ['high', 'critical'].includes(advisory.severity))
+  const counts = report.metadata.vulnerabilities
+
+  log(`Dependency audit summary: ${counts.critical} critical, ${counts.high} high, ${counts.moderate} moderate, ${counts.low} low.`)
+
+  if (highCritical.length > 0) {
+    error('')
+    error('High or critical dependency advisories found:')
+    for (const advisory of highCritical) error(`- ${advisory.severity}: ${advisory.module_name} — ${advisory.title}`)
+    return 1
+  }
+
+  log('No high or critical advisories found.')
+  return 0
 }
+
+if (import.meta.url === `file://${process.argv[1]}`) process.exitCode = runAudit()

--- a/scripts/audit-high-critical.test.mjs
+++ b/scripts/audit-high-critical.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import test from 'node:test'
+import { runAudit } from './audit-high-critical.mjs'
+
+const fixtures = resolve(import.meta.dirname, 'test-fixtures/audit-high-critical')
+const quiet = { log: () => {}, error: () => {} }
+
+function report(name) {
+  return readFileSync(resolve(fixtures, name), 'utf8')
+}
+
+function fakeResult({ status = 0, stdout, stderr = '', signal = null, error } = {}) {
+  return () => ({ status, stdout, stderr, signal, error })
+}
+
+test('accepts a clean status 0 audit report', () => {
+  assert.equal(runAudit({ spawn: fakeResult({ stdout: report('clean.json') }), ...quiet }), 0)
+})
+
+test('evaluates a structurally valid advisory report returned with status 1', () => {
+  assert.equal(runAudit({ spawn: fakeResult({ status: 1, stdout: report('advisory-status-1.json') }), ...quiet }), 0)
+})
+
+test('fails closed for malformed JSON and top-level error responses', () => {
+  assert.equal(runAudit({ spawn: fakeResult({ stdout: '' }), ...quiet }), 1)
+  assert.equal(runAudit({ spawn: fakeResult({ stdout: '{not json' }), ...quiet }), 1)
+  assert.equal(runAudit({ spawn: fakeResult({ status: 1, stdout: report('top-level-error.json') }), ...quiet }), 1)
+})
+
+test('fails closed for malformed metadata, advisory identity, severity, and high/critical count contradictions', () => {
+  for (const fixture of [
+    'missing-metadata.json',
+    'malformed-metadata.json',
+    'empty-advisory-identity.json',
+    'malformed-advisory-identity.json',
+    'unknown-severity.json',
+    'high-record-with-zero-metadata.json',
+    'high-metadata-without-record.json',
+    'critical-record-with-zero-metadata.json',
+    'critical-metadata-without-record.json',
+  ]) {
+    assert.equal(runAudit({ spawn: fakeResult({ status: 1, stdout: report(fixture) }), ...quiet }), 1, fixture)
+  }
+})
+
+test('fails closed for unknown high and critical advisories', () => {
+  assert.equal(runAudit({ spawn: fakeResult({ status: 1, stdout: report('unknown-high.json') }), ...quiet }), 1)
+  assert.equal(runAudit({ spawn: fakeResult({ status: 1, stdout: report('unknown-critical.json') }), ...quiet }), 1)
+})
+
+test('fails closed for spawn errors, signals, and unexpected statuses', () => {
+  assert.equal(runAudit({ spawn: () => { throw new Error('ENOENT') }, ...quiet }), 1)
+  assert.equal(runAudit({ spawn: fakeResult({ stdout: report('clean.json'), error: new Error('ENOENT') }), ...quiet }), 1)
+  assert.equal(runAudit({ spawn: fakeResult({ stdout: report('clean.json'), signal: 'SIGTERM' }), ...quiet }), 1)
+  assert.equal(runAudit({ spawn: fakeResult({ status: 2, stdout: report('clean.json') }), ...quiet }), 1)
+})

--- a/scripts/dependency-compatibility-smoke.test.mjs
+++ b/scripts/dependency-compatibility-smoke.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+import test from 'node:test'
+
+function requireFrom(packagePath) {
+  return createRequire(resolve(import.meta.dirname, '..', packagePath))
+}
+
+const minimatch3 = requireFrom('node_modules/.pnpm/minimatch@3.1.5/node_modules/minimatch/package.json')('.')
+const minimatch5 = requireFrom('node_modules/.pnpm/minimatch@5.1.9/node_modules/minimatch/package.json')('.')
+const minimatch10 = requireFrom('node_modules/.pnpm/minimatch@10.2.4/node_modules/minimatch/package.json')('.').minimatch
+const Ajv = requireFrom('node_modules/.pnpm/ajv@8.18.0/node_modules/ajv/package.json')('.')
+const addFormats = requireFrom('node_modules/.pnpm/ajv-formats@2.1.1_ajv@8.18.0/node_modules/ajv-formats/package.json')('.')
+const { JSDOM } = requireFrom('apps/web/package.json')('jsdom')
+
+for (const [line, minimatch] of [['3', minimatch3], ['5', minimatch5], ['10', minimatch10]]) {
+  test(`minimatch ${line} preserves brace alternation, ranges, escapes, matches, and non-matches`, () => {
+    assert.equal(minimatch('src/a.js', 'src/{a,b}.js'), true)
+    assert.equal(minimatch('file3.txt', 'file{1..3}.txt'), true)
+    assert.equal(minimatch('file4.txt', 'file{1..3}.txt'), false)
+    assert.equal(minimatch('literal{a}.txt', 'literal\\{a\\}.txt'), true)
+    assert.equal(minimatch('src/c.js', 'src/{a,b}.js'), false)
+  })
+}
+
+test('AJV 8 validates URI format through patched fast-uri', () => {
+  const ajv = new Ajv({ strict: false })
+  addFormats(ajv)
+  const validate = ajv.compile({ type: 'string', format: 'uri' })
+  assert.equal(validate('https://silent-suite.example/path?item=1'), true)
+  assert.equal(validate('not a uri'), false)
+})
+
+test('jsdom constructs and tears down through its patched undici dependency path', () => {
+  const dom = new JSDOM('<!doctype html><p id="status">ready</p>', { url: 'https://silent-suite.example/' })
+  assert.equal(dom.window.document.querySelector('#status')?.textContent, 'ready')
+  assert.equal(dom.window.location.origin, 'https://silent-suite.example')
+  dom.window.close()
+})

--- a/scripts/test-fixtures/audit-high-critical/advisory-status-1.json
+++ b/scripts/test-fixtures/audit-high-critical/advisory-status-1.json
@@ -1,0 +1,6 @@
+{
+  "advisories": {
+    "1": { "severity": "moderate", "module_name": "example-package", "title": "A valid moderate advisory", "url": "https://github.com/advisories/GHSA-aaaa-bbbb-cccc" }
+  },
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 0, "moderate": 1, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/clean.json
+++ b/scripts/test-fixtures/audit-high-critical/clean.json
@@ -1,0 +1,4 @@
+{
+  "advisories": {},
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 0, "moderate": 0, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/critical-metadata-without-record.json
+++ b/scripts/test-fixtures/audit-high-critical/critical-metadata-without-record.json
@@ -1,0 +1,4 @@
+{
+  "advisories": {},
+  "metadata": { "vulnerabilities": { "critical": 1, "high": 0, "moderate": 0, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/critical-record-with-zero-metadata.json
+++ b/scripts/test-fixtures/audit-high-critical/critical-record-with-zero-metadata.json
@@ -1,0 +1,6 @@
+{
+  "advisories": {
+    "1": { "severity": "critical", "module_name": "example-package", "title": "Critical advisory", "url": "https://github.com/advisories/GHSA-aaaa-bbbb-cccc" }
+  },
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 0, "moderate": 0, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/empty-advisory-identity.json
+++ b/scripts/test-fixtures/audit-high-critical/empty-advisory-identity.json
@@ -1,0 +1,6 @@
+{
+  "advisories": {
+    "1": { "severity": "moderate", "module_name": "example-package", "title": "Missing identity", "url": "" }
+  },
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 0, "moderate": 1, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/high-metadata-without-record.json
+++ b/scripts/test-fixtures/audit-high-critical/high-metadata-without-record.json
@@ -1,0 +1,4 @@
+{
+  "advisories": {},
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 1, "moderate": 0, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/high-record-with-zero-metadata.json
+++ b/scripts/test-fixtures/audit-high-critical/high-record-with-zero-metadata.json
@@ -1,0 +1,6 @@
+{
+  "advisories": {
+    "1": { "severity": "high", "module_name": "example-package", "title": "High advisory", "url": "https://github.com/advisories/GHSA-aaaa-bbbb-cccc" }
+  },
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 0, "moderate": 0, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/malformed-advisory-identity.json
+++ b/scripts/test-fixtures/audit-high-critical/malformed-advisory-identity.json
@@ -1,0 +1,6 @@
+{
+  "advisories": {
+    "1": { "severity": "moderate", "module_name": "example-package", "title": "Malformed identity", "url": "not-an-advisory" }
+  },
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 0, "moderate": 1, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/malformed-metadata.json
+++ b/scripts/test-fixtures/audit-high-critical/malformed-metadata.json
@@ -1,0 +1,4 @@
+{
+  "advisories": {},
+  "metadata": { "vulnerabilities": { "critical": 0, "high": "0", "moderate": 0, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/missing-metadata.json
+++ b/scripts/test-fixtures/audit-high-critical/missing-metadata.json
@@ -1,0 +1,3 @@
+{
+  "advisories": {}
+}

--- a/scripts/test-fixtures/audit-high-critical/top-level-error.json
+++ b/scripts/test-fixtures/audit-high-critical/top-level-error.json
@@ -1,0 +1,3 @@
+{
+  "error": { "code": "EAUDIT", "summary": "registry unavailable" }
+}

--- a/scripts/test-fixtures/audit-high-critical/unknown-critical.json
+++ b/scripts/test-fixtures/audit-high-critical/unknown-critical.json
@@ -1,0 +1,6 @@
+{
+  "advisories": {
+    "1": { "severity": "critical", "module_name": "unexpected-package", "title": "Unknown critical advisory", "url": "https://github.com/advisories/GHSA-zzzz-yyyy-xxxx" }
+  },
+  "metadata": { "vulnerabilities": { "critical": 1, "high": 0, "moderate": 0, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/unknown-high.json
+++ b/scripts/test-fixtures/audit-high-critical/unknown-high.json
@@ -1,0 +1,6 @@
+{
+  "advisories": {
+    "1": { "severity": "high", "module_name": "unexpected-package", "title": "Unknown high advisory", "url": "https://github.com/advisories/GHSA-zzzz-yyyy-xxxx" }
+  },
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 1, "moderate": 0, "low": 0 } }
+}

--- a/scripts/test-fixtures/audit-high-critical/unknown-severity.json
+++ b/scripts/test-fixtures/audit-high-critical/unknown-severity.json
@@ -1,0 +1,6 @@
+{
+  "advisories": {
+    "1": { "severity": "urgent", "module_name": "example-package", "title": "Unknown severity", "url": "https://github.com/advisories/GHSA-aaaa-bbbb-cccc" }
+  },
+  "metadata": { "vulnerabilities": { "critical": 0, "high": 0, "moderate": 0, "low": 0 } }
+}


### PR DESCRIPTION
## Summary

- pin compatible patched lines for undici, fast-uri, and brace-expansion
- replace broad cross-major overrides with exact vulnerable-range selectors
- retire all expired dependency-audit exceptions
- make the audit wrapper fail closed on registry, process, parse, schema, and metadata failures
- run deterministic audit and compatibility tests in the existing Dependency Audit job

## Security outcome

- remediates GHSA-4cwx-7wf7-3272
- remediates GHSA-7p8r-x3mc-p8w7
- remediates GHSA-rgw5-rvv9-x895
- active graph: 0 critical, 0 high, 4 moderate, 3 low

## Verification

- frozen pnpm 10.6.5 install
- 11 focused audit/dependency compatibility tests
- fail-closed unreachable-registry check
- npm integrity and signature verification for all patched snapshots
- full lint, type-check, tests, build, analytics, and docs distribution checks

Docker verification is delegated to the exact-head Build Web App CI job per workspace policy.