### PR TITLE
test(android): await replayed signup owner acknowledgement

### DIFF
--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/FirstRunSignInRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/FirstRunSignInRuntimeTest.kt
@@ -158,6 +158,21 @@ class FirstRunSignInRuntimeTest {
                 assertTrue("Signup replay Activity did not launch", replayReturn is SignupReturnActivity)
                 instrumentation.waitForIdleSync()
                 assertTrue("Signup replay Activity did not finish", replayReturn!!.isFinishing)
+                val replayDeadline = android.os.SystemClock.elapsedRealtime() + 5_000L
+                var replayAcknowledged = false
+                while (!replayAcknowledged && android.os.SystemClock.elapsedRealtime() < replayDeadline) {
+                    instrumentation.waitForIdleSync()
+                    scenario.onActivity { activity ->
+                        activity.supportFragmentManager.executePendingTransactions()
+                        replayAcknowledged =
+                            !activity.intent.hasExtra(LoginActivity.EXTRA_SIGNUP_CONTINUATION_TOKEN) &&
+                                (activity.supportFragmentManager.findFragmentByTag(LoginActivity.CREDENTIALS_TAG)
+                                    is LoginCredentialsFragment) &&
+                                callbackOwnerFlow(activity) == ownerFlow
+                    }
+                    if (!replayAcknowledged) android.os.SystemClock.sleep(25L)
+                }
+                assertTrue("Replayed handled callback was not acknowledged by the owning login", replayAcknowledged)
                 scenario.onActivity { activity ->
                     assertFalse(activity.intent.hasExtra(LoginActivity.EXTRA_SIGNUP_CONTINUATION_TOKEN))
                     assertFalse(activity.intent.extras?.keySet().orEmpty().any {
@@ -165,6 +180,10 @@ class FirstRunSignInRuntimeTest {
                             it.contains("credential", ignoreCase = true) ||
                             it.contains("session", ignoreCase = true)
                     })
+                    assertEquals(
+                        SignupContinuationRegistry.ClaimResult.SAME_FLOW_HANDLED,
+                        SignupContinuationRegistry.claim(owningToken, ownerFlow),
+                    )
                 }
 
                 val frozenNow = SetupElapsedClock.now()


### PR DESCRIPTION
## Summary

- wait for the owning `LoginActivity` to acknowledge a replayed handled signup callback before asserting owner state
- preserve delivery, token removal, and sensitive-extra assertions
- strengthen replay idempotency with destination, owner-flow, and `SAME_FLOW_HANDLED` checks

## Root cause

`SignupReturnActivity` finishing proves delivery/foreground routing completed, but owner acknowledgement happens later when `LoginActivity` resumes. The old test sampled the owner intent in that asynchronous gap. The same assertion failed twice on exact SHA `73af3fde` in CI run `31710864714`.

## TDD

- RED: exact API 36 `first-run-setup` shard failed twice at the immediate token-absence assertion
- GREEN required in CI: focused API 36 shard twice on the same corrected SHA, plus the full Android matrix

## Scope

One instrumentation-test block only. No production code, workflows, ledgers, selectors, retries, timeout widening elsewhere, or removed assertions.
