### PR TITLE
Fix Android system-bar and keyboard cutoffs

### DIFF
--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDashboardRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/AccountDashboardRuntimeTest.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.google.android.material.navigation.NavigationView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -60,6 +61,18 @@ class AccountDashboardRuntimeTest {
             val overallText = AtomicReference<String>("")
             val caldavText = AtomicReference<String>("")
             scenario.onActivity { activity ->
+                if (Build.VERSION.SDK_INT >= 35) {
+                    val systemBars = requireNotNull(ViewCompat.getRootWindowInsets(activity.window.decorView))
+                        .getInsets(WindowInsetsCompat.Type.systemBars())
+                    val dashboard = activity.findViewById<View>(R.id.parent)
+                    val location = IntArray(2)
+                    dashboard.getLocationOnScreen(location)
+                    assertTrue("Dashboard starts under the status bar", location[1] >= systemBars.top)
+                    assertTrue(
+                        "Dashboard ends under the navigation bar",
+                        location[1] + dashboard.height <= activity.window.decorView.height - systemBars.bottom,
+                    )
+                }
                 fun observe(viewId: Int, observed: AtomicReference<String>) {
                     val view = activity.findViewById<TextView>(viewId)
                     observed.set(view.text.toString())

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/ColorParityRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/ColorParityRuntimeTest.kt
@@ -20,6 +20,7 @@ import io.silentsuite.sync.R
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -153,6 +154,23 @@ class ColorParityRuntimeTest {
 
     private fun View.bounds() = Rect(left, top, right, bottom)
 
+    private fun View.paddingBounds() = Rect(paddingLeft, paddingTop, paddingRight, paddingBottom)
+
+    private fun assertContentInsets(activity: AboutActivity) {
+        if (Build.VERSION.SDK_INT < 35) return
+        val content = activity.findViewById<android.view.ViewGroup>(android.R.id.content)
+        val rootInsets = ViewCompat.getRootWindowInsets(activity.window.decorView)
+        assertNotNull(rootInsets)
+        val safeDrawing = rootInsets!!.getInsets(
+            WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+        )
+        assertEquals(
+            Rect(safeDrawing.left, safeDrawing.top, safeDrawing.right, safeDrawing.bottom),
+            content.paddingBounds(),
+        )
+        assertTrue("Content must retain its inflated child", content.childCount > 0)
+    }
+
     private fun expectedScrimBounds(decor: View, insets: Insets, gravity: Int): Rect =
         when (gravity) {
             Gravity.TOP -> Rect(0, 0, decor.width, insets.top)
@@ -194,6 +212,7 @@ class ColorParityRuntimeTest {
                     assertFalse(activity.window.isStatusBarContrastEnforced)
                     assertFalse(activity.window.isNavigationBarContrastEnforced)
                     assertScrimBounds(activity)
+                    assertContentInsets(activity)
                 } else {
                     val expected = ContextCompat.getColor(activity, R.color.semantic_system_bar)
                     assertEquals(expected, activity.window.statusBarColor)
@@ -212,8 +231,10 @@ class ColorParityRuntimeTest {
     @Test fun repeatedInsetDispatchIsIdempotentAndDoesNotMoveContent() {
         about { scenario ->
             var before: Rect? = null
+            var paddingBefore: Rect? = null
             scenario.onActivity { activity ->
                 before = activity.findViewById<View>(android.R.id.content).bounds()
+                paddingBefore = activity.findViewById<View>(android.R.id.content).paddingBounds()
                 ViewCompat.requestApplyInsets(activity.window.decorView)
             }
             InstrumentationRegistry.getInstrumentation().waitForIdleSync()
@@ -221,9 +242,11 @@ class ColorParityRuntimeTest {
             waitForAbout(scenario)
             scenario.onActivity { activity ->
                 assertEquals(before, activity.findViewById<View>(android.R.id.content).bounds())
+                assertEquals(paddingBefore, activity.findViewById<View>(android.R.id.content).paddingBounds())
                 if (Build.VERSION.SDK_INT >= 35) {
                     val decor = activity.window.decorView
                     assertScrimBounds(activity)
+                    assertContentInsets(activity)
                     assertEquals(8, BaseActivity.SCRIM_EDGES.sumOf { (_, suffix) ->
                         countTagged(decor, "${BaseActivity.STATUS_BAR_SCRIM_TAG}-$suffix") +
                             countTagged(decor, "${BaseActivity.NAVIGATION_BAR_SCRIM_TAG}-$suffix")

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/PostLoginSetupRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/PostLoginSetupRuntimeTest.kt
@@ -3,9 +3,12 @@ package io.silentsuite.sync.ui
 import android.accounts.Account
 import android.accounts.AccountManager
 import android.content.ContentResolver
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.test.core.app.ActivityScenario
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
@@ -59,6 +62,17 @@ class PostLoginSetupRuntimeTest {
         PostLoginSyncConfigurator.configureOverride={ _, _ -> false }
         try {
             ActivityScenario.launch<PostLoginSetupActivity>(PostLoginSetupActivity.newIntent(context,account,id)).use { scenario -> scenario.onActivity { activity ->
+                if (Build.VERSION.SDK_INT >= 35) {
+                    val systemBars = requireNotNull(ViewCompat.getRootWindowInsets(activity.window.decorView))
+                        .getInsets(WindowInsetsCompat.Type.systemBars())
+                    val actionBar = activity.findViewById<View>(R.id.setup_action_bar)
+                    val location = IntArray(2)
+                    actionBar.getLocationOnScreen(location)
+                    assertTrue(
+                        "Setup actions end under the navigation bar",
+                        location[1] + actionBar.height <= activity.window.decorView.height - systemBars.bottom,
+                    )
+                }
                 activity.findViewById<android.widget.Button>(R.id.setup_continue_limited).performClick()
                 assertEquals(PostLoginSetupState.ACCOUNT_CREATED,AccountSettings.setupState(manager,account,true))
                 assertEquals(id,manager.getUserData(account,AccountSettings.KEY_CREATION_ID))

--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/FirstRunSignInRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/setup/FirstRunSignInRuntimeTest.kt
@@ -3,12 +3,15 @@ package io.silentsuite.sync.ui.setup
 import android.accounts.AccountManager
 import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.os.Bundle
 import android.os.Build
+import android.os.Bundle
+import android.os.SystemClock
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -36,6 +39,13 @@ class FirstRunSignInRuntimeTest {
                 scenario.onActivity { activity ->
                     assertVisibleDestination(activity, "AccountChoiceFragment")
                     assertEquals("Add account", activity.title.toString())
+                }
+                waitForViewLayout(scenario, "account_choice_scroll")
+                scenario.onActivity { activity ->
+                    assertOutsideSystemBars(
+                        activity,
+                        activity.findViewById(requiredId(activity, "account_choice_scroll")),
+                    )
                     LoginActivity.browserLauncherForTest = { _, _ -> throw ActivityNotFoundException() }
                     activity.findViewById<View>(requiredId(activity, "account_choice_create_account")).performClick()
                     activity.supportFragmentManager.executePendingTransactions()
@@ -47,6 +57,9 @@ class FirstRunSignInRuntimeTest {
                     assertVisibleDestination(activity, "LoginCredentialsFragment")
                     assertEquals("Sign in", activity.title.toString())
                     assertEquals(1, activity.supportFragmentManager.backStackEntryCount)
+                }
+                assertImeKeepsPrimaryActionVisible(scenario)
+                scenario.onActivity { activity ->
                     val leaseBeforeMalformedRestore = requireNotNull(activity.setupLease())
                     val operationBeforeMalformedRestore = requireNotNull(
                         SetupSecretHolder.beginOperation(leaseBeforeMalformedRestore),
@@ -75,6 +88,74 @@ class FirstRunSignInRuntimeTest {
         } finally {
             finishScenario("choice-credentials-back-up", passed)
         }
+    }
+
+    private fun waitForViewLayout(scenario: ActivityScenario<LoginActivity>, idName: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        repeat(100) {
+            var laidOut = false
+            scenario.onActivity { activity ->
+                val view = activity.findViewById<View>(requiredId(activity, idName))
+                laidOut = ViewCompat.isLaidOut(view) && view.width > 0 && view.height > 0
+            }
+            if (laidOut) return
+            instrumentation.waitForIdleSync()
+            SystemClock.sleep(50)
+        }
+        throw AssertionError("$idName was not laid out")
+    }
+
+    private fun assertOutsideSystemBars(activity: LoginActivity, view: View) {
+        if (Build.VERSION.SDK_INT < 35) return
+        val insets = requireNotNull(ViewCompat.getRootWindowInsets(activity.window.decorView))
+            .getInsets(WindowInsetsCompat.Type.systemBars())
+        val location = IntArray(2)
+        view.getLocationOnScreen(location)
+        assertTrue(
+            "View starts under the status bar: top=${location[1]} inset=${insets.top}",
+            location[1] >= insets.top,
+        )
+        assertTrue(
+            "View ends under the navigation bar",
+            location[1] + view.height <= activity.window.decorView.height - insets.bottom,
+        )
+    }
+
+    private fun assertImeKeepsPrimaryActionVisible(scenario: ActivityScenario<LoginActivity>) {
+        if (Build.VERSION.SDK_INT < 35) return
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        scenario.onActivity { activity ->
+            val password = activity.findViewById<View>(requiredId(activity, "login_password"))
+            password.requestFocus()
+            ViewCompat.getWindowInsetsController(password)?.show(WindowInsetsCompat.Type.ime())
+            activity.getSystemService(InputMethodManager::class.java)?.showSoftInput(password, 0)
+        }
+        var verified = false
+        for (attempt in 0 until 100) {
+            instrumentation.waitForIdleSync()
+            scenario.onActivity { activity ->
+                val rootInsets = ViewCompat.getRootWindowInsets(activity.window.decorView) ?: return@onActivity
+                if (!rootInsets.isVisible(WindowInsetsCompat.Type.ime())) return@onActivity
+                val ime = rootInsets.getInsets(WindowInsetsCompat.Type.ime())
+                val primaryAction = activity.findViewById<View>(requiredId(activity, "login"))
+                val location = IntArray(2)
+                primaryAction.getLocationOnScreen(location)
+                // LoginActivity uses adjustResize. Depending on platform inset dispatch, the
+                // window can shrink above the IME or the pinned action can receive IME padding.
+                // The contract is the same in both cases: the action remains fully visible.
+                verified = location[1] + primaryAction.height <=
+                    activity.window.decorView.height - ime.bottom
+            }
+            if (verified) break
+            SystemClock.sleep(50)
+        }
+        assertTrue("IME did not leave the sign-in action fully visible", verified)
+        scenario.onActivity { activity ->
+            val password = activity.findViewById<View>(requiredId(activity, "login_password"))
+            ViewCompat.getWindowInsetsController(password)?.hide(WindowInsetsCompat.Type.ime())
+            password.clearFocus()
+        }
+        instrumentation.waitForIdleSync()
     }
 
     @Test

--- a/android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt
@@ -24,6 +24,18 @@ open class BaseActivity : AppCompatActivity() {
         applyReadableSystemBars()
     }
 
+    override fun onContentChanged() {
+        super.onContentChanged()
+        applyContentInsets()
+    }
+
+    override fun onPostCreate(savedInstanceState: Bundle?) {
+        super.onPostCreate(savedInstanceState)
+        // Fragment-only activities may never call setContentView(), so onContentChanged()
+        // is not guaranteed to run after AppCompat installs android.R.id.content.
+        applyContentInsets()
+    }
+
     override fun onResume() {
         super.onResume()
         applyReadableSystemBars()
@@ -82,18 +94,39 @@ open class BaseActivity : AppCompatActivity() {
             }
         statusBarScrims = scrims(statusBarScrims, STATUS_BAR_SCRIM_TAG)
         navigationBarScrims = scrims(navigationBarScrims, NAVIGATION_BAR_SCRIM_TAG)
-        ViewCompat.setOnApplyWindowInsetsListener(overlay) { _, insets ->
+        ViewCompat.setOnApplyWindowInsetsListener(overlay) { view, insets ->
             val status = insets.getInsets(WindowInsetsCompat.Type.statusBars())
             val navigation = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
-            statusBarScrims.forEach { (gravity, view) ->
-                view.layoutParams = scrimLayoutParams(status, gravity)
+            statusBarScrims.forEach { (gravity, scrim) ->
+                scrim.layoutParams = scrimLayoutParams(status, gravity)
             }
-            navigationBarScrims.forEach { (gravity, view) ->
-                view.layoutParams = scrimLayoutParams(navigation, gravity)
+            navigationBarScrims.forEach { (gravity, scrim) ->
+                scrim.layoutParams = scrimLayoutParams(navigation, gravity)
             }
-            insets
+            // A listener replaces DecorView's normal onApplyWindowInsets call. Invoke it so
+            // decor bookkeeping still runs and the resulting insets reach the content tree.
+            ViewCompat.onApplyWindowInsets(view, insets)
         }
         ViewCompat.requestApplyInsets(overlay)
+    }
+
+    /**
+     * API 35+ enforces edge-to-edge for this target SDK. Keep every [BaseActivity] content tree
+     * outside the system bars, then dispatch only the unclaimed inset space to descendants.
+     * Descendants can therefore add IME padding without double-claiming the navigation bar.
+     */
+    private fun applyContentInsets() {
+        if (Build.VERSION.SDK_INT < 35) return
+        val content = window.decorView.findViewById<ViewGroup>(android.R.id.content) ?: return
+        content.clipToPadding = false
+        ViewCompat.setOnApplyWindowInsetsListener(content) { view, insets ->
+            val safeDrawing = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+            )
+            view.setPadding(safeDrawing.left, safeDrawing.top, safeDrawing.right, safeDrawing.bottom)
+            ViewCompat.onApplyWindowInsets(view, insets.inset(safeDrawing))
+        }
+        ViewCompat.requestApplyInsets(content)
     }
 
     private fun scrimLayoutParams(insets: Insets, gravity: Int): FrameLayout.LayoutParams =

--- a/android/app/src/main/java/io/silentsuite/sync/ui/ViewInsets.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/ViewInsets.kt
@@ -1,0 +1,49 @@
+package io.silentsuite.sync.ui
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+/** Adds unclaimed system-bar and optional IME insets to this view's inflated padding. */
+internal fun View.applySystemBarInsetsAsPadding(
+    left: Boolean = true,
+    top: Boolean = true,
+    right: Boolean = true,
+    bottom: Boolean = true,
+    includeIme: Boolean = false,
+) {
+    val basePaddingLeft = paddingLeft
+    val basePaddingTop = paddingTop
+    val basePaddingRight = paddingRight
+    val basePaddingBottom = paddingBottom
+    val types = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout() or
+        (if (includeIme) WindowInsetsCompat.Type.ime() else 0)
+
+    ViewCompat.setOnApplyWindowInsetsListener(this) { view, insets ->
+        val applied = insets.getInsets(types)
+        view.setPadding(
+            basePaddingLeft + if (left) applied.left else 0,
+            basePaddingTop + if (top) applied.top else 0,
+            basePaddingRight + if (right) applied.right else 0,
+            basePaddingBottom + if (bottom) applied.bottom else 0,
+        )
+        insets
+    }
+    requestApplyInsetsWhenAttached()
+}
+
+/** Requests insets immediately when attached, or once after the next attachment. */
+internal fun View.requestApplyInsetsWhenAttached() {
+    if (ViewCompat.isAttachedToWindow(this)) {
+        ViewCompat.requestApplyInsets(this)
+    } else {
+        addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewAttachedToWindow(view: View) {
+                view.removeOnAttachStateChangeListener(this)
+                ViewCompat.requestApplyInsets(view)
+            }
+
+            override fun onViewDetachedFromWindow(view: View) = Unit
+        })
+    }
+}

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/AccountChoiceFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/AccountChoiceFragment.kt
@@ -15,6 +15,7 @@ import android.view.ViewGroup
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import io.silentsuite.sync.R
+import io.silentsuite.sync.ui.applySystemBarInsetsAsPadding
 
 /** Presentation-only first destination for account entry. */
 class AccountChoiceFragment : Fragment() {
@@ -56,20 +57,5 @@ class AccountChoiceFragment : Fragment() {
         super.onDestroyView()
     }
 
-    private fun applyInsets(root: View) {
-        val left = root.paddingLeft
-        val top = root.paddingTop
-        val right = root.paddingRight
-        val bottom = root.paddingBottom
-        ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
-            view.setPadding(
-                left + insets.systemWindowInsetLeft,
-                top + insets.systemWindowInsetTop,
-                right + insets.systemWindowInsetRight,
-                bottom + insets.systemWindowInsetBottom,
-            )
-            insets
-        }
-        ViewCompat.requestApplyInsets(root)
-    }
+    private fun applyInsets(root: View) = root.applySystemBarInsetsAsPadding()
 }

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/LoginCredentialsFragment.kt
@@ -24,6 +24,7 @@ import androidx.core.view.ViewCompat
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.R
 import io.silentsuite.sync.ui.WebViewActivity
+import io.silentsuite.sync.ui.applySystemBarInsetsAsPadding
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import net.cachapa.expandablelayout.ExpandableLayout
@@ -175,35 +176,8 @@ class LoginCredentialsFragment : Fragment() {
         )
     }
 
-    private fun applyLoginActionBarInsets(actionBar: View) {
-        val basePaddingLeft = actionBar.paddingLeft
-        val basePaddingTop = actionBar.paddingTop
-        val basePaddingRight = actionBar.paddingRight
-        val basePaddingBottom = actionBar.paddingBottom
-
-        ViewCompat.setOnApplyWindowInsetsListener(actionBar) { view, insets ->
-            view.setPadding(
-                    basePaddingLeft,
-                    basePaddingTop,
-                    basePaddingRight,
-                    basePaddingBottom + insets.systemWindowInsetBottom
-            )
-            insets
-        }
-
-        if (ViewCompat.isAttachedToWindow(actionBar)) {
-            ViewCompat.requestApplyInsets(actionBar)
-        } else {
-            actionBar.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
-                override fun onViewAttachedToWindow(view: View) {
-                    view.removeOnAttachStateChangeListener(this)
-                    ViewCompat.requestApplyInsets(view)
-                }
-
-                override fun onViewDetachedFromWindow(view: View) = Unit
-            })
-        }
-    }
+    private fun applyLoginActionBarInsets(actionBar: View) =
+            actionBar.applySystemBarInsetsAsPadding(top = false, includeIme = true)
 
     companion object {
         private const val KEY_ADVANCED_EXPANDED = "advancedExpanded"

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupActivity.kt
@@ -17,8 +17,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.observe
 import at.bitfire.ical4android.TaskProvider.ProviderName
 import io.silentsuite.sync.AccountSettings
@@ -30,6 +28,7 @@ import io.silentsuite.sync.syncadapter.requestSync
 import io.silentsuite.sync.ui.AccountActivity
 import io.silentsuite.sync.ui.BaseActivity
 import io.silentsuite.sync.ui.WebViewActivity
+import io.silentsuite.sync.ui.applySystemBarInsetsAsPadding
 import java.util.UUID
 
 /** Resumes a durable setup row. It deliberately accepts no credentials or session extra. */
@@ -698,35 +697,8 @@ class PostLoginSetupActivity : BaseActivity() {
             visible(actionButtons.any { it.visibility == View.VISIBLE })
     }
 
-    private fun applySetupActionBarInsets(actionBar: View) {
-        val basePaddingLeft = actionBar.paddingLeft
-        val basePaddingTop = actionBar.paddingTop
-        val basePaddingRight = actionBar.paddingRight
-        val basePaddingBottom = actionBar.paddingBottom
-
-        ViewCompat.setOnApplyWindowInsetsListener(actionBar) { view, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            view.setPadding(
-                basePaddingLeft + systemBars.left,
-                basePaddingTop,
-                basePaddingRight + systemBars.right,
-                basePaddingBottom + systemBars.bottom,
-            )
-            insets
-        }
-        if (ViewCompat.isAttachedToWindow(actionBar)) {
-            ViewCompat.requestApplyInsets(actionBar)
-        } else {
-            actionBar.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
-                override fun onViewAttachedToWindow(view: View) {
-                    view.removeOnAttachStateChangeListener(this)
-                    ViewCompat.requestApplyInsets(view)
-                }
-
-                override fun onViewDetachedFromWindow(view: View) = Unit
-            })
-        }
-    }
+    private fun applySetupActionBarInsets(actionBar: View) =
+        actionBar.applySystemBarInsetsAsPadding(top = false)
 
     private fun renderSetupStepper(presentation: PostLoginSetupPresentation) {
         val stages = listOf(

--- a/tests/test_android_first_run_setup_static.py
+++ b/tests/test_android_first_run_setup_static.py
@@ -249,8 +249,11 @@ def test_setup_has_approved_stage_surface_stable_ids_and_copy():
     constants = source(JAVA / "Constants.kt")
     assert 'appendEncodedPath("user-guide/apps/android")' in constants
     assert "applySetupActionBarInsets(findViewById(R.id.setup_action_bar))" in activity
-    assert "WindowInsetsCompat.Type.systemBars()" in activity
-    assert "basePaddingBottom + systemBars.bottom" in activity
+    view_insets = source(JAVA / "ui/ViewInsets.kt")
+    assert "WindowInsetsCompat.Type.systemBars()" in view_insets
+    assert "WindowInsetsCompat.Type.displayCutout()" in view_insets
+    assert "basePaddingBottom + if (bottom) applied.bottom else 0" in view_insets
+    assert "actionBar.applySystemBarInsetsAsPadding(top = false)" in activity
     blocked_visibility = activity.split(
         "findViewById<Button>(R.id.setup_continue_limited).visibility", 1
     )[1].split("findViewById<Button>(R.id.setup_retry_inventory)", 1)[0]

--- a/tests/test_android_web_color_parity_static.py
+++ b/tests/test_android_web_color_parity_static.py
@@ -668,6 +668,12 @@ def test_text_input_refresh_and_system_bar_mechanics_are_bounded():
     assert "Gravity.START" not in base and "Gravity.END" not in base
     for gravity, suffix in (("TOP", "top"), ("BOTTOM", "bottom"), ("LEFT", "left"), ("RIGHT", "right")):
         assert f'Gravity.{gravity} to "{suffix}"' in base
+    assert "ViewCompat.onApplyWindowInsets(view, insets)" in base
+    assert "applyContentInsets()" in base
+    assert "override fun onContentChanged()" in base
+    assert "override fun onPostCreate(savedInstanceState: Bundle?)" in base
+    assert "WindowInsetsCompat.Type.displayCutout()" in base
+    assert "insets.inset(safeDrawing)" in base
 
 
 def test_every_android_resource_xml_obeys_the_closed_color_contract():
@@ -948,6 +954,8 @@ def test_credential_free_evidence_and_runtime_routes_are_explicit():
     base_activity = source("android/app/src/main/java/io/silentsuite/sync/ui/BaseActivity.kt")
     assert "statusBarScrims: Map<Int, View>" in base_activity
     assert "navigationBarScrims: Map<Int, View>" in base_activity
+    assert "private fun assertContentInsets" in runtime
+    assert "content.paddingBounds()" in runtime
     for suffix in ("top", "bottom", "left", "right"):
         assert f'Gravity.{suffix.upper()} to "{suffix}"' in base_activity
 


### PR DESCRIPTION
Fixes #409

## Summary
- restore DecorView inset handling so insets continue into the activity content tree
- keep API 35+ BaseActivity content outside status and navigation bars while forwarding unclaimed insets
- use one idempotent padding helper for account choice, login IME, and post-login actions
- add focused runtime coverage for system bars, IME visibility, dashboard/setup geometry, and recreation

## Risk / blast radius
Risk: Tier 1 routine Android UI bug; no account, authentication, sync, or durable-state ownership changes.
Owners: BaseActivity system-bar dispatch, shared view padding, account choice, credentials, post-login setup.
Siblings: all BaseActivity routes on API 35+, API 21 behavior, day/night recreation, dashboard/header layouts.
Verification: local diff/static inspection; exact-head Android build and API runtime lanes; one immutable-head review; manual Waydroid remains.

## Local checks
- `git diff --check`
- Android builds, lint, JVM tests, and instrumentation are CI-only on this host.
