### PR TITLE
feat: expand privacy-safe public analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,24 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build public surfaces
         run: |
-          pnpm --filter @silentsuite/web build
+          NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=true pnpm --filter @silentsuite/web build
           SILENTSUITE_HOSTED_DOCS_ANALYTICS=1 pnpm --filter @silentsuite/docs exec vitepress build --outDir .vitepress/dist-hosted
           pnpm --filter @silentsuite/docs exec vitepress build --outDir .vitepress/dist-self
+          node scripts/verify-docs-analytics-build.mjs --dir apps/docs/.vitepress/dist-hosted --mode enabled
+          node scripts/verify-docs-analytics-build.mjs --dir apps/docs/.vitepress/dist-self --mode disabled
+      - name: Verify docs Turbo analytics cache isolation
+        run: |
+          rm -rf .turbo apps/docs/.vitepress/dist
+          SILENTSUITE_HOSTED_DOCS_ANALYTICS=1 pnpm run build:docs
+          node scripts/verify-docs-analytics-build.mjs --dir apps/docs/.vitepress/dist --mode enabled
+          pnpm run build:docs
+          node scripts/verify-docs-analytics-build.mjs --dir apps/docs/.vitepress/dist --mode disabled
+          SILENTSUITE_HOSTED_DOCS_ANALYTICS=1 pnpm run build:docs
+          node scripts/verify-docs-analytics-build.mjs --dir apps/docs/.vitepress/dist --mode enabled
       - name: Test Android distribution documentation
         run: pnpm --filter @silentsuite/docs test:android-distribution
       - name: Enforce source and bundle analytics boundary
-        run: pnpm run check:public-analytics
+        run: PUBLIC_ANALYTICS_ENABLED_BUILD=true pnpm run check:public-analytics
 
   lint-and-typecheck:
     name: Lint & Type Check

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -68,9 +68,12 @@ jobs:
         run: pnpm --filter @silentsuite/docs test:android-distribution
 
       - name: Build docs
-        run: pnpm run build --filter=@silentsuite/docs
+        run: pnpm --filter @silentsuite/docs exec vitepress build
         env:
           SILENTSUITE_HOSTED_DOCS_ANALYTICS: '1'
+
+      - name: Verify admitted docs artifact before upload
+        run: node scripts/verify-docs-analytics-build.mjs --dir apps/docs/.vitepress/dist --mode enabled
 
       - name: Upload admitted docs artifact
         id: upload
@@ -124,6 +127,7 @@ jobs:
           rm -rf apps/docs/.vitepress/dist
           mkdir -p apps/docs/.vitepress/dist
           unzip -q "$ARTIFACT_ZIP" -d apps/docs/.vitepress/dist
+          node scripts/verify-docs-analytics-build.mjs --dir apps/docs/.vitepress/dist --mode enabled
 
       - name: Re-assert owner approval immediately before deployment
         shell: bash

--- a/apps/docs/.vitepress/theme/docs-analytics-runtime.test.mts
+++ b/apps/docs/.vitepress/theme/docs-analytics-runtime.test.mts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { canonicalDocsPath, createDocsPageviewTracker } from './public-analytics.mts'
+
+test('registers only repository-owned canonical document paths', () => {
+  assert.equal(canonicalDocsPath('/user-guide/faq/?q=private#answer'), '/user-guide/faq')
+  assert.equal(canonicalDocsPath('/'), '/')
+  assert.equal(canonicalDocsPath('/local-search?q=secret'), undefined)
+  assert.equal(canonicalDocsPath('/not-a-document'), undefined)
+})
+
+test('sends initial and successful route pageviews without duplicate consecutive delivery', () => {
+  const deliveries: string[] = []
+  const tracker = createDocsPageviewTracker((path) => deliveries.push(path))
+
+  tracker('/user-guide/faq?query=private#heading')
+  tracker('/user-guide/faq/')
+  tracker('/self-hosting')
+  tracker('/not-a-document')
+  tracker('/user-guide/faq')
+
+  assert.deepEqual(deliveries, ['/user-guide/faq', '/self-hosting', '/user-guide/faq'])
+})

--- a/apps/docs/.vitepress/theme/index.mts
+++ b/apps/docs/.vitepress/theme/index.mts
@@ -1,8 +1,8 @@
 import DefaultTheme from 'vitepress/theme'
-import type { EnhanceAppContext } from 'vitepress'
+import { useRouter, type EnhanceAppContext } from 'vitepress'
 import { defineComponent, h, onMounted, onUnmounted } from 'vue'
 import AppLogoStrip from './components/AppLogoStrip.vue'
-import { classifyDocsOutboundEvent } from './public-analytics.mts'
+import { classifyDocsOutboundEvent, createDocsPageviewTracker } from './public-analytics.mts'
 import './custom.css'
 
 declare const __SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__: string
@@ -27,6 +27,21 @@ function sendDocsEvent(event: ReturnType<typeof classifyDocsOutboundEvent>) {
   })
 }
 
+function sendDocsPageview(path: string) {
+  const payload = JSON.stringify({
+    domain: 'docs.silentsuite.io',
+    name: 'pageview',
+    url: `https://docs.silentsuite.io${path}`,
+  })
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__, new Blob([payload], { type: 'application/json' }))
+    return
+  }
+  void fetch(__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: payload, keepalive: true,
+  })
+}
+
 export default {
   ...DefaultTheme,
   enhanceApp(context: EnhanceAppContext) {
@@ -35,6 +50,9 @@ export default {
   },
   Layout: defineComponent({
     setup() {
+      const router = useRouter()
+      const trackPageview = createDocsPageviewTracker((path) => sendDocsPageview(path))
+      let previousAfterRouteChanged: typeof router.onAfterRouteChanged | undefined
       const handleClick = (event: MouseEvent) => {
         if (!__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__ || window.location.hostname !== 'docs.silentsuite.io') return
         const anchor = event.target instanceof Element ? event.target.closest('a[href]') : null
@@ -42,8 +60,20 @@ export default {
         sendDocsEvent(analyticsEvent)
       }
 
-      onMounted(() => document.addEventListener('click', handleClick))
-      onUnmounted(() => document.removeEventListener('click', handleClick))
+      onMounted(() => {
+        if (!__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__ || window.location.protocol !== 'https:' || window.location.hostname !== 'docs.silentsuite.io') return
+        trackPageview(window.location.pathname)
+        previousAfterRouteChanged = router.onAfterRouteChanged
+        router.onAfterRouteChanged = (to) => {
+          previousAfterRouteChanged?.(to)
+          trackPageview(to)
+        }
+        document.addEventListener('click', handleClick)
+      })
+      onUnmounted(() => {
+        document.removeEventListener('click', handleClick)
+        if (router.onAfterRouteChanged !== previousAfterRouteChanged) router.onAfterRouteChanged = previousAfterRouteChanged
+      })
       return () => h(DefaultTheme.Layout!)
     },
   }),

--- a/apps/docs/.vitepress/theme/public-analytics.mts
+++ b/apps/docs/.vitepress/theme/public-analytics.mts
@@ -6,6 +6,36 @@ export type DocsOutboundEvent =
     }
   | { event: 'GitHub Click'; props: { surface: 'docs_android'; channel: 'repository' } }
 
+export const REGISTERED_DOCS_PATHS = new Set([
+  '/', '/app-logo-notices', '/bridge', '/contributing', '/contributing/architecture-overview',
+  '/contributing/code-conventions', '/contributing/dev-setup', '/contributing/pull-request-guide',
+  '/contributing/testing', '/self-hosting', '/self-hosting/admin-dashboard',
+  '/self-hosting/architecture', '/self-hosting/backup-and-restore', '/self-hosting/configuration',
+  '/self-hosting/manual-setup', '/self-hosting/quick-start', '/self-hosting/requirements',
+  '/self-hosting/troubleshooting', '/self-hosting/uninstalling', '/self-hosting/updating',
+  '/user-guide', '/user-guide/calendar', '/user-guide/contacts', '/user-guide/encryption-explained',
+  '/user-guide/faq', '/user-guide/getting-started', '/user-guide/tasks', '/user-guide/apps',
+  '/user-guide/apps/android', '/user-guide/apps/dav-bridge', '/user-guide/apps/evolution',
+  '/user-guide/apps/gnome', '/user-guide/apps/ios', '/user-guide/apps/kde',
+  '/user-guide/apps/linux-bridge', '/user-guide/apps/macos', '/user-guide/apps/tasks-org',
+  '/user-guide/apps/thunderbird', '/user-guide/apps/windows',
+])
+
+export function canonicalDocsPath(rawPath: string): string | undefined {
+  const path = rawPath.split(/[?#]/, 1)[0].replace(/\/$/, '') || '/'
+  return REGISTERED_DOCS_PATHS.has(path) ? path : undefined
+}
+
+export function createDocsPageviewTracker(deliver: (path: string) => void) {
+  let lastPath: string | undefined
+  return (rawPath: string) => {
+    const path = canonicalDocsPath(rawPath)
+    if (!path || path === lastPath) return
+    lastPath = path
+    deliver(path)
+  }
+}
+
 const APPROVED_DESTINATIONS: Readonly<Record<string, DocsOutboundEvent>> = {
   'https://app.silentsuite.io': {
     event: 'Hosted App Click',

--- a/apps/web/app/(app)/settings/subscription/__tests__/subscription-analytics.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/subscription-analytics.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { sendCommercialEvent, shouldSendCommercialAnalytics } from '@/app/(auth)/signup/commercial-funnel-analytics'
+import { buildSubscriptionManagementEntryPayload } from '@/app/lib/public-analytics'
+
+describe('subscription analytics transport boundary', () => {
+  it.each(['/settings', '/settings/account', '/calendar', '/contacts', '/tasks', '/signup'])('rejects subscription entry from %s', (pathname) => {
+    expect(shouldSendCommercialAnalytics(new URL(`https://app.silentsuite.io${pathname}`), buildSubscriptionManagementEntryPayload(), 'true')).toBe(false)
+  })
+
+  it('uses fetch fallback with the fixed subscription key/value payload', () => {
+    const fetcher = vi.fn()
+    sendCommercialEvent(buildSubscriptionManagementEntryPayload(), undefined, fetcher, new URL('https://app.silentsuite.io/settings/subscription'), 'true')
+    expect(fetcher).toHaveBeenCalledWith('https://plausible.silentsuite.io/api/event', expect.objectContaining({
+      method: 'POST', keepalive: true,
+      body: JSON.stringify({ domain: 'app.silentsuite.io', name: 'Subscription Management Entry', url: 'https://app.silentsuite.io/settings/subscription', props: { surface: 'subscription_settings' } }),
+    }))
+  })
+})

--- a/apps/web/app/(app)/settings/subscription/page.tsx
+++ b/apps/web/app/(app)/settings/subscription/page.tsx
@@ -8,6 +8,7 @@ import { formatDate as formatDateUtil } from '@/app/lib/date'
 import AddCardBanner from '@/app/components/add-card-banner'
 import PaymentChoicePanel from '@/app/components/payment-choice-panel'
 import { getPaidBonusAccessDate } from './bonus-access'
+import { SubscriptionEntry } from './subscription-entry'
 
 interface SubscriptionCapabilities {
   trialActive: boolean
@@ -79,6 +80,7 @@ function getCapabilities(data: SubscriptionData): SubscriptionCapabilities {
 function LoadingSkeleton() {
   return (
     <div className="space-y-6">
+      <SubscriptionEntry />
       <div className="rounded-lg border border-[rgb(var(--border))] p-4 space-y-4">
         <div className="h-4 w-32 animate-pulse rounded bg-[rgb(var(--border))]" />
         <div className="space-y-3">

--- a/apps/web/app/(app)/settings/subscription/subscription-entry.tsx
+++ b/apps/web/app/(app)/settings/subscription/subscription-entry.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { sendCommercialEvent } from '@/app/(auth)/signup/commercial-funnel-analytics'
+import { buildSubscriptionManagementEntryPayload } from '@/app/lib/public-analytics'
+
+export function SubscriptionEntry() {
+  const sent = useRef(false)
+  useEffect(() => { if (!sent.current) { sent.current = true; sendCommercialEvent(buildSubscriptionManagementEntryPayload()) } }, [])
+  return null
+}

--- a/apps/web/app/(auth)/signup/__tests__/commercial-funnel-analytics.test.ts
+++ b/apps/web/app/(auth)/signup/__tests__/commercial-funnel-analytics.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  sendCommercialEvent,
+  shouldSendCommercialAnalytics,
+} from '../commercial-funnel-analytics'
+import { buildCheckoutInitiatedPayload, buildCheckoutReturnedPayload, buildPlanSelectedPayload } from '@/app/lib/public-analytics'
+
+describe('commercial funnel analytics transport boundary', () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it.each([
+    'https://app.silentsuite.io/calendar',
+    'https://app.silentsuite.io/contacts',
+    'https://app.silentsuite.io/tasks',
+    'https://app.silentsuite.io/',
+    'https://app.silentsuite.io/settings',
+    'https://app.silentsuite.io/settings/subscription',
+    'https://previewapp.silentsuite.io/signup',
+    'http://app.silentsuite.io/signup',
+  ])('rejects Plan Selected from %s', (href) => {
+    expect(shouldSendCommercialAnalytics(new URL(href), buildPlanSelectedPayload('monthly'), 'true')).toBe(false)
+  })
+
+  it('binds checkout initiation and returns to their individual registered routes', () => {
+    expect(shouldSendCommercialAnalytics(new URL('https://app.silentsuite.io/signup'), buildCheckoutInitiatedPayload('monthly', 'stripe'), 'true')).toBe(true)
+    const returned = buildCheckoutReturnedPayload('returned', 'stripe')
+    expect(shouldSendCommercialAnalytics(new URL('https://app.silentsuite.io/signup/success'), returned, 'true')).toBe(true)
+    expect(shouldSendCommercialAnalytics(new URL('https://app.silentsuite.io/signup'), returned, 'true')).toBe(false)
+  })
+
+  it('sends a route-bound beacon payload', async () => {
+    const beacon = vi.fn(() => true)
+    sendCommercialEvent(buildPlanSelectedPayload('monthly'), beacon, vi.fn(), new URL('https://app.silentsuite.io/signup'), 'true')
+
+    expect(beacon).toHaveBeenCalledTimes(1)
+    const [endpoint, blob] = beacon.mock.calls[0]
+    expect(endpoint).toBe('https://plausible.silentsuite.io/api/event')
+    expect(JSON.parse(await blob.text())).toEqual({
+      domain: 'app.silentsuite.io', name: 'Plan Selected', url: 'https://app.silentsuite.io/signup', props: { plan_class: 'monthly' },
+    })
+  })
+
+  it('uses fetch fallback only on the payload route', () => {
+    const fetcher = vi.fn()
+    sendCommercialEvent(buildPlanSelectedPayload('annual'), undefined, fetcher, new URL('https://app.silentsuite.io/signup'), 'true')
+    expect(fetcher).toHaveBeenCalledWith('https://plausible.silentsuite.io/api/event', expect.objectContaining({
+      method: 'POST', keepalive: true,
+      body: JSON.stringify({ domain: 'app.silentsuite.io', name: 'Plan Selected', url: 'https://app.silentsuite.io/signup', props: { plan_class: 'annual' } }),
+    }))
+  })
+})

--- a/apps/web/app/(auth)/signup/__tests__/signup-analytics.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/signup-analytics.test.tsx
@@ -23,6 +23,9 @@ describe('signup analytics transport boundary', () => {
     'https://app.silentsuite.io.evil.test/signup',
     'https://self-hosted.example/signup',
     'https://app.silentsuite.io/calendar',
+    'https://app.silentsuite.io/signup/plan',
+    'https://app.silentsuite.io/signup/customer@example.com',
+    'https://app.silentsuite.io/signup/550e8400-e29b-41d4-a716-446655440000',
   ])('rejects noncanonical runtime URL %s even when enabled', (url) => {
     expect(shouldSendSignupAnalytics(new URL(url), 'true')).toBe(false)
   })
@@ -67,4 +70,11 @@ describe('signup analytics transport boundary', () => {
       }),
     )
   })
+
+  it.each(['/signup', '/signup/pending-payment', '/signup/success', '/signup/cancel'])(
+    'admits registered signup pageview route %s',
+    (pathname) => {
+      expect(shouldSendSignupAnalytics(new URL(`https://app.silentsuite.io${pathname}`), 'true')).toBe(true)
+    },
+  )
 })

--- a/apps/web/app/(auth)/signup/cancel/page.tsx
+++ b/apps/web/app/(auth)/signup/cancel/page.tsx
@@ -3,10 +3,12 @@
 import Link from 'next/link'
 import { XCircle } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
+import { CheckoutReturnAnalytics } from '../commercial-funnel-analytics'
 
 export default function SignupCancelPage() {
   return (
     <div className="max-w-md mx-auto space-y-6 text-center">
+      <CheckoutReturnAnalytics outcome="cancelled" paymentMethod="unknown" />
       <div className="flex flex-col items-center gap-4">
         <div className="rounded-full bg-[rgb(var(--surface))] p-4">
           <XCircle className="h-12 w-12 text-[rgb(var(--muted))]" />

--- a/apps/web/app/(auth)/signup/commercial-funnel-analytics.tsx
+++ b/apps/web/app/(auth)/signup/commercial-funnel-analytics.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { buildCheckoutInitiatedPayload, buildCheckoutReturnedPayload, buildPlanSelectedPayload, type CommercialEventPayload } from '@/app/lib/public-analytics'
+
+const PLAUSIBLE_EVENT_ENDPOINT = 'https://plausible.silentsuite.io/api/event'
+
+export function shouldSendCommercialAnalytics(location: URL, payload: CommercialEventPayload, enabled = process.env.NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED): boolean {
+  return enabled === 'true'
+    && location.protocol === 'https:'
+    && location.hostname === 'app.silentsuite.io'
+    && `${location.origin}${location.pathname}` === payload.url
+}
+
+export function sendCommercialEvent(payload: CommercialEventPayload, beacon = navigator.sendBeacon?.bind(navigator), fetcher: typeof fetch = fetch, location = new URL(window.location.href), enabled = process.env.NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED) {
+  if (!shouldSendCommercialAnalytics(location, payload, enabled)) return
+  const body = JSON.stringify(payload)
+  if (beacon) { beacon(PLAUSIBLE_EVENT_ENDPOINT, new Blob([body], { type: 'application/json' })); return }
+  void fetcher(PLAUSIBLE_EVENT_ENDPOINT, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body, keepalive: true })
+}
+
+export function CheckoutReturnAnalytics({ outcome, paymentMethod }: { outcome: 'returned' | 'cancelled' | 'failed' | 'pending'; paymentMethod: 'stripe' | 'btcpay' | 'unknown' }) {
+  const sent = useRef(false)
+  useEffect(() => { if (!sent.current) { sent.current = true; sendCommercialEvent(buildCheckoutReturnedPayload(outcome, paymentMethod)) } }, [outcome, paymentMethod])
+  return null
+}
+export function trackPlanSelected(planClass: 'monthly' | 'annual') { sendCommercialEvent(buildPlanSelectedPayload(planClass)) }
+export function trackCheckoutInitiated(planClass: 'monthly' | 'annual', paymentMethod: 'stripe' | 'btcpay') { sendCommercialEvent(buildCheckoutInitiatedPayload(planClass, paymentMethod)) }

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -25,6 +25,7 @@ import dynamic from 'next/dynamic'
 import { StepCreateVault } from './components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from './components/step-create-paid-account'
 import { QRCodeSVG } from 'qrcode.react'
+import { trackCheckoutInitiated, trackPlanSelected } from './commercial-funnel-analytics'
 
 const CRYPTO_CHECKOUT_ENABLED = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED === 'true'
 const BTCPAY_CHECKOUT_ORIGIN = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ORIGIN ?? 'https://btcpay.silentsuite.io'
@@ -691,14 +692,16 @@ function StepChoosePlan({
 
   const handleSelectCard = useCallback(() => {
     setPaymentMethodError(null)
+    trackPlanSelected(interval)
     onSelectPaid(promoCode)
-  }, [onSelectPaid, promoCode])
+  }, [interval, onSelectPaid, promoCode])
 
   const handleSelectBitcoin = useCallback(() => {
     if (interval !== 'annual') {
       onIntervalChange('annual')
     }
     setPaymentMethodError(null)
+    trackPlanSelected('annual')
     onSelectCrypto(interval !== 'annual')
   }, [interval, onIntervalChange, onSelectCrypto])
 
@@ -1437,6 +1440,7 @@ export default function SignupPage() {
       const planId: PlanId = selectedInterval === 'monthly' ? 'early_monthly' : 'early_annual'
       const result = await signup(planId, '30day', promoCode)
       if (result.clientSecret) {
+        trackCheckoutInitiated(selectedInterval, 'stripe')
         setClientSecret(result.clientSecret)
       }
     } catch (err: unknown) {
@@ -1487,6 +1491,7 @@ export default function SignupPage() {
         lookupToken: result.cryptoInvoiceLookupToken,
         checkoutUrl: checkoutUrl.toString(),
       })
+      trackCheckoutInitiated('annual', 'btcpay')
       setPlanView('crypto')
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to start crypto checkout'

--- a/apps/web/app/(auth)/signup/pending-payment/page.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/page.tsx
@@ -8,6 +8,7 @@ import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { StepCreateVault } from '../components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from '../components/step-create-paid-account'
+import { CheckoutReturnAnalytics } from '../commercial-funnel-analytics'
 
 type PaymentState = 'pending' | 'settled' | 'account' | 'vault' | 'expired' | 'timeout' | 'unknown'
 type PaymentFlowCheckState = 'idle' | 'loading' | 'ready' | 'failed'
@@ -388,6 +389,7 @@ export default function PendingPaymentPage() {
 
   return (
     <div className="mx-auto flex min-h-[60vh] max-w-md flex-col justify-center space-y-6 text-center">
+      <CheckoutReturnAnalytics outcome="pending" paymentMethod="btcpay" />
       <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-amber-500/30 bg-amber-500/10">
         {state === 'settled' ? <Check className="h-7 w-7 text-emerald-400" /> : isWaiting ? <Loader2 className="h-7 w-7 animate-spin text-amber-300" /> : <AlertTriangle className="h-7 w-7 text-amber-300" />}
       </div>

--- a/apps/web/app/(auth)/signup/signup-analytics.tsx
+++ b/apps/web/app/(auth)/signup/signup-analytics.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import { usePathname } from 'next/navigation'
-import { buildSignupPageviewPayload } from '@/app/lib/public-analytics'
+import { buildSignupPageviewPayload, SIGNUP_ANALYTICS_PATHS } from '@/app/lib/public-analytics'
 
 const PLAUSIBLE_EVENT_ENDPOINT = 'https://plausible.silentsuite.io/api/event'
 
@@ -13,7 +13,7 @@ export function shouldSendSignupAnalytics(
   return enabled === 'true'
     && location.protocol === 'https:'
     && location.hostname === 'app.silentsuite.io'
-    && (location.pathname === '/signup' || location.pathname.startsWith('/signup/'))
+    && SIGNUP_ANALYTICS_PATHS.includes(location.pathname as typeof SIGNUP_ANALYTICS_PATHS[number])
 }
 
 type SignupPageviewTransport = {
@@ -49,7 +49,7 @@ export function SignupAnalytics() {
   const pathname = usePathname()
 
   useEffect(() => {
-    if (!pathname?.startsWith('/signup')) return
+    if (!pathname || !SIGNUP_ANALYTICS_PATHS.includes(pathname as typeof SIGNUP_ANALYTICS_PATHS[number])) return
     const location = new URL(window.location.href)
     if (!shouldSendSignupAnalytics(location)) return
 

--- a/apps/web/app/(auth)/signup/success/page.tsx
+++ b/apps/web/app/(auth)/signup/success/page.tsx
@@ -10,6 +10,7 @@ import { formatDate as formatDateUtil } from '@/app/lib/date'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import { StepCreateVault } from '../components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from '../components/step-create-paid-account'
+import { CheckoutReturnAnalytics } from '../commercial-funnel-analytics'
 
 // ---------------------------------------------------------------------------
 // Inner component that reads searchParams (must be inside <Suspense>)
@@ -28,6 +29,7 @@ function SignupSuccessInner() {
   const setupIntent = searchParams.get('setup_intent')
   const returnTo = normalizeSignupReturnTo(searchParams.get('return_to'))
   const isStripeRedirect = !!(setupIntent && redirectStatus)
+  const checkoutReturn = <CheckoutReturnAnalytics outcome={redirectStatus === 'failed' ? 'failed' : 'returned'} paymentMethod={isStripeRedirect ? 'stripe' : 'unknown'} />
 
   const [state, setState] = useState<RedirectState>(isStripeRedirect ? 'loading' : 'none')
   const [restoredEmail, setRestoredEmail] = useState<string>('')
@@ -97,6 +99,7 @@ function SignupSuccessInner() {
   if (state === 'loading') {
     return (
       <div className="max-w-md mx-auto flex flex-col items-center justify-center py-12">
+        {checkoutReturn}
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-[rgb(var(--primary))] border-t-transparent" />
         <p className="mt-4 text-sm text-[rgb(var(--muted))]">Completing setup...</p>
       </div>
@@ -106,6 +109,7 @@ function SignupSuccessInner() {
   if (state === 'account') {
     return (
       <div className="max-w-md mx-auto space-y-6">
+        {checkoutReturn}
         <div className="flex items-center gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
           <CheckCircle className="h-5 w-5 text-emerald-500 shrink-0" />
           <div>
@@ -122,6 +126,7 @@ function SignupSuccessInner() {
   if (state === 'vault') {
     return (
       <div className="max-w-md mx-auto space-y-6">
+        {checkoutReturn}
         {/* Brief success confirmation before vault */}
         <div className="flex items-center gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
           <CheckCircle className="h-5 w-5 text-emerald-500 shrink-0" />
@@ -151,6 +156,7 @@ function SignupSuccessInner() {
   if (state === 'failed') {
     return (
       <div className="max-w-md mx-auto space-y-6 text-center">
+        {checkoutReturn}
         <div className="flex flex-col items-center gap-4">
           <div className="rounded-full bg-red-500/10 p-4">
             <AlertTriangle className="h-12 w-12 text-red-400" />
@@ -198,6 +204,7 @@ function SignupSuccessInner() {
 
   return (
     <div className="max-w-md mx-auto space-y-6 text-center">
+      {checkoutReturn}
       <div className="flex flex-col items-center gap-4">
         <div className="rounded-full bg-[rgb(var(--primary))]/10 p-4">
           <CheckCircle className="h-12 w-12 text-[rgb(var(--primary))]" />

--- a/apps/web/app/lib/__tests__/production-deploy-workflows.test.ts
+++ b/apps/web/app/lib/__tests__/production-deploy-workflows.test.ts
@@ -86,15 +86,15 @@ const jobContracts: Record<string, Record<string, { steps: string; permissions: 
     deploy: { steps: 'bbd0c9a9415d24b319bf53201011b78485a5a22674d36336b252fa770e19cf4c', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
   },
   'deploy-docs.yml': {
-    build: { steps: '91656156d61547951a0d50b9c710a6356288443ac53c935b12c050c730a9215f', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
-    deploy: { steps: '3637fc52acda8299a45cbc10b550f22c958b66ad938757f1c8ea13b8a1f87abb', permissions: '551b70084a8244c7f3114d8603c3d2ddac6b642093a4b34cd2e3a00b7e4f8ee1' },
+    build: { steps: '4152d1fcdb56f0c8d6f7bb6f5c192536a4c29c201da386efe7488e55c5bed9e5', permissions: 'd8d6aceb1abc41990618a503082c3badcca8897feee0976f222af5b74e30bec2' },
+    deploy: { steps: '9e11d7e32e0c425dcce74bcebcad1f8226610a896432764b5f42d33e2605819f', permissions: '551b70084a8244c7f3114d8603c3d2ddac6b642093a4b34cd2e3a00b7e4f8ee1' },
   },
 }
 
 const workflowContracts: Record<string, string> = {
   'deploy-web.yml': '67fe57e851cfa98a1736c623e070ddb3dc61bbc88f1b05f0f2b32cf8306ee74a',
   'deploy-server.yml': 'ee8015b23a29d0faa6b0ecb0371f049ae9189c37fe4c80591f82f0e844193312',
-  'deploy-docs.yml': 'd9f4bbecc94008729bf0d6b3ddc43ace09c420d6959a67263a4c1fd732ecec27',
+  'deploy-docs.yml': 'f2658b6a03897bb12fbd20c20387e0fbc2b861cb8ebe1ac37e7494e687ba7e50',
 }
 
 const approvedNode24ActionPins: Record<string, string> = {
@@ -354,7 +354,7 @@ describe('production deployment workflow integrity', () => {
     expect(deployJob).toContain('ACTUAL_ARTIFACT_DIGEST=$(sha256sum')
     expect(deployJob).toContain('test "$ACTUAL_ARTIFACT_DIGEST" = "$EXPECTED_ARTIFACT_DIGEST"')
     const download = deploySteps[downloadIndex]
-    expect(sha256(download?.run ?? '')).toBe('3839d4770098d4b1a20435631a3c1c628aed3648b5f1678f94fc965f949052eb')
+    expect(sha256(download?.run ?? '')).toBe('ee4fc688752cc0d5381af6ea1bf9be77f9b652c1de4ddb650847bc72f7ee9715')
     expect(deployJob).not.toContain('actions/download-artifact@')
     expect(deployJob).not.toContain('pnpm run build')
     expect(mutationActions).toHaveLength(1)

--- a/apps/web/app/lib/__tests__/public-analytics.test.ts
+++ b/apps/web/app/lib/__tests__/public-analytics.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildSignupPageviewPayload,
+  buildCheckoutReturnedPayload,
+  buildPlanSelectedPayload,
+  buildSubscriptionManagementEntryPayload,
   canonicalizeCampaignParams,
   classifyReferrer,
   sanitizedSignupPageUrl,
@@ -36,12 +39,21 @@ describe('public analytics privacy contract', () => {
     })
   })
 
-  it('sanitizes signup page URLs to canonical campaign values', () => {
+  it('strips all query and fragment data from signup page URLs', () => {
     expect(
       sanitizedSignupPageUrl(
         'https://app.silentsuite.io/signup?utm_source=github&utm_medium=referral&utm_content=email@example.com&returnTo=%2Fcalendar',
       ),
-    ).toBe('https://app.silentsuite.io/signup?utm_source=github&utm_medium=referral')
+    ).toBe('https://app.silentsuite.io/signup')
+  })
+
+  it('uses the fixed signup registry URL instead of an arbitrary origin or nested path', () => {
+    expect(sanitizedSignupPageUrl('https://previewapp.silentsuite.io/signup/plan?email=user@example.com#private')).toBe(
+      'https://app.silentsuite.io/signup',
+    )
+    expect(sanitizedSignupPageUrl('https://evil.test/signup/customer@example.com')).toBe(
+      'https://app.silentsuite.io/signup',
+    )
   })
 
   it('classifies the referrer without retaining its path', () => {
@@ -59,8 +71,20 @@ describe('public analytics privacy contract', () => {
     )).toEqual({
       domain: 'app.silentsuite.io',
       name: 'pageview',
-      url: 'https://app.silentsuite.io/signup?utm_source=github',
-      props: { referrer_category: 'github' },
+      url: 'https://app.silentsuite.io/signup',
+      props: { referrer_category: 'github', utm_source: 'github' },
+    })
+  })
+
+  it('creates only fixed commercial-funnel event payloads', () => {
+    expect(buildPlanSelectedPayload('monthly')).toEqual({
+      domain: 'app.silentsuite.io', name: 'Plan Selected', url: 'https://app.silentsuite.io/signup', props: { plan_class: 'monthly' },
+    })
+    expect(buildCheckoutReturnedPayload('cancelled', 'btcpay')).toEqual({
+      domain: 'app.silentsuite.io', name: 'Checkout Returned', url: 'https://app.silentsuite.io/signup/cancel', props: { outcome: 'cancelled', payment_method: 'btcpay' },
+    })
+    expect(buildSubscriptionManagementEntryPayload()).toEqual({
+      domain: 'app.silentsuite.io', name: 'Subscription Management Entry', url: 'https://app.silentsuite.io/settings/subscription', props: { surface: 'subscription_settings' },
     })
   })
 })

--- a/apps/web/app/lib/public-analytics.ts
+++ b/apps/web/app/lib/public-analytics.ts
@@ -10,8 +10,40 @@ export type SignupPageviewPayload = {
   domain: 'app.silentsuite.io'
   name: 'pageview'
   url: string
-  props: { referrer_category: ReferrerCategory }
+  props: { referrer_category: ReferrerCategory } & CampaignParams
 }
+
+export const SIGNUP_ANALYTICS_PATHS = ['/signup', '/signup/pending-payment', '/signup/success', '/signup/cancel'] as const
+type SignupAnalyticsPath = typeof SIGNUP_ANALYTICS_PATHS[number]
+
+type PlanClass = 'monthly' | 'annual'
+type PaymentMethod = 'stripe' | 'btcpay' | 'unknown'
+type CheckoutOutcome = 'returned' | 'cancelled' | 'failed' | 'pending'
+type PlanSelectedPayload = {
+  domain: 'app.silentsuite.io'
+  name: 'Plan Selected'
+  url: 'https://app.silentsuite.io/signup'
+  props: { plan_class: PlanClass }
+}
+type CheckoutInitiatedPayload = {
+  domain: 'app.silentsuite.io'
+  name: 'Checkout Initiated'
+  url: 'https://app.silentsuite.io/signup'
+  props: { plan_class: PlanClass, payment_method: Exclude<PaymentMethod, 'unknown'> }
+}
+type CheckoutReturnedPayload = {
+  domain: 'app.silentsuite.io'
+  name: 'Checkout Returned'
+  url: 'https://app.silentsuite.io/signup/pending-payment' | 'https://app.silentsuite.io/signup/success' | 'https://app.silentsuite.io/signup/cancel'
+  props: { outcome: CheckoutOutcome, payment_method: PaymentMethod }
+}
+type SubscriptionManagementEntryPayload = {
+  domain: 'app.silentsuite.io'
+  name: 'Subscription Management Entry'
+  url: 'https://app.silentsuite.io/settings/subscription'
+  props: { surface: 'subscription_settings' }
+}
+export type CommercialEventPayload = PlanSelectedPayload | CheckoutInitiatedPayload | CheckoutReturnedPayload | SubscriptionManagementEntryPayload
 
 const SOURCE_ALIASES: Readonly<Record<string, NonNullable<CampaignParams['utm_source']>>> = {
   google: 'search', bing: 'search', duckduckgo: 'search',
@@ -55,13 +87,10 @@ export function canonicalizeCampaignParams(search: string | URLSearchParams): Ca
 
 export function sanitizedSignupPageUrl(rawUrl: string): string {
   const current = new URL(rawUrl)
-  const sanitized = new URL(`${current.origin}${current.pathname}`)
-  if (current.pathname === '/signup') {
-    for (const [key, value] of Object.entries(canonicalizeCampaignParams(current.searchParams))) {
-      sanitized.searchParams.set(key, value)
-    }
-  }
-  return sanitized.toString()
+  const path: SignupAnalyticsPath = SIGNUP_ANALYTICS_PATHS.includes(current.pathname as SignupAnalyticsPath)
+    ? current.pathname as SignupAnalyticsPath
+    : '/signup'
+  return `https://app.silentsuite.io${path}`
 }
 
 function hostMatches(host: string, domain: string): boolean {
@@ -83,10 +112,32 @@ export function classifyReferrer(raw: string): ReferrerCategory | undefined {
 }
 
 export function buildSignupPageviewPayload(rawUrl: string, rawReferrer: string): SignupPageviewPayload {
+  const current = new URL(rawUrl)
   return {
     domain: 'app.silentsuite.io',
     name: 'pageview',
     url: sanitizedSignupPageUrl(rawUrl),
-    props: { referrer_category: classifyReferrer(rawReferrer) ?? 'other' },
+    props: { referrer_category: classifyReferrer(rawReferrer) ?? 'other', ...canonicalizeCampaignParams(current.searchParams) },
   }
+}
+
+export function buildPlanSelectedPayload(planClass: PlanClass): PlanSelectedPayload {
+  return { domain: 'app.silentsuite.io', name: 'Plan Selected', url: 'https://app.silentsuite.io/signup', props: { plan_class: planClass } }
+}
+
+export function buildCheckoutInitiatedPayload(planClass: PlanClass, paymentMethod: Exclude<PaymentMethod, 'unknown'>): CheckoutInitiatedPayload {
+  return { domain: 'app.silentsuite.io', name: 'Checkout Initiated', url: 'https://app.silentsuite.io/signup', props: { plan_class: planClass, payment_method: paymentMethod } }
+}
+
+export function buildCheckoutReturnedPayload(outcome: CheckoutOutcome, paymentMethod: PaymentMethod): CheckoutReturnedPayload {
+  const url = outcome === 'cancelled'
+    ? 'https://app.silentsuite.io/signup/cancel'
+    : outcome === 'pending'
+      ? 'https://app.silentsuite.io/signup/pending-payment'
+      : 'https://app.silentsuite.io/signup/success'
+  return { domain: 'app.silentsuite.io', name: 'Checkout Returned', url, props: { outcome, payment_method: paymentMethod } }
+}
+
+export function buildSubscriptionManagementEntryPayload(): SubscriptionManagementEntryPayload {
+  return { domain: 'app.silentsuite.io', name: 'Subscription Management Entry', url: 'https://app.silentsuite.io/settings/subscription', props: { surface: 'subscription_settings' } }
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -6,6 +6,7 @@ const { withSentryConfig } = require('@sentry/nextjs')
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts')
 const hostedConnectSources = "connect-src 'self' https://api.silentsuite.io https://server.silentsuite.io wss://server.silentsuite.io https://*.sentry.io"
 const signupConnectSources = `${hostedConnectSources} https://plausible.silentsuite.io https://api.stripe.com`
+const subscriptionConnectSources = `${hostedConnectSources} https://plausible.silentsuite.io`
 
 // Resolve etebase CJS entry — it's a dep of @silentsuite/core,
 // not directly in apps/web's node_modules (pnpm strict isolation).
@@ -39,6 +40,10 @@ const nextConfig = {
         source,
         headers: [{ key: 'Content-Security-Policy', value: hostedConnectSources }],
       })),
+      {
+        source: '/settings/subscription',
+        headers: [{ key: 'Content-Security-Policy', value: subscriptionConnectSources }],
+      },
     ]
   },
   webpack: (config) => {

--- a/apps/web/next.config.public-analytics.test.mjs
+++ b/apps/web/next.config.public-analytics.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const nextConfig = require('./next.config.js')
+
+function sourceMatches(source, pathname) {
+  const expression = source.replace('/:path*', '(?:/.*)?').replaceAll('/', '\\/')
+  return new RegExp(`^${expression}$`).test(pathname)
+}
+
+async function appliedCsp(pathname) {
+  const rules = await nextConfig.headers()
+  return rules
+    .filter((rule) => sourceMatches(rule.source, pathname))
+    .flatMap((rule) => rule.headers)
+    .filter((header) => header.key === 'Content-Security-Policy')
+    .at(-1)?.value
+}
+
+test('public analytics CSP uses the final matching route header', async () => {
+  assert.match(await appliedCsp('/settings/subscription'), /https:\/\/plausible\.silentsuite\.io/)
+  assert.match(await appliedCsp('/signup'), /https:\/\/plausible\.silentsuite\.io/)
+  for (const path of ['/settings', '/settings/account', '/calendar', '/contacts', '/tasks']) {
+    assert.doesNotMatch(await appliedCsp(path), /https:\/\/plausible\.silentsuite\.io/)
+  }
+})

--- a/apps/web/signup-plan-selected-contract.test.mjs
+++ b/apps/web/signup-plan-selected-contract.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const source = await readFile(new URL('./app/(auth)/signup/page.tsx', import.meta.url), 'utf8')
+
+function callbackBody(name, nextName) {
+  return source.slice(source.indexOf(`const ${name}`), source.indexOf(`const ${nextName}`))
+}
+
+test('Plan Selected is recorded on paid payment-method selection, not after signup succeeds', () => {
+  assert.match(callbackBody('handleSelectCard', 'handleSelectBitcoin'), /trackPlanSelected\(interval\)[\s\S]*onSelectPaid\(promoCode\)/)
+  assert.match(callbackBody('handleSelectBitcoin', 'hasEnteredPromoCode'), /trackPlanSelected\('annual'\)[\s\S]*onSelectCrypto\(interval !== 'annual'\)/)
+  assert.doesNotMatch(callbackBody('handleSelectPaid', 'handleSelectCrypto'), /trackPlanSelected/)
+  assert.doesNotMatch(callbackBody('handleSelectCrypto', 'handlePlanBack'), /trackPlanSelected/)
+})

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type-check": "turbo type-check",
     "i18n:check": "pnpm --filter @silentsuite/web i18n:check",
     "i18n:report": "pnpm --filter @silentsuite/web i18n:report",
-    "check:public-analytics": "node scripts/check-public-analytics.mjs && node --experimental-strip-types --test apps/docs/.vitepress/theme/public-analytics.test.mts",
+    "check:public-analytics": "node scripts/check-public-analytics.mjs && node --test apps/web/next.config.public-analytics.test.mjs apps/web/signup-plan-selected-contract.test.mjs scripts/check-public-analytics.test.mjs scripts/verify-docs-analytics-build.test.mjs scripts/docs-analytics-deploy.test.mjs && node --experimental-strip-types --test apps/docs/.vitepress/theme/public-analytics.test.mts apps/docs/.vitepress/theme/docs-analytics-runtime.test.mts",
     "test:dependency-security": "node --test scripts/audit-high-critical.test.mjs scripts/dependency-compatibility-smoke.test.mjs",
     "audit:security": "pnpm run test:dependency-security && node scripts/audit-high-critical.mjs"
   },

--- a/scripts/check-public-analytics.mjs
+++ b/scripts/check-public-analytics.mjs
@@ -2,8 +2,16 @@ import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 const appsRoot = path.resolve('apps')
+const analyticsEndpoint = 'plausible.silentsuite.io/api/event'
+const generatedAppRootArgument = process.argv.find((argument) => argument.startsWith('--generated-app-root='))
+const generatedAppRoot = generatedAppRootArgument
+  ? path.resolve(generatedAppRootArgument.slice('--generated-app-root='.length))
+  : path.join(appsRoot, 'web/.next/static/chunks/app/(app)')
+const enabledGeneratedBuild = process.argv.includes('--enabled-generated-build') || process.env.PUBLIC_ANALYTICS_ENABLED_BUILD === 'true'
 const allowedAnalyticsFiles = new Set([
   path.join(appsRoot, 'web/app/(auth)/signup/signup-analytics.tsx'),
+  path.join(appsRoot, 'web/app/(auth)/signup/commercial-funnel-analytics.tsx'),
+  path.join(appsRoot, 'web/app/(app)/settings/subscription/subscription-entry.tsx'),
   path.join(appsRoot, 'web/next.config.js'),
   path.join(appsRoot, 'docs/.vitepress/config.mts'),
   path.join(appsRoot, 'docs/.vitepress/theme/index.mts'),
@@ -26,7 +34,7 @@ async function walk(directory) {
       if (/utm_(?:content|term)/.test(source)) {
         violations.push(`${path.relative(process.cwd(), fullPath)}: prohibited free-form UTM key`)
       }
-      if (fullPath.includes(`${path.sep}web${path.sep}app${path.sep}(app)${path.sep}`) && /plausible|analytics/i.test(source)) {
+      if (fullPath.includes(`${path.sep}web${path.sep}app${path.sep}(app)${path.sep}`) && /plausible|analytics/i.test(source) && !allowedAnalyticsFiles.has(fullPath)) {
         violations.push(`${path.relative(process.cwd(), fullPath)}: analytics reference in authenticated app route`)
       }
     }
@@ -38,12 +46,14 @@ await walk(appsRoot)
 const requiredContracts = new Map([
   ['apps/docs/.vitepress/theme/public-analytics.mts', ['Hosted App Click', 'Android Download Click', 'github_release', 'repository']],
   ['apps/docs/.vitepress/theme/index.mts', ['__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__', 'window.location.hostname', 'classifyDocsOutboundEvent']],
-  ['apps/web/next.config.js', ['Content-Security-Policy', 'signupConnectSources', 'hostedConnectSources']],
+  ['apps/web/next.config.js', ['Content-Security-Policy', 'signupConnectSources', 'subscriptionConnectSources', "source: '/settings/subscription'", 'hostedConnectSources']],
   ['apps/web/app/(auth)/signup/signup-analytics.tsx', [
     "enabled === 'true'",
     "location.hostname === 'app.silentsuite.io'",
     "location.protocol === 'https:'",
   ]],
+  ['apps/web/app/(auth)/signup/commercial-funnel-analytics.tsx', ['buildPlanSelectedPayload', 'buildCheckoutInitiatedPayload', 'buildCheckoutReturnedPayload']],
+  ['apps/web/app/(app)/settings/subscription/subscription-entry.tsx', ['buildSubscriptionManagementEntryPayload']],
   ['Dockerfile.web', ['ARG NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=false']],
   ['.github/workflows/deploy-web.yml', ['NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=true']],
   ['.github/workflows/preview-web.yml', ['NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=false']],
@@ -56,18 +66,26 @@ for (const [relativePath, snippets] of requiredContracts) {
   }
 }
 
-const generatedAppRoot = path.join(appsRoot, 'web/.next/static/chunks/app/(app)')
 try {
+  let subscriptionRouteContainsEndpoint = false
   async function scanGenerated(directory) {
     for (const entry of await readdir(directory, { withFileTypes: true })) {
       const fullPath = path.join(directory, entry.name)
       if (entry.isDirectory()) await scanGenerated(fullPath)
-      else if (/\.js$/.test(entry.name) && /plausible\.silentsuite\.io|window\.plausible/.test(await readFile(fullPath, 'utf8'))) {
-        violations.push(`${path.relative(process.cwd(), fullPath)}: analytics endpoint in authenticated production bundle`)
+      else if (/\.js$/.test(entry.name)) {
+        const source = await readFile(fullPath, 'utf8')
+        if (!source.includes(analyticsEndpoint)) continue
+        const relativePath = path.relative(generatedAppRoot, fullPath)
+        const isSubscriptionRouteChunk = /^settings[\\/]subscription[\\/]page-[^\\/]+\.js$/.test(relativePath)
+        if (isSubscriptionRouteChunk) subscriptionRouteContainsEndpoint = true
+        else violations.push(`${path.relative(process.cwd(), fullPath)}: analytics endpoint in authenticated production bundle`)
       }
     }
   }
   await scanGenerated(generatedAppRoot)
+  if (enabledGeneratedBuild && !subscriptionRouteContainsEndpoint) {
+    violations.push('subscription route chunk: expected analytics endpoint absent')
+  }
 } catch (error) {
   if (error.code !== 'ENOENT') throw error
 }

--- a/scripts/check-public-analytics.test.mjs
+++ b/scripts/check-public-analytics.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import test from 'node:test'
+
+const execFileAsync = promisify(execFile)
+const endpoint = 'https://plausible.silentsuite.io/api/event'
+
+async function withGeneratedAppTree(files, run) {
+  const root = await mkdtemp(path.join(tmpdir(), 'public-analytics-'))
+  try {
+    for (const [relativePath, contents] of Object.entries(files)) {
+      const file = path.join(root, relativePath)
+      await mkdir(path.dirname(file), { recursive: true })
+      await writeFile(file, contents)
+    }
+    await run(root)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+async function checkGeneratedAppTree(root) {
+  try {
+    await execFileAsync(process.execPath, [
+      'scripts/check-public-analytics.mjs',
+      '--enabled-generated-build',
+      `--generated-app-root=${root}`,
+    ])
+    return ''
+  } catch (error) {
+    return `${error.stdout}\n${error.stderr}`
+  }
+}
+
+test('enabled generated app scan fails closed when the subscription route chunk lacks the approved endpoint', async () => {
+  await withGeneratedAppTree({
+    'settings/subscription/page-a.js': 'console.log("subscription")',
+  }, async (root) => {
+    assert.match(await checkGeneratedAppTree(root), /subscription route chunk: expected analytics endpoint absent/)
+  })
+})
+
+test('enabled generated app scan rejects endpoint contamination in sibling authenticated chunks', async () => {
+  await withGeneratedAppTree({
+    'settings/subscription/page-a.js': endpoint,
+    'calendar/page-b.js': endpoint,
+  }, async (root) => {
+    assert.match(await checkGeneratedAppTree(root), /calendar\/page-b\.js: analytics endpoint in authenticated production bundle/)
+  })
+})
+
+test('enabled generated app scan permits the endpoint only in the subscription route chunk', async () => {
+  await withGeneratedAppTree({
+    'settings/subscription/page-a.js': endpoint,
+  }, async (root) => {
+    assert.equal(await checkGeneratedAppTree(root), '')
+  })
+})

--- a/scripts/docs-analytics-deploy.test.mjs
+++ b/scripts/docs-analytics-deploy.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+test('docs production workflow verifies both built and downloaded bytes', async () => {
+  const workflow = await readFile('.github/workflows/deploy-docs.yml', 'utf8')
+  assert.equal((workflow.match(/verify-docs-analytics-build\.mjs/g) ?? []).length, 2)
+  assert.match(workflow, /pnpm --filter @silentsuite\/docs exec vitepress build/)
+  assert.match(workflow, /Upload admitted docs artifact[\s\S]*path: apps\/docs\/\.vitepress\/dist/)
+})
+
+test('CI verifies enabled and disabled docs artifacts across Turbo cache ordering', async () => {
+  const workflow = await readFile('.github/workflows/ci.yml', 'utf8')
+  assert.match(workflow, /SILENTSUITE_HOSTED_DOCS_ANALYTICS=1 pnpm run build:docs/)
+  assert.match(workflow, /pnpm run build:docs[\s\S]*--mode disabled/)
+  assert.match(workflow, /--mode enabled/)
+})

--- a/scripts/verify-docs-analytics-build.mjs
+++ b/scripts/verify-docs-analytics-build.mjs
@@ -1,0 +1,52 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const ENDPOINT = 'https://plausible.silentsuite.io/api/event'
+const REQUIRED_ENABLED_TEXT = ['docs.silentsuite.io', 'pageview', 'Hosted App Click', 'Android Download Click', 'GitHub Click']
+const PROHIBITED_TEXT = ['utm_content', 'utm_term', 'referrer_category']
+
+async function artifactText(directory) {
+  let text = ''
+  let files = 0
+  async function collect(current) {
+    for (const entry of await readdir(current, { withFileTypes: true })) {
+      const fullPath = path.join(current, entry.name)
+      if (entry.isDirectory()) await collect(fullPath)
+      else if (/\.(?:js|html)$/.test(entry.name)) {
+        files += 1
+        text += await readFile(fullPath, 'utf8')
+      }
+    }
+  }
+  await collect(directory)
+  if (!files) throw new Error('docs analytics artifact contains no emitted JS or HTML')
+  return text
+}
+
+export async function verifyDocsAnalyticsBuild(directory, mode) {
+  if (mode !== 'enabled' && mode !== 'disabled') throw new Error('mode must be enabled or disabled')
+  const text = await artifactText(directory)
+  if (text.includes('__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__')) throw new Error('docs artifact contains unresolved analytics compile constant')
+  const endpoints = text.match(/https:\/\/[^"'\s`]+\/api\/event/g) ?? []
+  if (endpoints.some((endpoint) => endpoint !== ENDPOINT)) throw new Error('docs artifact contains an unapproved event endpoint')
+  if (mode === 'disabled') {
+    if (text.includes(ENDPOINT)) throw new Error('disabled docs artifact contains analytics endpoint')
+    return
+  }
+  if (!text.includes(ENDPOINT)) throw new Error('enabled docs artifact is missing analytics endpoint')
+  for (const required of REQUIRED_ENABLED_TEXT) {
+    if (!text.includes(required)) throw new Error(`enabled docs artifact is missing required contract: ${required}`)
+  }
+  for (const prohibited of PROHIBITED_TEXT) {
+    if (text.includes(prohibited)) throw new Error(`docs artifact contains prohibited analytics property: ${prohibited}`)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2)
+  const directory = args[args.indexOf('--dir') + 1]
+  const mode = args[args.indexOf('--mode') + 1]
+  if (!directory || !mode) throw new Error('usage: verify-docs-analytics-build.mjs --dir <directory> --mode enabled|disabled')
+  await verifyDocsAnalyticsBuild(directory, mode)
+  console.log(`Docs analytics artifact verified (${mode})`)
+}

--- a/scripts/verify-docs-analytics-build.mjs
+++ b/scripts/verify-docs-analytics-build.mjs
@@ -5,6 +5,35 @@ const ENDPOINT = 'https://plausible.silentsuite.io/api/event'
 const REQUIRED_ENABLED_TEXT = ['docs.silentsuite.io', 'pageview', 'Hosted App Click', 'Android Download Click', 'GitHub Click']
 const PROHIBITED_TEXT = ['utm_content', 'utm_term', 'referrer_category']
 
+function normalizeResolvableLiteralText(text) {
+  let normalized = text
+    .replace(/\\(?:x2[fF]|u002[fF]|\/)/g, '/')
+    .replace(/(?:&sol;|&#(?:0*47|x0*2[fF]);)/gi, '/')
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    normalized = normalized.replace(/(?:%[\da-f]{2})+/gi, (encoded) => {
+      try { return decodeURIComponent(encoded) } catch { return encoded }
+    })
+  }
+  return normalized
+}
+
+function isApprovedEndpointOccurrence(text, occurrenceIndex) {
+  const eventPath = '/api/event'
+  const endpointStart = occurrenceIndex - (ENDPOINT.length - eventPath.length)
+  if (text.slice(endpointStart, occurrenceIndex + eventPath.length) !== ENDPOINT) return false
+
+  const before = text[endpointStart - 1]
+  const after = text[occurrenceIndex + eventPath.length]
+  return (before === undefined || /[\s"'`<>()\[\]{},;=:]/.test(before))
+    && (after === undefined || /[\s"'`<>()\[\]{},;]/.test(after))
+}
+
+function approvedEndpointOccurrences(text) {
+  const eventPath = '/api/event'
+  return [...text.matchAll(/https:\/\/plausible\.silentsuite\.io\/api\/event/g)]
+    .filter(({ index }) => isApprovedEndpointOccurrence(text, index + ENDPOINT.length - eventPath.length))
+}
+
 async function artifactText(directory) {
   let text = ''
   let files = 0
@@ -27,13 +56,19 @@ export async function verifyDocsAnalyticsBuild(directory, mode) {
   if (mode !== 'enabled' && mode !== 'disabled') throw new Error('mode must be enabled or disabled')
   const text = await artifactText(directory)
   if (text.includes('__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__')) throw new Error('docs artifact contains unresolved analytics compile constant')
-  const endpoints = text.match(/https:\/\/[^"'\s`]+\/api\/event/g) ?? []
-  if (endpoints.some((endpoint) => endpoint !== ENDPOINT)) throw new Error('docs artifact contains an unapproved event endpoint')
+  const literalText = normalizeResolvableLiteralText(text)
+  const eventOccurrences = [...literalText.matchAll(/\/api\/event/g)]
   if (mode === 'disabled') {
-    if (text.includes(ENDPOINT)) throw new Error('disabled docs artifact contains analytics endpoint')
+    if (eventOccurrences.length) throw new Error('disabled docs artifact contains analytics endpoint')
     return
   }
-  if (!text.includes(ENDPOINT)) throw new Error('enabled docs artifact is missing analytics endpoint')
+  const approvedOccurrences = approvedEndpointOccurrences(text)
+  if (!approvedOccurrences.length) {
+    throw new Error('enabled docs artifact is missing analytics endpoint')
+  }
+  if (eventOccurrences.length !== approvedOccurrences.length) {
+    throw new Error('docs artifact contains an unapproved event endpoint')
+  }
   for (const required of REQUIRED_ENABLED_TEXT) {
     if (!text.includes(required)) throw new Error(`enabled docs artifact is missing required contract: ${required}`)
   }

--- a/scripts/verify-docs-analytics-build.test.mjs
+++ b/scripts/verify-docs-analytics-build.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+import { verifyDocsAnalyticsBuild } from './verify-docs-analytics-build.mjs'
+
+async function fixture(contents) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), 'docs-analytics-'))
+  await writeFile(path.join(directory, 'index.html'), contents)
+  return directory
+}
+
+test('admits only an enabled artifact with the approved endpoint and taxonomy', async () => {
+  const directory = await fixture('https://plausible.silentsuite.io/api/event docs.silentsuite.io pageview Hosted App Click Android Download Click GitHub Click')
+  try {
+    await assert.doesNotReject(() => verifyDocsAnalyticsBuild(directory, 'enabled'))
+  } finally { await rm(directory, { recursive: true }) }
+})
+
+test('fails closed for disabled endpoint, unresolved values, wrong endpoints, and forbidden properties', async () => {
+  for (const [mode, contents] of [
+    ['disabled', 'https://plausible.silentsuite.io/api/event'],
+    ['enabled', '__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__ docs.silentsuite.io pageview'],
+    ['enabled', 'https://evil.example/api/event docs.silentsuite.io pageview'],
+    ['enabled', 'https://plausible.silentsuite.io/api/event docs.silentsuite.io pageview utm_content'],
+  ]) {
+    const directory = await fixture(contents)
+    try { await assert.rejects(() => verifyDocsAnalyticsBuild(directory, mode)) }
+    finally { await rm(directory, { recursive: true }) }
+  }
+})

--- a/scripts/verify-docs-analytics-build.test.mjs
+++ b/scripts/verify-docs-analytics-build.test.mjs
@@ -31,3 +31,31 @@ test('fails closed for disabled endpoint, unresolved values, wrong endpoints, an
     finally { await rm(directory, { recursive: true }) }
   }
 })
+
+test('rejects every unapproved event occurrence in enabled and disabled artifacts', async () => {
+  const taxonomy = 'docs.silentsuite.io pageview Hosted App Click Android Download Click GitHub Click'
+  const unapprovedOccurrences = [
+    '/api/event',
+    'http://plausible.silentsuite.io/api/event',
+    '//plausible.silentsuite.io/api/event',
+    'https://plausible.silentsuite.io/api/event/extra',
+    'https://plausible.silentsuite.io/api/event?source=docs',
+    'https://plausible.silentsuite.io/api/event#fragment',
+    'https://plausible.silentsuite.io.evil.example/api/event',
+    'https://plausible.silentsuite.io:8443/api/event',
+    'https://plausible.silentsuite.io/api/event https://evil.example/api/event',
+    '\\x2fapi\\x2fevent',
+    'https:%2F%2Fevil.example%2Fapi%2Fevent',
+  ]
+
+  for (const occurrence of unapprovedOccurrences) {
+    for (const [mode, contents] of [
+      ['enabled', `${occurrence} ${taxonomy}`],
+      ['disabled', occurrence],
+    ]) {
+      const directory = await fixture(contents)
+      try { await assert.rejects(() => verifyDocsAnalyticsBuild(directory, mode), occurrence) }
+      finally { await rm(directory, { recursive: true }) }
+    }
+  }
+})

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
+      "env": ["SILENTSUITE_HOSTED_DOCS_ANALYTICS"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**", ".vitepress/dist/**"]
     },
     "dev": {


### PR DESCRIPTION
## Summary

- add exact-route, identity-free docs pageviews and outbound conversion events
- add hosted signup/commercial-funnel events and one exact subscription-management entry event
- keep calendar, contacts, tasks, general settings, previews, and self-hosted builds untracked
- make docs analytics compile-time state part of the Turbo cache key
- fail closed on enabled/disabled docs artifacts and downloaded production bytes
- strengthen emitted web bundle and CSP analytics boundaries

## Privacy boundary

- fixed canonical query-free URLs only
- fixed low-cardinality event/property vocabulary
- no PIM content, account IDs, provider IDs, raw referrer paths, or raw query values
- browser events describe intent/return only; Billing remains conversion authority

## Verification

- `pnpm run check:public-analytics`
- web: 62 files / 796 tests
- web type-check
- repository lint
- enabled web production build and emitted route scan
- docs enabled and disabled builds
- Turbo enabled → disabled → enabled cache isolation
- downloaded-artifact workflow contract tests

## Review status

Initial GPT-5.6 Sol review found three Medium issues. The two code/content findings affecting this repository were corrected with GPT-5.6 Terra and their focused/full tests pass. A refreshed immutable Sol review is still required before merge but is currently blocked by Codex quota exhaustion until August 10. Do not merge before that review returns GREEN.

Closes #633
