### PR TITLE
fix(bridge): repair existing-cache upgrade integrity

### DIFF
--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -15,13 +15,14 @@ import re
 import threading
 import time
 from contextlib import contextmanager
+from functools import wraps
 
 import msgpack
 import peewee as pw
 from etebase import Account, Client, CollectionAccessLevel, FetchOptions
 
 from .. import config
-from ..privacy_logging import bounded_exception_class
+from ..privacy_logging import BoundedDiagnosticError, bounded_exception_class
 from . import db, models
 
 logger = logging.getLogger("silentsuite-bridge.cache")
@@ -31,6 +32,24 @@ DAV_UNRESOLVED_RETRY_LIMIT = 8
 
 class DavUnresolvedItemsError(RuntimeError):
     """A sync applied safe changes but retained unresolved DAV conflicts."""
+
+
+def _bounded_integrity(diagnostic_code):
+    """Translate one constrained-write failure into a fixed product code."""
+
+    def decorate(function):
+        @wraps(function)
+        def wrapped(*args, **kwargs):
+            try:
+                return function(*args, **kwargs)
+            except BoundedDiagnosticError:
+                raise
+            except pw.IntegrityError:
+                raise BoundedDiagnosticError(diagnostic_code) from None
+
+        return wrapped
+
+    return decorate
 
 
 @contextmanager
@@ -147,11 +166,16 @@ def _migrate_cache_schema(database):
         database.execute_sql(
             "ALTER TABLE itementity ADD COLUMN remote_uid VARCHAR(255)"
         )
-    database.execute_sql(
-        "CREATE UNIQUE INDEX IF NOT EXISTS "
-        "itementity_collection_remote_uid "
-        "ON itementity (collection_id, remote_uid)"
-    )
+    try:
+        database.execute_sql(
+            "CREATE UNIQUE INDEX IF NOT EXISTS "
+            "itementity_collection_remote_uid "
+            "ON itementity (collection_id, remote_uid)"
+        )
+    except pw.IntegrityError:
+        raise BoundedDiagnosticError(
+            "CacheSchemaRemoteUidIntegrityError"
+        ) from None
     if "davsynctoken" in tables:
         token_columns = {
             column.name for column in database.get_columns("davsynctoken")
@@ -160,11 +184,16 @@ def _migrate_cache_schema(database):
             database.execute_sql(
                 "ALTER TABLE davsynctoken ADD COLUMN state_hash VARCHAR(255)"
             )
-        database.execute_sql(
-            "CREATE UNIQUE INDEX IF NOT EXISTS "
-            "davsynctoken_collection_revision "
-            "ON davsynctoken (collection_id, revision)"
-        )
+        try:
+            database.execute_sql(
+                "CREATE UNIQUE INDEX IF NOT EXISTS "
+                "davsynctoken_collection_revision "
+                "ON davsynctoken (collection_id, revision)"
+            )
+        except pw.IntegrityError:
+            raise BoundedDiagnosticError(
+                "CacheSchemaTokenRevisionIntegrityError"
+            ) from None
     if "davrevision" in tables:
         revision_columns = {
             column.name for column in database.get_columns("davrevision")
@@ -513,19 +542,27 @@ def ensure_dav_href(
         return models.HrefMapper.get(models.HrefMapper.content == cache_item)
 
 
+@_bounded_integrity("CacheRevisionIntegrityError")
 def record_dav_change(
     cache_col, href, *, previous_state_hash, etag=None, deleted=False
 ):
     """Atomically advance a collection revision and record its latest href change."""
-    with db.database_proxy.atomic():
+    with db.database_proxy.atomic("IMMEDIATE"):
+        current_revision = models.CollectionEntity.get_by_id(
+            cache_col.id
+        ).dav_revision
+        retained_revision = (
+            models.DavRevision.select(pw.fn.MAX(models.DavRevision.revision))
+            .where(models.DavRevision.collection == cache_col)
+            .scalar()
+            or 0
+        )
+        revision = max(current_revision, retained_revision) + 1
         (
-            models.CollectionEntity.update(
-                dav_revision=models.CollectionEntity.dav_revision + 1
-            )
+            models.CollectionEntity.update(dav_revision=revision)
             .where(models.CollectionEntity.id == cache_col.id)
             .execute()
         )
-        revision = models.CollectionEntity.get_by_id(cache_col.id).dav_revision
         (
             models.DavChange.insert(
                 collection=cache_col,
@@ -675,6 +712,7 @@ class Etebase:
         _activate_dav_revision_ledger()
         _restrict_cache_database_files(getattr(database, "database", None))
 
+    @_bounded_integrity("CacheBackfillIntegrityError")
     def _backfill_remote_uids(self):
         """Recover stable Etebase item identities from cached envelopes only."""
         unresolved = 0
@@ -973,6 +1011,7 @@ class Etebase:
             .execute()
         )
 
+    @_bounded_integrity("CachePullItemIntegrityError")
     def _apply_pulled_item(
         self,
         cache_col,
@@ -989,16 +1028,17 @@ class Etebase:
                 (models.ItemEntity.collection == cache_col)
                 & (models.ItemEntity.remote_uid == item.uid)
             )
-            if cache_item is None and meta.get("name"):
+            local_uid = meta.get("name") or item.uid
+            if cache_item is None:
                 cache_item = models.ItemEntity.get_or_none(
                     (models.ItemEntity.collection == cache_col)
-                    & (models.ItemEntity.uid == meta["name"])
+                    & (models.ItemEntity.uid == local_uid)
                     & (models.ItemEntity.remote_uid.is_null(True))
                 )
                 if cache_item is None:
                     identity_bound_collision = models.ItemEntity.get_or_none(
                         (models.ItemEntity.collection == cache_col)
-                        & (models.ItemEntity.uid == meta["name"])
+                        & (models.ItemEntity.uid == local_uid)
                         & (models.ItemEntity.remote_uid.is_null(False))
                     )
                     if identity_bound_collision is not None:
@@ -1014,7 +1054,7 @@ class Etebase:
             if cache_item is None:
                 cache_item = models.ItemEntity(
                     collection=cache_col,
-                    uid=meta.get("name") or item.uid,
+                    uid=local_uid,
                 )
 
             if cache_item.id is not None and (cache_item.dirty or cache_item.new):
@@ -1087,6 +1127,7 @@ class Etebase:
             ).execute()
             return True
 
+    @_bounded_integrity("CacheUnresolvedRetryIntegrityError")
     def _retry_unresolved_items(self, cache_col, col, item_mgr):
         unresolved_items = list(
             models.DavUnresolvedItem.select().where(

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -117,19 +117,30 @@ def _init_cache_database(db_path=None):
     return database, True
 
 
+_BASE_CACHE_MODELS = (
+    models.Config,
+    models.User,
+    models.CollectionEntity,
+    models.ItemEntity,
+    models.HrefMapper,
+)
+
+
+def _create_and_migrate_base_tables(database):
+    """Create missing legacy tables, migrate existing ones, then add model indexes."""
+    existing_tables = set(database.get_tables())
+    for model in _BASE_CACHE_MODELS:
+        table_name = model._meta.table_name
+        if table_name not in existing_tables:
+            model.create_table(safe=True)
+            existing_tables.add(table_name)
+    _migrate_cache_schema(database)
+    database.create_tables(_BASE_CACHE_MODELS, safe=True)
+
+
 def _ensure_cache_tables(database):
     with _private_umask():
-        database.create_tables(
-            [
-                models.Config,
-                models.User,
-                models.CollectionEntity,
-                models.ItemEntity,
-                models.HrefMapper,
-            ],
-            safe=True,
-        )
-        _migrate_cache_schema(database)
+        _create_and_migrate_base_tables(database)
         database.create_tables(
             [
                 models.DavChange,
@@ -680,17 +691,7 @@ class Etebase:
             self._set_db(database)
 
     def _init_db_tables(self, database, additional_tables=None):
-        database.create_tables(
-            [
-                models.Config,
-                models.User,
-                models.CollectionEntity,
-                models.ItemEntity,
-                models.HrefMapper,
-            ],
-            safe=True,
-        )
-        _migrate_cache_schema(database)
+        _create_and_migrate_base_tables(database)
         database.create_tables(
             [
                 models.DavChange,
@@ -720,7 +721,14 @@ class Etebase:
         for cache_col in self.user.collections:
             col = col_mgr.cache_load(cache_col.eb_col)
             item_mgr = col_mgr.get_item_manager(col)
-            items = cache_col.items.where(models.ItemEntity.remote_uid.is_null(True))
+            items = cache_col.items.where(
+                models.ItemEntity.remote_uid.is_null(True)
+            ).order_by(
+                models.ItemEntity.dirty.asc(),
+                models.ItemEntity.new.asc(),
+                models.ItemEntity.deleted.asc(),
+                models.ItemEntity.id.asc(),
+            )
             for cache_item in items:
                 existing_quarantine = models.DavUnresolvedItem.get_or_none(
                     (models.DavUnresolvedItem.local_item == cache_item)
@@ -805,6 +813,11 @@ class Etebase:
                 .execute()
             )
             cache_item.remote_uid = None
+            if cache_item.dirty or cache_item.new:
+                # Preserve unsynced local intent and visibility. The push query
+                # excludes quarantined rows until retry can bind a remote UID.
+                cache_item.save(only=[models.ItemEntity.remote_uid])
+                return
             cache_item.deleted = True
             cache_item.save(
                 only=[
@@ -1020,6 +1033,7 @@ class Etebase:
         item,
         *,
         quarantine=True,
+        resolve_unresolved=True,
     ):
         meta = dict(item.meta)
         with db.database_proxy.atomic("IMMEDIATE"):
@@ -1061,10 +1075,11 @@ class Etebase:
                 if cache_item.remote_uid is None:
                     cache_item.remote_uid = item.uid
                     cache_item.save(only=[models.ItemEntity.remote_uid])
-                models.DavUnresolvedItem.delete().where(
-                    (models.DavUnresolvedItem.collection == cache_col)
-                    & (models.DavUnresolvedItem.local_item == cache_item)
-                ).execute()
+                if resolve_unresolved:
+                    models.DavUnresolvedItem.delete().where(
+                        (models.DavUnresolvedItem.collection == cache_col)
+                        & (models.DavUnresolvedItem.local_item == cache_item)
+                    ).execute()
                 return True
 
             cache_item.remote_uid = item.uid
@@ -1118,13 +1133,14 @@ class Etebase:
                     etag=item.etag,
                     deleted=item.deleted,
                 )
-            models.DavUnresolvedItem.delete().where(
-                (models.DavUnresolvedItem.collection == cache_col)
-                & (
-                    (models.DavUnresolvedItem.remote_uid == item.uid)
-                    | (models.DavUnresolvedItem.local_item == cache_item)
-                )
-            ).execute()
+            if resolve_unresolved:
+                models.DavUnresolvedItem.delete().where(
+                    (models.DavUnresolvedItem.collection == cache_col)
+                    & (
+                        (models.DavUnresolvedItem.remote_uid == item.uid)
+                        | (models.DavUnresolvedItem.local_item == cache_item)
+                    )
+                ).execute()
             return True
 
     @_bounded_integrity("CacheUnresolvedRetryIntegrityError")
@@ -1135,15 +1151,74 @@ class Etebase:
             )
         )
         for unresolved in unresolved_items:
-            if unresolved.reason == "legacy_duplicate":
+            retry_unresolved_state = (
+                unresolved.remote_uid,
+                unresolved.eb_item,
+                unresolved.deleted,
+                unresolved.attempts,
+                unresolved.reason,
+                unresolved.local_item_id,
+            )
+            pending_local_item = (
+                models.ItemEntity.get_or_none(
+                    models.ItemEntity.id == unresolved.local_item_id
+                )
+                if unresolved.local_item_id is not None
+                else None
+            )
+            preserves_local_intent = pending_local_item is not None and (
+                pending_local_item.dirty or pending_local_item.new
+            )
+            retry_local_state = None
+            retry_envelope = unresolved.eb_item
+            if pending_local_item is not None:
+                retry_envelope = pending_local_item.eb_item
+                retry_local_state = (
+                    pending_local_item.eb_item,
+                    pending_local_item.deleted,
+                    pending_local_item.dirty,
+                    pending_local_item.new,
+                    pending_local_item.remote_uid,
+                )
+            if unresolved.reason == "legacy_duplicate" and not preserves_local_intent:
                 continue
-            if unresolved.attempts >= DAV_UNRESOLVED_RETRY_LIMIT:
+            if (
+                unresolved.attempts >= DAV_UNRESOLVED_RETRY_LIMIT
+                and not preserves_local_intent
+            ):
                 continue
             try:
-                item = item_mgr.cache_load(unresolved.eb_item)
+                item = item_mgr.cache_load(retry_envelope)
             except Exception as exc:
-                unresolved.attempts += 1
-                unresolved.save(only=[models.DavUnresolvedItem.attempts])
+                with db.database_proxy.atomic("IMMEDIATE"):
+                    current_unresolved = models.DavUnresolvedItem.get_or_none(
+                        models.DavUnresolvedItem.id == unresolved.id
+                    )
+                    if current_unresolved is None or (
+                        current_unresolved.remote_uid,
+                        current_unresolved.eb_item,
+                        current_unresolved.deleted,
+                        current_unresolved.attempts,
+                        current_unresolved.reason,
+                        current_unresolved.local_item_id,
+                    ) != retry_unresolved_state:
+                        continue
+                    if retry_local_state is not None:
+                        current_local_item = models.ItemEntity.get_or_none(
+                            models.ItemEntity.id == unresolved.local_item_id
+                        )
+                        if current_local_item is None or (
+                            current_local_item.eb_item,
+                            current_local_item.deleted,
+                            current_local_item.dirty,
+                            current_local_item.new,
+                            current_local_item.remote_uid,
+                        ) != retry_local_state:
+                            continue
+                    current_unresolved.attempts += 1
+                    current_unresolved.save(
+                        only=[models.DavUnresolvedItem.attempts]
+                    )
                 logger.warning(
                     "Deferred unresolved DAV item after cache-load failure (%s)",
                     bounded_exception_class(exc),
@@ -1152,18 +1227,78 @@ class Etebase:
             if unresolved.local_item_id is not None:
                 remote_envelope = item_mgr.cache_save(item)
                 with db.database_proxy.atomic("IMMEDIATE"):
+                    current_unresolved = models.DavUnresolvedItem.get_or_none(
+                        models.DavUnresolvedItem.id == unresolved.id
+                    )
+                    if current_unresolved is None or (
+                        current_unresolved.remote_uid,
+                        current_unresolved.eb_item,
+                        current_unresolved.deleted,
+                        current_unresolved.attempts,
+                        current_unresolved.reason,
+                        current_unresolved.local_item_id,
+                    ) != retry_unresolved_state:
+                        continue
                     local_item = models.ItemEntity.get_or_none(
                         models.ItemEntity.id == unresolved.local_item_id
                     )
+                    if retry_local_state is not None and (
+                        local_item is None
+                        or (
+                            local_item.eb_item,
+                            local_item.deleted,
+                            local_item.dirty,
+                            local_item.new,
+                            local_item.remote_uid,
+                        )
+                        != retry_local_state
+                    ):
+                        continue
                     conflict = models.ItemEntity.get_or_none(
                         (models.ItemEntity.collection == cache_col)
                         & (models.ItemEntity.remote_uid == item.uid)
                         & (models.ItemEntity.id != unresolved.local_item_id)
                     )
+                    if (
+                        local_item is not None
+                        and conflict is not None
+                        and (local_item.dirty or local_item.new)
+                        and local_item.deleted
+                        and item.deleted
+                    ):
+                        local_item.dirty = False
+                        local_item.new = False
+                        local_item.save(
+                            only=[
+                                models.ItemEntity.dirty,
+                                models.ItemEntity.new,
+                            ]
+                        )
+                        current_unresolved.delete_instance()
+                        continue
+                    if (
+                        local_item is not None
+                        and conflict is not None
+                        and (local_item.dirty or local_item.new)
+                        and not item.deleted
+                    ):
+                        replacement = item_mgr.create(dict(item.meta), item.content)
+                        local_item.remote_uid = replacement.uid
+                        local_item.eb_item = item_mgr.cache_save(replacement)
+                        local_item.new = True
+                        local_item.save(
+                            only=[
+                                models.ItemEntity.remote_uid,
+                                models.ItemEntity.eb_item,
+                                models.ItemEntity.new,
+                            ]
+                        )
+                        current_unresolved.delete_instance()
+                        continue
                     if local_item is None or conflict is not None:
-                        unresolved.reason = "legacy_duplicate"
-                        unresolved.attempts += 1
-                        unresolved.save(
+                        current_unresolved.reason = "legacy_duplicate"
+                        current_unresolved.attempts += 1
+                        current_unresolved.save(
                             only=[
                                 models.DavUnresolvedItem.reason,
                                 models.DavUnresolvedItem.attempts,
@@ -1174,7 +1309,7 @@ class Etebase:
                         if local_item.remote_uid is None:
                             local_item.remote_uid = item.uid
                             local_item.save(only=[models.ItemEntity.remote_uid])
-                        unresolved.delete_instance()
+                        current_unresolved.delete_instance()
                         continue
                     previous_state_hash = dav_collection_state_hash(cache_col)
                     local_item.remote_uid = item.uid
@@ -1198,20 +1333,36 @@ class Etebase:
                             etag=getattr(item, "etag", None),
                             deleted=item.deleted,
                         )
-                    unresolved.delete_instance()
+                    current_unresolved.delete_instance()
                 continue
-            applied = self._apply_pulled_item(
-                cache_col,
-                col,
-                item_mgr,
-                item,
-                quarantine=False,
-            )
-            if not applied:
-                unresolved.attempts += 1
-                unresolved.save(only=[models.DavUnresolvedItem.attempts])
-            else:
-                unresolved.delete_instance()
+            with db.database_proxy.atomic("IMMEDIATE"):
+                current_unresolved = models.DavUnresolvedItem.get_or_none(
+                    models.DavUnresolvedItem.id == unresolved.id
+                )
+                if current_unresolved is None or (
+                    current_unresolved.remote_uid,
+                    current_unresolved.eb_item,
+                    current_unresolved.deleted,
+                    current_unresolved.attempts,
+                    current_unresolved.reason,
+                    current_unresolved.local_item_id,
+                ) != retry_unresolved_state:
+                    continue
+                applied = self._apply_pulled_item(
+                    cache_col,
+                    col,
+                    item_mgr,
+                    item,
+                    quarantine=False,
+                    resolve_unresolved=False,
+                )
+                if not applied:
+                    current_unresolved.attempts += 1
+                    current_unresolved.save(
+                        only=[models.DavUnresolvedItem.attempts]
+                    )
+                else:
+                    current_unresolved.delete_instance()
 
     def pull_collection(self, uid):
         with db.database_proxy.connection_context():
@@ -1221,8 +1372,7 @@ class Etebase:
             col = col_mgr.cache_load(cache_col.eb_col)
             item_mgr = col_mgr.get_item_manager(col)
             with self._mutation_session_guard():
-                with db.database_proxy.atomic("IMMEDIATE"):
-                    self._retry_unresolved_items(cache_col, col, item_mgr)
+                self._retry_unresolved_items(cache_col, col, item_mgr)
             stoken = cache_col.local_stoken
             done = False
 
@@ -1251,8 +1401,12 @@ class Etebase:
                         )
 
     def _collection_dirty_get(self, collection):
+        quarantined_local_items = models.DavUnresolvedItem.select(
+            models.DavUnresolvedItem.local_item
+        ).where(models.DavUnresolvedItem.local_item.is_null(False))
         return collection.items.where(
-            models.ItemEntity.dirty | models.ItemEntity.new
+            (models.ItemEntity.dirty | models.ItemEntity.new)
+            & ~(models.ItemEntity.id << quarantined_local_items)
         )
 
     def collection_is_dirty(self, uid):

--- a/bridge/src/silentsuite_bridge/privacy_logging.py
+++ b/bridge/src/silentsuite_bridge/privacy_logging.py
@@ -38,7 +38,10 @@ def bounded_identifier(value, *, fallback="Exception", max_length=64):
 
 def bounded_exception_class(error):
     """Return a bounded exception-class identifier for product diagnostics."""
-    if isinstance(error, BoundedDiagnosticError):
+    if (
+        isinstance(error, BoundedDiagnosticError)
+        and error.diagnostic_code in _BOUNDED_DIAGNOSTIC_CODES
+    ):
         return error.diagnostic_code
     return bounded_identifier(error.__class__.__name__)
 

--- a/bridge/src/silentsuite_bridge/privacy_logging.py
+++ b/bridge/src/silentsuite_bridge/privacy_logging.py
@@ -2,6 +2,28 @@
 
 import re
 
+_BOUNDED_DIAGNOSTIC_CODES = frozenset(
+    {
+        "CacheBackfillIntegrityError",
+        "CachePullItemIntegrityError",
+        "CacheRevisionIntegrityError",
+        "CacheSchemaRemoteUidIntegrityError",
+        "CacheSchemaTokenRevisionIntegrityError",
+        "CacheSyncTokenIntegrityError",
+        "CacheUnresolvedRetryIntegrityError",
+    }
+)
+
+
+class BoundedDiagnosticError(RuntimeError):
+    """Carry one allowlisted product diagnostic code without private details."""
+
+    def __init__(self, diagnostic_code):
+        if diagnostic_code not in _BOUNDED_DIAGNOSTIC_CODES:
+            raise ValueError("unsupported diagnostic code")
+        super().__init__("Bridge operation failed")
+        self.diagnostic_code = diagnostic_code
+
 
 def bounded_identifier(value, *, fallback="Exception", max_length=64):
     """Return one short source-style identifier or a fixed fallback."""
@@ -16,6 +38,8 @@ def bounded_identifier(value, *, fallback="Exception", max_length=64):
 
 def bounded_exception_class(error):
     """Return a bounded exception-class identifier for product diagnostics."""
+    if isinstance(error, BoundedDiagnosticError):
+        return error.diagnostic_code
     return bounded_identifier(error.__class__.__name__)
 
 

--- a/bridge/src/silentsuite_bridge/radicale/application.py
+++ b/bridge/src/silentsuite_bridge/radicale/application.py
@@ -5,7 +5,7 @@ import re
 
 from radicale.app import Application as RadicaleApplication
 
-from ..privacy_logging import bounded_identifier
+from ..privacy_logging import bounded_exception_class, bounded_identifier
 
 _MAX_DIAGNOSTIC_LENGTH = 320
 
@@ -15,7 +15,12 @@ def _safe_exception_diagnostic(exc_info):
     if not exc_info or not exc_info[0]:
         return "Radicale server request failed"
 
-    exception_class = bounded_identifier(getattr(exc_info[0], "__name__", None))
+    exception = exc_info[1] if len(exc_info) > 1 else None
+    exception_class = (
+        bounded_exception_class(exception)
+        if exception is not None
+        else bounded_identifier(getattr(exc_info[0], "__name__", None))
+    )
 
     product_origin = None
     traceback = exc_info[2]

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -18,6 +18,7 @@ import threading
 import time
 from contextlib import contextmanager
 
+import peewee as pw
 import vobject
 from radicale import pathutils
 from radicale.item import Item
@@ -44,7 +45,7 @@ from ..local_cache.models import (
     HrefMapper,
     ItemEntity,
 )
-from ..privacy_logging import bounded_exception_class
+from ..privacy_logging import BoundedDiagnosticError, bounded_exception_class
 from ..web import log_sync_event, update_status
 from .etesync_cache import etesync_for_user, forget_etesync_user
 
@@ -701,13 +702,18 @@ class Collection(BaseCollection):
                 return _INVALID_SYNC_HISTORY
             current_token_row = None
         if current_token_row is None:
-            current_token_row = DavSyncToken.create(
-                collection=self.collection.cache_col,
-                revision=revision,
-                token=secrets.token_urlsafe(24),
-                created_at=int(time.time()),
-                state_hash=state_hash,
-            )
+            try:
+                current_token_row = DavSyncToken.create(
+                    collection=self.collection.cache_col,
+                    token=secrets.token_urlsafe(24),
+                    revision=revision,
+                    created_at=int(time.time()),
+                    state_hash=state_hash,
+                )
+            except pw.IntegrityError:
+                raise BoundedDiagnosticError(
+                    "CacheSyncTokenIntegrityError"
+                ) from None
         self._prune_sync_history()
         token = token_prefix + current_token_row.token
 

--- a/bridge/tests/test_carddav_report.py
+++ b/bridge/tests/test_carddav_report.py
@@ -241,6 +241,27 @@ def test_radicale_filter_redacts_server_request_exception():
     assert private_value not in record.getMessage()
 
 
+def test_radicale_server_reports_allowlisted_bridge_stage():
+    error = BoundedDiagnosticError("CacheSyncTokenIntegrityError")
+    record = logging.LogRecord(
+        name="radicale.server",
+        level=logging.ERROR,
+        pathname="/site-packages/radicale/server.py",
+        lineno=1,
+        msg="An exception occurred during request: %s",
+        args=(error,),
+        exc_info=(BoundedDiagnosticError, error, None),
+    )
+
+    bridge_application._DavDiagnosticRedactionFilter().filter(record)
+
+    assert record.getMessage() == (
+        "Radicale server request failed (CacheSyncTokenIntegrityError)"
+    )
+    assert "BoundedDiagnosticError" not in record.getMessage()
+    assert record.exc_info is None
+
+
 def test_radicale_item_normalization_diagnostic_redacts_component_uid():
     private_uid = "private-calendar-component-uid"
     record = logging.LogRecord(

--- a/bridge/tests/test_carddav_report.py
+++ b/bridge/tests/test_carddav_report.py
@@ -3,11 +3,14 @@ import logging
 import xml.etree.ElementTree as ET
 from unittest.mock import MagicMock
 
+import peewee as pw
+import pytest
 from playhouse.sqlite_ext import SqliteExtDatabase
 
 from silentsuite_bridge import config
 from silentsuite_bridge import local_cache as local_cache_module
 from silentsuite_bridge.local_cache import db, models, record_dav_change
+from silentsuite_bridge.privacy_logging import BoundedDiagnosticError
 from silentsuite_bridge.radicale import application as bridge_application
 from silentsuite_bridge.radicale import storage as bridge_storage
 from silentsuite_bridge.radicale.storage import Collection
@@ -26,6 +29,38 @@ SYNC_REPORT = b"""<?xml version="1.0" encoding="utf-8"?>
   <d:prop><d:getetag /></d:prop>
 </d:sync-collection>
 """
+
+
+def test_sync_token_integrity_failure_reports_bounded_stage(
+    mem_db,
+    user,
+    monkeypatch,
+):
+    cache_col = models.CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    cached_collection = MagicMock()
+    cached_collection.cache_col = cache_col
+    cached_collection.col_type = "etebase.vcard"
+    cached_collection.list.return_value = []
+    etesync = MagicMock()
+    etesync.get.return_value = cached_collection
+    storage = MagicMock()
+    storage.etesync = etesync
+    collection = Collection(storage, f"/{user.username}/contacts")
+    monkeypatch.setattr(
+        models.DavSyncToken,
+        "create",
+        MagicMock(side_effect=pw.IntegrityError("private token details")),
+    )
+
+    with pytest.raises(BoundedDiagnosticError) as error:
+        collection.sync(None)
+
+    assert error.value.diagnostic_code == "CacheSyncTokenIntegrityError"
+    assert "private token details" not in str(error.value)
 
 
 def test_sync_collection_report_emits_literal_404_for_remote_deletion(

--- a/bridge/tests/test_local_cache.py
+++ b/bridge/tests/test_local_cache.py
@@ -843,6 +843,37 @@ class TestSyncLogic:
             assert persisted.dirty is True
             mock_item_mgr.list.assert_called_once()
 
+    def test_pull_collection_retries_outside_writer_transaction(self, mem_db, user):
+        cache_col = CollectionEntity.create(
+            local_user=user,
+            uid="contacts",
+            eb_col=b"collection-cache",
+        )
+        item_mgr = MagicMock()
+        item_mgr.list.return_value = MagicMock(data=[], done=True, stoken="new-token")
+        col_mgr = MagicMock()
+        col = MagicMock()
+        col_mgr.cache_load.return_value = col
+        col_mgr.get_item_manager.return_value = item_mgr
+        account = MagicMock()
+        account.get_collection_manager.return_value = col_mgr
+        etebase = Etebase.__new__(Etebase)
+        etebase.etebase = account
+        etebase.user = user
+        retry_transaction_states = []
+
+        def inspect_retry_transaction(*_args):
+            retry_transaction_states.append(mem_db.in_transaction())
+
+        etebase._retry_unresolved_items = MagicMock(
+            side_effect=inspect_retry_transaction
+        )
+
+        with patch.object(mem_db, "close", return_value=False):
+            etebase.pull_collection(cache_col.uid)
+
+        assert retry_transaction_states == [False]
+
     def test_superseded_session_cannot_apply_page_or_advance_token(self, mem_db):
         user = User.create(username="superseded@example.com")
         collection = CollectionEntity.create(
@@ -1137,6 +1168,42 @@ def test_partial_cache_duplicate_remote_uids_reports_bounded_migration_stage(tmp
 
     with pytest.raises(BoundedDiagnosticError) as error:
         local_cache_module._migrate_cache_schema(database)
+
+    assert error.value.diagnostic_code == "CacheSchemaRemoteUidIntegrityError"
+
+
+def test_partial_cache_duplicate_remote_uids_are_bounded_during_table_init(tmp_path):
+    cache_path = tmp_path / "partial-init-cache.sqlite"
+    database = pw.SqliteDatabase(str(cache_path), pragmas={"foreign_keys": 1})
+    db.database_proxy.initialize(database)
+    database.execute_sql(
+        "CREATE TABLE collectionentity (id INTEGER PRIMARY KEY)"
+    )
+    database.execute_sql(
+        "CREATE TABLE itementity ("
+        "id INTEGER PRIMARY KEY, "
+        "collection_id INTEGER NOT NULL, "
+        "uid VARCHAR(255) NOT NULL, "
+        "eb_item BLOB NOT NULL, "
+        "new INTEGER NOT NULL DEFAULT 0, "
+        "dirty INTEGER NOT NULL DEFAULT 0, "
+        "deleted INTEGER NOT NULL DEFAULT 0, "
+        "remote_uid VARCHAR(255)"
+        ")"
+    )
+    database.execute_sql("INSERT INTO collectionentity (id) VALUES (1)")
+    database.execute_sql(
+        "INSERT INTO itementity (collection_id, uid, eb_item, remote_uid) "
+        "VALUES (1, 'first', X'01', 'duplicate')"
+    )
+    database.execute_sql(
+        "INSERT INTO itementity (collection_id, uid, eb_item, remote_uid) "
+        "VALUES (1, 'second', X'02', 'duplicate')"
+    )
+    etebase = Etebase.__new__(Etebase)
+
+    with pytest.raises(BoundedDiagnosticError) as error:
+        etebase._init_db_tables(database)
 
     assert error.value.diagnostic_code == "CacheSchemaRemoteUidIntegrityError"
 
@@ -1554,6 +1621,183 @@ def test_backfill_quarantines_legacy_duplicate_remote_identity(mem_db, user):
     assert quarantine.attempts == 0
 
 
+def test_backfill_prefers_clean_remote_uid_owner_over_earlier_dirty_row(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    pending = ItemEntity.create(
+        collection=cache_col,
+        uid="pending-contact",
+        eb_item=b"pending-envelope",
+        dirty=True,
+        new=True,
+    )
+    clean = ItemEntity.create(
+        collection=cache_col,
+        uid="clean-contact",
+        eb_item=b"clean-envelope",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_load.return_value = MagicMock(uid="shared-remote-item")
+    col_mgr = MagicMock()
+    col_mgr.cache_load.return_value = MagicMock(collection_type="etebase.vcard")
+    col_mgr.get_item_manager.return_value = item_mgr
+    account = MagicMock()
+    account.get_collection_manager.return_value = col_mgr
+    etebase = Etebase.__new__(Etebase)
+    etebase.etebase = account
+    etebase.user = user
+
+    assert etebase._backfill_remote_uids() == 1
+
+    assert ItemEntity.get_by_id(clean.id).remote_uid == "shared-remote-item"
+    preserved = ItemEntity.get_by_id(pending.id)
+    assert preserved.remote_uid is None
+    assert preserved.deleted is False
+    assert preserved.dirty is True
+    assert preserved.new is True
+    assert models.DavUnresolvedItem.get().local_item_id == pending.id
+
+
+def test_dirty_new_legacy_duplicate_is_forked_before_push(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    owner = ItemEntity.create(
+        collection=cache_col,
+        uid="contact-1",
+        eb_item=b"owner-envelope",
+    )
+    pending = ItemEntity.create(
+        collection=cache_col,
+        uid="contact-2",
+        eb_item=b"pending-envelope",
+        dirty=True,
+        new=True,
+    )
+    HrefMapper.create(content=owner, href="contact-1.vcf")
+    HrefMapper.create(content=pending, href="contact-2.vcf")
+    owner_remote = MagicMock(uid="shared-remote-item")
+    pending_remote = MagicMock(
+        uid="shared-remote-item",
+        meta={"name": "contact-2"},
+        content=b"pending-content",
+        deleted=False,
+    )
+    edited_remote = MagicMock(
+        uid="shared-remote-item",
+        meta={"name": "contact-2"},
+        content=b"edited-content",
+        deleted=False,
+    )
+    forked_remote = MagicMock(uid="fresh-remote-item", deleted=False)
+    item_mgr = MagicMock()
+    item_mgr.cache_load.side_effect = lambda envelope: {
+        b"owner-envelope": owner_remote,
+        b"pending-envelope": pending_remote,
+        b"edited-envelope": edited_remote,
+    }[envelope]
+    item_mgr.create.return_value = forked_remote
+    item_mgr.cache_save.return_value = b"forked-envelope"
+    col = MagicMock(collection_type="etebase.vcard")
+    col_mgr = MagicMock()
+    col_mgr.cache_load.return_value = col
+    col_mgr.get_item_manager.return_value = item_mgr
+    account = MagicMock()
+    account.get_collection_manager.return_value = col_mgr
+    etebase = Etebase.__new__(Etebase)
+    etebase.etebase = account
+    etebase.user = user
+
+    assert etebase._backfill_remote_uids() == 1
+    assert ItemEntity.get_by_id(pending.id).deleted is False
+    assert list(etebase._collection_dirty_get(cache_col)) == []
+    (
+        ItemEntity.update(eb_item=b"edited-envelope")
+        .where(ItemEntity.id == pending.id)
+        .execute()
+    )
+
+    etebase._retry_unresolved_items(cache_col, col, item_mgr)
+
+    recovered = ItemEntity.get_by_id(pending.id)
+    assert ItemEntity.get_by_id(owner.id).remote_uid == "shared-remote-item"
+    assert recovered.remote_uid == "fresh-remote-item"
+    assert recovered.eb_item == b"forked-envelope"
+    assert recovered.deleted is False
+    assert recovered.dirty is True
+    assert recovered.new is True
+    assert models.DavUnresolvedItem.select().count() == 0
+    assert list(etebase._collection_dirty_get(cache_col)) == [recovered]
+    item_mgr.create.assert_called_once_with(
+        {"name": "contact-2"},
+        b"edited-content",
+    )
+
+
+def test_deleted_dirty_new_legacy_duplicate_resolves_without_remote_write(
+    mem_db,
+    user,
+):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    owner = ItemEntity.create(
+        collection=cache_col,
+        uid="contact-1",
+        remote_uid="shared-remote-item",
+        eb_item=b"owner-envelope",
+    )
+    pending = ItemEntity.create(
+        collection=cache_col,
+        uid="contact-2",
+        eb_item=b"deleted-envelope",
+        deleted=True,
+        dirty=True,
+        new=True,
+    )
+    models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="legacy-cache:pending",
+        eb_item=b"stale-live-envelope",
+        deleted=True,
+        reason="legacy_duplicate",
+        local_item=pending,
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_load.side_effect = lambda envelope: {
+        b"stale-live-envelope": MagicMock(
+            uid="shared-remote-item",
+            deleted=False,
+        ),
+        b"deleted-envelope": MagicMock(
+            uid="shared-remote-item",
+            deleted=True,
+        ),
+    }[envelope]
+    etebase = Etebase.__new__(Etebase)
+    etebase.user = user
+
+    etebase._retry_unresolved_items(cache_col, MagicMock(), item_mgr)
+
+    resolved = ItemEntity.get_by_id(pending.id)
+    assert ItemEntity.get_by_id(owner.id).remote_uid == "shared-remote-item"
+    assert resolved.remote_uid is None
+    assert resolved.deleted is True
+    assert resolved.dirty is False
+    assert resolved.new is False
+    assert models.DavUnresolvedItem.select().count() == 0
+    assert list(etebase._collection_dirty_get(cache_col)) == []
+    item_mgr.create.assert_not_called()
+    item_mgr.batch.assert_not_called()
+
+
 def test_unresolved_retry_preserves_concurrent_local_item_mutation(mem_db, user):
     cache_col = CollectionEntity.create(
         local_user=user,
@@ -1602,7 +1846,278 @@ def test_unresolved_retry_preserves_concurrent_local_item_mutation(mem_db, user)
     persisted = ItemEntity.get_by_id(local_item.id)
     assert persisted.eb_item == b"local-envelope"
     assert persisted.dirty is True
-    assert persisted.remote_uid == "remote-contact"
+    assert persisted.remote_uid is None
+    assert models.DavUnresolvedItem.select().count() == 1
+
+    item_mgr.cache_save.side_effect = None
+    item_mgr.cache_save.return_value = b"unused-remote-envelope"
+    etebase._retry_unresolved_items(
+        cache_col,
+        MagicMock(collection_type="etebase.vcard"),
+        item_mgr,
+    )
+
+    recovered = ItemEntity.get_by_id(local_item.id)
+    assert recovered.eb_item == b"local-envelope"
+    assert recovered.dirty is True
+    assert recovered.remote_uid == "remote-contact"
+    assert models.DavUnresolvedItem.select().count() == 0
+
+
+def test_clean_unresolved_retry_defers_concurrent_local_revival(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    ItemEntity.create(
+        collection=cache_col,
+        uid="owner",
+        remote_uid="shared-remote-item",
+        eb_item=b"owner-envelope",
+    )
+    local_item = ItemEntity.create(
+        collection=cache_col,
+        uid="quarantined",
+        eb_item=b"stale-envelope",
+        deleted=True,
+    )
+    unresolved = models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="legacy-cache:quarantined",
+        eb_item=b"stale-envelope",
+        deleted=True,
+        reason="legacy_corrupt",
+        local_item=local_item,
+    )
+    stale_item = MagicMock(
+        uid="shared-remote-item",
+        meta={"name": "quarantined"},
+        content=b"stale-content",
+        deleted=False,
+    )
+    item_mgr = MagicMock()
+
+    def revive_during_parse(_envelope):
+        (
+            ItemEntity.update(
+                eb_item=b"revived-envelope",
+                deleted=False,
+                dirty=True,
+            )
+            .where(ItemEntity.id == local_item.id)
+            .execute()
+        )
+        return stale_item
+
+    item_mgr.cache_load.side_effect = revive_during_parse
+    etebase = Etebase.__new__(Etebase)
+    etebase.user = user
+
+    etebase._retry_unresolved_items(cache_col, MagicMock(), item_mgr)
+
+    revived = ItemEntity.get_by_id(local_item.id)
+    assert revived.eb_item == b"revived-envelope"
+    assert revived.deleted is False
+    assert revived.dirty is True
+    assert models.DavUnresolvedItem.get_by_id(unresolved.id)
+    item_mgr.create.assert_not_called()
+
+
+def test_attached_retry_defers_concurrent_identity_and_quarantine_change(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    local_item = ItemEntity.create(
+        collection=cache_col,
+        uid="pending",
+        eb_item=b"pending-envelope",
+        dirty=True,
+        new=True,
+    )
+    unresolved = models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="legacy-cache:pending",
+        eb_item=b"pending-envelope",
+        reason="legacy_corrupt",
+        local_item=local_item,
+    )
+    parsed_item = MagicMock(uid="parsed-remote", deleted=False)
+    item_mgr = MagicMock()
+
+    def mutate_ownership_during_parse(_envelope):
+        (
+            ItemEntity.update(remote_uid="concurrent-remote")
+            .where(ItemEntity.id == local_item.id)
+            .execute()
+        )
+        (
+            models.DavUnresolvedItem.update(
+                reason="concurrent_update",
+                attempts=7,
+            )
+            .where(models.DavUnresolvedItem.id == unresolved.id)
+            .execute()
+        )
+        return parsed_item
+
+    item_mgr.cache_load.side_effect = mutate_ownership_during_parse
+    etebase = Etebase.__new__(Etebase)
+    etebase.user = user
+
+    etebase._retry_unresolved_items(cache_col, MagicMock(), item_mgr)
+
+    assert ItemEntity.get_by_id(local_item.id).remote_uid == "concurrent-remote"
+    retained = models.DavUnresolvedItem.get_by_id(unresolved.id)
+    assert retained.reason == "concurrent_update"
+    assert retained.attempts == 7
+    item_mgr.create.assert_not_called()
+
+
+def test_unresolved_retry_bookkeeping_uses_immediate_transactions(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    failed = models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="failed-item",
+        eb_item=b"failed-envelope",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_load.side_effect = ValueError("private parser details")
+    transaction_states = []
+    original_execute_sql = mem_db.execute_sql
+
+    def inspect_execute(sql, params=None, commit=None):
+        if sql.startswith('UPDATE "davunresolveditem"'):
+            transaction_states.append(mem_db.in_transaction())
+        return original_execute_sql(sql, params, commit)
+
+    etebase = Etebase.__new__(Etebase)
+    etebase.user = user
+    with patch.object(mem_db, "execute_sql", side_effect=inspect_execute):
+        etebase._retry_unresolved_items(cache_col, MagicMock(), item_mgr)
+
+    assert models.DavUnresolvedItem.get_by_id(failed.id).attempts == 1
+    assert transaction_states == [True]
+
+
+def test_unresolved_retry_resolution_delete_uses_immediate_transaction(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    resolved = models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="resolved-item",
+        eb_item=b"resolved-envelope",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_load.return_value = MagicMock(uid="resolved-item")
+    transaction_states = []
+    original_execute_sql = mem_db.execute_sql
+
+    def inspect_execute(sql, params=None, commit=None):
+        if sql.startswith('DELETE FROM "davunresolveditem"'):
+            transaction_states.append(mem_db.in_transaction())
+        return original_execute_sql(sql, params, commit)
+
+    etebase = Etebase.__new__(Etebase)
+    etebase.user = user
+    apply_states = []
+
+    def apply_without_resolving(*_args, **kwargs):
+        apply_states.append((mem_db.in_transaction(), kwargs["resolve_unresolved"]))
+        return True
+
+    etebase._apply_pulled_item = MagicMock(side_effect=apply_without_resolving)
+    with patch.object(mem_db, "execute_sql", side_effect=inspect_execute):
+        etebase._retry_unresolved_items(cache_col, MagicMock(), item_mgr)
+
+    assert models.DavUnresolvedItem.get_or_none(id=resolved.id) is None
+    assert transaction_states == [True]
+    assert apply_states == [(True, False)]
+
+
+def test_unattached_retry_defers_concurrent_quarantine_refresh(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    unresolved = models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="remote-item",
+        eb_item=b"stale-envelope",
+    )
+    item_mgr = MagicMock()
+
+    def refresh_during_parse(_envelope):
+        (
+            models.DavUnresolvedItem.update(
+                eb_item=b"fresh-envelope",
+                attempts=3,
+            )
+            .where(models.DavUnresolvedItem.id == unresolved.id)
+            .execute()
+        )
+        return MagicMock(uid="remote-item")
+
+    item_mgr.cache_load.side_effect = refresh_during_parse
+    etebase = Etebase.__new__(Etebase)
+    etebase.user = user
+    etebase._apply_pulled_item = MagicMock(return_value=True)
+
+    etebase._retry_unresolved_items(cache_col, MagicMock(), item_mgr)
+
+    retained = models.DavUnresolvedItem.get_by_id(unresolved.id)
+    assert retained.eb_item == b"fresh-envelope"
+    assert retained.attempts == 3
+    etebase._apply_pulled_item.assert_not_called()
+
+
+def test_attached_cache_load_failure_defers_concurrent_local_change(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    local_item = ItemEntity.create(
+        collection=cache_col,
+        uid="pending",
+        eb_item=b"stale-envelope",
+        dirty=True,
+    )
+    unresolved = models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="legacy-cache:pending",
+        eb_item=b"stale-envelope",
+        reason="legacy_corrupt",
+        local_item=local_item,
+    )
+    item_mgr = MagicMock()
+
+    def edit_then_fail(_envelope):
+        (
+            ItemEntity.update(eb_item=b"edited-envelope")
+            .where(ItemEntity.id == local_item.id)
+            .execute()
+        )
+        raise ValueError("private parser details")
+
+    item_mgr.cache_load.side_effect = edit_then_fail
+    etebase = Etebase.__new__(Etebase)
+    etebase.user = user
+
+    etebase._retry_unresolved_items(cache_col, MagicMock(), item_mgr)
+
+    assert ItemEntity.get_by_id(local_item.id).eb_item == b"edited-envelope"
+    assert models.DavUnresolvedItem.get_by_id(unresolved.id).attempts == 0
 
 
 def test_unresolved_retry_integrity_failure_reports_bounded_stage(
@@ -1680,6 +2195,61 @@ def test_backfill_quarantines_malformed_legacy_envelope(mem_db, user):
 
     assert models.DavUnresolvedItem.get_by_id(quarantine.id).attempts == 8
     item_mgr.cache_load.assert_not_called()
+
+
+def test_backfill_preserves_malformed_dirty_new_item_until_retry(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    pending = ItemEntity.create(
+        collection=cache_col,
+        uid="pending-contact",
+        eb_item=b"malformed-local-envelope",
+        dirty=True,
+        new=True,
+    )
+    HrefMapper.create(content=pending, href="pending-contact.vcf")
+    item_mgr = MagicMock()
+    item_mgr.cache_load.side_effect = ValueError("private parser details")
+    col = MagicMock(collection_type="etebase.vcard")
+    col_mgr = MagicMock()
+    col_mgr.cache_load.return_value = col
+    col_mgr.get_item_manager.return_value = item_mgr
+    account = MagicMock()
+    account.get_collection_manager.return_value = col_mgr
+    etebase = Etebase.__new__(Etebase)
+    etebase.etebase = account
+    etebase.user = user
+
+    assert etebase._backfill_remote_uids() == 1
+
+    preserved = ItemEntity.get_by_id(pending.id)
+    assert preserved.deleted is False
+    assert preserved.dirty is True
+    assert preserved.new is True
+    assert models.DavRevision.select().count() == 0
+    quarantine = models.DavUnresolvedItem.get(collection=cache_col)
+    assert quarantine.local_item_id == pending.id
+    assert quarantine.deleted is False
+    assert list(etebase._collection_dirty_get(cache_col)) == []
+    quarantine.attempts = local_cache_module.DAV_UNRESOLVED_RETRY_LIMIT
+    quarantine.save(only=[models.DavUnresolvedItem.attempts])
+
+    remote_item = MagicMock(uid="remote-contact", deleted=False)
+    item_mgr.cache_load.side_effect = None
+    item_mgr.cache_load.return_value = remote_item
+    item_mgr.cache_save.return_value = b"remote-envelope"
+    etebase._retry_unresolved_items(cache_col, col, item_mgr)
+
+    recovered = ItemEntity.get_by_id(pending.id)
+    assert recovered.deleted is False
+    assert recovered.dirty is True
+    assert recovered.new is True
+    assert recovered.remote_uid == "remote-contact"
+    assert models.DavUnresolvedItem.select().count() == 0
+    assert list(etebase._collection_dirty_get(cache_col)) == [recovered]
 
 
 def test_backfill_quarantine_advances_past_retained_revision(mem_db, user):

--- a/bridge/tests/test_local_cache.py
+++ b/bridge/tests/test_local_cache.py
@@ -30,6 +30,7 @@ from silentsuite_bridge.local_cache.models import (
     ItemEntity,
     User,
 )
+from silentsuite_bridge.privacy_logging import BoundedDiagnosticError
 from tests.conftest import (
     SAMPLE_VCALENDAR_VEVENT,
     SAMPLE_VCARD,
@@ -1113,6 +1114,72 @@ def test_remote_tombstone_without_name_reuses_remote_identity_and_original_href(
     assert CollectionEntity.get_by_id(cache_col.id).dav_revision == 1
 
 
+def test_partial_cache_duplicate_remote_uids_reports_bounded_migration_stage(tmp_path):
+    cache_path = tmp_path / "partial-cache.sqlite"
+    database = pw.SqliteDatabase(str(cache_path), pragmas={"foreign_keys": 1})
+    database.execute_sql(
+        "CREATE TABLE collectionentity (id INTEGER PRIMARY KEY)"
+    )
+    database.execute_sql(
+        "CREATE TABLE itementity ("
+        "id INTEGER PRIMARY KEY, "
+        "collection_id INTEGER NOT NULL, "
+        "remote_uid VARCHAR(255)"
+        ")"
+    )
+    database.execute_sql("INSERT INTO collectionentity (id) VALUES (1)")
+    database.execute_sql(
+        "INSERT INTO itementity (collection_id, remote_uid) VALUES (1, 'duplicate')"
+    )
+    database.execute_sql(
+        "INSERT INTO itementity (collection_id, remote_uid) VALUES (1, 'duplicate')"
+    )
+
+    with pytest.raises(BoundedDiagnosticError) as error:
+        local_cache_module._migrate_cache_schema(database)
+
+    assert error.value.diagnostic_code == "CacheSchemaRemoteUidIntegrityError"
+
+
+def test_partial_cache_duplicate_token_revisions_reports_bounded_migration_stage(
+    tmp_path,
+):
+    cache_path = tmp_path / "partial-token-cache.sqlite"
+    database = pw.SqliteDatabase(str(cache_path), pragmas={"foreign_keys": 1})
+    database.execute_sql(
+        "CREATE TABLE collectionentity (id INTEGER PRIMARY KEY)"
+    )
+    database.execute_sql(
+        "CREATE TABLE itementity ("
+        "id INTEGER PRIMARY KEY, "
+        "collection_id INTEGER NOT NULL, "
+        "remote_uid VARCHAR(255)"
+        ")"
+    )
+    database.execute_sql(
+        "CREATE TABLE davsynctoken ("
+        "id INTEGER PRIMARY KEY, "
+        "collection_id INTEGER NOT NULL, "
+        "revision INTEGER NOT NULL, "
+        "state_hash VARCHAR(255)"
+        ")"
+    )
+    database.execute_sql("INSERT INTO collectionentity (id) VALUES (1)")
+    database.execute_sql(
+        "INSERT INTO davsynctoken (collection_id, revision) VALUES (1, 4)"
+    )
+    database.execute_sql(
+        "INSERT INTO davsynctoken (collection_id, revision) VALUES (1, 4)"
+    )
+
+    with pytest.raises(BoundedDiagnosticError) as error:
+        local_cache_module._migrate_cache_schema(database)
+
+    assert error.value.diagnostic_code == (
+        "CacheSchemaTokenRevisionIntegrityError"
+    )
+
+
 def test_v1_cache_is_migrated_additively_without_bumping_legacy_version(tmp_path):
     cache_path = tmp_path / "legacy-v1.sqlite"
     legacy_db = pw.SqliteDatabase(str(cache_path), pragmas={"foreign_keys": 1})
@@ -1246,6 +1313,36 @@ def test_revision_ledger_activation_rolls_back_marker_when_token_deletion_fails(
     assert models.DavSyncToken.select().count() == 0
 
 
+def test_dav_revision_integrity_failure_reports_bounded_stage_and_rolls_back(
+    mem_db,
+    user,
+    monkeypatch,
+):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    monkeypatch.setattr(
+        models.DavRevision,
+        "create",
+        MagicMock(side_effect=pw.IntegrityError("private revision details")),
+    )
+
+    with pytest.raises(BoundedDiagnosticError) as error:
+        local_cache_module.record_dav_change(
+            cache_col,
+            "contact.vcf",
+            previous_state_hash="previous-state",
+            deleted=True,
+        )
+
+    assert error.value.diagnostic_code == "CacheRevisionIntegrityError"
+    assert "private revision details" not in str(error.value)
+    assert CollectionEntity.get_by_id(cache_col.id).dav_revision == 0
+    assert models.DavChange.select().count() == 0
+
+
 def test_backfill_remote_uids_uses_cached_envelopes_without_remote_io(mem_db, user):
     cache_col = CollectionEntity.create(
         local_user=user,
@@ -1274,6 +1371,40 @@ def test_backfill_remote_uids_uses_cached_envelopes_without_remote_io(mem_db, us
     assert unresolved == 0
     assert ItemEntity.get_by_id(cache_item.id).remote_uid == "remote-item-1"
     item_mgr.cache_load.assert_called_once_with(b"item-cache")
+
+
+def test_backfill_integrity_failure_reports_bounded_stage(mem_db, user, monkeypatch):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    ItemEntity.create(
+        collection=cache_col,
+        uid="malformed-contact",
+        eb_item=b"malformed-cache",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_load.side_effect = ValueError("private parser details")
+    col_mgr = MagicMock()
+    col_mgr.cache_load.return_value = MagicMock()
+    col_mgr.get_item_manager.return_value = item_mgr
+    account = MagicMock()
+    account.get_collection_manager.return_value = col_mgr
+    etebase = Etebase.__new__(Etebase)
+    etebase.etebase = account
+    etebase.user = user
+    monkeypatch.setattr(
+        etebase,
+        "_quarantine_legacy_cache_item",
+        MagicMock(side_effect=pw.IntegrityError("private quarantine details")),
+    )
+
+    with pytest.raises(BoundedDiagnosticError) as error:
+        etebase._backfill_remote_uids()
+
+    assert error.value.diagnostic_code == "CacheBackfillIntegrityError"
+    assert "private quarantine details" not in str(error.value)
 
 
 def test_backfill_replaces_unsafe_legacy_href_and_invalidates_tokens(mem_db, user):
@@ -1474,6 +1605,41 @@ def test_unresolved_retry_preserves_concurrent_local_item_mutation(mem_db, user)
     assert persisted.remote_uid == "remote-contact"
 
 
+def test_unresolved_retry_integrity_failure_reports_bounded_stage(
+    mem_db,
+    user,
+    monkeypatch,
+):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="remote-contact",
+        eb_item=b"deferred-envelope",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_load.side_effect = ValueError("private parser details")
+    monkeypatch.setattr(
+        models.DavUnresolvedItem,
+        "save",
+        MagicMock(side_effect=pw.IntegrityError("private retry details")),
+    )
+    etebase = Etebase.__new__(Etebase)
+
+    with pytest.raises(BoundedDiagnosticError) as error:
+        etebase._retry_unresolved_items(
+            cache_col,
+            MagicMock(collection_type="etebase.vcard"),
+            item_mgr,
+        )
+
+    assert error.value.diagnostic_code == "CacheUnresolvedRetryIntegrityError"
+    assert "private retry details" not in str(error.value)
+
+
 def test_backfill_quarantines_malformed_legacy_envelope(mem_db, user):
     cache_col = CollectionEntity.create(
         local_user=user,
@@ -1514,6 +1680,225 @@ def test_backfill_quarantines_malformed_legacy_envelope(mem_db, user):
 
     assert models.DavUnresolvedItem.get_by_id(quarantine.id).attempts == 8
     item_mgr.cache_load.assert_not_called()
+
+
+def test_backfill_quarantine_advances_past_retained_revision(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+        dav_revision=0,
+    )
+    malformed = ItemEntity.create(
+        collection=cache_col,
+        uid="malformed-contact",
+        eb_item=b"malformed-cache",
+    )
+    HrefMapper.create(content=malformed, href="malformed-contact.vcf")
+    models.DavRevision.create(
+        collection=cache_col,
+        href="retained-contact.vcf",
+        revision=1,
+        deleted=True,
+        state_hash="retained-state",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_load.side_effect = ValueError("private parser details")
+    col_mgr = MagicMock()
+    col_mgr.cache_load.return_value = MagicMock()
+    col_mgr.get_item_manager.return_value = item_mgr
+    account = MagicMock()
+    account.get_collection_manager.return_value = col_mgr
+    etebase = Etebase.__new__(Etebase)
+    etebase.etebase = account
+    etebase.user = user
+
+    assert etebase._backfill_remote_uids() == 1
+
+    assert CollectionEntity.get_by_id(cache_col.id).dav_revision == 2
+    assert [
+        row.revision
+        for row in models.DavRevision.select()
+        .where(models.DavRevision.collection == cache_col)
+        .order_by(models.DavRevision.revision)
+    ] == [1, 2]
+    assert models.DavUnresolvedItem.get(collection=cache_col).reason == (
+        "legacy_corrupt"
+    )
+
+
+def test_partial_upgrade_backfill_sync_dav_read_and_restart_is_idempotent(
+    mem_db,
+    user,
+):
+    from silentsuite_bridge.radicale.storage import Collection
+
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+        dav_revision=0,
+    )
+    legacy = ItemEntity.create(
+        collection=cache_col,
+        uid="remote-contact",
+        eb_item=b"legacy-envelope",
+    )
+    HrefMapper.create(content=legacy, href="legacy-contact.vcf")
+    models.DavRevision.create(
+        collection=cache_col,
+        href="retained-contact.vcf",
+        revision=1,
+        deleted=True,
+        state_hash="retained-state",
+    )
+
+    remote_item = MagicMock(
+        uid="remote-contact",
+        meta={},
+        deleted=False,
+        etag="remote-etag",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_load.side_effect = ValueError("legacy parser failure")
+    item_mgr.cache_save.return_value = b"remote-envelope"
+    remote_collection = MagicMock(
+        uid="contacts",
+        col_type="etebase.vcard",
+        collection_type="etebase.vcard",
+    )
+    remote_collection.list.return_value = []
+    col_mgr = MagicMock()
+    col_mgr.cache_load.return_value = remote_collection
+    col_mgr.get_item_manager.return_value = item_mgr
+    account = MagicMock()
+    account.get_collection_manager.return_value = col_mgr
+
+    etebase = Etebase.__new__(Etebase)
+    etebase.etebase = account
+    etebase.username = user.username
+    etebase._set_db(mem_db)
+
+    cache_col = CollectionEntity.get_by_id(cache_col.id)
+    assert cache_col.dav_revision == 2
+    assert models.DavUnresolvedItem.select().count() == 1
+
+    item_mgr.cache_load.side_effect = None
+    item_mgr.cache_load.return_value = remote_item
+    etebase.sync_collection_list = MagicMock()
+    etebase.list = MagicMock(return_value=[MagicMock(uid="contacts")])
+
+    def sync_collection(_uid):
+        etebase._retry_unresolved_items(cache_col, remote_collection, item_mgr)
+        etebase._apply_pulled_item(
+            cache_col,
+            remote_collection,
+            item_mgr,
+            remote_item,
+        )
+
+    etebase.sync_collection = sync_collection
+    etebase.sync()
+
+    migrated = ItemEntity.get_by_id(legacy.id)
+    assert migrated.remote_uid == "remote-contact"
+    assert migrated.deleted is False
+    assert models.DavUnresolvedItem.select().count() == 0
+
+    storage = MagicMock()
+    storage.etesync = MagicMock()
+    storage.etesync.get.return_value = remote_collection
+    remote_collection.cache_col = cache_col
+    token, _hrefs = Collection(storage, f"/{user.username}/contacts").sync(None)
+    assert token.startswith("http://radicale.org/ns/sync/")
+
+    revision_before_restart = CollectionEntity.get_by_id(
+        cache_col.id
+    ).dav_revision
+    restart = Etebase.__new__(Etebase)
+    restart.etebase = account
+    restart.username = user.username
+    restart._set_db(mem_db)
+
+    assert CollectionEntity.get_by_id(cache_col.id).dav_revision == (
+        revision_before_restart
+    )
+    assert ItemEntity.select().count() == 1
+    assert models.DavUnresolvedItem.select().count() == 0
+
+
+def test_pulled_item_without_name_reuses_identityless_legacy_uid(mem_db, user):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    legacy = ItemEntity.create(
+        collection=cache_col,
+        uid="remote-contact",
+        eb_item=b"legacy-envelope",
+    )
+    HrefMapper.create(content=legacy, href="legacy-contact.vcf")
+    item = MagicMock(
+        uid="remote-contact",
+        meta={},
+        deleted=False,
+        etag="remote-etag",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_save.return_value = b"remote-envelope"
+    etebase = Etebase.__new__(Etebase)
+
+    assert etebase._apply_pulled_item(
+        cache_col,
+        MagicMock(collection_type="etebase.vcard"),
+        item_mgr,
+        item,
+    ) is True
+
+    rows = list(ItemEntity.select().where(ItemEntity.collection == cache_col))
+    assert len(rows) == 1
+    assert rows[0].id == legacy.id
+    assert rows[0].remote_uid == "remote-contact"
+    assert rows[0].eb_item == b"remote-envelope"
+    assert HrefMapper.get(content=rows[0]).href == "legacy-contact.vcf"
+
+
+def test_pulled_item_integrity_failure_reports_bounded_stage(
+    mem_db,
+    user,
+    monkeypatch,
+):
+    cache_col = CollectionEntity.create(
+        local_user=user,
+        uid="contacts",
+        eb_col=b"collection-cache",
+    )
+    item = MagicMock(
+        uid="remote-contact",
+        meta={},
+        deleted=False,
+        etag="remote-etag",
+    )
+    item_mgr = MagicMock()
+    item_mgr.cache_save.return_value = b"remote-envelope"
+    etebase = Etebase.__new__(Etebase)
+    monkeypatch.setattr(
+        ItemEntity,
+        "save",
+        MagicMock(side_effect=pw.IntegrityError("private row details")),
+    )
+
+    with pytest.raises(BoundedDiagnosticError) as error:
+        etebase._apply_pulled_item(
+            cache_col,
+            MagicMock(collection_type="etebase.vcard"),
+            item_mgr,
+            item,
+        )
+
+    assert error.value.diagnostic_code == "CachePullItemIntegrityError"
+    assert "private row details" not in str(error.value)
 
 
 def test_pulled_carddav_item_uses_single_segment_opaque_href(mem_db, user):

--- a/bridge/tests/test_main_startup.py
+++ b/bridge/tests/test_main_startup.py
@@ -120,6 +120,21 @@ def test_bounded_failure_logging_drops_exception_text_and_traceback(caplog):
     assert len(caplog.messages[0]) < 80
 
 
+def test_bounded_diagnostic_error_exposes_only_allowlisted_code():
+    private_value = "private.person@example.invalid/private/path"
+
+    error = privacy_logging.BoundedDiagnosticError("CachePullItemIntegrityError")
+
+    assert privacy_logging.bounded_exception_class(error) == (
+        "CachePullItemIntegrityError"
+    )
+    assert private_value not in privacy_logging.bounded_exception_class(error)
+    with pytest.raises(ValueError):
+        privacy_logging.BoundedDiagnosticError(
+            "PrivatePersonIntegrityError",
+        )
+
+
 def test_product_logging_call_sites_use_the_bounded_exception_helper():
     package_root = Path(bridge_main.__file__).parent
     violations = []

--- a/bridge/tests/test_main_startup.py
+++ b/bridge/tests/test_main_startup.py
@@ -133,6 +133,9 @@ def test_bounded_diagnostic_error_exposes_only_allowlisted_code():
         privacy_logging.BoundedDiagnosticError(
             "PrivatePersonIntegrityError",
         )
+    error.diagnostic_code = private_value
+    assert privacy_logging.bounded_exception_class(error) == "BoundedDiagnosticError"
+    assert private_value not in str(error)
 
 
 def test_product_logging_call_sites_use_the_bounded_exception_helper():


### PR DESCRIPTION
## Summary

- repair existing-cache startup quarantine when `CollectionEntity.dav_revision` trails retained `DavRevision` rows
- reuse identityless legacy rows when pulled items omit `meta.name`, avoiding duplicate `(collection, uid)` inserts
- emit fixed, allowlisted integrity-stage diagnostics without exception text or tracebacks
- add synthetic migration, backfill, first-sync, DAV-read, and restart coverage
- preserve quarantined dirty/new local intent and defer its push until retry binds a remote identity
- fork live duplicate identities safely while resolving already-deleted duplicates without a remote write
- revalidate local envelope and state snapshots under the write transaction so concurrent edits or deletes cannot be overwritten
- parse retry envelopes outside SQLite's writer transaction, then commit only after snapshot revalidation
- select clean legacy owners deterministically and use transactional compare-and-swap retry bookkeeping
- revalidate complete attached quarantine and local identity snapshots before every retry mutation
- migrate existing base tables before Peewee materializes new model indexes
- retain allowlisted DAV stage codes through the Radicale redaction boundary

## Root cause

During startup backfill, a malformed legacy envelope is quarantined and publishes a DAV tombstone. `record_dav_change()` previously advanced only the collection counter. If an interrupted or partial upgrade retained revision 1 while the collection counter remained 0, quarantine attempted to insert another revision 1 and SQLite raised `IntegrityError` before the first full-sync-cycle log.

The repaired path serializes publication with an immediate transaction and advances from the greater of the collection counter and retained ledger maximum. Existing state-chain validation continues to invalidate inconsistent old tokens rather than accepting incomplete incremental history.

A separate reproducible pull-path defect occurred when a remote item omitted `meta.name`: an identityless legacy row keyed by the remote UID was not considered and a duplicate row insert could violate `(collection, uid)`. The pull path now reuses that row.

## Privacy

All new diagnostic values come from a closed allowlist. Raw Peewee/SQLite messages, SQL, hrefs, UIDs, account identifiers, payloads, paths, and traceback chains are not retained or logged.

## Verification

- focused local-cache, startup/privacy, and CardDAV REPORT matrix passed
- `528 passed` across the complete Bridge suite
- Python `compileall` passed for Bridge source and changed tests
- Ruff passed for changed files with only pre-existing naming rules excluded
- synthetic lifecycle passes: partial migration → backfill/quarantine → first full sync → DAV sync read → restart/idempotence

## Planning

Surface & Sibling-Path Map: silent-suite/silentsuite-internal#368

Follow-up to the Bridge v0.5.0-beta release-integrity work tracked in #579. This PR does not delete or reset existing customer cache data.