### PR TITLE
docs: add beta and compatibility report guidance

### DIFF
--- a/apps/docs/user-guide/apps/android.md
+++ b/apps/docs/user-guide/apps/android.md
@@ -128,6 +128,17 @@ The SilentSuite Android app is open source. The source lives in the `android/` d
 
 - [github.com/silent-suite/silentsuite/tree/main/android](https://github.com/silent-suite/silentsuite/tree/main/android)
 
+## What to include in a beta test report
+
+When you report a beta test result, include:
+
+- **Android version** (for example, Android 15).
+- **Device model** (for example, Pixel 8).
+- **Install source** -- Google Play, Obtainium, Zapstore, or a signed APK from GitHub Releases. F-Droid is not available yet.
+- **Signup/login result** -- whether account creation and login succeeded.
+- **Sync result for contacts, calendars, and tasks** -- what synced, what did not, and any error message shown.
+- **Errors or screenshots** -- redact your username, email address, server URL (if self-hosted), and any contact, event, or task content before sharing.
+
 ## Troubleshooting
 
 ### Data not syncing

--- a/apps/docs/user-guide/apps/index.md
+++ b/apps/docs/user-guide/apps/index.md
@@ -50,3 +50,16 @@ On Linux, start with the [Linux desktop bridge guide](./linux-bridge.md) for ins
 ::: tip
 Use one of the documented desktop clients above with the [SilentSuite Bridge](./dav-bridge.md). Protocol support alone does not establish SilentSuite compatibility. iOS is not currently supported.
 :::
+
+## How to report bridge compatibility
+
+If you try an app with the [SilentSuite Bridge](./dav-bridge.md), report your result with:
+
+- **App name and version** you tested.
+- **Operating system** (for example, macOS 15, Windows 11, Ubuntu 24.04).
+- **Bridge version** you were running.
+- **Calendar sync:** yes, no, or partial.
+- **Contacts sync:** yes, no, or partial.
+- **Notes or errors** -- what worked, what failed, and any error message or log excerpt.
+
+Redact private data before sharing: remove usernames, email addresses, server URLs, and any event or contact content from logs and screenshots. Only report apps you have actually tested -- an untested app is not known to work.


### PR DESCRIPTION
## Summary
- add an Android beta-test report checklist
- add a Bridge compatibility-report template
- include explicit private-data redaction guidance

## Validation
- `pnpm --filter @silentsuite/docs build`
- `git diff --check`

Closes #249
Closes #250