### PR TITLE
docs(user-guide): align hosted signup verification flow

### DIFF
--- a/apps/docs/user-guide/getting-started.md
+++ b/apps/docs/user-guide/getting-started.md
@@ -5,9 +5,9 @@ Set up SilentSuite and start syncing your calendar, contacts, and tasks with end
 ## 1. Create an Account
 
 1. Go to [app.silentsuite.io](https://app.silentsuite.io).
-2. Click **Sign Up**.
-3. New hosted billing is annual only: Early Adopter access is €36 annually (€3 per month, billed annually), while future Standard access is €48 annually (€4 per month, billed annually). Choose a 7-day no-card trial with no automatic charge or a 30-day card-backed trial. Billing shows the exact annual charge date and cancellation deadline; cancel before that deadline. Card and prepaid Bitcoin annual payments include a 30-day refund promise. Self-hosting is free with every feature unlocked.
-4. Enter your email and choose a strong password.
+2. Click **Sign Up**, then enter your email and choose a strong password.
+3. Verify your email — hosted signup pauses while SilentSuite emails you a verification link. Open the link in the same browser you signed up in; the plan step stays locked until the link is opened, and your password is not saved while you wait.
+4. Re-enter your password, then choose your plan. New hosted billing is annual only: Early Adopter access is €36 annually (€3 per month, billed annually), while future Standard access is €48 annually (€4 per month, billed annually). Choose a 7-day no-card trial with no automatic charge or a 30-day card-backed trial. Billing shows the exact annual charge date and cancellation deadline; cancel before that deadline. Card and prepaid Bitcoin annual payments include a 30-day refund promise. Self-hosting is free with every feature unlocked and skips the verification and billing steps entirely.
 
 Your password is used to derive your encryption keys locally on your device. It never leaves your device, and the server never sees it.
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -4,17 +4,16 @@ A walkthrough of creating your account and getting your first event syncing acro
 
 ## 1. Create an Account
 
-Go to [app.silentsuite.io](https://app.silentsuite.io/signup). For the hosted service the signup flow is three steps:
+Go to [app.silentsuite.io](https://app.silentsuite.io/signup). For the hosted service the signup flow is four steps:
 
 1. **Account** — email and password.
-2. **Plan** — new hosted billing is annual only: Early Adopter access is €36 annually (€3 per month, billed annually), while future Standard access is €48 annually (€4 per month, billed annually). Choose your trial:
+2. **Verify your email** — signup pauses while SilentSuite emails a verification link to your address. Open that link in the same browser you started signing up in; the plan step stays locked until the link is opened, and your password is not saved while you wait.
+3. **Plan** — after verifying, you re-enter your password (the emailed link never contains it), then pick your plan. New hosted billing is annual only: Early Adopter access is €36 annually (€3 per month, billed annually), while future Standard access is €48 annually (€4 per month, billed annually). Choose your trial:
    - **7-day free trial** — full access, no credit card required and no automatic charge.
    - **30-day free trial** — a card secures the trial; Billing shows the exact annual charge date and cancellation deadline, and you can cancel before that deadline. Card and prepaid Bitcoin annual payments include a 30-day refund promise.
-3. **Setup** — your encryption keys are derived from your password on this device. Store the password somewhere safe; without it, your data cannot be recovered. SilentSuite has no way to reset it because the server never sees your keys.
+4. **Setup** — your encryption keys are derived from your password on this device. Store the password somewhere safe; without it, your data cannot be recovered. SilentSuite has no way to reset it because the server never sees your keys.
 
-After signup, an inline **Verify your email** banner stays at the top of the app until you click the link sent to your registered address. (No banner on self-hosted accounts.)
-
-Self-hosting your own server? Expand **Advanced Settings** on the signup page and enter your server URL before submitting. The flow becomes four steps (Account → Self-Hosting → Admin Setup → Setup) and skips the plan / billing entirely. Self-hosting is free with every feature unlocked. See the [Self-Hosting guide](../self-hosting/) for the server side of that.
+Self-hosting your own server? Expand **Advanced Settings** on the signup page and enter your server URL before submitting. The flow becomes Account → Self-Hosting → Admin Setup → Setup, and skips the email-verification gate and the plan / billing steps entirely. Self-hosting is free with every feature unlocked. See the [Self-Hosting guide](../self-hosting/) for the server side of that.
 
 ## 2. Add Your First Event
 

--- a/scripts/check-billing-copy.test.mjs
+++ b/scripts/check-billing-copy.test.mjs
@@ -1,9 +1,34 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 import { collectBillingCopyViolations } from './check-billing-copy.mjs'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
 test('annual-only billing copy guard accepts the repository', () => {
   assert.deepEqual(collectBillingCopyViolations(), [])
+})
+
+test('getting-started docs preserve the mandatory hosted email-verification signup sequence', () => {
+  for (const file of ['docs/user-guide/getting-started.md', 'apps/docs/user-guide/getting-started.md']) {
+    const content = readFileSync(resolve(repoRoot, file), 'utf8')
+    assert.match(content, /verification link/i,
+      `${file} must describe the emailed verification link required for hosted signup`)
+    assert.match(content, /same browser/i,
+      `${file} must direct users to open the verification link in the same browser they signed up in`)
+    assert.match(content, /plan[^.\n]{0,160}(?:unlocks?|locked)|(?:unlocks?|locked)[^.\n]{0,160}plan/i,
+      `${file} must state that plan selection stays locked until the emailed link is opened`)
+    assert.match(content, /re-?enter[^.\n]{0,80}password|password[^.\n]{0,80}re-?enter/i,
+      `${file} must describe password re-entry after the email-link continuation`)
+    const verifyIndex = content.search(/verification link/i)
+    const planChoiceIndex = content.search(/choose[^.\n]{0,60}(?:plan|trial)/i)
+    assert.ok(verifyIndex !== -1 && planChoiceIndex > verifyIndex,
+      `${file} must describe email verification before plan/trial selection`)
+    assert.doesNotMatch(content, /verify your email[^.\n]{0,140}banner|banner[^.\n]{0,140}until you (?:click|open)/i,
+      `${file} must not present hosted email verification as an optional post-signup banner`)
+  }
 })
 
 test('annual-only billing copy guard catches prohibited purchase copy', () => {


### PR DESCRIPTION
## Summary

- align both public getting-started guides with the mandatory hosted email-ownership gate
- document same-browser verification-link continuation, password re-entry, and plan selection only after verification
- add a focused copy-contract test preventing regression to the old optional post-signup banner flow

## Verification

- RED: focused guard failed on the old docs because the required emailed-link step was absent
- GREEN: `node --test scripts/check-billing-copy.test.mjs` (9/9)
- GREEN: `pnpm run check:billing-copy` (12/12 plus guard)
- GREEN: `pnpm run check:public-analytics`
- GREEN: `git diff --check`

## Scope

Documentation and a focused guard test only. No implementation, deployment, provider, production, or analytics setting changes.
