### PR TITLE
docs(bridge): clarify remote DAV access boundary

### DIFF
--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -116,6 +116,28 @@ Enabling bridge SSL changes the single local DAV listener from HTTP to HTTPS. Ex
 
 For detailed Apple setup fields and troubleshooting, see [macOS Calendar & Contacts](./macos.md).
 
+## Remote DAV Access (Tailscale / Private Networks)
+
+An explicit non-loopback bind exposes the Bridge's CalDAV and CardDAV endpoints
+to the configured private network. It does **not** expose the SilentSuite
+dashboard: the unauthenticated dashboard is disabled for the entire remote
+bind. To use the dashboard again, run the Bridge with a loopback bind on the
+Bridge host and open it from that host.
+
+`127.0.0.1` and `localhost` always refer to the device making the request. A
+DAV client on another Tailscale or private-network device must therefore use
+the Bridge host's private IP address, MagicDNS name, or another approved private
+hostname instead. Do not expose the Bridge listener to the public internet.
+
+When HTTPS is enabled, the exact IP address or hostname used by the DAV client
+must be present in the certificate's Subject Alternative Names (SANs). Do not
+bypass certificate verification. Certificate support for explicit Tailscale
+IPs and MagicDNS names is tracked in [#518](https://github.com/silent-suite/silentsuite/issues/518).
+
+Opening a remote listener in a browser can show `Radicale works!` or a similar
+generic Radicale status response. That confirms that the DAV listener is
+reachable; it is not the SilentSuite dashboard.
+
 ## Multi-Account Use
 
 The bridge can keep multiple accounts active in one local bridge profile. Each account has its own credentials, local cache namespace, sync thread, and DAV path.
@@ -281,7 +303,11 @@ silentsuite-bridge --login
 
 ### Can't connect from your app
 
-1. Verify the bridge is running: open `http://127.0.0.1:37358/` in your browser
+1. On the Bridge host with the default loopback bind, open
+   `http://127.0.0.1:37358/` and confirm the dashboard loads. For an intentional
+   remote bind, test the configured scheme and private-network address instead;
+   `Radicale works!` or a similar generic Radicale status response confirms
+   listener reachability, not dashboard availability.
 2. Check the tray icon color (green = OK, red = error)
 3. Check the dashboard sync log for errors
 4. If you installed on Windows, also check `%LOCALAPPDATA%\SilentSuite\install.log` and `%LOCALAPPDATA%\SilentSuite\bridge.log`
@@ -318,7 +344,9 @@ GNOME removed native tray support. Install the [AppIndicator extension](https://
 
 ### Firewall blocking
 
-Ensure `localhost:37358` is not blocked by your firewall. The bridge only listens on localhost -- it never accepts connections from other machines.
+With the default bind, ensure `localhost:37358` is not blocked by your firewall.
+If you explicitly enabled a remote bind, allow the configured port only on the
+intended private-network interface and keep it closed to the public internet.
 
 ## Next Steps
 

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -561,7 +561,11 @@ def run_server():
                 "Remote bridge bind enabled by SILENTSUITE_ALLOW_REMOTE=1. "
                 "DAV traffic is plaintext HTTP unless protected by your own proxy/VPN."
             )
-        logger.warning("Bridge dashboard disabled while remote bind is configured.")
+        logger.warning(
+            "Remote listener exposes DAV endpoints only; the bridge dashboard is "
+            "disabled for this bind. Use a loopback bind on the Bridge host to "
+            "access the dashboard."
+        )
     logger.info("Etebase server configured")
     logger.info("Bridge data directory configured")
     logger.info("CalDAV/CardDAV scheme: %s", config.dav_scheme())

--- a/bridge/tests/test_main_startup.py
+++ b/bridge/tests/test_main_startup.py
@@ -507,7 +507,10 @@ def test_remote_bind_warning_mentions_plaintext_when_ssl_disabled(monkeypatch, c
 
     text = caplog.text
     assert "DAV traffic is plaintext HTTP unless protected by your own proxy/VPN" in text
-    assert "Bridge dashboard disabled while remote bind is configured" in text
+    assert (
+        "Remote listener exposes DAV endpoints only; the bridge dashboard is disabled for this bind. "
+        "Use a loopback bind on the Bridge host to access the dashboard."
+    ) in caplog.messages
 
 
 def test_remote_bind_warning_avoids_plaintext_claim_when_ssl_enabled(monkeypatch, caplog, tmp_path):
@@ -528,4 +531,8 @@ def test_remote_bind_warning_avoids_plaintext_claim_when_ssl_enabled(monkeypatch
     text = caplog.text
     assert "exposes decrypted DAV data over the network" in text
     assert "without an intentional network/security design" in text
+    assert (
+        "Remote listener exposes DAV endpoints only; the bridge dashboard is disabled for this bind. "
+        "Use a loopback bind on the Bridge host to access the dashboard."
+    ) in caplog.messages
     assert "plaintext HTTP" not in text


### PR DESCRIPTION
## What changed?

- document that an explicit remote/Tailscale bind exposes DAV endpoints only while the dashboard remains loopback-only
- clarify remote host addresses, certificate SAN validation, the #518 follow-up, and Radicale's generic status response
- make the startup warning explicit and lock its exact wording for HTTP and HTTPS remote binds

Closes #659

## How I checked it

- `pnpm install --frozen-lockfile`
- `pnpm --filter @silentsuite/docs test:android-distribution` (11 passed)
- `pnpm --filter @silentsuite/docs build`
- `pnpm lint`
- `pnpm type-check`
- `pnpm build` on the repository's Node 22 line
- `python -m pytest tests/test_main_startup.py -q` (33 passed)
- targeted Ruff on the two changed Python files
- full Bridge suite: 527 passed; one unchanged macOS installer fixture fails because it provisions Linux-only `sha256sum`
- full JS suite on Node 22: core 321 passed; web 839 passed, with three unchanged CalendarGrid timing tests failing locally
- `git diff --check`

Current `dev` hosted checks are green; the PR workflows remain the authoritative Linux/Bridge gate.

## AI assistance

Prepared with OpenAI Codex and independently reviewed against the current Bridge configuration, Radicale 3.2.3 behavior, and issue acceptance criteria.