### PR TITLE
docs: link self-hosting troubleshooting

### DIFF
--- a/apps/docs/self-hosting/quick-start.md
+++ b/apps/docs/self-hosting/quick-start.md
@@ -112,6 +112,7 @@ Your data is end-to-end encrypted. The server never sees your plaintext calendar
 
 ## Next Steps
 
+- [Troubleshooting](./troubleshooting.md) -- common install, reverse proxy, and health-check problems.
 - [Configuration](./configuration.md) -- understand and customize your environment variables.
 - [Admin Dashboard](./admin-dashboard.md) -- manage users via the web app admin panel.
 - [Backup & Restore](./backup-and-restore.md) -- set up automated backups.


### PR DESCRIPTION
Added a beginner-facing link from the self-hosting quick start to troubleshooting guidance for common install, reverse proxy, and health-check problems.

Checks:
- git diff --check
- pnpm --filter @silentsuite/docs build

Addresses #253