### PR TITLE
fix(web): make payment provider switching explicit and Bitcoin-safe

### DIFF
--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -220,7 +220,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     fireEvent.click(dialog.previousElementSibling!)
     expect(screen.getByRole('dialog', { name: /continue with silentsuite\.io/i })).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /cancel and choose another method/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel card payment' }))
     await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([url, init]) => (
       url === 'https://billing.test/subscription/payment-flows/cancel'
         && (init as RequestInit | undefined)?.method === 'POST'
@@ -277,14 +277,15 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     render(<SubscriptionPage />)
     fireEvent.click(await screen.findByRole('button', { name: /choose payment/i }))
     await screen.findByRole('button', { name: /retry payment status/i })
-    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel any payment in progress and close' }))
 
     await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([url, init]) => (
       url === 'https://billing.test/subscription/payment-flows/cancel'
         && (init as RequestInit | undefined)?.method === 'POST'
     ))).toBe(true))
     expect(screen.getByRole('dialog', { name: /continue with silentsuite\.io/i })).toBeInTheDocument()
-    expect(await screen.findByText('Cancellation could not be confirmed.')).toBeInTheDocument()
+    expect(await screen.findByText('Could not cancel the pending payment flow.')).toBeInTheDocument()
+    expect(screen.queryByText('Cancellation could not be confirmed.')).not.toBeInTheDocument()
   })
 
   it('shows subscribe recovery for expired no-card trials', async () => {
@@ -591,7 +592,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
       await Promise.resolve()
     })
     expect(screen.getByText(/card payment in progress/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel card payment' })).toBeInTheDocument()
     expect(screen.queryByText(/taking longer than expected/i)).not.toBeInTheDocument()
   })
 
@@ -658,7 +659,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
 
     expect(screen.getByText(/^payment in progress$/i)).toBeInTheDocument()
     expect(screen.queryByText(/card payment in progress/i)).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel card payment' })).toBeInTheDocument()
   })
 
   it('opens current-flow recovery after a failed Stripe redirect when subscription data is unavailable', async () => {
@@ -679,7 +680,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     fireEvent.click(screen.getByRole('button', { name: /review payment options/i }))
     expect(await screen.findByText(/^payment in progress$/i)).toBeInTheDocument()
     expect(screen.queryByText(/card payment in progress/i)).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel card payment' })).toBeInTheDocument()
     expect(window.location.search).toBe('')
   })
 
@@ -702,7 +703,7 @@ describe('SubscriptionPage billing recovery CTAs', () => {
     expect(screen.getByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /review payment options/i }))
     expect(await screen.findByText(/card payment in progress/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel card payment' })).toBeInTheDocument()
     expect(screen.queryByText(/Stripe could not confirm this payment/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/confirming your payment/i)).not.toBeInTheDocument()
     expect(window.location.search).toBe('')

--- a/apps/web/app/components/__tests__/payment-choice-panel-btcpay-continuation.test.tsx
+++ b/apps/web/app/components/__tests__/payment-choice-panel-btcpay-continuation.test.tsx
@@ -100,7 +100,7 @@ describe('PaymentChoicePanel BTCPay continuation link', () => {
     // The surrounding flow UI must survive: an unusable URL is not a reason to
     // destroy the only cancellation control mid-payment.
     expect(await screen.findByText(/payment already in progress/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /cancel and choose another method/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel Bitcoin payment and choose card' })).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /continue in btcpay/i })).not.toBeInTheDocument()
   })
 })

--- a/apps/web/app/components/__tests__/payment-choice-panel.test.tsx
+++ b/apps/web/app/components/__tests__/payment-choice-panel.test.tsx
@@ -173,11 +173,12 @@ describe('PaymentChoicePanel cancellation safety', () => {
     const onCancel = renderPanel()
 
     expect(await screen.findByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel any payment in progress and close' }))
 
     await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).endsWith('/payment-flows/cancel'))).toBe(true))
     expect(onCancel).not.toHaveBeenCalled()
-    expect(await screen.findByText('Cancellation could not be confirmed.')).toBeInTheDocument()
+    expect(await screen.findByText('Could not cancel the pending payment flow.')).toBeInTheDocument()
+    expect(screen.queryByText('Cancellation could not be confirmed.')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /retry payment status/i }))
     expect(await screen.findByRole('button', { name: /continue to card payment/i })).toBeInTheDocument()
@@ -200,7 +201,7 @@ describe('PaymentChoicePanel cancellation safety', () => {
     })
     const onCancel = renderPanel()
 
-    fireEvent.click(await screen.findByRole('button', { name: /cancel and choose another method/i }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel card payment' }))
     await waitFor(() => expect(resolveCancellation).toBeTypeOf('function'))
     expect(onCancel).not.toHaveBeenCalled()
 

--- a/apps/web/app/components/__tests__/payment-flow-lifecycle.test.tsx
+++ b/apps/web/app/components/__tests__/payment-flow-lifecycle.test.tsx
@@ -1,0 +1,295 @@
+import React from 'react'
+import fs from 'node:fs'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import PaymentChoicePanel from '../payment-choice-panel'
+import StripePaymentForm from '../stripe-payment-form'
+
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED = 'true'
+  process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ORIGIN = 'https://btcpay.test'
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = 'pk_test_lifecycle'
+})
+
+const stripeMocks = vi.hoisted(() => ({
+  confirmPayment: vi.fn(async () => ({ paymentIntent: { status: 'succeeded' } })),
+  confirmSetup: vi.fn(async () => ({ setupIntent: { status: 'succeeded' } })),
+}))
+
+vi.mock('next/dynamic', () => ({
+  default: () => (props: { returnPath?: string; mode?: string; submitLabel?: string }) => (
+    <div
+      data-testid="stripe-payment-form"
+      data-return-path={props.returnPath ?? ''}
+      data-mode={props.mode ?? ''}
+      data-submit-label={props.submitLabel ?? ''}
+    />
+  ),
+}))
+
+vi.mock('@silentsuite/ui', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => <svg />,
+  Crown: () => <svg />,
+  ExternalLink: () => <svg />,
+  Lock: () => <svg />,
+  Zap: () => <svg />,
+}))
+
+vi.mock('@/app/lib/config', () => ({ BILLING_API_URL: 'https://billing.example.test' }))
+
+vi.mock('next-themes', () => ({ useTheme: () => ({ resolvedTheme: 'dark' }) }))
+
+vi.mock('@/app/stores/use-auth-store', () => ({
+  useAuthStore: {
+    getState: () => ({
+      pendingSignup: null,
+      user: { email: 'person@example.test' },
+      saveSignupStateForRedirect: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('@stripe/stripe-js/pure', () => ({
+  loadStripe: async () => ({ confirmPayment: stripeMocks.confirmPayment, confirmSetup: stripeMocks.confirmSetup }),
+}))
+
+vi.mock('@stripe/react-stripe-js', () => ({
+  Elements: ({ children }: { children: React.ReactNode }) => <div data-testid="stripe-elements">{children}</div>,
+  PaymentElement: ({ onReady }: { onReady: () => void }) => {
+    React.useEffect(() => { onReady() }, [onReady])
+    return <div data-testid="payment-element" />
+  },
+  useStripe: () => ({ confirmPayment: stripeMocks.confirmPayment, confirmSetup: stripeMocks.confirmSetup }),
+  useElements: () => ({}),
+}))
+
+const COMPONENT_DIR = path.resolve(__dirname, '..')
+const stripeFormSource = fs.readFileSync(path.join(COMPONENT_DIR, 'stripe-payment-form.tsx'), 'utf8')
+const choicePanelSource = fs.readFileSync(path.join(COMPONENT_DIR, 'payment-choice-panel.tsx'), 'utf8')
+const bitcoinPanelSource = fs.readFileSync(path.join(COMPONENT_DIR, 'bitcoin-payment-panel.tsx'), 'utf8')
+
+const annualOffer = {
+  contractVersion: 2,
+  requestId: 'e91a6d70-0d4e-4352-9bdc-426d1f76d771',
+  offer: {
+    planId: 'early_annual', customerClass: 'early', billingInterval: 'annual', annualAmountMinor: 3600,
+    monthlyEquivalentMinor: 300, currency: 'EUR', providers: ['stripe', 'btcpay'], offerRevision: 1,
+    offerToken: 'signed-offer', expiresAt: '2026-08-10T12:10:00Z',
+  },
+}
+
+const activation = {
+  contractVersion: 2,
+  checkoutIntentToken: 'A'.repeat(43),
+  expiresAt: '2026-08-10T12:05:00Z',
+  disclosure: {
+    kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,
+    monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null, cancelBy: null,
+    cancelByInclusive: false, autoRenew: true, prepaid: false, refundWindowDays: 30, bonusDays: 14,
+    periodEndRule: 'confirmation_bonus_then_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null,
+  },
+}
+
+function response(body: unknown, ok = true, status = ok ? 200 : 500) {
+  return { ok, status, json: async () => body } as Response
+}
+
+function mockBilling(cancel?: () => Promise<Response>, paymentFlow?: () => Promise<Response>) {
+  vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.endsWith('/subscription/payment-flows/current')) return response({ flow: null })
+    if (url.endsWith('/subscription/offers/v2')) return response(annualOffer)
+    if (url.endsWith('/subscription/offers/v2/activate')) return response(activation)
+    if (url.endsWith('/subscription/payment-flows/v2')) {
+      return paymentFlow?.() ?? response({ contractVersion: 2, kind: 'stripe', authorityId: annualOffer.requestId, clientSecret: 'pi_secret_value' })
+    }
+    if (url.endsWith('/subscription/payment-flows/cancel')) return cancel?.() ?? response({ cancelled: true, flowKind: 'stripe_pay_now' })
+    if (url.includes('/subscription/crypto/invoice/')) {
+      if (url.endsWith('/payment-methods')) {
+        return response({ paymentMethods: [{ id: 'BTC', label: 'Bitcoin', qrValue: 'bitcoin:bc1qexample', address: 'bc1qexample', amountDue: '0.0004', cryptoCode: 'BTC' }] })
+      }
+      return response({ status: 'pending' })
+    }
+    return response({}, false)
+  })
+}
+
+async function openCardAuthority() {
+  const view = render(<PaymentChoicePanel onSuccess={vi.fn()} onCancel={vi.fn()} />)
+  fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
+  fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
+  await screen.findByTestId('stripe-payment-form')
+  return view
+}
+
+function cancellationCalls() {
+  return vi.mocked(fetch).mock.calls.filter(([input]) => String(input).endsWith('/payment-flows/cancel'))
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+  stripeMocks.confirmPayment.mockClear()
+  stripeMocks.confirmSetup.mockClear()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('payment lifecycle never cancels an authority implicitly', () => {
+  it('makes no cancellation request when the card authority is unmounted', async () => {
+    mockBilling()
+    const view = await openCardAuthority()
+
+    view.unmount()
+
+    expect(cancellationCalls()).toHaveLength(0)
+  })
+
+  it.each(['pagehide', 'beforeunload', 'unload', 'visibilitychange'] as const)(
+    'makes no cancellation request on %s while a card authority is displayed',
+    async (eventName) => {
+      mockBilling()
+      await openCardAuthority()
+
+      await act(async () => {
+        window.dispatchEvent(new Event(eventName))
+        document.dispatchEvent(new Event(eventName))
+      })
+
+      expect(cancellationCalls()).toHaveLength(0)
+      expect(screen.getByTestId('stripe-payment-form')).toBeInTheDocument()
+    },
+  )
+
+  it('makes no cancellation request when a Bitcoin authority is unmounted or the page is hidden', async () => {
+    mockBilling(undefined, async () => response({
+      contractVersion: 2, kind: 'btcpay', authorityId: annualOffer.requestId,
+      checkoutUrl: 'https://btcpay.test/i/abc123', invoiceId: 'invoice-1', invoiceLookupToken: 'B'.repeat(43),
+    }))
+    const view = render(<PaymentChoicePanel onSuccess={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.click(await screen.findByRole('button', { name: /pay .* with bitcoin for/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
+    await screen.findByRole('heading', { name: /pay .* annual with bitcoin/i })
+
+    await act(async () => { window.dispatchEvent(new Event('pagehide')) })
+    view.unmount()
+
+    expect(cancellationCalls()).toHaveLength(0)
+  })
+
+  it('keeps the card authority mounted when an explicit cancellation fails', async () => {
+    mockBilling(async () => response({ type: 'https://api.silentsuite.io/errors/provider-cancellation-failed' }, false, 502))
+    await openCardAuthority()
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Cancel card payment and choose Bitcoin' })[0]!)
+
+    await waitFor(() => expect(cancellationCalls()).toHaveLength(1))
+    expect(screen.getByTestId('stripe-payment-form')).toBeInTheDocument()
+  })
+
+  it('clears the card authority only after an authoritative cancellation succeeds', async () => {
+    mockBilling()
+    await openCardAuthority()
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Cancel card payment and choose Bitcoin' })[0]!)
+
+    await waitFor(() => expect(screen.queryByTestId('stripe-payment-form')).not.toBeInTheDocument())
+    expect(cancellationCalls()).toHaveLength(1)
+  })
+
+  it('hands the Stripe form the same-origin settings return path and payment mode', async () => {
+    mockBilling()
+    await openCardAuthority()
+
+    const form = screen.getByTestId('stripe-payment-form')
+    expect(form).toHaveAttribute('data-return-path', '/settings/subscription')
+    expect(form).toHaveAttribute('data-mode', 'payment')
+    expect(form).toHaveAttribute('data-submit-label', 'Pay €36.00')
+  })
+})
+
+describe('StripePaymentForm SCA and redirect behaviour', () => {
+  it('confirms payments with a bounded same-origin return URL and redirect: if_required', async () => {
+    render(<StripePaymentForm clientSecret="pi_secret_value" onSuccess={vi.fn()} mode="payment" returnPath="/settings/subscription" submitLabel="Pay €36.00" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Pay €36.00' }))
+
+    await waitFor(() => expect(stripeMocks.confirmPayment).toHaveBeenCalledTimes(1))
+    const [call] = stripeMocks.confirmPayment.mock.calls as unknown as [[{ confirmParams: { return_url: string }; redirect: string }]]
+    expect(call[0].redirect).toBe('if_required')
+    expect(call[0].confirmParams.return_url).toBe(`${window.location.origin}/settings/subscription`)
+    expect(stripeMocks.confirmSetup).not.toHaveBeenCalled()
+  })
+
+  it('registers no page-lifecycle listeners and cancels nothing when unmounted mid-confirmation', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+    const windowSpy = vi.spyOn(window, 'addEventListener')
+    const documentSpy = vi.spyOn(document, 'addEventListener')
+
+    const view = render(<StripePaymentForm clientSecret="pi_secret_value" onSuccess={vi.fn()} mode="payment" returnPath="/settings/subscription" />)
+    await screen.findByTestId('payment-element')
+    view.unmount()
+
+    const listened = [...windowSpy.mock.calls, ...documentSpy.mock.calls].map(([type]) => type)
+    expect(listened).not.toContain('pagehide')
+    expect(listened).not.toContain('beforeunload')
+    expect(listened).not.toContain('unload')
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled()
+
+    windowSpy.mockRestore()
+    documentSpy.mockRestore()
+  })
+})
+
+describe('payment surface source guards', () => {
+  it.each([
+    ['stripe-payment-form.tsx', stripeFormSource],
+    ['payment-choice-panel.tsx', choicePanelSource],
+    ['bitcoin-payment-panel.tsx', bitcoinPanelSource],
+  ] as const)('%s registers no page-lifecycle unload hooks', (_name, source) => {
+    for (const hook of ['pagehide', 'beforeunload', "'unload'", 'visibilitychange']) {
+      expect(source).not.toContain(hook)
+    }
+  })
+
+  it('keeps the Stripe form free of any payment-flow cancellation call', () => {
+    expect(stripeFormSource).not.toContain('payment-flows/cancel')
+    expect(stripeFormSource).not.toContain('cancelPaymentFlow')
+  })
+
+  it('keeps both Stripe confirmations on redirect: if_required', () => {
+    expect(stripeFormSource).toContain("stripe.confirmSetup({ elements, confirmParams, redirect: 'if_required' })")
+    expect(stripeFormSource).toContain("stripe.confirmPayment({ elements, confirmParams, redirect: 'if_required' })")
+  })
+
+  it('keeps the PaymentElement readiness timeout bounded and cleaned up', () => {
+    expect(stripeFormSource).toContain('window.setTimeout(')
+    expect(stripeFormSource).toContain('}, 15_000)')
+    expect(stripeFormSource).toContain('return () => window.clearTimeout(timer)')
+  })
+
+  it('builds the return URL through the shared same-origin helper', () => {
+    expect(stripeFormSource).toContain('paymentReturnUrl(window.location.origin, returnPath, currentReturnTo)')
+    expect(choicePanelSource).toContain('returnPath="/settings/subscription"')
+  })
+
+  it('clears the card client secret only on renewal or successful cancellation paths', () => {
+    const clears = choicePanelSource.split('\n').filter((line) => line.includes('setClientSecret(null)'))
+    expect(clears).toHaveLength(2)
+  })
+
+  it('never clears an error message after an authoritative current-flow lookup', () => {
+    expect(choicePanelSource).not.toMatch(/await loadCurrentFlow\([^)]*\)\s*\n\s*setError\(null\)/)
+  })
+
+  it('re-proves the current flow through the shared authoritative lookup only', () => {
+    const lookups = choicePanelSource.split('\n').filter((line) => line.includes('payment-flows/current'))
+    expect(lookups).toHaveLength(1)
+  })
+})

--- a/apps/web/app/components/__tests__/payment-provider-switching.test.tsx
+++ b/apps/web/app/components/__tests__/payment-provider-switching.test.tsx
@@ -1,0 +1,686 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import PaymentChoicePanel from '../payment-choice-panel'
+import { BITCOIN_CANCELLATION_WARNING, PAYMENT_FLOW_CANCELLATION_MESSAGES } from '@/app/lib/payment-flow-cancellation'
+
+vi.hoisted(() => {
+  process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED = 'true'
+  process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ORIGIN = 'https://btcpay.test'
+})
+
+vi.mock('next/dynamic', () => ({
+  default: () => () => <div data-testid="stripe-payment-form" />,
+}))
+
+vi.mock('@silentsuite/ui', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => <svg />,
+  Crown: () => <svg />,
+  ExternalLink: () => <svg />,
+  Lock: () => <svg />,
+  Zap: () => <svg />,
+}))
+
+vi.mock('@/app/lib/config', () => ({
+  BILLING_API_URL: 'https://billing.example.test',
+}))
+
+const earlyOffer = {
+  contractVersion: 2,
+  requestId: 'e91a6d70-0d4e-4352-9bdc-426d1f76d771',
+  offer: {
+    planId: 'early_annual',
+    customerClass: 'early',
+    billingInterval: 'annual',
+    annualAmountMinor: 3600,
+    monthlyEquivalentMinor: 300,
+    currency: 'EUR',
+    providers: ['stripe', 'btcpay'],
+    offerRevision: 1,
+    offerToken: 'signed-offer',
+    expiresAt: '2026-08-10T12:10:00Z',
+  },
+}
+
+const stripeOnlyOffer = {
+  ...earlyOffer,
+  offer: {
+    ...earlyOffer.offer,
+    planId: 'standard_annual',
+    customerClass: 'standard',
+    annualAmountMinor: 4800,
+    monthlyEquivalentMinor: 400,
+    providers: ['stripe'],
+  },
+}
+
+const activation = {
+  contractVersion: 2,
+  checkoutIntentToken: 'A'.repeat(43),
+  expiresAt: '2026-08-10T12:05:00Z',
+  disclosure: {
+    kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,
+    monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null, cancelBy: null,
+    cancelByInclusive: false, autoRenew: true, prepaid: false, refundWindowDays: 30, bonusDays: 14,
+    periodEndRule: 'confirmation_bonus_then_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null,
+  },
+}
+
+function flow(overrides: Record<string, unknown> = {}) {
+  return {
+    flowKind: 'stripe_pay_now',
+    provider: 'stripe',
+    status: 'processing',
+    planId: 'early_annual',
+    amount: '36.00',
+    currency: 'EUR',
+    createdAt: '2026-08-10T12:00:00Z',
+    cancellable: true,
+    ...overrides,
+  }
+}
+
+const bitcoinFlow = flow({
+  flowKind: 'btcpay_annual',
+  provider: 'btcpay',
+  status: 'provider_pending',
+  invoiceId: 'invoice-1',
+  checkoutUrl: 'https://btcpay.test/i/abc123',
+})
+
+function response(body: unknown, ok = true, status = ok ? 200 : 500) {
+  return { ok, status, json: async () => body } as Response
+}
+
+type Routes = {
+  currentFlow?: () => Promise<Response>
+  offer?: () => Promise<Response>
+  cancel?: () => Promise<Response>
+  paymentFlow?: () => Promise<Response>
+}
+
+function mockBilling(routes: Routes) {
+  vi.mocked(fetch).mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.endsWith('/subscription/payment-flows/current')) return routes.currentFlow?.() ?? response({ flow: null })
+    if (url.endsWith('/subscription/offers/v2')) return routes.offer?.() ?? response(earlyOffer)
+    if (url.endsWith('/subscription/offers/v2/activate')) return response(activation)
+    if (url.endsWith('/subscription/payment-flows/v2')) return routes.paymentFlow?.() ?? response({}, false)
+    if (url.endsWith('/subscription/payment-flows/cancel')) return routes.cancel?.() ?? response({ cancelled: true, flowKind: 'stripe_pay_now' })
+    if (url.includes('/subscription/crypto/invoice/')) {
+      if (url.endsWith('/payment-methods')) {
+        return response({ paymentMethods: [{ id: 'BTC', label: 'Bitcoin', qrValue: 'bitcoin:bc1qexample', address: 'bc1qexample', amountDue: '0.0004', cryptoCode: 'BTC' }] })
+      }
+      return response({ status: 'pending' })
+    }
+    return response({}, false)
+  })
+}
+
+function renderPanel() {
+  const onCancel = vi.fn()
+  render(<PaymentChoicePanel onSuccess={vi.fn()} onCancel={onCancel} />)
+  return onCancel
+}
+
+async function openInlineStripePanel() {
+  mockBilling({
+    paymentFlow: async () => response({ contractVersion: 2, kind: 'stripe', authorityId: earlyOffer.requestId, clientSecret: 'pi_secret_value' }),
+  })
+  renderPanel()
+  fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
+  fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
+  await screen.findByTestId('stripe-payment-form')
+}
+
+async function openInlineBitcoinPanel() {
+  mockBilling({
+    paymentFlow: async () => response({
+      contractVersion: 2,
+      kind: 'btcpay',
+      authorityId: earlyOffer.requestId,
+      checkoutUrl: 'https://btcpay.test/i/abc123',
+      invoiceId: 'invoice-1',
+      invoiceLookupToken: 'B'.repeat(43),
+    }),
+  })
+  renderPanel()
+  fireEvent.click(await screen.findByRole('button', { name: /pay .* with bitcoin for/i }))
+  fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
+  await screen.findByRole('heading', { name: /pay .* annual with bitcoin/i })
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('explicit provider-switch consequence labels', () => {
+  it('labels the resumed card flow with the Bitcoin switch it actually performs', async () => {
+    mockBilling({ currentFlow: async () => response({ flow: flow() }) })
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: 'Cancel card payment and choose Bitcoin' })).toBeEnabled()
+    expect(screen.queryByRole('button', { name: /cancel and choose another method/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByText(BITCOIN_CANCELLATION_WARNING)).not.toBeInTheDocument()
+  })
+
+  it('labels the resumed Bitcoin flow with the card switch and preserves the validated BTCPay continuation link', async () => {
+    mockBilling({ currentFlow: async () => response({ flow: bitcoinFlow }) })
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: 'Cancel Bitcoin payment and choose card' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /continue in btcpay/i })).toHaveAttribute('href', 'https://btcpay.test/i/abc123')
+  })
+
+  it('does not promise a provider the current server offer does not expose', async () => {
+    mockBilling({ currentFlow: async () => response({ flow: flow() }), offer: async () => response(stripeOnlyOffer) })
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: 'Cancel card payment' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /choose bitcoin/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps a truthful Bitcoin cancellation consequence when no offer authority is available', async () => {
+    mockBilling({ currentFlow: async () => response({ flow: bitcoinFlow }), offer: async () => response({}, false) })
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: 'Cancel Bitcoin payment' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /choose card/i })).not.toBeInTheDocument()
+  })
+
+  it('replaces every generic Back control on the inline card panel with the switch consequence', async () => {
+    await openInlineStripePanel()
+
+    const switches = screen.getAllByRole('button', { name: 'Cancel card payment and choose Bitcoin' })
+    expect(switches).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: /back to (payment )?options/i })).not.toBeInTheDocument()
+  })
+
+  it('replaces the generic Back control on the inline Bitcoin panel with the switch consequence', async () => {
+    await openInlineBitcoinPanel()
+
+    expect(screen.getAllByRole('button', { name: 'Cancel Bitcoin payment and choose card' })).toHaveLength(2)
+    expect(screen.queryByRole('button', { name: /back to payment options/i })).not.toBeInTheDocument()
+  })
+
+  it('keeps the pre-authority terms screen on a plain non-cancelling Back control', async () => {
+    mockBilling({})
+    renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
+
+    fireEvent.click(await screen.findByRole('button', { name: /back to payment options/i }))
+
+    expect(await screen.findByRole('button', { name: /continue to card payment/i })).toBeInTheDocument()
+    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).endsWith('/payment-flows/cancel'))).toBe(false)
+  })
+})
+
+describe('Bitcoin cancellation acknowledgement', () => {
+  it('gates the resumed Bitcoin switch behind an unchecked acknowledgement and the exact neutral warning', async () => {
+    mockBilling({ currentFlow: async () => response({ flow: bitcoinFlow }) })
+    renderPanel()
+
+    const action = await screen.findByRole('button', { name: 'Cancel Bitcoin payment and choose card' })
+    const acknowledgement = screen.getByRole('checkbox', { name: /have not sent bitcoin/i })
+    expect(acknowledgement).not.toBeChecked()
+    expect(action).toBeDisabled()
+    expect(screen.getByText(BITCOIN_CANCELLATION_WARNING)).toBeInTheDocument()
+
+    fireEvent.click(acknowledgement)
+
+    expect(acknowledgement).toBeChecked()
+    expect(action).toBeEnabled()
+  })
+
+  it('gates the inline Bitcoin panel switch behind the same acknowledgement', async () => {
+    await openInlineBitcoinPanel()
+
+    const actions = screen.getAllByRole('button', { name: 'Cancel Bitcoin payment and choose card' })
+    actions.forEach((action) => expect(action).toBeDisabled())
+    expect(screen.getByText(BITCOIN_CANCELLATION_WARNING)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /have not sent bitcoin/i }))
+
+    screen.getAllByRole('button', { name: 'Cancel Bitcoin payment and choose card' }).forEach((action) => expect(action).toBeEnabled())
+  })
+
+  it('renders exactly one acknowledgement control adjacent to the Bitcoin action', async () => {
+    await openInlineBitcoinPanel()
+
+    expect(screen.getAllByRole('checkbox', { name: /have not sent bitcoin/i })).toHaveLength(1)
+    expect(screen.getAllByText(BITCOIN_CANCELLATION_WARNING)).toHaveLength(1)
+  })
+
+  it('never auto-checks the acknowledgement and resets it when the provider flow changes', async () => {
+    let currentFlowReads = 0
+    mockBilling({
+      currentFlow: async () => {
+        currentFlowReads += 1
+        return response({ flow: currentFlowReads === 1 ? bitcoinFlow : flow() })
+      },
+      cancel: async () => response({}, false, 502),
+    })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: /have not sent bitcoin/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Bitcoin payment and choose card' }))
+
+    // A refused cancellation leaves the Bitcoin authority in place and must
+    // force a fresh, deliberate acknowledgement before the next attempt.
+    await waitFor(() => expect(screen.getByRole('checkbox', { name: /have not sent bitcoin/i })).not.toBeChecked())
+    expect(screen.getByRole('button', { name: 'Cancel Bitcoin payment and choose card' })).toBeDisabled()
+  })
+
+  it('sends the literal acknowledgement only after the user checks it', async () => {
+    let currentFlowReads = 0
+    mockBilling({
+      currentFlow: async () => {
+        currentFlowReads += 1
+        return response({ flow: currentFlowReads === 1 ? bitcoinFlow : null })
+      },
+      cancel: async () => response({ cancelled: true, flowKind: 'btcpay_annual' }),
+    })
+    renderPanel()
+
+    const action = await screen.findByRole('button', { name: 'Cancel Bitcoin payment and choose card' })
+    fireEvent.click(action)
+    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).endsWith('/payment-flows/cancel'))).toBe(false)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /have not sent bitcoin/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Bitcoin payment and choose card' }))
+
+    await waitFor(() => {
+      const call = vi.mocked(fetch).mock.calls.find(([input]) => String(input).endsWith('/payment-flows/cancel'))
+      expect(call).toBeDefined()
+      expect((call?.[1] as RequestInit).body).toBe('{"confirmNoBitcoinSent":true}')
+    })
+  })
+
+  it('sends no Bitcoin assertion when cancelling a card flow', async () => {
+    let currentFlowReads = 0
+    mockBilling({
+      currentFlow: async () => {
+        currentFlowReads += 1
+        return response({ flow: currentFlowReads === 1 ? flow() : null })
+      },
+    })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel card payment and choose Bitcoin' }))
+
+    await waitFor(() => {
+      const call = vi.mocked(fetch).mock.calls.find(([input]) => String(input).endsWith('/payment-flows/cancel'))
+      expect(call).toBeDefined()
+      expect((call?.[1] as RequestInit).body).toBe('{}')
+    })
+  })
+
+  it('reveals the acknowledgement when an unverified cancellation proves a Bitcoin authority exists', async () => {
+    mockBilling({
+      currentFlow: async () => response({}, false),
+      cancel: async () => response(
+        { type: 'https://api.silentsuite.io/errors/bitcoin-cancellation-acknowledgement-required', detail: 'invoice inv_secret_1 still open' },
+        false,
+        400,
+      ),
+    })
+    renderPanel()
+
+    await screen.findByRole('button', { name: /retry payment status/i })
+    const cancelAction = screen.getByRole('button', { name: /cancel any payment in progress and close/i })
+    fireEvent.click(cancelAction)
+
+    const acknowledgement = await screen.findByRole('checkbox', { name: /have not sent bitcoin/i })
+    expect(acknowledgement).not.toBeChecked()
+    expect(screen.getByText(BITCOIN_CANCELLATION_WARNING)).toBeInTheDocument()
+    expect(screen.queryByText(/inv_secret_1/)).not.toBeInTheDocument()
+    expect(within(document.body).queryByText(/still open/)).not.toBeInTheDocument()
+  })
+})
+
+const CREATE_CARD = /continue to card payment/i
+const CREATE_BITCOIN = /pay .* with bitcoin for/i
+
+function creationActions() {
+  return [
+    ...screen.queryAllByRole('button', { name: CREATE_CARD }),
+    ...screen.queryAllByRole('button', { name: CREATE_BITCOIN }),
+  ]
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+describe('provider switching never creates a second authority', () => {
+  it('exposes Bitcoin creation only after the card cancellation is proven by a null current flow', async () => {
+    const secondLookup = deferred<Response>()
+    let currentFlowReads = 0
+    mockBilling({
+      currentFlow: async () => {
+        currentFlowReads += 1
+        return currentFlowReads === 1 ? response({ flow: flow() }) : secondLookup.promise
+      },
+      cancel: async () => response({ cancelled: true, flowKind: 'stripe_pay_now' }),
+    })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel card payment and choose Bitcoin' }))
+
+    await waitFor(() => expect(currentFlowReads).toBe(2))
+    expect(creationActions()).toHaveLength(0)
+    expect(screen.getByRole('button', { name: /checking current payment/i })).toBeInTheDocument()
+
+    await act(async () => { secondLookup.resolve(response({ flow: null })) })
+
+    expect(await screen.findByRole('button', { name: CREATE_BITCOIN })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: CREATE_CARD })).toBeInTheDocument()
+  })
+
+  it('exposes card creation only after an acknowledged Bitcoin cancellation is proven by a null current flow', async () => {
+    const secondLookup = deferred<Response>()
+    let currentFlowReads = 0
+    mockBilling({
+      currentFlow: async () => {
+        currentFlowReads += 1
+        return currentFlowReads === 1 ? response({ flow: bitcoinFlow }) : secondLookup.promise
+      },
+      cancel: async () => response({ cancelled: true, flowKind: 'btcpay_annual' }),
+    })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: /have not sent bitcoin/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Bitcoin payment and choose card' }))
+
+    await waitFor(() => expect(currentFlowReads).toBe(2))
+    const cancelCall = vi.mocked(fetch).mock.calls.find(([input]) => String(input).endsWith('/payment-flows/cancel'))
+    expect((cancelCall?.[1] as RequestInit).body).toBe('{"confirmNoBitcoinSent":true}')
+    expect(creationActions()).toHaveLength(0)
+
+    await act(async () => { secondLookup.resolve(response({ flow: null })) })
+
+    expect(await screen.findByRole('button', { name: CREATE_CARD })).toBeInTheDocument()
+    // The acknowledgement never survives the authority it was given for.
+    expect(screen.queryByRole('checkbox', { name: /have not sent bitcoin/i })).not.toBeInTheDocument()
+  })
+
+  it('offers no provider creation path while a successful cancellation cannot be re-verified', async () => {
+    let currentFlowReads = 0
+    mockBilling({
+      currentFlow: async () => {
+        currentFlowReads += 1
+        return currentFlowReads === 1 ? response({ flow: flow() }) : response({}, false)
+      },
+      cancel: async () => response({ cancelled: true, flowKind: 'stripe_pay_now' }),
+    })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel card payment and choose Bitcoin' }))
+
+    expect(await screen.findByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    expect(creationActions()).toHaveLength(0)
+  })
+
+  it.each([
+    ['a provider refusal', 502, 'https://api.silentsuite.io/errors/provider-cancellation-failed', 'provider-cancellation-failed'],
+    ['local authority ambiguity', 409, 'https://api.silentsuite.io/errors/payment_reconciliation_required', 'payment-reconciliation-required'],
+    ['a malformed cancellation request', 400, 'https://api.silentsuite.io/errors/invalid-cancellation-request', 'invalid-cancellation-request'],
+  ] as const)('keeps the current Bitcoin authority displayed after %s', async (_label, status, type, failure) => {
+    mockBilling({
+      currentFlow: async () => response({ flow: bitcoinFlow }),
+      cancel: async () => response({ type, detail: 'invoice inv_secret_1 for cus_9999 at https://btcpay.test/i/secret' }, false, status),
+    })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: /have not sent bitcoin/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel Bitcoin payment and choose card' }))
+
+    expect(await screen.findByText(PAYMENT_FLOW_CANCELLATION_MESSAGES[failure])).toBeInTheDocument()
+    expect(screen.getByText(/payment already in progress/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel Bitcoin payment and choose card' })).toBeInTheDocument()
+    expect(creationActions()).toHaveLength(0)
+    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).endsWith('/offers/v2/activate'))).toBe(false)
+    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).endsWith('/payment-flows/v2'))).toBe(false)
+    for (const secret of ['inv_secret_1', 'cus_9999', '/i/secret']) {
+      expect(document.body.textContent).not.toContain(secret)
+    }
+  })
+
+  it.each([
+    ['a malformed success body', () => response({ cancelled: 'yes', detail: 'pi_3Qsecret' })],
+    ['a lost response', () => { throw new Error('pi_3Qsecret network detail') }],
+  ] as const)('keeps the current card authority displayed after %s', async (_label, cancel) => {
+    mockBilling({ currentFlow: async () => response({ flow: flow() }), cancel: async () => cancel() })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel card payment and choose Bitcoin' }))
+
+    expect(await screen.findByText(PAYMENT_FLOW_CANCELLATION_MESSAGES.unavailable)).toBeInTheDocument()
+    expect(screen.getByText(/payment already in progress/i)).toBeInTheDocument()
+    expect(creationActions()).toHaveLength(0)
+    expect(document.body.textContent).not.toContain('pi_3Qsecret')
+  })
+
+  it('offers no provider creation path while the current-flow lookup is still pending', async () => {
+    const lookup = deferred<Response>()
+    mockBilling({ currentFlow: () => lookup.promise })
+    renderPanel()
+
+    await screen.findAllByRole('button', { name: /checking current payment/i })
+    expect(creationActions()).toHaveLength(0)
+
+    await act(async () => { lookup.resolve(response({ flow: null })) })
+    expect(await screen.findByRole('button', { name: CREATE_CARD })).toBeInTheDocument()
+  })
+
+  it('offers no provider creation path when the current-flow lookup fails', async () => {
+    mockBilling({ currentFlow: async () => response({}, false) })
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: /retry payment status/i })).toBeInTheDocument()
+    expect(creationActions()).toHaveLength(0)
+  })
+
+  it('preserves the annual-only offer copy and signed-offer confirmation across a provider switch', async () => {
+    let currentFlowReads = 0
+    mockBilling({
+      currentFlow: async () => {
+        currentFlowReads += 1
+        return response({ flow: currentFlowReads === 1 ? flow() : null })
+      },
+      cancel: async () => response({ cancelled: true, flowKind: 'stripe_pay_now' }),
+    })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel card payment and choose Bitcoin' }))
+
+    expect(await screen.findByText(/pay now \+ 14 bonus days/i)).toBeInTheDocument()
+    expect(screen.getByText(/€36\.00\/year/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: CREATE_BITCOIN }))
+
+    expect(await screen.findByRole('heading', { name: /confirm annual terms/i })).toBeInTheDocument()
+    expect(screen.getByText(/14 bonus days after confirmed payment/i)).toBeInTheDocument()
+    expect(screen.getByText(/30-day refund window/i)).toBeInTheDocument()
+  })
+})
+
+describe('post-cancellation provider creation stays closed until the lookup proves it', () => {
+  function switchRoutes(current: () => Promise<Response>, offer: () => Promise<Response>) {
+    mockBilling({
+      currentFlow: current,
+      offer,
+      cancel: async () => response({ cancelled: true, flowKind: 'stripe_pay_now' }),
+    })
+  }
+
+  it('holds creation closed when the post-cancel offer refresh resolves before the current-flow lookup', async () => {
+    const offerRefresh = deferred<Response>()
+    const secondLookup = deferred<Response>()
+    let currentFlowReads = 0
+    let offerReads = 0
+    switchRoutes(
+      async () => {
+        currentFlowReads += 1
+        return currentFlowReads === 1 ? response({ flow: flow() }) : secondLookup.promise
+      },
+      async () => {
+        offerReads += 1
+        return offerReads === 1 ? response(earlyOffer) : offerRefresh.promise
+      },
+    )
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel card payment and choose Bitcoin' }))
+    await waitFor(() => expect(offerReads).toBe(2))
+
+    // The mandatory re-proof is in flight before the offer refresh can return,
+    // so there is no window in which a resolved offer meets a stale "loaded"
+    // current-flow state.
+    expect(currentFlowReads).toBe(2)
+    expect(screen.getByRole('button', { name: /checking current payment/i })).toBeInTheDocument()
+    expect(creationActions()).toHaveLength(0)
+
+    await act(async () => { offerRefresh.resolve(response(earlyOffer)) })
+
+    // The offer is now authoritative again while the current-flow lookup has
+    // still not resolved: creation must remain unavailable.
+    expect(creationActions()).toHaveLength(0)
+    expect(screen.getByRole('button', { name: /checking current payment/i })).toBeInTheDocument()
+
+    await act(async () => { secondLookup.resolve(response({ flow: null })) })
+
+    expect(await screen.findByRole('button', { name: CREATE_BITCOIN })).toBeEnabled()
+    expect(screen.getByRole('button', { name: CREATE_CARD })).toBeEnabled()
+  })
+
+  it('keeps creation closed when the re-proof returns an authority the cancellation did not release', async () => {
+    const offerRefresh = deferred<Response>()
+    const secondLookup = deferred<Response>()
+    let currentFlowReads = 0
+    let offerReads = 0
+    switchRoutes(
+      async () => {
+        currentFlowReads += 1
+        return currentFlowReads === 1 ? response({ flow: flow() }) : secondLookup.promise
+      },
+      async () => {
+        offerReads += 1
+        return offerReads === 1 ? response(earlyOffer) : offerRefresh.promise
+      },
+    )
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel card payment and choose Bitcoin' }))
+    await waitFor(() => expect(offerReads).toBe(2))
+
+    await act(async () => { offerRefresh.resolve(response(earlyOffer)) })
+    await act(async () => { secondLookup.resolve(response({ flow: bitcoinFlow })) })
+
+    expect(await screen.findByText(/payment already in progress/i)).toBeInTheDocument()
+    expect(creationActions()).toHaveLength(0)
+  })
+})
+
+describe('a 2xx current-flow lookup releases creation only when the body proves no flow', () => {
+  const MALFORMED_BODIES: ReadonlyArray<readonly [string, unknown]> = [
+    ['an empty object', {}],
+    ['an explicitly undefined flow', { flow: undefined }],
+    ['an inherited rather than own flow', Object.create({ flow: null }) as unknown],
+    ['a null body', null],
+    ['an array body', []],
+    ['a string body', 'no flow'],
+    ['a numeric body', 0],
+    ['a boolean body', true],
+    ['a non-object flow', { flow: 'stripe_pay_now' }],
+    ['an array flow', { flow: [flow()] }],
+    ['an unknown flow kind', { flow: flow({ flowKind: 'paypal_annual' }) }],
+    ['a missing flow kind', { flow: flow({ flowKind: undefined }) }],
+    ['a non-boolean cancellable', { flow: flow({ cancellable: 'yes' }) }],
+    ['a missing cancellable', { flow: flow({ cancellable: undefined }) }],
+    ['an empty creation timestamp', { flow: flow({ createdAt: '' }) }],
+    ['a non-string creation timestamp', { flow: flow({ createdAt: 1755000000 }) }],
+  ]
+
+  it.each(MALFORMED_BODIES)('fails closed with a retry on %s', async (_label, body) => {
+    mockBilling({ currentFlow: async () => response(body) })
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: /retry payment status/i })).toBeEnabled()
+    expect(screen.getByText(/could not verify whether a payment is already in progress/i)).toBeInTheDocument()
+    expect(creationActions()).toHaveLength(0)
+    expect(screen.queryByText(/payment already in progress/i)).not.toBeInTheDocument()
+  })
+
+  it('renders no backend detail, identifier or checkout URL from a malformed reply', async () => {
+    mockBilling({
+      currentFlow: async () => response({
+        detail: 'pi_3Qsecret belongs to cus_9999',
+        flow: {
+          flowKind: 'paypal_annual',
+          invoiceId: 'inv_secret_1',
+          checkoutUrl: 'https://btcpay.test/i/secret',
+          createdAt: '2026-08-10T12:00:00Z',
+          cancellable: true,
+        },
+      }),
+    })
+    renderPanel()
+
+    await screen.findByRole('button', { name: /retry payment status/i })
+    for (const secret of ['pi_3Qsecret', 'cus_9999', 'inv_secret_1', '/i/secret', 'paypal_annual']) {
+      expect(document.body.textContent).not.toContain(secret)
+    }
+  })
+
+  it('releases creation on an own literal null flow', async () => {
+    mockBilling({ currentFlow: async () => response({ flow: null }) })
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: CREATE_CARD })).toBeEnabled()
+    expect(screen.getByRole('button', { name: CREATE_BITCOIN })).toBeEnabled()
+    expect(screen.queryByText(/could not verify whether a payment is already in progress/i)).not.toBeInTheDocument()
+  })
+
+  it('releases creation when a retry replaces a malformed reply with a proven null flow', async () => {
+    let currentFlowReads = 0
+    mockBilling({
+      currentFlow: async () => {
+        currentFlowReads += 1
+        return response(currentFlowReads === 1 ? {} : { flow: null })
+      },
+    })
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: /retry payment status/i }))
+
+    expect(await screen.findByRole('button', { name: CREATE_CARD })).toBeEnabled()
+    expect(creationActions()).toHaveLength(2)
+  })
+
+  it.each([
+    ['card', 'stripe_pay_now', 'Cancel card payment and choose Bitcoin'],
+    ['Bitcoin', 'btcpay_annual', 'Cancel Bitcoin payment and choose card'],
+  ] as const)('keeps a valid %s authority carrying only the fields the panel needs', async (_label, flowKind, action) => {
+    mockBilling({
+      currentFlow: async () => response({ flow: { flowKind, createdAt: '2026-08-10T12:00:00Z', cancellable: true } }),
+    })
+    renderPanel()
+
+    expect(await screen.findByRole('button', { name: action })).toBeInTheDocument()
+    expect(screen.getByText(/payment already in progress/i)).toBeInTheDocument()
+    expect(creationActions()).toHaveLength(0)
+  })
+})

--- a/apps/web/app/components/bitcoin-payment-panel.tsx
+++ b/apps/web/app/components/bitcoin-payment-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { ArrowLeft, ExternalLink } from 'lucide-react'
 import { QRCodeSVG } from 'qrcode.react'
 import { BILLING_API_URL } from '@/app/lib/config'
@@ -30,6 +30,15 @@ type BitcoinPaymentPanelProps = {
   onInvoiceInactive?: () => void
   onPaymentComplete: () => void | Promise<void>
   externalCheckoutLabel?: string
+  /**
+   * Callers that own a provider authority replace the generic back label with
+   * the exact consequence the control performs, gate it behind a local
+   * acknowledgement, and render that acknowledgement adjacent to it. Defaults
+   * keep every other caller's behaviour unchanged.
+   */
+  backLabel?: string
+  backDisabled?: boolean
+  backHint?: ReactNode
 }
 
 export default function BitcoinPaymentPanel({
@@ -41,6 +50,9 @@ export default function BitcoinPaymentPanel({
   onInvoiceInactive,
   onPaymentComplete,
   externalCheckoutLabel = 'Open in BTCPay instead',
+  backLabel = 'Back to payment options',
+  backDisabled = false,
+  backHint,
 }: BitcoinPaymentPanelProps) {
   const [paymentMethods, setPaymentMethods] = useState<CryptoPaymentMethod[]>([])
   const [selectedMethodId, setSelectedMethodId] = useState<string | null>(null)
@@ -136,10 +148,11 @@ export default function BitcoinPaymentPanel({
     <button
       type="button"
       onClick={() => { void handleBack() }}
-      className="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--muted))] transition-colors hover:text-[rgb(var(--foreground))]"
+      disabled={backDisabled}
+      className="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--muted))] transition-colors hover:text-[rgb(var(--foreground))] disabled:opacity-50"
     >
       <ArrowLeft className="h-4 w-4" />
-      Back to payment options
+      {backLabel}
     </button>
   )
 
@@ -213,6 +226,7 @@ export default function BitcoinPaymentPanel({
         </div>
       )}
 
+      {backHint}
       <div>{backButton}</div>
     </div>
   )

--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -22,6 +22,12 @@ import {
   formatAnnualOfferAmount,
   isAnnualOfferProviderAvailable,
 } from '@/app/lib/annual-offer-presentation'
+import {
+  BITCOIN_CANCELLATION_WARNING,
+  PAYMENT_FLOW_CANCELLATION_MESSAGES,
+  cancelPaymentFlow,
+  type PaymentFlowCancellationProvider,
+} from '@/app/lib/payment-flow-cancellation'
 import BitcoinPaymentPanel, { type BitcoinPaymentSession } from './bitcoin-payment-panel'
 
 const CRYPTO_CHECKOUT_ENABLED = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED === 'true'
@@ -43,17 +49,13 @@ type PaymentOption = {
   enabled: boolean
 }
 
+const CURRENT_FLOW_KINDS = ['stripe_pay_now', 'btcpay_annual'] as const
+
 type CurrentPaymentFlow = {
-  flowKind: 'stripe_pay_now' | 'btcpay_annual'
-  provider: 'stripe' | 'btcpay'
-  status: string
-  planId: string
-  amount: string
-  currency: string
+  flowKind: (typeof CURRENT_FLOW_KINDS)[number]
   createdAt: string
   cancellable: boolean
-  invoiceId?: string | null
-  checkoutUrl?: string | null
+  checkoutUrl: string | null
 }
 
 interface PaymentChoicePanelProps {
@@ -110,6 +112,87 @@ function resolveBtcpayUrl(rawUrl: unknown): string | null {
   return checkoutUrl.toString()
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * A 2xx reply is authoritative only when the body itself states the outcome.
+ * Provider creation is released solely by an own, literal `flow: null`; a
+ * present flow must carry the smallest fields this panel depends on: the kind
+ * that identifies the provider authority, the creation timestamp that binds a
+ * Bitcoin acknowledgement to it, and the cancellable state that gates its
+ * cancel control. Anything else is malformed and throws, so the caller fails
+ * closed on its retry path instead of treating an unreadable success as proof
+ * that no payment exists. The thrown reason is never rendered: server detail,
+ * identifiers and checkout URLs stay out of the error surface.
+ */
+function readCurrentPaymentFlow(data: unknown): CurrentPaymentFlow | null {
+  const malformed = () => new Error('The current payment flow reply could not be read.')
+  if (!isPlainObject(data) || !Object.prototype.hasOwnProperty.call(data, 'flow')) throw malformed()
+  const flow = data.flow
+  if (flow === null) return null
+  if (!isPlainObject(flow)) throw malformed()
+  const flowKind = CURRENT_FLOW_KINDS.find((kind) => kind === flow.flowKind)
+  if (!flowKind) throw malformed()
+  if (typeof flow.cancellable !== 'boolean') throw malformed()
+  if (typeof flow.createdAt !== 'string' || flow.createdAt === '') throw malformed()
+  return {
+    flowKind,
+    createdAt: flow.createdAt,
+    cancellable: flow.cancellable,
+    checkoutUrl: typeof flow.checkoutUrl === 'string' ? flow.checkoutUrl : null,
+  }
+}
+
+/**
+ * Cancellation is provider-bound: a BTCPay authority can settle out-of-band, so
+ * the client must know which provider it is releasing before it decides whether
+ * a local Bitcoin acknowledgement is required.
+ */
+function cancellationProviderOf(flowKind: string | null | undefined): PaymentFlowCancellationProvider {
+  if (flowKind === 'btcpay_annual') return 'btcpay'
+  if (flowKind === 'stripe_pay_now') return 'stripe'
+  return 'unknown'
+}
+
+/**
+ * Every cancellation control states the consequence it performs. Where the
+ * current server offer does not expose the other provider, the label stops at
+ * the cancellation instead of promising a method the user cannot then choose.
+ */
+function cancellationActionLabel(provider: PaymentFlowCancellationProvider, otherProviderAvailable: boolean): string {
+  if (provider === 'btcpay') return otherProviderAvailable ? 'Cancel Bitcoin payment and choose card' : 'Cancel Bitcoin payment'
+  if (provider === 'stripe') return otherProviderAvailable ? 'Cancel card payment and choose Bitcoin' : 'Cancel card payment'
+  return 'Cancel payment'
+}
+
+function BitcoinCancellationAcknowledgement({
+  checked,
+  disabled,
+  onChange,
+}: {
+  checked: boolean
+  disabled: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <div className="space-y-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-left">
+      <p className="text-xs text-amber-700 dark:text-amber-200">{BITCOIN_CANCELLATION_WARNING}</p>
+      <label className="flex items-start gap-2 text-xs text-[rgb(var(--foreground))]">
+        <input
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.checked)}
+          className="mt-0.5 h-4 w-4 shrink-0"
+        />
+        <span>I have not sent Bitcoin for this payment.</span>
+      </label>
+    </div>
+  )
+}
+
 function safeBtcpayUrl(rawUrl: string): string {
   const checkoutUrl = resolveBtcpayUrl(rawUrl)
   if (!checkoutUrl) throw new Error('Bitcoin checkout returned an unexpected payment URL.')
@@ -136,6 +219,10 @@ export default function PaymentChoicePanel({
   const [currentFlowLoaded, setCurrentFlowLoaded] = useState(false)
   const [currentFlowLoadFailed, setCurrentFlowLoadFailed] = useState(false)
   const [offerRefreshFailed, setOfferRefreshFailed] = useState(false)
+  const [bitcoinCancelAcknowledged, setBitcoinCancelAcknowledged] = useState(false)
+  // Set when the authoritative endpoint proves a Bitcoin authority the local
+  // state could not identify, so the acknowledgement can be offered truthfully.
+  const [bitcoinAcknowledgementProven, setBitcoinAcknowledgementProven] = useState(false)
 
   const applyAnnualOffer = useCallback((offer: AnnualOfferResponse) => {
     setAnnualOffer(offer)
@@ -205,6 +292,35 @@ export default function PaymentChoicePanel({
   const currentFlowCheckoutUrl = useMemo(() => resolveBtcpayUrl(currentFlow?.checkoutUrl), [currentFlow?.checkoutUrl])
   const stripeAvailable = Boolean(annualOffer && isAnnualOfferProviderAvailable(annualOffer.offer, 'stripe'))
   const btcpayAvailable = Boolean(annualOffer && isAnnualOfferProviderAvailable(annualOffer.offer, 'btcpay', CRYPTO_CHECKOUT_ENABLED))
+  const cancellationProvider: PaymentFlowCancellationProvider = bitcoinSession
+    ? 'btcpay'
+    : clientSecret
+      ? 'stripe'
+      : cancellationProviderOf(currentFlow?.flowKind)
+  const otherProviderAvailable = cancellationProvider === 'btcpay'
+    ? stripeAvailable
+    : cancellationProvider === 'stripe'
+      ? btcpayAvailable
+      : false
+  const cancellationLabel = cancellationActionLabel(cancellationProvider, otherProviderAvailable)
+  const bitcoinAcknowledgementRequired = cancellationProvider === 'btcpay' || bitcoinAcknowledgementProven
+  const cancellationBlocked = bitcoinAcknowledgementRequired && !bitcoinCancelAcknowledged
+  const cancellationDisabled = loading !== null || cancellationBlocked
+  // Identity of the provider authority currently on screen. A different
+  // authority must never inherit a previous acknowledgement.
+  const activeFlowKey = bitcoinSession
+    ? `btcpay:${bitcoinSession.invoiceId}`
+    : clientSecret
+      ? 'stripe:inline'
+      : currentFlow
+        ? `${currentFlow.flowKind}:${currentFlow.createdAt}`
+        : 'none'
+
+  useEffect(() => {
+    setBitcoinCancelAcknowledged(false)
+    setBitcoinAcknowledgementProven(false)
+  }, [activeFlowKey])
+
   const implicitDismissible = currentFlowLoaded
     && !currentFlowLoadFailed
     && !currentFlow
@@ -220,8 +336,7 @@ export default function PaymentChoicePanel({
     try {
       const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows/current`, { credentials: 'include' })
       if (!res.ok) throw new Error('Could not verify the current payment flow.')
-      const data = await res.json()
-      const flow = data.flow ?? null
+      const flow = readCurrentPaymentFlow(await res.json())
       if (!isCancelled()) {
         setCurrentFlow(flow)
         setCurrentFlowLoaded(true)
@@ -248,35 +363,46 @@ export default function PaymentChoicePanel({
     onDismissibilityChange?.(implicitDismissible)
   }, [implicitDismissible, onDismissibilityChange])
 
-  async function handleFlowInProgress() {
-    await loadCurrentFlow()
-    setError(null)
-  }
-
-  const cancelCurrentFlow = async (): Promise<boolean> => {
+  const cancelCurrentFlow = async (provider: PaymentFlowCancellationProvider = cancellationProvider): Promise<boolean> => {
+    // A Bitcoin authority is never released without a local acknowledgement,
+    // even if a control were somehow actioned while blocked.
+    if (provider === 'btcpay' && !bitcoinCancelAcknowledged) {
+      setBitcoinAcknowledgementProven(true)
+      setError(PAYMENT_FLOW_CANCELLATION_MESSAGES['bitcoin-acknowledgement-required'])
+      return false
+    }
     setLoading('cancel-flow')
     setError(null)
     try {
-      const res = await fetch(`${BILLING_API_URL}/subscription/payment-flows/cancel`, {
-        method: 'POST',
-        credentials: 'include',
+      const result = await cancelPaymentFlow({
+        fetcher: fetch,
+        billingApiUrl: BILLING_API_URL,
+        provider,
+        confirmNoBitcoinSent: bitcoinCancelAcknowledged,
       })
-      const data = await res.json().catch(() => null)
-      if (!res.ok || !data || data.cancelled !== true) {
-        throw new Error(data?.detail ?? 'Could not cancel the pending payment flow.')
+      if (!result.cancelled) {
+        // The provider authority survives every refusal, ambiguity and lost
+        // response: local panel state is left exactly as it was.
+        if (result.failure === 'bitcoin-acknowledgement-required') setBitcoinAcknowledgementProven(true)
+        setError(result.message)
+        return false
       }
       setCurrentFlow(null)
-      setCurrentFlowLoaded(true)
       setClientSecret(null)
       setPaymentOffer(null)
       setBitcoinSession(null)
+      setBitcoinAcknowledgementProven(false)
+      // Provider creation stays unavailable continuously from cancellation
+      // success until a fresh lookup proves `flow: null`. The re-proof is
+      // started in the same commit that releases the authority, so a faster
+      // offer refresh can never repopulate the creation controls first.
+      const reprovedCurrentFlow = loadCurrentFlow()
       await loadOptions()
-      await loadCurrentFlow()
+      await reprovedCurrentFlow
       return true
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Could not cancel the pending payment flow.')
-      return false
     } finally {
+      // Each attempt requires its own deliberate acknowledgement.
+      setBitcoinCancelAcknowledged(false)
       setLoading(null)
     }
   }
@@ -417,7 +543,23 @@ export default function PaymentChoicePanel({
         title={`Pay ${annualOfferAnnualLabel(annualOffer.offer)} annual with Bitcoin`}
         description={`Scan the QR code or copy the payment details to pay ${formatAnnualOfferAmount(annualOffer.offer)} for ${annualOfferPlanLabel(annualOffer.offer)} (${annualOffer.offer.planId}). Your 14 bonus days and paid access apply after settlement confirms.`}
         settledMessage="Payment settled. Refreshing your subscription..."
-        onBack={() => { void cancelCurrentFlow() }}
+        backLabel={loading === 'cancel-flow' ? 'Cancelling payment flow...' : cancellationLabel}
+        backDisabled={cancellationDisabled}
+        backHint={(
+          <div className="space-y-3">
+            <BitcoinCancellationAcknowledgement
+              checked={bitcoinCancelAcknowledged}
+              disabled={loading !== null}
+              onChange={setBitcoinCancelAcknowledged}
+            />
+            {error && (
+              <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+                <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+              </div>
+            )}
+          </div>
+        )}
+        onBack={() => { void cancelCurrentFlow('btcpay') }}
         onPaymentComplete={async () => {
           await onSuccess()
           await successPoll?.()
@@ -431,11 +573,11 @@ export default function PaymentChoicePanel({
       <div className="space-y-4">
         <button
           type="button"
-          onClick={() => { void cancelCurrentFlow() }}
-          disabled={loading !== null}
+          onClick={() => { void cancelCurrentFlow('stripe') }}
+          disabled={cancellationDisabled}
           className="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--muted))] transition-colors hover:text-[rgb(var(--foreground))] disabled:opacity-50"
         >
-          ← Back to payment options
+          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : cancellationLabel}
         </button>
 
         <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
@@ -467,12 +609,17 @@ export default function PaymentChoicePanel({
           mode="payment"
           returnPath="/settings/subscription"
         />
+        {error && (
+          <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+            <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+          </div>
+        )}
         <button
-          onClick={() => { void cancelCurrentFlow() }}
-          disabled={loading !== null}
+          onClick={() => { void cancelCurrentFlow('stripe') }}
+          disabled={cancellationDisabled}
           className="w-full text-center text-xs text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors disabled:opacity-50"
         >
-          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : '← Back to options'}
+          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : cancellationLabel}
         </button>
       </div>
     )
@@ -502,8 +649,15 @@ export default function PaymentChoicePanel({
             <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
           </div>
         )}
-        <Button onClick={() => { void cancelCurrentFlow() }} disabled={loading !== null || !currentFlow.cancellable} variant="outline" className="w-full">
-          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : 'Cancel and choose another method'}
+        {bitcoinAcknowledgementRequired && (
+          <BitcoinCancellationAcknowledgement
+            checked={bitcoinCancelAcknowledged}
+            disabled={loading !== null || !currentFlow.cancellable}
+            onChange={setBitcoinCancelAcknowledged}
+          />
+        )}
+        <Button onClick={() => { void cancelCurrentFlow() }} disabled={cancellationDisabled || !currentFlow.cancellable} variant="outline" className="w-full">
+          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : cancellationLabel}
         </Button>
         {!currentFlow.cancellable && (
           <p className="text-xs text-[rgb(var(--muted))]">This payment is already being confirmed. Please wait for the provider update or contact support.</p>
@@ -589,15 +743,30 @@ export default function PaymentChoicePanel({
       )}
 
       {onCancel && (
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleExplicitCancel}
-          disabled={loading !== null || (!currentFlowLoaded && !currentFlowLoadFailed)}
-          className="w-full"
-        >
-          {loading === 'cancel-flow' ? 'Cancelling payment flow...' : !currentFlowLoaded && !currentFlowLoadFailed ? 'Checking current payment...' : 'Cancel'}
-        </Button>
+        <>
+          {bitcoinAcknowledgementRequired && (
+            <BitcoinCancellationAcknowledgement
+              checked={bitcoinCancelAcknowledged}
+              disabled={loading !== null}
+              onChange={setBitcoinCancelAcknowledged}
+            />
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExplicitCancel}
+            disabled={cancellationDisabled || (!currentFlowLoaded && !currentFlowLoadFailed)}
+            className="w-full"
+          >
+            {loading === 'cancel-flow'
+              ? 'Cancelling payment flow...'
+              : !currentFlowLoaded && !currentFlowLoadFailed
+                ? 'Checking current payment...'
+                : implicitDismissible
+                  ? 'Cancel'
+                  : 'Cancel any payment in progress and close'}
+          </Button>
+        </>
       )}
     </div>
   )

--- a/apps/web/app/lib/__tests__/payment-flow-cancellation.test.ts
+++ b/apps/web/app/lib/__tests__/payment-flow-cancellation.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BITCOIN_CANCELLATION_WARNING,
+  PAYMENT_FLOW_CANCELLATION_MESSAGES,
+  cancelPaymentFlow,
+} from '../payment-flow-cancellation'
+
+const BILLING = 'https://billing.example.test'
+const CANCEL_URL = `${BILLING}/subscription/payment-flows/cancel`
+
+function ok(body: unknown, status = 200) {
+  return { ok: true, status, json: async () => body } as Response
+}
+
+function problem(status: number, type: string | null, detail: string) {
+  return {
+    ok: false,
+    status,
+    json: async () => (type === null ? { detail } : { type, detail }),
+  } as Response
+}
+
+function fetcherReturning(response: Response) {
+  return vi.fn(async () => response)
+}
+
+function requestOf(fetcher: ReturnType<typeof fetcherReturning>) {
+  const call = fetcher.mock.calls[0] as unknown as [RequestInfo | URL, RequestInit]
+  return { url: String(call[0]), init: call[1] }
+}
+
+describe('cancelPaymentFlow request shape', () => {
+  it('sends the closed bitcoin acknowledgement body only after an explicit local acknowledgement', async () => {
+    const fetcher = fetcherReturning(ok({ cancelled: true, flowKind: 'btcpay_annual' }))
+
+    const result = await cancelPaymentFlow({
+      fetcher,
+      billingApiUrl: BILLING,
+      provider: 'btcpay',
+      confirmNoBitcoinSent: true,
+    })
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    const { url, init } = requestOf(fetcher)
+    expect(url).toBe(CANCEL_URL)
+    expect(init.method).toBe('POST')
+    expect(init.credentials).toBe('include')
+    expect(init.headers).toMatchObject({ 'content-type': 'application/json' })
+    expect(init.body).toBe('{"confirmNoBitcoinSent":true}')
+    expect(result).toEqual({ cancelled: true, flowKind: 'btcpay_annual' })
+  })
+
+  it('makes zero cancellation requests for a bitcoin flow without acknowledgement', async () => {
+    const fetcher = fetcherReturning(ok({ cancelled: true, flowKind: 'btcpay_annual' }))
+
+    const result = await cancelPaymentFlow({
+      fetcher,
+      billingApiUrl: BILLING,
+      provider: 'btcpay',
+      confirmNoBitcoinSent: false,
+    })
+
+    expect(fetcher).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      cancelled: false,
+      failure: 'bitcoin-acknowledgement-required',
+      message: PAYMENT_FLOW_CANCELLATION_MESSAGES['bitcoin-acknowledgement-required'],
+    })
+  })
+
+  it.each([true, false])('never asserts bitcoin facts for a card flow (acknowledged=%s)', async (confirmNoBitcoinSent) => {
+    const fetcher = fetcherReturning(ok({ cancelled: true, flowKind: 'stripe_pay_now' }))
+
+    const result = await cancelPaymentFlow({ fetcher, billingApiUrl: BILLING, provider: 'stripe', confirmNoBitcoinSent })
+
+    const { init } = requestOf(fetcher)
+    expect(init.body).toBe('{}')
+    expect(String(init.body)).not.toContain('confirmNoBitcoinSent')
+    expect(result).toEqual({ cancelled: true, flowKind: 'stripe_pay_now' })
+  })
+
+  it.each([
+    ['unacknowledged', false, '{}'],
+    ['acknowledged', true, '{"confirmNoBitcoinSent":true}'],
+  ] as const)('sends the %s closed body for an unverified provider', async (_label, confirmNoBitcoinSent, body) => {
+    const fetcher = fetcherReturning(ok({ cancelled: true, flowKind: 'stripe_pay_now' }))
+
+    await cancelPaymentFlow({ fetcher, billingApiUrl: BILLING, provider: 'unknown', confirmNoBitcoinSent })
+
+    expect(requestOf(fetcher).init.body).toBe(body)
+  })
+
+  it('tolerates a trailing slash on the billing base URL', async () => {
+    const fetcher = fetcherReturning(ok({ cancelled: true, flowKind: 'stripe_pay_now' }))
+
+    await cancelPaymentFlow({ fetcher, billingApiUrl: `${BILLING}/`, provider: 'stripe', confirmNoBitcoinSent: false })
+
+    expect(requestOf(fetcher).url).toBe(CANCEL_URL)
+  })
+
+  it('returns a null flow kind when the server omits it', async () => {
+    const fetcher = fetcherReturning(ok({ cancelled: true }))
+
+    expect(await cancelPaymentFlow({ fetcher, billingApiUrl: BILLING, provider: 'stripe', confirmNoBitcoinSent: false }))
+      .toEqual({ cancelled: true, flowKind: null })
+  })
+})
+
+describe('cancelPaymentFlow failure mapping', () => {
+  const SENSITIVE = 'pi_3QsecretABC / cus_9999 / https://checkout.stripe.com/c/pay/cs_live_secret'
+
+  it.each([
+    [400, 'https://api.silentsuite.io/errors/bitcoin-cancellation-acknowledgement-required', 'bitcoin-acknowledgement-required'],
+    [400, 'https://api.silentsuite.io/errors/invalid-cancellation-request', 'invalid-cancellation-request'],
+    [409, 'https://api.silentsuite.io/errors/payment_reconciliation_required', 'payment-reconciliation-required'],
+    [502, 'https://api.silentsuite.io/errors/provider-cancellation-failed', 'provider-cancellation-failed'],
+  ] as const)('maps %s %s to fixed client-owned copy', async (status, type, failure) => {
+    const fetcher = fetcherReturning(problem(status, type, SENSITIVE))
+
+    const result = await cancelPaymentFlow({
+      fetcher,
+      billingApiUrl: BILLING,
+      provider: 'btcpay',
+      confirmNoBitcoinSent: true,
+    })
+
+    expect(result).toEqual({ cancelled: false, failure, message: PAYMENT_FLOW_CANCELLATION_MESSAGES[failure] })
+    expect(JSON.stringify(result)).not.toContain('secret')
+    expect(JSON.stringify(result)).not.toContain('cus_')
+  })
+
+  it('accepts bare problem slugs as well as absolute problem type URLs', async () => {
+    const fetcher = fetcherReturning(problem(409, 'payment_reconciliation_required', SENSITIVE))
+
+    expect(await cancelPaymentFlow({ fetcher, billingApiUrl: BILLING, provider: 'stripe', confirmNoBitcoinSent: false }))
+      .toEqual({
+        cancelled: false,
+        failure: 'payment-reconciliation-required',
+        message: PAYMENT_FLOW_CANCELLATION_MESSAGES['payment-reconciliation-required'],
+      })
+  })
+
+  it.each([
+    ['an unknown problem type', () => problem(400, 'https://api.silentsuite.io/errors/some-new-thing', SENSITIVE)],
+    ['a known slug on the wrong status', () => problem(500, 'https://api.silentsuite.io/errors/provider-cancellation-failed', SENSITIVE)],
+    ['an untyped failure', () => problem(503, null, SENSITIVE)],
+    ['a 200 body that does not confirm cancellation', () => ok({ cancelled: false, detail: SENSITIVE })],
+    ['a 200 body with a non-literal cancelled flag', () => ok({ cancelled: 'true', detail: SENSITIVE })],
+  ] as const)('falls back to one generic message for %s', async (_label, make) => {
+    const fetcher = fetcherReturning(make())
+
+    const result = await cancelPaymentFlow({ fetcher, billingApiUrl: BILLING, provider: 'stripe', confirmNoBitcoinSent: false })
+
+    expect(result).toEqual({
+      cancelled: false,
+      failure: 'unavailable',
+      message: PAYMENT_FLOW_CANCELLATION_MESSAGES.unavailable,
+    })
+  })
+
+  it.each([
+    ['an unparseable body', () => Promise.resolve({ ok: true, status: 200, json: async () => { throw new SyntaxError('bad json') } } as unknown as Response)],
+    ['a lost response', () => Promise.reject<Response>(new Error(SENSITIVE))],
+  ] as const)('falls back to one generic message for %s', async (_label, make) => {
+    const fetcher = vi.fn(() => make())
+
+    const result = await cancelPaymentFlow({
+      fetcher,
+      billingApiUrl: BILLING,
+      provider: 'stripe',
+      confirmNoBitcoinSent: false,
+    })
+
+    expect(result).toEqual({
+      cancelled: false,
+      failure: 'unavailable',
+      message: PAYMENT_FLOW_CANCELLATION_MESSAGES.unavailable,
+    })
+  })
+
+  it('exposes the exact neutral bitcoin cancellation warning', () => {
+    expect(BITCOIN_CANCELLATION_WARNING).toBe(
+      'Only cancel if you have not sent Bitcoin. After cancelling, do not pay the previous QR code or address. '
+      + 'A payment sent afterward cannot be credited automatically; contact support for manual review.',
+    )
+  })
+})

--- a/apps/web/app/lib/payment-flow-cancellation.ts
+++ b/apps/web/app/lib/payment-flow-cancellation.ts
@@ -1,0 +1,120 @@
+/**
+ * Closed client for Billing's additive payment-flow cancellation contract.
+ *
+ * Cancelling a payment authority is the only way to switch providers, and a
+ * Bitcoin flow can be settled out-of-band at any moment. The client therefore
+ * never guesses: it sends an explicit, closed acknowledgement body, and it
+ * renders only fixed client-owned copy. Backend `detail`, problem titles,
+ * identifiers, checkout URLs, client secrets and exception text are never
+ * surfaced — a cancellation error must not become a data-leak surface.
+ */
+import type { BillingV2Fetch } from './billing-v2'
+
+/** `unknown` covers a local state where the authoritative flow kind is not proven. */
+export type PaymentFlowCancellationProvider = 'stripe' | 'btcpay' | 'unknown'
+
+export type PaymentFlowCancellationFailure =
+  | 'bitcoin-acknowledgement-required'
+  | 'invalid-cancellation-request'
+  | 'payment-reconciliation-required'
+  | 'provider-cancellation-failed'
+  | 'unavailable'
+
+export type PaymentFlowCancellationResult =
+  | { cancelled: true; flowKind: string | null }
+  | { cancelled: false; failure: PaymentFlowCancellationFailure; message: string }
+
+/**
+ * The exact neutral Bitcoin cancellation warning. It states the irreversible
+ * consequence without implying the user has already paid, and it names the
+ * manual-review path instead of promising automatic crediting.
+ */
+export const BITCOIN_CANCELLATION_WARNING =
+  'Only cancel if you have not sent Bitcoin. After cancelling, do not pay the previous QR code or address. '
+  + 'A payment sent afterward cannot be credited automatically; contact support for manual review.'
+
+export const PAYMENT_FLOW_CANCELLATION_MESSAGES: Record<PaymentFlowCancellationFailure, string> = {
+  'bitcoin-acknowledgement-required': 'Confirm that you have not sent Bitcoin before cancelling this Bitcoin payment.',
+  'invalid-cancellation-request': 'This payment could not be cancelled. Reload the page and try again.',
+  'payment-reconciliation-required': 'This payment is still being reconciled and cannot be cancelled yet. Wait for the provider update or contact support.',
+  'provider-cancellation-failed': 'The payment provider would not cancel this payment. It may already have been paid. Wait for the provider update or contact support.',
+  unavailable: 'Could not cancel the pending payment flow.',
+}
+
+/** Known (status, problem slug) pairs. Anything else uses the single generic fallback. */
+const KNOWN_FAILURES: ReadonlyArray<readonly [number, string, PaymentFlowCancellationFailure]> = [
+  [400, 'bitcoin-cancellation-acknowledgement-required', 'bitcoin-acknowledgement-required'],
+  [400, 'invalid-cancellation-request', 'invalid-cancellation-request'],
+  [409, 'payment-reconciliation-required', 'payment-reconciliation-required'],
+  [502, 'provider-cancellation-failed', 'provider-cancellation-failed'],
+]
+
+function failed(failure: PaymentFlowCancellationFailure): PaymentFlowCancellationResult {
+  return { cancelled: false, failure, message: PAYMENT_FLOW_CANCELLATION_MESSAGES[failure] }
+}
+
+/**
+ * Reduce a Problem Details `type` to its trailing slug so the client is not
+ * coupled to the absolute problem-type origin, and so `_` and `-` spellings of
+ * the same server-owned error are treated identically.
+ */
+function problemSlug(value: unknown): string | null {
+  if (typeof value !== 'string' || value === '') return null
+  const tail = value.split(/[/#]/).filter(Boolean).pop()
+  if (!tail) return null
+  return tail.toLowerCase().replaceAll('_', '-')
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * Bitcoin cancellation asserts a fact only the user can know, so it is sent
+ * only when the user acknowledged it locally. A card flow never carries the
+ * assertion at all, and an unproven flow carries it only if the user
+ * acknowledged it anyway.
+ */
+function cancellationBody(provider: PaymentFlowCancellationProvider, confirmNoBitcoinSent: boolean): string {
+  if (provider === 'stripe') return '{}'
+  return confirmNoBitcoinSent ? JSON.stringify({ confirmNoBitcoinSent: true }) : '{}'
+}
+
+export async function cancelPaymentFlow(params: {
+  fetcher: BillingV2Fetch
+  billingApiUrl: string
+  provider: PaymentFlowCancellationProvider
+  confirmNoBitcoinSent: boolean
+}): Promise<PaymentFlowCancellationResult> {
+  // A Bitcoin flow without a local acknowledgement is refused before any
+  // request leaves the browser: the server would reject it anyway, and an
+  // un-acknowledged attempt must never reach the provider.
+  if (params.provider === 'btcpay' && params.confirmNoBitcoinSent !== true) {
+    return failed('bitcoin-acknowledgement-required')
+  }
+
+  let response: Response
+  let body: unknown
+  try {
+    response = await params.fetcher(`${params.billingApiUrl.replace(/\/$/, '')}/subscription/payment-flows/cancel`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: cancellationBody(params.provider, params.confirmNoBitcoinSent),
+    })
+    body = await response.json()
+  } catch {
+    // Transport loss and unparseable replies are indistinguishable from the
+    // client's side: neither proves the authority was released.
+    return failed('unavailable')
+  }
+
+  if (!response.ok) {
+    const slug = isObject(body) ? problemSlug(body.type) : null
+    const known = KNOWN_FAILURES.find(([status, knownSlug]) => status === response.status && knownSlug === slug)
+    return failed(known ? known[2] : 'unavailable')
+  }
+
+  if (!isObject(body) || body.cancelled !== true) return failed('unavailable')
+  return { cancelled: true, flowKind: typeof body.flowKind === 'string' ? body.flowKind : null }
+}


### PR DESCRIPTION
Closes #683

## Summary

Adds explicit, fail-closed switching between card and Bitcoin payment flows after payable instructions have been created.

- Replaces generic Back actions with consequence-specific cancellation labels.
- Requires an unchecked “no Bitcoin sent” acknowledgement before cancelling a BTCPay invoice.
- Sends the acknowledgement only for Bitcoin; card cancellation sends an empty closed body.
- Maps known cancellation problems to fixed client-owned copy and never renders provider details, IDs, secrets, or checkout URLs as errors.
- Keeps the existing provider authority visible after refusal, ambiguity, malformed success, or response loss.
- Keeps all provider-creation controls unavailable until a fresh current-flow lookup returns an own literal `flow: null`.
- Treats malformed successful current-flow responses as verification failures rather than proof that no flow exists.
- Preserves Stripe redirect/SCA behavior and never cancels on unload, page hide, unmount, or effect cleanup.

## Verification

- 122 focused payment switching, cancellation, lifecycle, continuation, and subscription-page tests passed.
- Web type-check passed.
- Web lint passed with pre-existing warnings outside the changed paths.
- `git diff --check` passed.

## Risk and boundaries

This public-web change depends on the additive Billing cancellation contract already merged into internal `dev`. It does not deploy Billing, mutate provider/customer state, change analytics, add migrations, or alter annual pricing/terms.

Bitcoin payable instructions cannot be revoked after display. The UI therefore states the accepted boundary explicitly: after cancellation, the previous QR/address must not be paid; a late payment requires manual support review.