### PR TITLE
fix: authenticate release registry verification

### DIFF
--- a/.github/workflows/release-bridge.yml
+++ b/.github/workflows/release-bridge.yml
@@ -71,9 +71,21 @@ jobs:
           clean: true
           persist-credentials: false
 
-      - name: Download all artifacts
+      # Only this lane's own producer artifacts. Without a filter this step
+      # downloads every artifact in the controller run — the server's two child
+      # digests, the Conscrypt AAR, and Buildx's `.dockerbuild` records — and the
+      # staging helper correctly refuses the first unexpected name, so no bridge
+      # asset is ever attached.
+      #
+      # `merge-multiple: false` is the other half: each artifact keeps its own
+      # directory under `release-assets/`, which is the one-source-directory
+      # layout the staging helper flattens and closes over. Merging them would
+      # collapse that structure and hide a duplicate name from it.
+      - name: Download the bridge producer artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: silentsuite-bridge-*
+          merge-multiple: false
           path: release-assets/
 
       - name: Flatten artifacts and build the checksum manifest

--- a/.github/workflows/release-server-image.yml
+++ b/.github/workflows/release-server-image.yml
@@ -217,9 +217,24 @@ jobs:
           echo "amd64=$AMD64" >> "$GITHUB_OUTPUT"
           echo "arm64=$ARM64" >> "$GITHUB_OUTPUT"
 
+      # The verifier talks to the GHCR API directly rather than through the
+      # Docker client, so `docker/login-action` below does nothing for it: it
+      # needs its own pull token, and it mints one from REGISTRY_USERNAME /
+      # REGISTRY_PASSWORD. Without them it asks ghcr.io/token anonymously, which
+      # a package that is not publicly readable answers with 403 — and the
+      # verifier, being fail-closed, stops the release there.
+      #
+      # These two variables are set on each verifier-running step and nowhere
+      # else: not at job scope, and not on any step that executes candidate
+      # code. The password is the workflow token this job already holds, used
+      # here only for the `:pull` scope it needs; the job's `packages: write`
+      # ceiling is unchanged and no new secret is introduced.
       - name: Record the current latest reference
         id: latest-before
         shell: bash
+        env:
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           BEFORE="$(trusted/scripts/verify-server-image-release.sh --repository "$IMAGE_NAME" --resolve latest)"
@@ -253,6 +268,8 @@ jobs:
           AMD64_DIGEST: ${{ steps.digests.outputs.amd64 }}
           ARM64_DIGEST: ${{ steps.digests.outputs.arm64 }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           COMMIT_REF="selfhost-${RELEASE_COMMIT}"
@@ -354,6 +371,8 @@ jobs:
         env:
           AMD64_DIGEST: ${{ steps.digests.outputs.amd64 }}
           ARM64_DIGEST: ${{ steps.digests.outputs.arm64 }}
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           trusted/scripts/verify-server-image-release.sh \
@@ -369,6 +388,8 @@ jobs:
         shell: bash
         env:
           LATEST_BEFORE: ${{ steps.latest-before.outputs.digest }}
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           AFTER="$(trusted/scripts/verify-server-image-release.sh --repository "$IMAGE_NAME" --resolve latest)"

--- a/scripts/verify-server-image-release.sh
+++ b/scripts/verify-server-image-release.sh
@@ -80,14 +80,26 @@ fi
 
 ACCEPT_TYPES='application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json'
 
+# ghcr.io issues an anonymous pull token only for a publicly readable package.
+# For anything else it answers 403, which `curl -f` reports as exit 22 — and
+# under `set -e` that used to abort the script before the diagnostic below could
+# run, leaving a bare "curl: (22)" as the only explanation. The failure is
+# reported here instead, so a caller that forgot the credentials is told so.
 registry_token() {
-  curl -fsSL -u "${REGISTRY_USERNAME:-}:${REGISTRY_PASSWORD:-}" \
-    "https://ghcr.io/token?service=ghcr.io&scope=repository:${IMAGE_PATH}:pull" | jq -r '.token'
+  local response
+  if ! response="$(curl -fsSL -u "${REGISTRY_USERNAME:-}:${REGISTRY_PASSWORD:-}" \
+      "https://ghcr.io/token?service=ghcr.io&scope=repository:${IMAGE_PATH}:pull" 2>/dev/null)"; then
+    return 1
+  fi
+  printf '%s' "$response" | jq -r '.token // empty'
 }
 
-TOKEN="$(registry_token)"
-if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+TOKEN=""
+if ! TOKEN="$(registry_token)" || [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   echo "ERROR: could not obtain a registry pull token for ${IMAGE_PATH}" >&2
+  echo "       Set REGISTRY_USERNAME and REGISTRY_PASSWORD; a workflow" >&2
+  echo "       GITHUB_TOKEN with packages:read is enough. An anonymous read" >&2
+  echo "       succeeds only for a publicly readable package." >&2
   exit 1
 fi
 

--- a/scripts/verify-server-image-release.sh
+++ b/scripts/verify-server-image-release.sh
@@ -36,6 +36,20 @@ set -euo pipefail
 #
 # Credentials: REGISTRY_USERNAME / REGISTRY_PASSWORD (a workflow GITHUB_TOKEN
 # with packages:read is enough). Never a production or VPS credential.
+#
+# No credential value is ever passed to curl on a command line. `-u user:pass`
+# and `-H "Authorization: Bearer …"` both place the secret in the child's argv,
+# which every process on the runner can read from /proc/<pid>/cmdline for as
+# long as the request lasts. Both are supplied through curl config files
+# instead: a 0600 file inside a 0700 private directory, written with a umask
+# that never lets the bytes exist group- or world-readable, removed on success,
+# failure and signal. `--netrc-file` would cover the basic pair but not the
+# bearer header, so one mechanism covers both rather than two half-measures.
+#
+# What that does and does not buy: argv is world-readable, a 0600 file is not.
+# Anything running as this user — or as root — can still read the file while it
+# exists, which is the same trust boundary the environment variables already sit
+# behind.
 
 REPOSITORY=""
 TAG=""
@@ -80,6 +94,67 @@ fi
 
 ACCEPT_TYPES='application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json'
 
+# ── Credential handling ───────────────────────────────────────────────
+
+WORKDIR="$(mktemp -d)"
+CREDENTIAL_DIR="$WORKDIR/credentials"
+mkdir -m 700 "$CREDENTIAL_DIR"
+TOKEN_CONFIG="$CREDENTIAL_DIR/token.conf"
+BEARER_CONFIG="$CREDENTIAL_DIR/bearer.conf"
+
+# Installed before the first credential byte is written, and covering the
+# signals a cancelled workflow job actually sends, so no config file outlives
+# the run that created it.
+cleanup_credentials() {
+  rm -rf "$WORKDIR"
+}
+trap cleanup_credentials EXIT
+trap 'cleanup_credentials; trap - EXIT; exit 130' HUP INT QUIT TERM
+
+# Every character GitHub can put in an actor login, a workflow token or a
+# ghcr.io bearer. Validation is not the only defence — the writer escapes as
+# well — but it is the one that refuses a value carrying a newline, which is
+# the single character that could turn one config line into two.
+#
+# Matching happens with the bash regex operator rather than grep: grep is
+# line-oriented, so `^…$` would happily match each line of an injected value
+# separately, and it would also place the value in a child's argv.
+ACTOR_PATTERN='^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?(\[bot\])?$'
+SECRET_PATTERN='^[A-Za-z0-9._~+/=:-]+$'
+
+assert_credential_shape() {
+  local label="$1" value="$2" pattern="$3"
+  if [[ ! "$value" =~ $pattern ]]; then
+    echo "ERROR: ${label} contains characters this verifier will not hand to curl" >&2
+    echo "       (its value is not printed; expected only the characters GitHub" >&2
+    echo "        issues for an actor login, a workflow token or a pull token)" >&2
+    exit 2
+  fi
+}
+
+# Write one curl config option whose value is a secret. The value is passed by
+# variable *name* and dereferenced inside, because bash expands a function
+# call's arguments before it traces them: passing the value itself would print
+# it under `set -x` no matter what the body does.
+#
+# The file is created inside the 0700 directory under a 0077 umask, so the bytes
+# are never momentarily group- or world-readable.
+write_curl_config() {
+  local path="$1" option="$2" variable="$3" xtrace="" value
+  case "$-" in
+    *x*) xtrace=1; set +x ;;
+  esac
+  value="${!variable}"
+  # Escape for a double-quoted curl config value: backslash first, then quote.
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  ( umask 077; : > "$path" )
+  printf '%s = "%s"\n' "$option" "$value" > "$path"
+  if [ -n "$xtrace" ]; then
+    set -x
+  fi
+}
+
 # ghcr.io issues an anonymous pull token only for a publicly readable package.
 # For anything else it answers 403, which `curl -f` reports as exit 22 — and
 # under `set -e` that used to abort the script before the diagnostic below could
@@ -87,12 +162,40 @@ ACCEPT_TYPES='application/vnd.oci.image.index.v1+json,application/vnd.oci.image.
 # reported here instead, so a caller that forgot the credentials is told so.
 registry_token() {
   local response
-  if ! response="$(curl -fsSL -u "${REGISTRY_USERNAME:-}:${REGISTRY_PASSWORD:-}" \
+  if ! response="$(curl -fsSL --config "$TOKEN_CONFIG" \
       "https://ghcr.io/token?service=ghcr.io&scope=repository:${IMAGE_PATH}:pull" 2>/dev/null)"; then
     return 1
   fi
   printf '%s' "$response" | jq -r '.token // empty'
 }
+
+# Everything that touches a credential value runs with tracing suspended, and
+# the region is deliberately wider than the writes themselves: `set -x` prints
+# an assignment together with the value assigned, so `TOKEN="$(registry_token)"`
+# would publish the bearer to stderr on its own. Tracing resumes immediately
+# afterwards — the curl calls below carry no secret in argv, so they stay
+# visible to anyone debugging a release.
+CREDENTIAL_XTRACE=""
+case "$-" in
+  *x*) CREDENTIAL_XTRACE=1; set +x ;;
+esac
+
+# An empty pair is still written, so the request shape is exactly what it was
+# when this was `-u ":"`: ghcr.io answers a genuinely anonymous read only for a
+# publicly readable package, and the diagnostic below depends on that 403.
+if [ -n "${REGISTRY_USERNAME:-}" ]; then
+  assert_credential_shape REGISTRY_USERNAME "$REGISTRY_USERNAME" "$ACTOR_PATTERN"
+fi
+if [ -n "${REGISTRY_PASSWORD:-}" ]; then
+  assert_credential_shape REGISTRY_PASSWORD "$REGISTRY_PASSWORD" "$SECRET_PATTERN"
+fi
+CURL_BASIC_PAIR="${REGISTRY_USERNAME:-}:${REGISTRY_PASSWORD:-}"
+write_curl_config "$TOKEN_CONFIG" user CURL_BASIC_PAIR
+unset CURL_BASIC_PAIR
+
+# Past this point nothing in this process needs them, so no child — curl, jq,
+# sha256sum, awk — inherits them either.
+unset REGISTRY_USERNAME REGISTRY_PASSWORD
 
 TOKEN=""
 if ! TOKEN="$(registry_token)" || [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
@@ -103,8 +206,17 @@ if ! TOKEN="$(registry_token)" || [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
   exit 1
 fi
 
-WORKDIR="$(mktemp -d)"
-trap 'rm -rf "$WORKDIR"' EXIT
+assert_credential_shape "the minted registry pull token" "$TOKEN" "$SECRET_PATTERN"
+CURL_BEARER_HEADER="Authorization: Bearer $TOKEN"
+write_curl_config "$BEARER_CONFIG" header CURL_BEARER_HEADER
+# The basic pair has done its one job; the bearer lives in its file from here.
+unset CURL_BEARER_HEADER
+TOKEN=""
+rm -f "$TOKEN_CONFIG"
+
+if [ -n "$CREDENTIAL_XTRACE" ]; then
+  set -x
+fi
 
 # Fetch a manifest by reference. Writes the body to $2, sets MANIFEST_DIGEST to
 # the SHA-256 of the exact bytes received and MANIFEST_BYTES to their exact
@@ -126,7 +238,7 @@ fetch_manifest() {
   MANIFEST_BYTES=""
   : > "$body"
   status="$(curl -sS -o "$body" -D "$headers" -w '%{http_code}' \
-    -H "Authorization: Bearer $TOKEN" -H "Accept: $ACCEPT_TYPES" \
+    --config "$BEARER_CONFIG" -H "Accept: $ACCEPT_TYPES" \
     "https://ghcr.io/v2/${IMAGE_PATH}/manifests/${reference}")"
   case "$status" in
     200) ;;
@@ -158,7 +270,7 @@ fetch_manifest() {
 }
 
 fetch_blob() {
-  curl -fsSL -H "Authorization: Bearer $TOKEN" \
+  curl -fsSL --config "$BEARER_CONFIG" \
     "https://ghcr.io/v2/${IMAGE_PATH}/blobs/$1"
 }
 

--- a/tests/test_self_host_release_admission.py
+++ b/tests/test_self_host_release_admission.py
@@ -546,3 +546,196 @@ def test_staging_refuses_to_reuse_an_existing_directory(tmp_path: Path):
 
     assert result.returncode != 0
     assert "already exists" in result.stderr
+
+
+# ── Bridge artifact acquisition: the real mixed run ───────────────────
+#
+# Controller run 33269466888 held ten artifacts at once. The Bridge attachment
+# job's `actions/download-artifact` named none of them and matched no pattern,
+# so it took all ten; the staging helper refused a foreign file and the lane
+# attached nothing. These cases reproduce that run's artifact set and prove the
+# acquisition filter — not a change to the helper — is what fixes it.
+
+import fnmatch  # noqa: E402
+import re as _re  # noqa: E402
+
+import yaml as _yaml  # noqa: E402
+
+BRIDGE_WORKFLOW = ROOT / ".github" / "workflows" / "release-bridge.yml"
+BRIDGE_PATTERN = "silentsuite-bridge-*"
+
+# Artifact name -> the files that artifact contains, as the run produced them.
+# `merge-multiple: false` gives each artifact its own directory, so this is the
+# tree the staging helper is handed.
+REAL_RUN_ARTIFACTS: dict[str, dict[str, str]] = {
+    "silentsuite-bridge-linux-x86_64": {
+        "silentsuite-bridge-linux-x86_64": "linux-x86_64-binary\n",
+        "silentsuite-bridge-linux-x86_64.sha256": "aaa  silentsuite-bridge-linux-x86_64\n",
+    },
+    "silentsuite-bridge-linux-arm64": {
+        "silentsuite-bridge-linux-arm64": "linux-arm64-binary\n",
+        "silentsuite-bridge-linux-arm64.sha256": "bbb  silentsuite-bridge-linux-arm64\n",
+    },
+    "silentsuite-bridge-macos-x86_64": {
+        "silentsuite-bridge-macos-x86_64": "macos-x86_64-binary\n",
+        "silentsuite-bridge-macos-x86_64.sha256": "ccc  silentsuite-bridge-macos-x86_64\n",
+    },
+    "silentsuite-bridge-macos-arm64": {
+        "silentsuite-bridge-macos-arm64": "macos-arm64-binary\n",
+        "silentsuite-bridge-macos-arm64.sha256": "ddd  silentsuite-bridge-macos-arm64\n",
+    },
+    "silentsuite-bridge-windows-x86_64.exe": {
+        "silentsuite-bridge-windows-x86_64.exe": "windows-binary\n",
+        "silentsuite-bridge-windows-x86_64.exe.sha256": "eee  silentsuite-bridge-windows-x86_64.exe\n",
+    },
+    # Sibling lanes' artifacts, present in the same run.
+    "server-image-digest-amd64": {"amd64.digest": "sha256:" + "1" * 64 + "\n"},
+    "server-image-digest-arm64": {"arm64.digest": "sha256:" + "2" * 64 + "\n"},
+    # Buildx build records. The upstream file name is not asserted anywhere here;
+    # what matters is that a foreign artifact's contents reach staging at all.
+    "build-amd64-dockerbuild": {"Build and push linux (amd64).dockerbuild": "record\n"},
+    "build-arm64-dockerbuild": {"Build and push linux (arm64).dockerbuild": "record\n"},
+    "conscrypt-r28-abc123": {
+        "org/conscrypt/conscrypt-android/2.6.3-r28/conscrypt-android-2.6.3-r28.aar": "aar\n",
+    },
+}
+
+
+def workflow_expected_inventory() -> list[str]:
+    """The closed name set the attachment job asserts, read from the workflow."""
+
+    workflow = _yaml.safe_load(BRIDGE_WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["attach-release-assets"]["steps"]
+    run = next(s for s in steps if s.get("name") == "Re-assert the closed asset inventory")["run"]
+    block = run.split("printf '%s\\n' \\", 1)[1].split("| LC_ALL=C sort)", 1)[0]
+    return sorted(_re.findall(r"[A-Za-z0-9][A-Za-z0-9._-]*", block))
+
+
+def materialise(root: Path, artifacts: dict[str, dict[str, str]]) -> Path:
+    """Lay artifacts out the way download-artifact does with merge-multiple: false."""
+
+    source = root / "release-assets"
+    for artifact, files in artifacts.items():
+        for relative, content in files.items():
+            target = source / artifact / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+    return source
+
+
+def run_staging(source: Path, staging: Path):
+    return subprocess.run(
+        ["bash", str(STAGE), str(source), str(staging)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def filtered(artifacts: dict[str, dict[str, str]]) -> dict[str, dict[str, str]]:
+    return {
+        name: files
+        for name, files in artifacts.items()
+        if fnmatch.fnmatch(name, BRIDGE_PATTERN)
+    }
+
+
+def test_the_real_run_held_ten_artifacts_and_the_filter_admits_exactly_five():
+    assert len(REAL_RUN_ARTIFACTS) == 10
+    admitted = sorted(filtered(REAL_RUN_ARTIFACTS))
+    assert admitted == [
+        "silentsuite-bridge-linux-arm64",
+        "silentsuite-bridge-linux-x86_64",
+        "silentsuite-bridge-macos-arm64",
+        "silentsuite-bridge-macos-x86_64",
+        "silentsuite-bridge-windows-x86_64.exe",
+    ]
+    rejected = sorted(set(REAL_RUN_ARTIFACTS) - set(admitted))
+    assert rejected == [
+        "build-amd64-dockerbuild",
+        "build-arm64-dockerbuild",
+        "conscrypt-r28-abc123",
+        "server-image-digest-amd64",
+        "server-image-digest-arm64",
+    ]
+
+
+def test_the_unfiltered_acquisition_stops_the_lane_before_anything_is_attached(tmp_path: Path):
+    """The observed failure, reproduced: staging is handed foreign artifacts."""
+
+    source = materialise(tmp_path, REAL_RUN_ARTIFACTS)
+    staging = tmp_path / "flat"
+
+    result = run_staging(source, staging)
+
+    assert result.returncode != 0, "the helper accepted a run it should have refused"
+    assert not (staging / "SHA256SUMS.txt").exists(), "a manifest was built from foreign inputs"
+
+
+def test_the_filtered_acquisition_stages_exactly_the_closed_bridge_inventory(tmp_path: Path):
+    """With the pattern applied, only the five producers reach the helper."""
+
+    source = materialise(tmp_path, filtered(REAL_RUN_ARTIFACTS))
+    staging = tmp_path / "flat"
+
+    result = run_staging(source, staging)
+
+    assert result.returncode == 0, result.stderr
+    staged = sorted(entry.name for entry in staging.iterdir())
+    assert staged == workflow_expected_inventory()
+    assert len(staged) == 11, staged
+    # The manifest is the per-asset sidecars concatenated in C-locale order.
+    manifest = (staging / "SHA256SUMS.txt").read_text(encoding="utf-8")
+    sidecars = sorted(name for name in staged if name.endswith(".sha256"))
+    assert manifest == "".join(
+        (staging / name).read_text(encoding="utf-8") for name in sidecars
+    )
+
+
+def test_a_missing_bridge_producer_fails_the_closed_inventory(tmp_path: Path):
+    artifacts = filtered(REAL_RUN_ARTIFACTS)
+    del artifacts["silentsuite-bridge-macos-arm64"]
+    source = materialise(tmp_path, artifacts)
+    staging = tmp_path / "flat"
+
+    assert run_staging(source, staging).returncode == 0
+    staged = sorted(entry.name for entry in staging.iterdir())
+    assert staged != workflow_expected_inventory()
+    assert set(workflow_expected_inventory()) - set(staged) == {
+        "silentsuite-bridge-macos-arm64",
+        "silentsuite-bridge-macos-arm64.sha256",
+    }
+
+
+def test_a_duplicated_bridge_producer_is_refused_by_the_helper(tmp_path: Path):
+    """Two artifacts carrying one name must not silently overwrite each other."""
+
+    artifacts = dict(filtered(REAL_RUN_ARTIFACTS))
+    artifacts["silentsuite-bridge-linux-x86_64-rerun"] = {
+        "silentsuite-bridge-linux-x86_64": "a-different-binary\n",
+    }
+    source = materialise(tmp_path, artifacts)
+
+    result = run_staging(source, tmp_path / "flat")
+
+    assert result.returncode != 0
+    assert "both named" in result.stderr
+
+
+def test_an_unexpected_extra_bridge_asset_fails_the_closed_inventory(tmp_path: Path):
+    artifacts = dict(filtered(REAL_RUN_ARTIFACTS))
+    artifacts["silentsuite-bridge-freebsd-x86_64"] = {
+        "silentsuite-bridge-freebsd-x86_64": "unexpected\n",
+        "silentsuite-bridge-freebsd-x86_64.sha256": "fff  silentsuite-bridge-freebsd-x86_64\n",
+    }
+    source = materialise(tmp_path, artifacts)
+    staging = tmp_path / "flat"
+
+    # It matches the acquisition pattern, so the filter alone does not stop it;
+    # the closed inventory is what does.
+    assert fnmatch.fnmatch("silentsuite-bridge-freebsd-x86_64", BRIDGE_PATTERN)
+    assert run_staging(source, staging).returncode == 0
+    staged = sorted(entry.name for entry in staging.iterdir())
+    assert set(staged) - set(workflow_expected_inventory()) == {
+        "silentsuite-bridge-freebsd-x86_64",
+        "silentsuite-bridge-freebsd-x86_64.sha256",
+    }

--- a/tests/test_self_host_release_workflows.py
+++ b/tests/test_self_host_release_workflows.py
@@ -20,6 +20,7 @@ boundaries fixed:
 from __future__ import annotations
 
 import re
+from fnmatch import fnmatch
 from pathlib import Path
 
 import pytest
@@ -575,8 +576,17 @@ def test_the_registry_credentials_are_scoped_to_those_steps_alone():
                 )
 
 
-def test_the_registry_password_is_never_placed_on_a_command_line():
-    """A secret in argv is visible to every process on the runner."""
+def test_the_workflow_never_writes_a_credential_into_a_step_script():
+    """Scope note: this covers the YAML only.
+
+    It proves the workflow hands the verifier its credentials through the step
+    environment rather than composing them into a shell command. It says
+    nothing about what the verifier then does with them — a script can receive
+    a secret by environment and still put it in a child's argv, which is
+    exactly the defect this file used to claim to have ruled out. The argv of
+    the processes the verifier actually spawns is proved in
+    tests/test_server_image_verifier.py, by recording it.
+    """
 
     for job in RELEASE["jobs"].values():
         for step in steps(job):
@@ -587,16 +597,47 @@ def test_the_registry_password_is_never_placed_on_a_command_line():
             assert "secrets.GITHUB_TOKEN" not in body, "a secret must reach a script by env"
 
 
-def test_the_verifier_reads_its_credentials_only_from_the_environment():
+def test_the_verifier_hands_curl_its_credentials_through_config_files():
+    """Both credentials, and neither on a command line.
+
+    `-u user:pass` and `-H "Authorization: Bearer …"` publish the secret in the
+    child's argv for the life of the request. Both now travel in curl config
+    files instead. The behavioural proof — recorded argv, file mode, directory
+    mode, cleanup — is in tests/test_server_image_verifier.py; these are the
+    structural invariants that keep it that way.
+    """
+
     verifier = (ROOT / "scripts" / REGISTRY_VERIFIER).read_text(encoding="utf-8")
-    assert '-u "${REGISTRY_USERNAME:-}:${REGISTRY_PASSWORD:-}"' in verifier
-    assert "--registry-username" not in verifier, "credentials must not be CLI arguments"
+    # Comments name the removed forms in order to explain them, so the argv
+    # assertions below look at executable lines only.
+    code = "\n".join(
+        line for line in verifier.splitlines() if not line.lstrip().startswith("#")
+    )
+
+    # The two argv forms that leaked are gone, including any spelling of them.
+    for leaking in ('-u "', "--user ", '-H "Authorization:', '--header "Authorization:'):
+        assert leaking not in code, f"{leaking!r} would place a secret in argv"
+
+    # Both credentials arrive by --config, from a private directory.
+    assert code.count('--config "$TOKEN_CONFIG"') == 1
+    assert code.count('--config "$BEARER_CONFIG"') == 2, "manifest and blob calls"
+    assert 'mkdir -m 700 "$CREDENTIAL_DIR"' in verifier
+    assert "umask 077" in verifier
+
+    # Removed on success, failure and the signals a cancelled job sends.
+    assert "trap cleanup_credentials EXIT" in verifier
+    assert "trap 'cleanup_credentials; trap - EXIT; exit 130' HUP INT QUIT TERM" in verifier
+
+    # Validated before use, and never inherited by an unrelated child.
+    assert "assert_credential_shape" in verifier
+    assert "unset REGISTRY_USERNAME REGISTRY_PASSWORD" in verifier
+
     # It fails closed when no token can be minted rather than proceeding.
     assert "could not obtain a registry pull token" in verifier
     assert "set -euo pipefail" in verifier
     # And it never echoes what it was given.
-    assert "echo \"$REGISTRY_PASSWORD" not in verifier
-    assert "REGISTRY_PASSWORD}\"" not in verifier.replace('${REGISTRY_PASSWORD:-}"', "")
+    assert 'echo "$REGISTRY_PASSWORD' not in verifier
+    assert 'echo "$TOKEN' not in verifier
 
 
 def test_the_docker_login_is_not_what_authenticates_the_verifier():
@@ -1197,3 +1238,104 @@ def test_the_attachment_helper_revalidates_before_each_individual_write():
     assert lines[create - 1] == 'revalidate "before-create"'
     upload = lines.index('echo "  ${asset}: uploading"')
     assert lines[upload - 1] == 'revalidate "before-upload:${asset}"'
+
+
+# ── Artifact acquisition: each lane takes only its own producers ──────
+#
+# A controller run holds every component's artifacts at once. An acquisition
+# with no `name` and no `pattern` takes all of them, so the Bridge attachment
+# job downloaded the server's child digests, the Conscrypt AAR and Buildx's
+# `.dockerbuild` records alongside its five binaries. The staging helper refused
+# the first unexpected name — correctly — and the lane attached nothing.
+
+
+BRIDGE_PRODUCER_ARTIFACTS = (
+    "silentsuite-bridge-linux-x86_64",
+    "silentsuite-bridge-linux-arm64",
+    "silentsuite-bridge-macos-x86_64",
+    "silentsuite-bridge-macos-arm64",
+    "silentsuite-bridge-windows-x86_64.exe",
+)
+# Artifact names the same run really produced, from controller run 33269466888.
+FOREIGN_RUN_ARTIFACTS = (
+    "server-image-digest-amd64",
+    "server-image-digest-arm64",
+    "conscrypt-r28-${{ inputs.source_sha }}",
+    "silentsuite-android-release-assets-${{ inputs.source_sha }}",
+    "build-amd64-dockerbuild",
+    "build-arm64-dockerbuild",
+    "silentsuite-self-host-release-assets",
+    "android-tracker-scan-${{ inputs.source_sha }}",
+)
+BRIDGE_ACQUISITION_STEP = "Download the bridge producer artifacts"
+BRIDGE_ARTIFACT_PATTERN = "silentsuite-bridge-*"
+
+
+def download_steps(job: dict) -> list[dict]:
+    return [
+        step
+        for step in steps(job)
+        if str(step.get("uses", "")).startswith("actions/download-artifact@")
+    ]
+
+
+def test_the_bridge_attachment_downloads_only_its_own_producer_artifacts():
+    job = BRIDGE["jobs"]["attach-release-assets"]
+    acquisitions = download_steps(job)
+    assert len(acquisitions) == 1, "the bridge lane acquires artifacts exactly once"
+    step = step_named(job, BRIDGE_ACQUISITION_STEP)
+    assert step["with"]["pattern"] == BRIDGE_ARTIFACT_PATTERN
+    assert step["with"]["path"] == "release-assets/"
+    # No `name`: a single named artifact would take one platform, not five.
+    assert "name" not in step["with"]
+
+
+def test_the_bridge_acquisition_keeps_one_directory_per_artifact():
+    """`merge-multiple: false` is what preserves the staging helper's input shape.
+
+    The helper flattens one source tree into a closed set of names and refuses a
+    collision. Merging the artifacts before it runs would do that flattening
+    unchecked, outside the helper, and a duplicate would be silently overwritten.
+    """
+
+    step = step_named(BRIDGE["jobs"]["attach-release-assets"], BRIDGE_ACQUISITION_STEP)
+    assert step["with"]["merge-multiple"] == "false"
+
+
+def test_no_release_lane_acquires_artifacts_without_a_filter():
+    """The defect in run 33269466888, stated as a repository-wide rule."""
+
+    unfiltered = []
+    for path in (*CONTROL_PLANE, BRIDGE_BUILD_WORKFLOW):
+        for job_name, job in load(path).get("jobs", {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in download_steps(job):
+                options = step.get("with") or {}
+                if not options.get("name") and not options.get("pattern"):
+                    unfiltered.append(f"{path.name}:{job_name}: {step.get('name')}")
+    assert unfiltered == [], (
+        "these steps download every artifact in the run, including sibling lanes': "
+        f"{unfiltered}"
+    )
+
+
+@pytest.mark.parametrize("artifact", BRIDGE_PRODUCER_ARTIFACTS)
+def test_every_bridge_producer_artifact_matches_the_acquisition_pattern(artifact):
+    assert fnmatch(artifact, BRIDGE_ARTIFACT_PATTERN), artifact
+
+
+@pytest.mark.parametrize("artifact", FOREIGN_RUN_ARTIFACTS)
+def test_no_sibling_lane_artifact_matches_the_acquisition_pattern(artifact):
+    assert not fnmatch(artifact, BRIDGE_ARTIFACT_PATTERN), artifact
+
+
+def test_the_pattern_covers_exactly_the_five_matrix_producers():
+    """The uploaded names come from the build matrix, so compare against it."""
+
+    matrix = load(BRIDGE_BUILD_WORKFLOW)["jobs"]["build"]["strategy"]["matrix"]["include"]
+    produced = {entry["asset-name"] for entry in matrix}
+    assert produced == set(BRIDGE_PRODUCER_ARTIFACTS)
+    upload = step_named(load(BRIDGE_BUILD_WORKFLOW)["jobs"]["build"], "Upload artifact")
+    assert upload["with"]["name"] == "${{ matrix.asset-name }}"
+    assert {name for name in produced if fnmatch(name, BRIDGE_ARTIFACT_PATTERN)} == produced

--- a/tests/test_self_host_release_workflows.py
+++ b/tests/test_self_host_release_workflows.py
@@ -510,6 +510,106 @@ def test_release_verifier_can_validate_an_existing_alias_identity():
     assert "revision label is" in verifier
 
 
+# ── Registry verifier credentials ─────────────────────────────────────
+#
+# The verifier queries the GHCR API directly instead of going through the Docker
+# client, so `docker/login-action` does nothing for it. It mints its own pull
+# token from REGISTRY_USERNAME / REGISTRY_PASSWORD, and asks anonymously when
+# they are unset — which a package that is not publicly readable answers with
+# 403. Every step that runs it therefore needs exactly those two variables, and
+# no other step may carry them.
+
+REGISTRY_VERIFIER = "verify-server-image-release.sh"
+REGISTRY_CREDENTIALS = {
+    "REGISTRY_USERNAME": "${{ github.actor }}",
+    "REGISTRY_PASSWORD": "${{ secrets.GITHUB_TOKEN }}",
+}
+
+
+def verifier_steps(workflow: dict) -> list[tuple[str, dict]]:
+    """Every step whose script actually executes the registry verifier."""
+
+    found = []
+    for job_name, job in workflow["jobs"].items():
+        for step in steps(job):
+            if REGISTRY_VERIFIER in str(step.get("run", "")):
+                found.append((f"{job_name}/{step.get('name')}", step))
+    return found
+
+
+def test_every_registry_verifier_step_can_obtain_a_pull_token():
+    """The whole point: an uncredentialed call gets 403 and stops the release."""
+
+    found = verifier_steps(RELEASE)
+    # latest-before, alias resolve/verify, published-image verify, latest-after.
+    assert [name for name, _ in found] == [
+        "publish-index/Record the current latest reference",
+        "publish-index/Merge verified children into the release index",
+        "publish-index/Verify the published release image",
+        "publish-index/Assert latest was not moved",
+    ], found
+    for name, step in found:
+        env = step.get("env") or {}
+        for key, value in REGISTRY_CREDENTIALS.items():
+            assert env.get(key) == value, f"{name} is missing {key}={value}"
+
+
+def test_the_registry_credentials_are_scoped_to_those_steps_alone():
+    """Never job scope, never workflow scope, never a candidate step."""
+
+    for path in all_workflows():
+        workflow = load(path)
+        assert not set(REGISTRY_CREDENTIALS) & set(workflow.get("env") or {}), path.name
+        for job_name, job in workflow.get("jobs", {}).items():
+            assert not set(REGISTRY_CREDENTIALS) & set(job.get("env") or {}), (
+                f"{path.name}:{job_name} grants the registry credentials to every step"
+            )
+            for step in steps(job):
+                carried = set(REGISTRY_CREDENTIALS) & set(step.get("env") or {})
+                if not carried:
+                    continue
+                assert path == RELEASE_WORKFLOW, f"{path.name} must not carry {carried}"
+                assert REGISTRY_VERIFIER in str(step.get("run", "")), (
+                    f"{path.name}:{job_name}/{step.get('name')!r} carries {carried} "
+                    "without running the verifier"
+                )
+
+
+def test_the_registry_password_is_never_placed_on_a_command_line():
+    """A secret in argv is visible to every process on the runner."""
+
+    for job in RELEASE["jobs"].values():
+        for step in steps(job):
+            body = str(step.get("run", ""))
+            for key in REGISTRY_CREDENTIALS:
+                assert f"--{key.lower()}" not in body
+                assert f"{key}=" not in body, f"{key} must be inherited, not re-assigned"
+            assert "secrets.GITHUB_TOKEN" not in body, "a secret must reach a script by env"
+
+
+def test_the_verifier_reads_its_credentials_only_from_the_environment():
+    verifier = (ROOT / "scripts" / REGISTRY_VERIFIER).read_text(encoding="utf-8")
+    assert '-u "${REGISTRY_USERNAME:-}:${REGISTRY_PASSWORD:-}"' in verifier
+    assert "--registry-username" not in verifier, "credentials must not be CLI arguments"
+    # It fails closed when no token can be minted rather than proceeding.
+    assert "could not obtain a registry pull token" in verifier
+    assert "set -euo pipefail" in verifier
+    # And it never echoes what it was given.
+    assert "echo \"$REGISTRY_PASSWORD" not in verifier
+    assert "REGISTRY_PASSWORD}\"" not in verifier.replace('${REGISTRY_PASSWORD:-}"', "")
+
+
+def test_the_docker_login_is_not_what_authenticates_the_verifier():
+    """Documented so the next reader does not delete the env as redundant."""
+
+    names = step_names(RELEASE["jobs"]["publish-index"])
+    assert names.index("Record the current latest reference") < names.index(
+        "Login to GitHub Container Registry"
+    ), "the first verifier call precedes the Docker login, which cannot serve it"
+    source = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    assert "does nothing for it" in source
+
+
 def test_release_never_pushes_or_moves_latest():
     source = RELEASE_WORKFLOW.read_text(encoding="utf-8")
     assert ":latest" not in source

--- a/tests/test_server_image_verifier.py
+++ b/tests/test_server_image_verifier.py
@@ -25,11 +25,26 @@ COMMIT = "b" * 40
 COMMIT_REFERENCE = f"selfhost-{COMMIT}"
 OCI_MANIFEST = "application/vnd.oci.image.manifest.v1+json"
 
+# Distinctive enough that finding any of them in a recorded argv is unambiguous,
+# and shaped like the real thing: a login, a ghs_ workflow token, and a
+# base64url bearer with the dots a ghcr.io JWT carries.
+FIXTURE_USER = "fixture-actor"
+FIXTURE_PASSWORD = "ghs_fixturepassword0123456789"
+FIXTURE_BEARER = "eyJmaXh0dXJl.YmVhcmVy.dG9rZW4-value_0123"
+
 CURL_STUB = r'''#!/usr/bin/env python3
-"""Minimal ghcr.io stand-in: exact fixture bytes plus an honest digest header."""
+"""Minimal ghcr.io stand-in.
+
+Serves exact fixture bytes with an honest digest header, and — because a
+credential that reaches curl by argv is the defect under test — records the
+exact argv of every call plus, for any `--config` file, its mode, its parent's
+mode and its contents. The verifier's secrets must appear in the second set and
+never in the first.
+"""
 import hashlib
 import json
 import os
+import stat
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
@@ -39,16 +54,96 @@ routes = json.loads((fixture / "routes.json").read_text())
 args = sys.argv[1:]
 parsed = urlparse(args[-1])
 
+
+def unescape(value):
+    """Reverse the escaping curl applies inside a double-quoted config value."""
+    out, index = [], 0
+    while index < len(value):
+        character = value[index]
+        if character == "\\" and index + 1 < len(value):
+            index += 1
+            out.append({"n": "\n", "r": "\r", "t": "\t", "v": "\v"}.get(value[index], value[index]))
+        else:
+            out.append(character)
+        index += 1
+    return "".join(out)
+
+
+def read_config(path):
+    """Return {option: value} from a curl config file."""
+    options = {}
+    for line in Path(path).read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        option, _, raw = line.partition("=")
+        option, raw = option.strip(), raw.strip()
+        if raw.startswith('"') and raw.endswith('"'):
+            raw = unescape(raw[1:-1])
+        options.setdefault(option, []).append(raw)
+    return options
+
+
+configs = {}
+options = {}
+for index, argument in enumerate(args):
+    if argument in ("--config", "-K") and index + 1 < len(args):
+        path = Path(args[index + 1])
+        entry = {
+            "path": str(path),
+            "exists": path.exists(),
+            "mode": None,
+            "parent_mode": None,
+            "content": None,
+        }
+        if path.exists():
+            entry["mode"] = stat.S_IMODE(path.stat().st_mode)
+            entry["parent_mode"] = stat.S_IMODE(path.parent.stat().st_mode)
+            entry["content"] = path.read_text()
+            for option, values in read_config(path).items():
+                options.setdefault(option, []).extend(values)
+        configs[str(path)] = entry
+
+log = os.environ.get("VERIFIER_ARGV_LOG")
+if log:
+    with open(log, "a", encoding="utf-8") as handle:
+        handle.write(
+            json.dumps(
+                {
+                    "argv": args,
+                    "url": args[-1],
+                    "path": parsed.path,
+                    "configs": configs,
+                    "config_options": options,
+                    "environ": {
+                        name: os.environ[name]
+                        for name in ("REGISTRY_USERNAME", "REGISTRY_PASSWORD")
+                        if name in os.environ
+                    },
+                }
+            )
+            + "\n"
+        )
+
 if parsed.path == "/token":
     # ghcr.io issues an anonymous pull token only for a publicly readable
     # package. For anything else it answers 403, and `curl -f` exits 22.
-    credentials = args[args.index("-u") + 1] if "-u" in args else ":"
+    credentials = options.get("user", [":"])[0]
     user, _, password = credentials.partition(":")
     if not user or not password:
         sys.stderr.write("curl: (22) The requested URL returned error: 403\n")
         raise SystemExit(22)
-    print(json.dumps({"token": "fixture-token"}))
+    print(json.dumps({"token": FIXTURE_BEARER}))
     raise SystemExit(0)
+
+# Every other route is authenticated by the minted bearer, which must arrive in
+# a config file rather than on the command line.
+if not any(
+    value.strip().lower() == "authorization: bearer " + FIXTURE_BEARER.lower()
+    for value in options.get("header", [])
+):
+    sys.stderr.write("curl: (22) The requested URL returned error: 401\n")
+    raise SystemExit(22)
 
 if "/blobs/" in parsed.path:
     digest = parsed.path.rsplit("/blobs/", 1)[1]
@@ -229,12 +324,16 @@ def _registry_fixture(
     registry.publish()
 
     curl = tmp_path / "curl"
-    curl.write_text(CURL_STUB, encoding="utf-8")
+    shebang, _, body = CURL_STUB.partition("\n")
+    curl.write_text(
+        f"{shebang}\nFIXTURE_BEARER = {FIXTURE_BEARER!r}\n{body}", encoding="utf-8"
+    )
     curl.chmod(0o755)
 
     return {
         "path": directory,
         "curl": curl,
+        "argv_log": tmp_path / "curl-argv.jsonl",
         "amd64_digest": children["amd64"]["digest"],
         "arm64_digest": children["arm64"]["digest"],
         "index_digest": index_digest,
@@ -252,8 +351,9 @@ def _verifier_environment(fixture: dict, *, credentials: bool = True) -> dict:
         }
     )
     if credentials:
-        environment["REGISTRY_USERNAME"] = "fixture-user"
-        environment["REGISTRY_PASSWORD"] = "fixture-password"
+        environment["REGISTRY_USERNAME"] = FIXTURE_USER
+        environment["REGISTRY_PASSWORD"] = FIXTURE_PASSWORD
+    environment["VERIFIER_ARGV_LOG"] = str(fixture["argv_log"])
     return environment
 
 
@@ -467,3 +567,226 @@ def test_the_credentials_never_appear_in_verifier_output(tmp_path: Path):
     for secret in ("fixture-password", "fixture-user"):
         assert secret not in result.stdout
         assert secret not in result.stderr
+
+
+# ── Credentials never reach a command line ────────────────────────────
+#
+# `-u user:pass` and `-H "Authorization: Bearer …"` put the secret in the
+# child's argv, which every process on the runner can read out of
+# /proc/<pid>/cmdline. These run the real verifier against the stand-in curl,
+# which records the exact argv of every call, and assert the secrets are absent
+# from all of it — while proving they did reach curl, through a 0600 config
+# file inside a 0700 directory that no longer exists once the run ends.
+
+SECRETS = (FIXTURE_USER, FIXTURE_PASSWORD, FIXTURE_BEARER, f"{FIXTURE_USER}:{FIXTURE_PASSWORD}")
+
+
+def _calls(fixture: dict) -> list[dict]:
+    log = fixture["argv_log"]
+    assert log.exists(), "the stand-in curl recorded no call at all"
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+def _token_call(calls: list[dict]) -> dict:
+    matches = [call for call in calls if call["path"] == "/token"]
+    assert len(matches) == 1, f"expected one token call, got {len(matches)}"
+    return matches[0]
+
+
+def _registry_calls(calls: list[dict]) -> list[dict]:
+    return [call for call in calls if call["path"] != "/token"]
+
+
+def test_no_credential_value_appears_in_any_curl_argv(tmp_path: Path):
+    """The finding, stated as a property of every recorded invocation."""
+
+    fixture = _registry_fixture(tmp_path)
+    result = _run_verifier(fixture)
+    assert result.returncode == 0, result.stderr
+
+    calls = _calls(fixture)
+    assert len(calls) >= 4, "the fixture should cover token, index, children and configs"
+    for call in calls:
+        flat = "\x00".join(call["argv"])
+        for secret in SECRETS:
+            assert secret not in flat, f"{secret!r} reached argv of {call['url']}"
+        # Not even the option that would carry one.
+        assert "-u" not in call["argv"], call["argv"]
+        assert "--user" not in call["argv"], call["argv"]
+        assert not [
+            argument for argument in call["argv"] if argument.lower().startswith("authorization:")
+        ], call["argv"]
+        # The config path travels in argv too, so it must not encode a secret
+        # in its own name.
+        for path in call["configs"]:
+            assert Path(path).name in ("token.conf", "bearer.conf"), path
+
+
+def test_the_basic_pair_reaches_curl_through_a_protected_config_file(tmp_path: Path):
+    fixture = _registry_fixture(tmp_path)
+    assert _run_verifier(fixture).returncode == 0
+
+    call = _token_call(_calls(fixture))
+    assert "--config" in call["argv"]
+    (entry,) = list(call["configs"].values())
+    assert entry["exists"], "curl was pointed at a config file that was not there"
+    # 0600 for the file, 0700 for the directory holding it: never group- or
+    # world-readable at any point curl could read it.
+    assert entry["mode"] == 0o600, oct(entry["mode"])
+    assert entry["parent_mode"] == 0o700, oct(entry["parent_mode"])
+    # And it really is how the credentials travelled.
+    assert call["config_options"]["user"] == [f"{FIXTURE_USER}:{FIXTURE_PASSWORD}"]
+    assert FIXTURE_PASSWORD in entry["content"]
+
+
+def test_the_minted_bearer_reaches_curl_through_a_protected_config_file(tmp_path: Path):
+    fixture = _registry_fixture(tmp_path)
+    assert _run_verifier(fixture).returncode == 0
+
+    registry_calls = _registry_calls(_calls(fixture))
+    assert registry_calls, "no manifest or blob call was recorded"
+    for call in registry_calls:
+        assert "--config" in call["argv"], call["argv"]
+        (entry,) = list(call["configs"].values())
+        assert entry["mode"] == 0o600, oct(entry["mode"])
+        assert entry["parent_mode"] == 0o700, oct(entry["parent_mode"])
+        assert call["config_options"]["header"] == [f"Authorization: Bearer {FIXTURE_BEARER}"]
+
+
+def test_both_manifest_and_blob_calls_are_covered(tmp_path: Path):
+    """The blob fetch reads the image config; it authenticates the same way."""
+
+    fixture = _registry_fixture(tmp_path)
+    assert _run_verifier(fixture).returncode == 0
+
+    calls = _calls(fixture)
+    assert any("/manifests/" in call["path"] for call in calls)
+    assert any("/blobs/" in call["path"] for call in calls)
+
+
+def test_the_config_material_is_removed_when_the_run_finishes(tmp_path: Path):
+    fixture = _registry_fixture(tmp_path)
+    assert _run_verifier(fixture).returncode == 0
+
+    referenced = {
+        path for call in _calls(fixture) for path in call["configs"]
+    }
+    assert referenced, "no config file was ever referenced"
+    for path in referenced:
+        assert not Path(path).exists(), f"{path} outlived the run"
+        assert not Path(path).parent.exists(), f"{Path(path).parent} outlived the run"
+
+
+def test_the_config_material_is_removed_when_the_run_fails(tmp_path: Path):
+    """Failure is the path a leak would survive on, so it gets its own case."""
+
+    fixture = _registry_fixture(tmp_path, swap_child_bodies=True)
+    result = _run_verifier(fixture)
+    assert result.returncode != 0, "this fixture is supposed to be rejected"
+
+    referenced = {path for call in _calls(fixture) for path in call["configs"]}
+    assert referenced
+    for path in referenced:
+        assert not Path(path).exists(), f"{path} outlived a failed run"
+
+
+def test_the_token_config_is_dropped_once_the_bearer_exists(tmp_path: Path):
+    """The basic pair has one job; it does not linger for the whole run."""
+
+    fixture = _registry_fixture(tmp_path)
+    assert _run_verifier(fixture).returncode == 0
+
+    calls = _calls(fixture)
+    token_config = next(iter(_token_call(calls)["configs"]))
+    for call in _registry_calls(calls):
+        assert token_config not in call["configs"]
+        assert not any(
+            token_config == argument for argument in call["argv"]
+        ), "the registry calls still point at the basic-auth config"
+
+
+def test_the_registry_credentials_are_not_inherited_by_curl(tmp_path: Path):
+    """Unset after use, so no child process carries them in its environment."""
+
+    fixture = _registry_fixture(tmp_path)
+    assert _run_verifier(fixture).returncode == 0
+
+    for call in _calls(fixture):
+        assert call["environ"] == {}, f"{call['url']} inherited {sorted(call['environ'])}"
+
+
+def test_no_credential_value_appears_in_output_or_artifacts(tmp_path: Path):
+    fixture = _registry_fixture(tmp_path)
+    digest_file = tmp_path / "index.digest"
+    result = _run_verifier(
+        fixture,
+        arguments=[
+            "--tag",
+            TAG,
+            "--commit",
+            COMMIT,
+            "--amd64-digest",
+            fixture["amd64_digest"],
+            "--arm64-digest",
+            fixture["arm64_digest"],
+            "--index-digest-file",
+            str(digest_file),
+        ],
+    )
+    assert result.returncode == 0, result.stderr
+
+    for secret in SECRETS:
+        assert secret not in result.stdout
+        assert secret not in result.stderr
+        assert secret not in digest_file.read_text(encoding="utf-8")
+
+
+def test_shell_tracing_does_not_publish_a_credential(tmp_path: Path):
+    """`bash -x` prints every expansion, including the ones that matter."""
+
+    fixture = _registry_fixture(tmp_path)
+    result = subprocess.run(
+        ["bash", "-x", str(VERIFIER), "--repository", REPOSITORY, "--resolve", TAG],
+        cwd=ROOT,
+        env=_verifier_environment(fixture),
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    combined = result.stdout + result.stderr
+    assert "+ " in result.stderr, "the run was not actually traced"
+    for secret in SECRETS:
+        assert secret not in combined, f"{secret!r} appeared in a shell trace"
+
+
+@pytest.mark.parametrize(
+    ("variable", "value", "why"),
+    [
+        ("REGISTRY_PASSWORD", "good\nheader = \"X: y\"", "a newline could add a config line"),
+        ("REGISTRY_PASSWORD", 'quo"te', "a bare quote could end the value early"),
+        ("REGISTRY_PASSWORD", "back\\slash", "a backslash could escape the closing quote"),
+        ("REGISTRY_USERNAME", "space actor", "a login never contains a space"),
+        ("REGISTRY_USERNAME", "semi;colon", "a login never contains a semicolon"),
+    ],
+)
+def test_a_credential_that_could_break_out_of_the_config_is_refused(
+    tmp_path: Path, variable: str, value: str, why: str
+):
+    fixture = _registry_fixture(tmp_path)
+    environment = _verifier_environment(fixture)
+    environment[variable] = value
+
+    result = subprocess.run(
+        ["bash", str(VERIFIER), "--repository", REPOSITORY, "--resolve", TAG],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2, why
+    assert "will not hand to curl" in result.stderr
+    # The refusal never quotes the value back.
+    assert value not in result.stdout + result.stderr
+    assert not fixture["argv_log"].exists(), "curl was called before the value was checked"

--- a/tests/test_server_image_verifier.py
+++ b/tests/test_server_image_verifier.py
@@ -40,6 +40,13 @@ args = sys.argv[1:]
 parsed = urlparse(args[-1])
 
 if parsed.path == "/token":
+    # ghcr.io issues an anonymous pull token only for a publicly readable
+    # package. For anything else it answers 403, and `curl -f` exits 22.
+    credentials = args[args.index("-u") + 1] if "-u" in args else ":"
+    user, _, password = credentials.partition(":")
+    if not user or not password:
+        sys.stderr.write("curl: (22) The requested URL returned error: 403\n")
+        raise SystemExit(22)
     print(json.dumps({"token": "fixture-token"}))
     raise SystemExit(0)
 
@@ -234,22 +241,27 @@ def _registry_fixture(
     }
 
 
-def _run_verifier(fixture: dict) -> subprocess.CompletedProcess[str]:
+def _verifier_environment(fixture: dict, *, credentials: bool = True) -> dict:
     environment = dict(os.environ)
+    environment.pop("REGISTRY_USERNAME", None)
+    environment.pop("REGISTRY_PASSWORD", None)
     environment.update(
         {
             "PATH": f"{fixture['curl'].parent}:{environment['PATH']}",
             "VERIFIER_FIXTURE": str(fixture["path"]),
-            "REGISTRY_USERNAME": "fixture-user",
-            "REGISTRY_PASSWORD": "fixture-password",
         }
     )
-    return subprocess.run(
-        [
-            "bash",
-            str(VERIFIER),
-            "--repository",
-            REPOSITORY,
+    if credentials:
+        environment["REGISTRY_USERNAME"] = "fixture-user"
+        environment["REGISTRY_PASSWORD"] = "fixture-password"
+    return environment
+
+
+def _run_verifier(
+    fixture: dict, *, credentials: bool = True, arguments: list[str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    if arguments is None:
+        arguments = [
             "--tag",
             TAG,
             "--commit",
@@ -258,9 +270,11 @@ def _run_verifier(fixture: dict) -> subprocess.CompletedProcess[str]:
             fixture["amd64_digest"],
             "--arm64-digest",
             fixture["arm64_digest"],
-        ],
+        ]
+    return subprocess.run(
+        ["bash", str(VERIFIER), "--repository", REPOSITORY, *arguments],
         cwd=ROOT,
-        env=environment,
+        env=_verifier_environment(fixture, credentials=credentials),
         capture_output=True,
         text=True,
     )
@@ -360,3 +374,96 @@ def test_the_verified_index_digest_is_the_hash_of_the_bytes_the_registry_served(
     assert result.returncode == 0, result.stderr
     assert _digest(served) == fixture["index_digest"]
     assert f"{REPOSITORY}@{fixture['index_digest']}" in result.stdout
+
+
+# ── Registry authentication ───────────────────────────────────────────
+#
+# The first real v0.5.4-beta release stopped here: `--resolve latest` ran with
+# no REGISTRY_USERNAME / REGISTRY_PASSWORD, asked ghcr.io/token anonymously and
+# was answered 403. These reproduce that against the stand-in registry, in both
+# the mode that failed and every other mode the release workflow uses.
+
+
+@pytest.mark.parametrize(
+    ("mode", "arguments"),
+    [
+        ("resolve", ["--resolve", "latest"]),
+        ("resolve-alias", ["--resolve", TAG]),
+        ("verify-tag", None),
+        (
+            "verify-reference",
+            ["--verify-reference", TAG, "--commit", COMMIT],
+        ),
+    ],
+)
+def test_every_verifier_mode_fails_closed_without_registry_credentials(
+    tmp_path: Path, mode: str, arguments
+):
+    """No credentials means no pull token, and no pull token means no release."""
+
+    fixture = _registry_fixture(tmp_path)
+    if arguments is not None and mode == "verify-reference":
+        arguments = arguments + [
+            "--amd64-digest",
+            fixture["amd64_digest"],
+            "--arm64-digest",
+            fixture["arm64_digest"],
+        ]
+
+    result = _run_verifier(fixture, credentials=False, arguments=arguments)
+
+    assert result.returncode != 0, f"{mode} continued without a registry token"
+    assert "could not obtain a registry pull token" in result.stderr
+    # Nothing is reported as verified, and no digest is emitted for a caller to
+    # mistake for a resolved reference.
+    assert "absent" not in result.stdout
+    assert "sha256:" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("mode", "arguments"),
+    [
+        ("resolve", ["--resolve", "latest"]),
+        ("verify-tag", None),
+    ],
+)
+def test_the_same_modes_succeed_once_the_credentials_are_present(
+    tmp_path: Path, mode: str, arguments
+):
+    fixture = _registry_fixture(tmp_path)
+
+    result = _run_verifier(fixture, credentials=True, arguments=arguments)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_a_partial_credential_pair_is_not_treated_as_anonymous_success(tmp_path: Path):
+    """A username with no password must fail, not silently degrade."""
+
+    fixture = _registry_fixture(tmp_path)
+    environment = _verifier_environment(fixture, credentials=False)
+    environment["REGISTRY_USERNAME"] = "fixture-user"
+
+    result = subprocess.run(
+        ["bash", str(VERIFIER), "--repository", REPOSITORY, "--resolve", "latest"],
+        cwd=ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "could not obtain a registry pull token" in result.stderr
+
+
+def test_the_credentials_never_appear_in_verifier_output(tmp_path: Path):
+    """Redaction is GitHub's job for the secret; the script must not help it leak."""
+
+    fixture = _registry_fixture(tmp_path)
+
+    result = _run_verifier(fixture)
+
+    assert result.returncode == 0, result.stderr
+    for secret in ("fixture-password", "fixture-user"):
+        assert secret not in result.stdout
+        assert secret not in result.stderr


### PR DESCRIPTION
## Root causes from the first real controller run

The immutable `v0.5.4-beta` controller admitted the correct protected-main source and then failed closed before creating a usable umbrella draft:

1. Both native server-image children built, pushed by digest, and passed smoke. The merge job then called the registry verifier without its supported GHCR credentials, so pull-token acquisition returned 403 before any version/commit alias was published.
2. The Bridge attachment job downloaded every artifact in the controller run. The trusted staging helper correctly rejected a foreign Buildx `.dockerbuild` artifact before attaching anything.
3. The signed Android job never started because the live `android-release` environment still permits only `v*` tag refs, while the protected controller runs from `main`.

## What this changes

- scopes the existing workflow token and actor only to the four trusted server-image verifier steps
- supplies both token-acquisition credentials and minted bearer authorization through mode-600 curl config files inside a mode-700 directory, never curl argv
- removes credential material on success, failure and cancellation signals; prevents shell-trace, output and child-environment leakage
- preserves fail-closed registry hashing, alias conflict checks, `latest` invariance, provenance and bundle semantics
- filters Bridge attachment acquisition to `silentsuite-bridge-*` while retaining separate artifact directories and the unchanged exact staging inventory
- adds behavioral secret-argv/config/cleanup tests and a mixed 10-artifact fixture reproducing the real Bridge failure

## Verification

- 872 repository tests passed, plus 26 subtests
- release control-plane and Android signing-boundary checker passed
- live server-image material contract passed
- strict workflow YAML/action-pin scan passed
- mutation checks proved the registry credential, argv, cleanup, Bridge pattern and directory-shape contracts are non-vacuous
- protected controller, Android, readiness, hosted-production, staging helper and attachment helper remain unchanged

## Operational prerequisite after merge

Before retrying the immutable tag, transition the `android-release` environment custom policy safely:

1. add exact branch policy `main`;
2. read back both `main` and legacy tag policy `v*`;
3. remove legacy policy ID `56037473`;
4. read back exactly `main`, preserving custom-policy mode, environment secrets and all other settings.

Only `.github/workflows/release-android.yml:build-release` names this environment. That workflow is reusable-only and is called solely by the protected-main release controller after owner-sender, live-tag, main-ancestry and structural boundary gates.

## Boundaries

This PR does not move/recreate the immutable tag, publish image aliases, create/publish a release, move `latest`, upload to a store, or deploy hosted production.