### PR TITLE
docs: use standard size for Orion tile

### DIFF
--- a/apps/docs/.vitepress/theme/custom.css
+++ b/apps/docs/.vitepress/theme/custom.css
@@ -210,10 +210,6 @@
   .android-channel-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-
-  .android-channel-button.is-wide {
-    grid-column: 1 / -1;
-  }
 }
 
 /* App directory logos */

--- a/apps/docs/scripts/android-distribution.test.mjs
+++ b/apps/docs/scripts/android-distribution.test.mjs
@@ -222,14 +222,15 @@ test('hosted Android guide exposes direct logo buttons for every distribution st
   assert.match(hostedAndroid, /class="android-channel-button is-pending"[^>]*aria-label="F-Droid, on the roadmap, pending official inclusion"/)
 })
 
-test('hosted Android guide presents Orion as a full-width third-party tile below the other stores', () => {
+test('hosted Android guide presents Orion as a standard-size third-party tile below the other stores', () => {
   assert.match(hostedAndroid, /### Other community stores/)
   assert.match(hostedAndroid, /https:\/\/github\.com\/RookieEnough\/Orion-Store/)
-  assert.match(hostedAndroid, /class="android-channel-button is-wide" href="orionstore:\/\/app\/silentsuite"/)
+  assert.match(hostedAndroid, /class="android-channel-button" href="orionstore:\/\/app\/silentsuite"/)
   assert.match(hostedAndroid, /\/channel-icons\/orion\.png/)
   assert.match(hostedAndroid, /<strong>Orion Store<\/strong><small>Third-party community store<\/small>/)
-  assert.match(hostedAndroid, /F-Droid[\s\S]*class="android-channel-button is-wide" href="orionstore:\/\/app\/silentsuite"/)
-  assert.match(themeCss, /\.android-channel-button\.is-wide\s*\{[^}]*grid-column:\s*1 \/ -1/s)
+  assert.match(hostedAndroid, /F-Droid[\s\S]*class="android-channel-button" href="orionstore:\/\/app\/silentsuite"/)
+  assert.doesNotMatch(hostedAndroid, /android-channel-button is-wide/)
+  assert.doesNotMatch(themeCss, /\.android-channel-button\.is-wide/)
   assert.match(hostedAndroid, /retrieves the developer-signed APK from SilentSuite's GitHub Releases/)
   assert.match(hostedAndroid, /third-party distribution client and is not operated by SilentSuite/)
   assert.match(hostedAndroid, /confirm that Orion shows the expected SilentSuite version and GitHub release source/)

--- a/apps/docs/user-guide/apps/android.md
+++ b/apps/docs/user-guide/apps/android.md
@@ -29,7 +29,7 @@ downloads keep independent distribution paths available.
     <span class="android-channel-logo"><img src="/channel-icons/fdroid.png" alt="" aria-hidden="true"></span>
     <span class="android-channel-copy"><strong>F-Droid</strong><small>Pending official inclusion</small><span class="android-channel-status">On the roadmap</span></span>
   </div>
-  <a class="android-channel-button is-wide" href="orionstore://app/silentsuite">
+  <a class="android-channel-button" href="orionstore://app/silentsuite">
     <span class="android-channel-logo"><img src="/channel-icons/orion.png" alt="" aria-hidden="true"></span>
     <span class="android-channel-copy"><strong>Orion Store</strong><small>Third-party community store</small></span>
   </a>


### PR DESCRIPTION
## Summary
- make Orion Store use the same card width as the other Android store options
- keep Orion as the final grid item beneath the existing store rows
- retain its icon, deep link, third-party disclosure, and provenance records
- update regression coverage to reject the removed full-width modifier

## Verification
- `pnpm --filter @silentsuite/docs test:android-distribution` (11/11)
- `pnpm --filter @silentsuite/docs build`
- `git diff --check`
- independent review: approved