### PR TITLE
fix(web): restore reliable signup pageviews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   analytics-boundary:
     name: Public Analytics Boundary
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -37,6 +37,13 @@ jobs:
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      # Baseline signup pageviews are independent of the commercial event flag, so the
+      # emitted signup layout transport is verified in the disabled build mode too. The
+      # enabled build below then overwrites .next for the final enabled-mode check.
+      - name: Verify disabled-mode web analytics artifacts
+        run: |
+          NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=false pnpm --filter @silentsuite/web build
+          node scripts/check-public-analytics.mjs
       - name: Build public surfaces
         run: |
           NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=true pnpm --filter @silentsuite/web build

--- a/apps/web/app/(auth)/signup/__tests__/signup-analytics.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/signup-analytics.test.tsx
@@ -10,12 +10,15 @@ describe('signup analytics transport boundary', () => {
     vi.unstubAllEnvs()
   })
 
-  it('is disabled unless the build flag is exactly true', () => {
-    expect(shouldSendSignupAnalytics(new URL('https://app.silentsuite.io/signup'), undefined)).toBe(false)
-    expect(shouldSendSignupAnalytics(new URL('https://app.silentsuite.io/signup'), 'false')).toBe(false)
-    expect(shouldSendSignupAnalytics(new URL('https://app.silentsuite.io/signup'), 'TRUE')).toBe(false)
-    expect(shouldSendSignupAnalytics(new URL('https://app.silentsuite.io/signup'), 'true')).toBe(true)
-  })
+  // Baseline pageviews are independent of NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED, which
+  // gates commercial/custom events only. The runtime gate is canonical origin + route.
+  it.each([undefined, 'false', 'TRUE', 'true', ''])(
+    'admits the baseline signup pageview regardless of the commercial event flag %s',
+    (flag) => {
+      vi.stubEnv('NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED', flag)
+      expect(shouldSendSignupAnalytics(new URL('https://app.silentsuite.io/signup'))).toBe(true)
+    },
+  )
 
   it.each([
     'http://app.silentsuite.io/signup',
@@ -26,11 +29,12 @@ describe('signup analytics transport boundary', () => {
     'https://app.silentsuite.io/signup/plan',
     'https://app.silentsuite.io/signup/customer@example.com',
     'https://app.silentsuite.io/signup/550e8400-e29b-41d4-a716-446655440000',
-  ])('rejects noncanonical runtime URL %s even when enabled', (url) => {
-    expect(shouldSendSignupAnalytics(new URL(url), 'true')).toBe(false)
+  ])('rejects noncanonical runtime URL %s', (url) => {
+    vi.stubEnv('NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED', 'true')
+    expect(shouldSendSignupAnalytics(new URL(url))).toBe(false)
   })
 
-  it('sends only the canonicalized payload through beacon', async () => {
+  it('sends only the canonicalized property-free payload through an accepting beacon', async () => {
     const beacon = vi.fn(() => true)
     const fetcher = vi.fn()
 
@@ -51,11 +55,41 @@ describe('signup analytics transport boundary', () => {
       name: 'pageview',
       url: 'https://app.silentsuite.io/signup',
       referrer: 'https://github.com/',
-      props: { referrer_category: 'github', utm_source: 'github' },
     }))
   })
 
-  it('uses the same canonical payload for the fetch fallback', async () => {
+  it('falls back to a keepalive fetch with an identical body when the beacon refuses', async () => {
+    const beacon = vi.fn(() => false)
+    const fetcher = vi.fn(async () => new Response(null, { status: 202 }))
+
+    sendSignupPageview({
+      pageUrl: 'https://app.silentsuite.io/signup?utm_source=github',
+      referrer: 'https://github.com/silent-suite/silentsuite/issues/123?token=secret',
+      beacon,
+      fetcher,
+    })
+
+    const expectedBody = JSON.stringify({
+      domain: 'app.silentsuite.io',
+      name: 'pageview',
+      url: 'https://app.silentsuite.io/signup',
+      referrer: 'https://github.com/',
+    })
+
+    expect(beacon).toHaveBeenCalledTimes(1)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    await expect((beacon.mock.calls[0][1] as Blob).text()).resolves.toBe(expectedBody)
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://plausible.silentsuite.io/api/event',
+      expect.objectContaining({
+        method: 'POST',
+        body: expectedBody,
+        keepalive: true,
+      }),
+    )
+  })
+
+  it('uses the same canonical payload for the fetch fallback when no beacon exists', async () => {
     const fetcher = vi.fn(async () => new Response(null, { status: 202 }))
 
     sendSignupPageview({
@@ -64,6 +98,7 @@ describe('signup analytics transport boundary', () => {
       fetcher,
     })
 
+    expect(fetcher).toHaveBeenCalledTimes(1)
     expect(fetcher).toHaveBeenCalledWith(
       'https://plausible.silentsuite.io/api/event',
       expect.objectContaining({
@@ -72,16 +107,17 @@ describe('signup analytics transport boundary', () => {
           domain: 'app.silentsuite.io',
           name: 'pageview',
           url: 'https://app.silentsuite.io/signup/success',
-          props: { referrer_category: 'other' },
         }),
+        keepalive: true,
       }),
     )
   })
 
   it.each(['/signup', '/signup/pending-payment', '/signup/success', '/signup/cancel'])(
-    'admits registered signup pageview route %s',
+    'admits registered signup pageview route %s with the commercial event flag unset',
     (pathname) => {
-      expect(shouldSendSignupAnalytics(new URL(`https://app.silentsuite.io${pathname}`), 'true')).toBe(true)
+      vi.stubEnv('NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED', undefined)
+      expect(shouldSendSignupAnalytics(new URL(`https://app.silentsuite.io${pathname}`))).toBe(true)
     },
   )
 })

--- a/apps/web/app/(auth)/signup/signup-analytics.tsx
+++ b/apps/web/app/(auth)/signup/signup-analytics.tsx
@@ -6,12 +6,12 @@ import { buildSignupPageviewPayload, SIGNUP_ANALYTICS_PATHS } from '@/app/lib/pu
 
 const PLAUSIBLE_EVENT_ENDPOINT = 'https://plausible.silentsuite.io/api/event'
 
-export function shouldSendSignupAnalytics(
-  location: URL,
-  enabled = process.env.NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED,
-): boolean {
-  return enabled === 'true'
-    && location.protocol === 'https:'
+// The baseline pageview gate is the canonical production origin plus the registered
+// route only. It is deliberately independent of NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED,
+// which gates commercial/custom events; self-hosted and preview origins stay silent
+// because they never match app.silentsuite.io over https.
+export function shouldSendSignupAnalytics(location: URL): boolean {
+  return location.protocol === 'https:'
     && location.hostname === 'app.silentsuite.io'
     && SIGNUP_ANALYTICS_PATHS.includes(location.pathname as typeof SIGNUP_ANALYTICS_PATHS[number])
 }
@@ -33,8 +33,7 @@ export function sendSignupPageview({
 
   if (beacon) {
     const blob = new Blob([payload], { type: 'application/json' })
-    beacon(PLAUSIBLE_EVENT_ENDPOINT, blob)
-    return
+    if (beacon(PLAUSIBLE_EVENT_ENDPOINT, blob)) return
   }
 
   void fetcher(PLAUSIBLE_EVENT_ENDPOINT, {

--- a/apps/web/app/lib/__tests__/public-analytics.test.ts
+++ b/apps/web/app/lib/__tests__/public-analytics.test.ts
@@ -67,30 +67,42 @@ describe('public analytics privacy contract', () => {
     expect(classifyReferrer('bad url')).toBeUndefined()
   })
 
-  it('builds the exact identity-free signup pageview payload', () => {
-    expect(buildSignupPageviewPayload(
+  it('builds the exact identity-free signup pageview payload without custom properties', () => {
+    const payload = buildSignupPageviewPayload(
       'https://app.silentsuite.io/signup?utm_source=github&utm_content=user@example.com&returnTo=/calendar',
       'https://github.com/silent-suite/silentsuite/issues/123?token=secret',
-    )).toEqual({
+    )
+
+    expect(payload).toEqual({
       domain: 'app.silentsuite.io',
       name: 'pageview',
       url: 'https://app.silentsuite.io/signup',
       referrer: 'https://github.com/',
-      props: { referrer_category: 'github', utm_source: 'github' },
     })
+    expect(payload).not.toHaveProperty('props')
+    expect(Object.keys(payload)).toEqual(['domain', 'name', 'url', 'referrer'])
   })
 
   it('sends the fixed Google referrer for a recognized regional Google source', () => {
-    expect(buildSignupPageviewPayload(
+    const payload = buildSignupPageviewPayload(
       'https://app.silentsuite.io/signup',
       'https://www.google.co.uk/search?q=silentsuite',
-    )).toEqual({
+    )
+
+    expect(payload).toEqual({
       domain: 'app.silentsuite.io',
       name: 'pageview',
       url: 'https://app.silentsuite.io/signup',
       referrer: 'https://www.google.com/',
-      props: { referrer_category: 'search' },
     })
+    expect(payload).not.toHaveProperty('props')
+  })
+
+  it.each([
+    'https://app.silentsuite.io/signup?utm_source=paid&utm_medium=cpc&utm_campaign=beta-2026-q2',
+    'https://app.silentsuite.io/signup?utm_source=github',
+  ])('never attaches campaign properties to the baseline pageview for %s', (rawUrl) => {
+    expect(buildSignupPageviewPayload(rawUrl, '')).not.toHaveProperty('props')
   })
 
   it.each([

--- a/apps/web/app/lib/public-analytics.ts
+++ b/apps/web/app/lib/public-analytics.ts
@@ -6,12 +6,15 @@ export type CampaignParams = Partial<{
 
 export type ReferrerCategory = 'direct' | 'search' | 'social' | 'github' | 'known_partner' | 'other'
 
+// Baseline pageviews are deliberately property-free: a Plausible site property
+// allowlist can discard every pageview that carries an unapproved custom property,
+// so the signup pageview transmits only the canonical route and referrer. Campaign
+// and referrer dimensions live on flag-gated commercial events, never here.
 export type SignupPageviewPayload = {
   domain: 'app.silentsuite.io'
   name: 'pageview'
   url: string
   referrer?: CanonicalReferrer
-  props: { referrer_category: ReferrerCategory } & CampaignParams
 }
 
 export const SIGNUP_ANALYTICS_PATHS = ['/signup', '/signup/pending-payment', '/signup/success', '/signup/cancel'] as const
@@ -190,14 +193,12 @@ export function canonicalizeReferrer(raw: string): CanonicalReferrer | undefined
 }
 
 export function buildSignupPageviewPayload(rawUrl: string, rawReferrer: string): SignupPageviewPayload {
-  const current = new URL(rawUrl)
   const referrer = canonicalizeReferrer(rawReferrer)
   return {
     domain: 'app.silentsuite.io',
     name: 'pageview',
     url: sanitizedSignupPageUrl(rawUrl),
     ...(referrer ? { referrer } : {}),
-    props: { referrer_category: classifyReferrer(rawReferrer) ?? 'other', ...canonicalizeCampaignParams(current.searchParams) },
   }
 }
 

--- a/scripts/check-public-analytics.mjs
+++ b/scripts/check-public-analytics.mjs
@@ -7,6 +7,10 @@ const generatedAppRootArgument = process.argv.find((argument) => argument.starts
 const generatedAppRoot = generatedAppRootArgument
   ? path.resolve(generatedAppRootArgument.slice('--generated-app-root='.length))
   : path.join(appsRoot, 'web/.next/static/chunks/app/(app)')
+const generatedAuthRootArgument = process.argv.find((argument) => argument.startsWith('--generated-auth-root='))
+const generatedAuthRoot = generatedAuthRootArgument
+  ? path.resolve(generatedAuthRootArgument.slice('--generated-auth-root='.length))
+  : path.join(appsRoot, 'web/.next/static/chunks/app/(auth)')
 const enabledGeneratedBuild = process.argv.includes('--enabled-generated-build') || process.env.PUBLIC_ANALYTICS_ENABLED_BUILD === 'true'
 const allowedAnalyticsFiles = new Set([
   path.join(appsRoot, 'web/app/(auth)/signup/signup-analytics.tsx'),
@@ -47,17 +51,27 @@ const requiredContracts = new Map([
   ['apps/docs/.vitepress/theme/public-analytics.mts', ['Hosted App Click', 'Android Download Click', 'github_release', 'repository']],
   ['apps/docs/.vitepress/theme/index.mts', ['__SILENTSUITE_DOCS_ANALYTICS_ENDPOINT__', 'window.location.hostname', 'classifyDocsOutboundEvent']],
   ['apps/web/next.config.js', ['Content-Security-Policy', 'signupConnectSources', 'subscriptionConnectSources', "source: '/settings/subscription'", 'hostedConnectSources']],
+  // Baseline signup pageviews: origin/route gate only, property-free builder, beacon
+  // with keepalive fetch fallback. The commercial event flag is pinned on the
+  // commercial entry below, because baseline pageviews must not depend on it.
   ['apps/web/app/(auth)/signup/signup-analytics.tsx', [
-    "enabled === 'true'",
+    'buildSignupPageviewPayload',
     "location.hostname === 'app.silentsuite.io'",
     "location.protocol === 'https:'",
+    'keepalive: true',
   ]],
-  ['apps/web/app/(auth)/signup/commercial-funnel-analytics.tsx', ['buildPlanSelectedPayload', 'buildCheckoutInitiatedPayload', 'buildCheckoutReturnedPayload']],
+  ['apps/web/app/(auth)/signup/commercial-funnel-analytics.tsx', ["enabled === 'true'", 'buildPlanSelectedPayload', 'buildCheckoutInitiatedPayload', 'buildCheckoutReturnedPayload']],
   ['apps/web/app/(app)/settings/subscription/subscription-entry.tsx', ['buildSubscriptionManagementEntryPayload']],
   ['Dockerfile.web', ['ARG NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=false']],
   ['.github/workflows/deploy-web.yml', ['NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=true']],
   ['.github/workflows/preview-web.yml', ['NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=false']],
-  ['.github/workflows/ci.yml', ['pnpm run check:public-analytics']],
+  // Baseline pageview transport must be verified in both build flag modes, because it
+  // is independent of NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED and must ship in every build.
+  ['.github/workflows/ci.yml', [
+    'pnpm run check:public-analytics',
+    'NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=false pnpm --filter @silentsuite/web build',
+    'NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED=true pnpm --filter @silentsuite/web build',
+  ]],
 ])
 for (const [relativePath, snippets] of requiredContracts) {
   const source = await readFile(path.resolve(relativePath), 'utf8')
@@ -85,6 +99,38 @@ try {
   await scanGenerated(generatedAppRoot)
   if (enabledGeneratedBuild && !subscriptionRouteContainsEndpoint) {
     violations.push('subscription route chunk: expected analytics endpoint absent')
+  }
+} catch (error) {
+  if (error.code !== 'ENOENT') throw error
+}
+
+// Baseline signup pageview transport must survive into the emitted signup layout
+// chunk. signup-analytics.tsx is imported only by the signup layout and defines the
+// endpoint and keepalive fallback module-locally, so the emitting chunk is the
+// identity. Commercial modules reach only signup page entries, and the shared
+// 'pageview' literal lives in the common builder module, so neither co-located
+// endpoint text nor pageview text may stand in for the baseline sender. This scan is
+// build-flag independent: post-repair, the baseline transport ships in every mode.
+try {
+  let signupLayoutCarriesTransport = false
+  async function scanGeneratedAuth(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) await scanGeneratedAuth(fullPath)
+      else if (/\.js$/.test(entry.name)) {
+        const source = await readFile(fullPath, 'utf8')
+        if (source.includes('NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED')) {
+          violations.push(`${path.relative(process.cwd(), fullPath)}: unresolved signup analytics flag literal in public bundle`)
+        }
+        const relativePath = path.relative(generatedAuthRoot, fullPath)
+        if (!/^signup[\\/]layout-[^\\/]+\.js$/.test(relativePath)) continue
+        if (source.includes(analyticsEndpoint) && source.includes('keepalive')) signupLayoutCarriesTransport = true
+      }
+    }
+  }
+  await scanGeneratedAuth(generatedAuthRoot)
+  if (!signupLayoutCarriesTransport) {
+    violations.push('signup layout chunk: expected baseline pageview transport absent')
   }
 } catch (error) {
   if (error.code !== 'ENOENT') throw error

--- a/scripts/check-public-analytics.test.mjs
+++ b/scripts/check-public-analytics.test.mjs
@@ -36,6 +36,94 @@ async function checkGeneratedAppTree(root) {
   }
 }
 
+// The signup (auth) scan is baseline-specific: the pageview sender lives in
+// signup-analytics.tsx, which only the signup layout imports, so its transport
+// literals must survive into the emitted signup layout chunk. Commercial modules
+// reach only page entries, and the shared 'pageview' literal lives in the common
+// builder module — neither may satisfy this assertion.
+async function checkGeneratedAuthTree(root, extraArguments = []) {
+  try {
+    await execFileAsync(process.execPath, [
+      'scripts/check-public-analytics.mjs',
+      `--generated-app-root=${path.join(root, 'absent-app-root')}`,
+      `--generated-auth-root=${root}`,
+      ...extraArguments,
+    ])
+    return ''
+  } catch (error) {
+    return `${error.stdout}\n${error.stderr}`
+  }
+}
+
+const commercialPageChunk = `${endpoint} keepalive:!0 "pageview" buildSignupPageviewPayload`
+
+test('generated auth scan rejects a commercial page chunk standing in for the baseline sender', async () => {
+  await withGeneratedAppTree({
+    'signup/page-a.js': commercialPageChunk,
+  }, async (root) => {
+    assert.match(
+      await checkGeneratedAuthTree(root),
+      /signup layout chunk: expected baseline pageview transport absent/,
+    )
+  })
+})
+
+test('generated auth scan rejects a stub signup layout chunk alongside a populated commercial chunk', async () => {
+  await withGeneratedAppTree({
+    'signup/layout-a.js': 'console.log("layout")',
+    'signup/page-a.js': commercialPageChunk,
+  }, async (root) => {
+    assert.match(
+      await checkGeneratedAuthTree(root),
+      /signup layout chunk: expected baseline pageview transport absent/,
+    )
+  })
+})
+
+test('generated auth scan rejects a signup layout chunk missing the keepalive fallback', async () => {
+  await withGeneratedAppTree({
+    'signup/layout-a.js': endpoint,
+    'signup/page-a.js': commercialPageChunk,
+  }, async (root) => {
+    assert.match(
+      await checkGeneratedAuthTree(root),
+      /signup layout chunk: expected baseline pageview transport absent/,
+    )
+  })
+})
+
+test('generated auth scan permits a signup layout chunk carrying the baseline transport', async () => {
+  await withGeneratedAppTree({
+    'signup/layout-a.js': `${endpoint} keepalive:!0`,
+    'signup/page-a.js': commercialPageChunk,
+  }, async (root) => {
+    assert.equal(await checkGeneratedAuthTree(root), '')
+  })
+})
+
+test('generated auth scan enforces the baseline transport in both build flag modes', async () => {
+  await withGeneratedAppTree({
+    'signup/page-a.js': commercialPageChunk,
+  }, async (root) => {
+    assert.match(
+      await checkGeneratedAuthTree(root, ['--enabled-generated-build']),
+      /signup layout chunk: expected baseline pageview transport absent/,
+    )
+  })
+})
+
+test('generated auth scan rejects an unresolved signup analytics flag literal', async () => {
+  await withGeneratedAppTree({
+    'signup/layout-a.js': `${endpoint} keepalive:!0`,
+    'signup/page-a.js': 'process.env.NEXT_PUBLIC_SIGNUP_ANALYTICS_ENABLED',
+  }, async (root) => {
+    assert.match(
+      await checkGeneratedAuthTree(root),
+      /signup\/page-a\.js: unresolved signup analytics flag literal in public bundle/,
+    )
+  })
+})
+
 test('enabled generated app scan fails closed when the subscription route chunk lacks the approved endpoint', async () => {
   await withGeneratedAppTree({
     'settings/subscription/page-a.js': 'console.log("subscription")',


### PR DESCRIPTION
## Summary

- make baseline signup pageviews property-free so Plausible property allowlists cannot discard them
- keep baseline pageviews independent of the custom/commercial analytics flag
- respect `sendBeacon()` refusal with a `fetch(..., { keepalive: true })` fallback
- verify the baseline sender survives in enabled and disabled signup layout artifacts

## Surface and privacy contract

- only the existing registered production signup routes are admitted
- query strings and fragments remain excluded
- only approved canonical referrer origins may be sent; arbitrary raw referrers remain omitted
- commercial/custom events remain separately gated and unchanged
- Landing, Docs, Billing, and shared analytics packages are untouched

## Verification

- [x] strict TDD with regression-sensitive RED cases for property-bearing payloads, flag suppression, Beacon refusal, and artifact false-passes
- [x] web tests: 849 passed
- [x] focused analytics tests: 76 passed
- [x] analytics verifier tests: 9 passed
- [x] `pnpm run check:public-analytics`
- [x] web type-check
- [x] web lint, with only pre-existing warnings in untouched files
- [x] enabled and disabled production builds retain the baseline signup layout transport
- [x] independent immutable review approved commit `59483b530c04a8e5b8fbd8ccf983ec66895d7c66`, tree `afd89338934028c25dc90ee0c6ece820343f4589`

## PR #661 overlap

This repair remains separate from #661. It should land first, after which #661 should rebase and rerun its analytics and annual-billing gates. Overlaps are limited to adjacent/disjoint regions in `public-analytics.ts`, its tests, and separate jobs in `ci.yml`.

Closes #662
