### PR TITLE
fix(deps): update nanoid for security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "brace-expansion@>=3.0.0 <3.0.6": "3.0.6",
       "brace-expansion@>=5.0.0 <5.0.9": "5.0.9",
       "js-yaml@>=4.0.0 <4.3.1": "4.3.1",
-      "nanoid@>=3.0.0 <3.3.17": "3.3.17",
+      "nanoid@>=3.0.0 <3.3.18": "3.3.18",
       "postcss": "^8.5.18",
       "sharp": "^0.35.0",
       "@babel/plugin-transform-modules-systemjs": "^7.29.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   brace-expansion@>=3.0.0 <3.0.6: 3.0.6
   brace-expansion@>=5.0.0 <5.0.9: 5.0.9
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
-  nanoid@>=3.0.0 <3.3.17: 3.3.17
+  nanoid@>=3.0.0 <3.3.18: 3.3.18
   postcss: ^8.5.18
   sharp: ^0.35.0
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
@@ -4496,8 +4496,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10333,7 +10333,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -10575,7 +10575,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/scripts/dependency-compatibility-smoke.test.mjs
+++ b/scripts/dependency-compatibility-smoke.test.mjs
@@ -15,7 +15,7 @@ const Ajv = requireFrom('node_modules/.pnpm/ajv@8.18.0/node_modules/ajv/package.
 const addFormats = requireFrom('node_modules/.pnpm/ajv-formats@2.1.1_ajv@8.18.0/node_modules/ajv-formats/package.json')('.')
 const { JSDOM } = requireFrom('apps/web/package.json')('jsdom')
 const yaml = requireFrom('node_modules/.pnpm/js-yaml@4.3.1/node_modules/js-yaml/package.json')('.')
-const { customAlphabet, nanoid } = requireFrom('node_modules/.pnpm/nanoid@3.3.17/node_modules/nanoid/package.json')('.')
+const { customAlphabet, nanoid } = requireFrom('node_modules/.pnpm/nanoid@3.3.18/node_modules/nanoid/package.json')('.')
 const manifest = JSON.parse(readFileSync(resolve(import.meta.dirname, '..', 'package.json'), 'utf8'))
 
 for (const [line, minimatch] of [['3', minimatch3], ['5', minimatch5], ['10', minimatch10]]) {
@@ -56,7 +56,7 @@ test('nanoid 3 patched generators preserve normal positive-size behavior', () =>
 
 test('security overrides remain scoped to compatible vulnerable major lines', () => {
   assert.equal(manifest.pnpm.overrides['js-yaml@>=4.0.0 <4.3.1'], '4.3.1')
-  assert.equal(manifest.pnpm.overrides['nanoid@>=3.0.0 <3.3.17'], '3.3.17')
+  assert.equal(manifest.pnpm.overrides['nanoid@>=3.0.0 <3.3.18'], '3.3.18')
   assert.equal(Object.hasOwn(manifest.pnpm.overrides, 'js-yaml'), false)
-  assert.equal(Object.hasOwn(manifest.pnpm.overrides, 'nanoid@<3.3.17'), false)
+  assert.equal(Object.hasOwn(manifest.pnpm.overrides, 'nanoid@<3.3.18'), false)
 })


### PR DESCRIPTION
## Summary

- update the scoped nanoid 3.x override from 3.3.17 to 3.3.18
- refresh only the corresponding lockfile resolution
- update compatibility smoke coverage for the patched package

## Security

Fixes GHSA-2v37-7h3g-55p8, which caused the high/critical dependency audit gate to begin failing on the unchanged `dev` baseline.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run test:dependency-security`
- `pnpm run audit:security` — 0 critical, 0 high
- `pnpm run type-check`
- substantive immutable exact-head review approved

Closes #669
