### PR TITLE
fix: validate release drafts and Android signing keys

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -258,13 +258,40 @@ jobs:
             --commit "$SOURCE_SHA" \
             --stage android-signing-material
 
+      # `echo` mangles a value containing backslashes or a leading `-`, and a
+      # failing `base64 -d` inside a pipeline is invisible without pipefail — the
+      # decode that produced v0.5.4-beta's unreadable store reported success.
+      # Now: private mode, literal write, strict decode, and a store that must
+      # exist as a non-empty regular file before anything else runs.
       - name: Decode release keystore
         env:
           KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
         run: |
+          set -euo pipefail
+          umask 077
           mkdir -p "$RUNNER_TEMP/keystore"
-          echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/keystore/silentsuite-release.jks"
-          echo "KEYSTORE_PATH=$RUNNER_TEMP/keystore/silentsuite-release.jks" >> "$GITHUB_ENV"
+          KEYSTORE_FILE="$RUNNER_TEMP/keystore/silentsuite-release.jks"
+          if ! printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_FILE"; then
+            echo "Refusing to sign: the encoded keystore secret is not valid base64" >&2
+            exit 1
+          fi
+          if [ ! -f "$KEYSTORE_FILE" ] || [ ! -s "$KEYSTORE_FILE" ]; then
+            echo "Refusing to sign: the decoded keystore is missing or empty" >&2
+            exit 1
+          fi
+          echo "KEYSTORE_PATH=$KEYSTORE_FILE" >> "$GITHUB_ENV"
+
+      # Trusted code, from the controller checkout, opening the store with
+      # keytool before Gradle ever sees it. It reports only whether the store
+      # opens, whether the configured alias is a PrivateKeyEntry, and the public
+      # certificate fingerprint — never the password, the alias or key material.
+      - name: Verify the release keystore before Gradle
+        env:
+          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          bash "$GITHUB_WORKSPACE/.release-trusted/scripts/verify-android-release-keystore.sh"
 
       - name: Build signed release APK and AAB
         env:

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -11,14 +11,23 @@ name: Release Android
 # The signing boundary this preserves is unchanged from the tag-triggered
 # design and is enforced byte-for-byte by scripts/check-android-signing-boundary.py:
 #
-#   signing-policy       trusted structural gate, contents: read
-#   conscrypt-r28        candidate build, contents: read
-#   build-release        holds the keystore; contents: read, no persisted
-#                        checkout credential or release API; the read token is
-#                        scoped only to trusted identity-revalidation steps
+#   signing-policy         trusted structural gate, contents: read
+#   conscrypt-r28          candidate build, contents: read
+#   build-unsigned-release candidate Gradle, contents: read, no environment and
+#                          no signing secret — the runner holds nothing worth
+#                          taking, and hands over a closed, checksummed artifact
+#   sign-release           a fresh runner that never checks out or executes
+#                          candidate code; holds the keystore, binds the
+#                          protected environment, contents: read
 #   attach-release-assets  holds contents: write; no environment, no signing
-#                        secret, no Gradle — only the closed artifact and the
-#                        trusted attachment helper
+#                          secret, no Gradle — only the closed artifact and the
+#                          trusted attachment helper
+#
+# The job split is the load-bearing part. A GitHub-hosted runner grants every
+# job passwordless sudo, so candidate code that shares a runner with signing
+# material can replace trusted helper bytes, poison PATH or BASH_ENV through
+# $GITHUB_ENV, and substitute the very tools that verify it. Ordering steps
+# cannot close that; a separate runner can.
 
 on:
   workflow_call:
@@ -155,30 +164,23 @@ jobs:
             --stage android-signing
 
   # ─────────────────────────────────────────────────────────────────────
-  # Release build — signed, on the admitted commit only.
+  # Unsigned producer — candidate code, and nothing it could want.
   #
-  # Uses a protected GitHub Environment so signing secrets are not
-  # accessible to PRs, forks, or anything outside this called lane.
+  # This is where the tag's own Gradle, its build scripts and its NDK toolchain
+  # run. It holds no signing secret, binds no environment, and its token is
+  # read-only, so there is nothing on this runner worth compromising it for.
   #
-  # This job holds signing material and therefore holds no repository write: no
-  # contents:write, no persisted checkout credential, no release API write, no
-  # attachment helper. It hands its signed output to `attach-release-assets`
-  # through a closed artifact, and that job — which has none of the signing
-  # material — is the only thing that can write a release.
-  #
-  # It does carry the read-only workflow token, and only in the three reviewed
-  # revalidation steps below. Those run trusted verifier code checked out
-  # separately from `${{ github.sha }}` into `.release-trusted`, and they bracket
-  # every irreversible act in this job: the keystore is not decoded, no signed
-  # byte leaves, and the closed asset set is not handed to the write-capable lane
-  # until the live tag, its commit and both tag rulesets have just been
-  # re-confirmed. Candidate Gradle and candidate scripts never see the token.
+  # That separation is the whole point. A GitHub-hosted runner gives every job
+  # passwordless sudo, so candidate code sharing a runner with signing material
+  # can rewrite any file, any tool on PATH, and the environment of every later
+  # step. No amount of ordering fixes that; only a fresh runner does. The
+  # keystore is therefore decoded in `sign-release`, on a machine this job has
+  # never touched.
   # ─────────────────────────────────────────────────────────────────────
-  build-release:
-    name: Build (signed, admitted release)
-    needs: [signing-policy, conscrypt-r28, revalidate-signing]
+  build-unsigned-release:
+    name: Build (unsigned, admitted release)
+    needs: [signing-policy, conscrypt-r28]
     runs-on: ubuntu-latest
-    environment: android-release
     permissions:
       contents: read
     defaults:
@@ -186,20 +188,10 @@ jobs:
         working-directory: android
 
     steps:
-      - name: Checkout
+      - name: Checkout the admitted commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.source_sha }}
-          persist-credentials: false
-
-      # Second, and into its own directory: the candidate checkout above cleans
-      # the workspace root, so the trusted verifier has to land after it and
-      # outside it. Nothing in the Android build reads from this path.
-      - name: Check out the trusted controller revision
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.sha }}
-          path: .release-trusted
           persist-credentials: false
 
       - name: Set up JDK 17
@@ -244,72 +236,18 @@ jobs:
           name: conscrypt-r28-${{ inputs.source_sha }}
           path: android/build/conscrypt-m2
 
-      # Immediately before the release key exists on this runner. Everything
-      # above is reversible; nothing below it is.
-      - name: Revalidate the release identity before decoding signing material
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          SOURCE_SHA: ${{ inputs.source_sha }}
-        run: |
-          set -euo pipefail
-          bash "$GITHUB_WORKSPACE/.release-trusted/scripts/verify-release-identity.sh" \
-            --tag "$RELEASE_TAG" \
-            --commit "$SOURCE_SHA" \
-            --stage android-signing-material
-
-      # `echo` mangles a value containing backslashes or a leading `-`, and a
-      # failing `base64 -d` inside a pipeline is invisible without pipefail — the
-      # decode that produced v0.5.4-beta's unreadable store reported success.
-      # Now: private mode, literal write, strict decode, and a store that must
-      # exist as a non-empty regular file before anything else runs.
-      - name: Decode release keystore
-        env:
-          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-        run: |
-          set -euo pipefail
-          umask 077
-          mkdir -p "$RUNNER_TEMP/keystore"
-          KEYSTORE_FILE="$RUNNER_TEMP/keystore/silentsuite-release.jks"
-          if ! printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_FILE"; then
-            echo "Refusing to sign: the encoded keystore secret is not valid base64" >&2
-            exit 1
-          fi
-          if [ ! -f "$KEYSTORE_FILE" ] || [ ! -s "$KEYSTORE_FILE" ]; then
-            echo "Refusing to sign: the decoded keystore is missing or empty" >&2
-            exit 1
-          fi
-          echo "KEYSTORE_PATH=$KEYSTORE_FILE" >> "$GITHUB_ENV"
-
-      # Trusted code, from the controller checkout, opening the store with
-      # keytool before Gradle ever sees it. It reports only whether the store
-      # opens, whether the configured alias is a PrivateKeyEntry, and the public
-      # certificate fingerprint — never the password, the alias or key material.
-      - name: Verify the release keystore before Gradle
-        env:
-          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-        run: |
-          set -euo pipefail
-          bash "$GITHUB_WORKSPACE/.release-trusted/scripts/verify-android-release-keystore.sh"
-
-      - name: Build signed release APK and AAB
-        env:
-          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      # No -PsigningStoreLocation/-PsigningKeyAlias, so app/build.gradle leaves
+      # the release build type unsigned and AGP emits app-release-unsigned.apk.
+      - name: Build the unsigned release APK and AAB
         run: |
           ./gradlew assembleRelease bundleRelease --no-daemon \
             -PrequireEtebase16Kb=true \
-            -PrequireConscryptR28=true \
-            -PsigningStoreLocation="$KEYSTORE_PATH" \
-            -PsigningKeyAlias="$KEY_ALIAS"
+            -PrequireConscryptR28=true
 
-      - name: Capture release dependency graph and generate signed-release splits
+      - name: Capture release dependency graph and unsigned split evidence
         env:
           BUNDLETOOL_VERSION: '1.18.1'
           BUNDLETOOL_SHA256: '675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c'
-          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
           set -euo pipefail
           mkdir -p build/privacy-evidence/dependencies build/privacy-evidence/build-metadata
@@ -319,19 +257,12 @@ jobs:
             "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar" \
             --output "$RUNNER_TEMP/bundletool.jar"
           echo "$BUNDLETOOL_SHA256  $RUNNER_TEMP/bundletool.jar" | sha256sum --check --strict
-          umask 077
-          BUNDLETOOL_PASSWORD_FILE="$RUNNER_TEMP/keystore/bundletool-password"
-          printf '%s' "$KSTOREPWD" > "$BUNDLETOOL_PASSWORD_FILE"
-          unset KSTOREPWD
           java -jar "$RUNNER_TEMP/bundletool.jar" build-apks \
             --bundle app/build/outputs/bundle/release/app-release.aab \
-            --output build/privacy-evidence/signed-release.apks \
-            --mode universal \
-            --ks="$KEYSTORE_PATH" --ks-key-alias="$KEY_ALIAS" \
-            --ks-pass="file:$BUNDLETOOL_PASSWORD_FILE" \
-            --key-pass="file:$BUNDLETOOL_PASSWORD_FILE"
-          unzip -q build/privacy-evidence/signed-release.apks \
-            -d build/privacy-evidence/signed-release-splits
+            --output build/privacy-evidence/unsigned-release.apks \
+            --mode universal
+          unzip -q build/privacy-evidence/unsigned-release.apks \
+            -d build/privacy-evidence/unsigned-release-splits
           test -s app/build/outputs/mapping/release/mapping.txt
           mkdir -p build/privacy-evidence/build-metadata/app/build/outputs/mapping/release
           cp app/build/outputs/mapping/release/mapping.txt \
@@ -339,10 +270,13 @@ jobs:
           find app/build/intermediates -type f \
             \( -iname '*manifest*.xml' -o -iname '*mapping*.txt' -o -iname 'resources*.txt' -o -iname 'resources*.arsc' \) \
             -exec cp --parents {} build/privacy-evidence/build-metadata/ \;
-          sha256sum app/build/outputs/apk/release/*.apk \
-            app/build/outputs/bundle/release/*.aab \
-            build/privacy-evidence/signed-release.apks \
-            > build/privacy-evidence/artifact-sha256.txt
+
+      # The tracker scan belongs here, on the runner where the candidate code
+      # that could introduce a tracker actually executed. Signing adds a
+      # signature block; it cannot add an SDK.
+      - name: Scan the unsigned build for tracker signatures
+        run: |
+          set -euo pipefail
           python3 scripts/scan-tracker-signatures.py \
             --manifest security/tracker-signatures.json \
             --summary build/privacy-evidence/tracker-scan-summary.json \
@@ -350,31 +284,10 @@ jobs:
             build/privacy-evidence/build-metadata \
             app/build/outputs/apk/release \
             app/build/outputs/bundle/release \
-            build/privacy-evidence/signed-release.apks \
-            build/privacy-evidence/signed-release-splits
+            build/privacy-evidence/unsigned-release.apks \
+            build/privacy-evidence/unsigned-release-splits
 
-      # The privacy evidence carries the signed universal .apks set, so this is
-      # the first byte produced with the release key that leaves the job.
-      - name: Revalidate the release identity before publishing signed artifacts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
-          SOURCE_SHA: ${{ inputs.source_sha }}
-        run: |
-          set -euo pipefail
-          bash "$GITHUB_WORKSPACE/.release-trusted/scripts/verify-release-identity.sh" \
-            --tag "$RELEASE_TAG" \
-            --commit "$SOURCE_SHA" \
-            --stage android-signed-artifact-egress
-
-      - name: Upload signed tracker verification evidence
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: android-tracker-scan-${{ inputs.source_sha }}
-          path: android/build/privacy-evidence/
-          retention-days: 30
-
-      - name: Verify release native libraries
+      - name: Verify unsigned release native libraries
         run: |
           python3 scripts/verify-native-16kb.py \
             --require-lib libetebase_android.so \
@@ -405,75 +318,258 @@ jobs:
             --bundle app/build/outputs/bundle/release/app-release.aab \
             --symbols app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
 
-      - name: Verify APK signature
+      - name: Upload unsigned tracker verification evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: android-tracker-scan-${{ inputs.source_sha }}
+          path: android/build/privacy-evidence/
+          retention-days: 30
+
+      # Exactly eight files with fixed names, a producer-side checksum manifest
+      # over the six payload files, and the commit this was built from. The
+      # signing job re-derives all of it before the keystore is decoded.
+      - name: Stage the closed unsigned handoff
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
-          BUILD_TOOLS=$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -1)
-          "$BUILD_TOOLS/apksigner" verify --print-certs app/build/outputs/apk/release/*.apk
+          set -euo pipefail
+          shopt -s nullglob
+          unsigned_apks=(app/build/outputs/apk/release/*.apk)
+          [ "${#unsigned_apks[@]}" -eq 1 ] \
+            || { echo "expected exactly one unsigned release APK, found ${#unsigned_apks[@]}" >&2; exit 1; }
+          rm -rf build/unsigned-handoff
+          mkdir -p build/unsigned-handoff
+          cp "${unsigned_apks[0]}" build/unsigned-handoff/app-release-unsigned.apk
+          cp app/build/outputs/bundle/release/app-release.aab build/unsigned-handoff/app-release.aab
+          cp app/build/outputs/mapping/release/mapping.txt build/unsigned-handoff/mapping.txt
+          cp app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip \
+            build/unsigned-handoff/native-debug-symbols.zip
+          cp build/privacy-evidence/dependencies/release-runtime.txt \
+            build/unsigned-handoff/release-runtime-dependencies.txt
+          cp build/privacy-evidence/tracker-scan-summary.json \
+            build/unsigned-handoff/tracker-scan-summary.json
+          printf '%s\n' "$SOURCE_SHA" > build/unsigned-handoff/source-sha
+          ( cd build/unsigned-handoff && chmod 0644 ./*
+            for payload in \
+              app-release-unsigned.apk \
+              app-release.aab \
+              mapping.txt \
+              native-debug-symbols.zip \
+              release-runtime-dependencies.txt \
+              tracker-scan-summary.json; do
+              [ -s "$payload" ] \
+                || { echo "refusing empty unsigned handoff file: $payload" >&2; exit 1; }
+            done
+            sha256sum \
+              app-release-unsigned.apk \
+              app-release.aab \
+              mapping.txt \
+              native-debug-symbols.zip \
+              release-runtime-dependencies.txt \
+              tracker-scan-summary.json > SHA256SUMS )
+          ls -l build/unsigned-handoff
 
-      - name: Verify AAB signature
-        run: jarsigner -verify -certs -verbose app/build/outputs/bundle/release/*.aab
+      - name: Publish the unsigned build to the signing job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: silentsuite-android-unsigned-${{ inputs.source_sha }}
+          path: android/build/unsigned-handoff/
+          if-no-files-found: error
+          retention-days: 14
 
-      - name: Revalidate the release identity before publishing signed release outputs
+  # ─────────────────────────────────────────────────────────────────────
+  # Signing — a fresh runner that never sees candidate code.
+  #
+  # No candidate checkout, no Gradle, no build script, no candidate PATH entry.
+  # The only things executed here are the protected controller's own scripts,
+  # JDK tools and Android build-tools resolved by absolute path, and the pinned
+  # bundletool jar. The candidate contributes data — an APK, an AAB and their
+  # evidence — which is admitted as hostile input before the keystore exists.
+  #
+  # Ordering inside the job: admit the data, prove the tools, revalidate the
+  # live release identity, decode, verify the store, sign, prove the signature,
+  # stage, hand off. The keystore is removed unconditionally at the end.
+  # ─────────────────────────────────────────────────────────────────────
+  sign-release:
+    name: Sign (admitted release)
+    needs: [signing-policy, conscrypt-r28, revalidate-signing, build-unsigned-release]
+    runs-on: ubuntu-latest
+    environment: android-release
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out the trusted controller revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          clean: true
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Install the exact Android signing tools
+        run: |
+          set -euo pipefail
+          SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+          [ -f "$SDKMANAGER" ] && [ -x "$SDKMANAGER" ] \
+            || { echo "fixed Android sdkmanager is missing or not executable" >&2; exit 1; }
+          CANONICAL_ANDROID_HOME="$(readlink -f -- "$ANDROID_HOME")"
+          CANONICAL_SDKMANAGER="$(readlink -f -- "$SDKMANAGER")"
+          case "$CANONICAL_SDKMANAGER" in
+            "$CANONICAL_ANDROID_HOME"/*) ;;
+            *) echo "fixed Android sdkmanager resolves outside ANDROID_HOME" >&2; exit 1 ;;
+          esac
+          "$SDKMANAGER" "build-tools;36.0.0"
+          BUILD_TOOLS="$ANDROID_HOME/build-tools/36.0.0"
+          [ -d "$BUILD_TOOLS" ] \
+            || { echo "build-tools;36.0.0 was not installed at its exact path" >&2; exit 1; }
+          for tool in zipalign apksigner; do
+            [ -f "$BUILD_TOOLS/$tool" ] && [ -x "$BUILD_TOOLS/$tool" ] \
+              || { echo "build-tools;36.0.0/$tool is missing or not executable" >&2; exit 1; }
+          done
+
+      - name: Download the unsigned build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: silentsuite-android-unsigned-${{ inputs.source_sha }}
+          path: unsigned
+
+      - name: Admit the unsigned build
+        env:
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          bash "$GITHUB_WORKSPACE/scripts/admit-unsigned-android-artifact.sh" \
+            --directory "$GITHUB_WORKSPACE/unsigned" \
+            --source-sha "$SOURCE_SHA"
+
+      - name: Fetch the pinned bundletool
+        env:
+          BUNDLETOOL_VERSION: '1.18.1'
+          BUNDLETOOL_SHA256: '675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c'
+        run: |
+          set -euo pipefail
+          curl --fail --location --silent --show-error \
+            "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar" \
+            --output "$RUNNER_TEMP/bundletool.jar"
+          echo "$BUNDLETOOL_SHA256  $RUNNER_TEMP/bundletool.jar" | sha256sum --check --strict
+
+      # The last gate before the release key exists on this runner.
+      - name: Revalidate the release identity before decoding signing material
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
-          bash "$GITHUB_WORKSPACE/.release-trusted/scripts/verify-release-identity.sh" \
+          bash "$GITHUB_WORKSPACE/scripts/verify-release-identity.sh" \
             --tag "$RELEASE_TAG" \
             --commit "$SOURCE_SHA" \
-            --stage android-release-output-egress
+            --stage android-signing-material
 
-      - name: Upload signed release APK, AAB, and native debug symbols
+      - name: Decode release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          mkdir -p "$RUNNER_TEMP/keystore"
+          KEYSTORE_FILE="$RUNNER_TEMP/keystore/silentsuite-release.jks"
+          if ! printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_FILE"; then
+            echo "Refusing to sign: the encoded keystore secret is not valid base64" >&2
+            exit 1
+          fi
+          if [ ! -f "$KEYSTORE_FILE" ] || [ ! -s "$KEYSTORE_FILE" ]; then
+            echo "Refusing to sign: the decoded keystore is missing or empty" >&2
+            exit 1
+          fi
+          echo "KEYSTORE_PATH=$KEYSTORE_FILE" >> "$GITHUB_ENV"
+
+      - name: Verify the release keystore before signing
+        env:
+          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          bash "$GITHUB_WORKSPACE/scripts/verify-android-release-keystore.sh"
+
+      - name: Sign the admitted APK and AAB
+        env:
+          KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          set -euo pipefail
+          UNSIGNED_DIR="$GITHUB_WORKSPACE/unsigned" \
+          OUTPUT_DIR="$GITHUB_WORKSPACE/signed" \
+          BUNDLETOOL_JAR="$RUNNER_TEMP/bundletool.jar" \
+          bash "$GITHUB_WORKSPACE/scripts/sign-android-release.sh"
+
+      - name: Verify the signed native libraries
+        run: |
+          set -euo pipefail
+          python3 "$GITHUB_WORKSPACE/android/scripts/verify-native-16kb.py" \
+            --require-lib libetebase_android.so \
+            --require-lib libconscrypt_jni.so \
+            --require-android-ndk-major libetebase_android.so=28 \
+            --require-android-ndk-major libconscrypt_jni.so=28 \
+            "$GITHUB_WORKSPACE/signed/app-release.apk" \
+            "$GITHUB_WORKSPACE/signed/app-release.aab"
+
+      - name: Verify the signed native debug symbols
+        run: |
+          set -euo pipefail
+          python3 "$GITHUB_WORKSPACE/android/scripts/verify-native-debug-symbols.py" \
+            --require-lib libetebase_android.so \
+            --require-lib libconscrypt_jni.so \
+            --require-symbol arm64-v8a/libetebase_android.so \
+            --require-symbol x86_64/libetebase_android.so \
+            --bundle "$GITHUB_WORKSPACE/signed/app-release.aab" \
+            --symbols "$GITHUB_WORKSPACE/unsigned/native-debug-symbols.zip"
+
+      - name: Revalidate the release identity before publishing signed artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          bash "$GITHUB_WORKSPACE/scripts/verify-release-identity.sh" \
+            --tag "$RELEASE_TAG" \
+            --commit "$SOURCE_SHA" \
+            --stage android-signed-artifact-egress
+
+      - name: Upload signed split evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: silentsuite-release-${{ inputs.source_sha }}
-          path: |
-            android/app/build/outputs/apk/release/*.apk
-            android/app/build/outputs/bundle/release/*.aab
-            android/app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
+          path: signed/signed-release.apks
           if-no-files-found: error
           retention-days: 30
 
-      - name: Rename Android artifacts for release
-        env:
-          RELEASE_TAG: ${{ inputs.release_tag }}
-        run: |
-          set -euo pipefail
-          mv app/build/outputs/apk/release/app-release.apk \
-             "app/build/outputs/apk/release/silentsuite-android-${RELEASE_TAG}.apk"
-          mv app/build/outputs/bundle/release/app-release.aab \
-             "app/build/outputs/bundle/release/silentsuite-android-${RELEASE_TAG}.aab"
-          mv app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip \
-             "app/build/outputs/native-debug-symbols/release/silentsuite-android-${RELEASE_TAG}-native-debug-symbols.zip"
-          cd app/build/outputs/apk/release
-          sha256sum "silentsuite-android-${RELEASE_TAG}.apk" \
-            > "silentsuite-android-${RELEASE_TAG}-installer.sha256"
-          cd ../../bundle/release
-          sha256sum "silentsuite-android-${RELEASE_TAG}.aab" \
-            > "silentsuite-android-${RELEASE_TAG}-bundle.sha256"
-          cd ../../native-debug-symbols/release
-          sha256sum "silentsuite-android-${RELEASE_TAG}-native-debug-symbols.zip" \
-            > "silentsuite-android-${RELEASE_TAG}-native-debug-symbols.sha256"
-
-      # Collect exactly the six release assets into one flat directory, so the
-      # artifact this job publishes has a closed, named inventory the attachment
-      # job can re-assert before it writes anything.
+      # Same six versioned filenames the umbrella readiness contract expects.
       - name: Stage the closed release-asset set
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          mkdir -p build/release-assets
-          mv "app/build/outputs/apk/release/silentsuite-android-${RELEASE_TAG}.apk" \
-             "app/build/outputs/apk/release/silentsuite-android-${RELEASE_TAG}-installer.sha256" \
-             "app/build/outputs/bundle/release/silentsuite-android-${RELEASE_TAG}.aab" \
-             "app/build/outputs/bundle/release/silentsuite-android-${RELEASE_TAG}-bundle.sha256" \
-             "app/build/outputs/native-debug-symbols/release/silentsuite-android-${RELEASE_TAG}-native-debug-symbols.zip" \
-             "app/build/outputs/native-debug-symbols/release/silentsuite-android-${RELEASE_TAG}-native-debug-symbols.sha256" \
-             build/release-assets/
-          ls -l build/release-assets
+          mkdir -p release-assets
+          cp signed/app-release.apk "release-assets/silentsuite-android-${RELEASE_TAG}.apk"
+          cp signed/app-release.aab "release-assets/silentsuite-android-${RELEASE_TAG}.aab"
+          cp unsigned/native-debug-symbols.zip \
+            "release-assets/silentsuite-android-${RELEASE_TAG}-native-debug-symbols.zip"
+          cd release-assets
+          sha256sum "silentsuite-android-${RELEASE_TAG}.apk" \
+            > "silentsuite-android-${RELEASE_TAG}-installer.sha256"
+          sha256sum "silentsuite-android-${RELEASE_TAG}.aab" \
+            > "silentsuite-android-${RELEASE_TAG}-bundle.sha256"
+          sha256sum "silentsuite-android-${RELEASE_TAG}-native-debug-symbols.zip" \
+            > "silentsuite-android-${RELEASE_TAG}-native-debug-symbols.sha256"
+          ls -l
 
       # The last gate in this job: past this point the closed asset set is
       # available to `attach-release-assets`, which holds contents: write.
@@ -484,7 +580,7 @@ jobs:
           SOURCE_SHA: ${{ inputs.source_sha }}
         run: |
           set -euo pipefail
-          bash "$GITHUB_WORKSPACE/.release-trusted/scripts/verify-release-identity.sh" \
+          bash "$GITHUB_WORKSPACE/scripts/verify-release-identity.sh" \
             --tag "$RELEASE_TAG" \
             --commit "$SOURCE_SHA" \
             --stage android-attachment-handoff
@@ -493,7 +589,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: silentsuite-android-release-assets-${{ inputs.source_sha }}
-          path: android/build/release-assets/
+          path: release-assets/
           if-no-files-found: error
           retention-days: 14
 
@@ -517,7 +613,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   attach-release-assets:
     name: Attach Android assets to the draft release
-    needs: build-release
+    needs: sign-release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/admit-unsigned-android-artifact.sh
+++ b/scripts/admit-unsigned-android-artifact.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Admit — or refuse — the unsigned Android build handed over by the candidate
+# producer job, before any signing material exists on this runner.
+#
+# The signing job never checks out or executes candidate code. What it does
+# consume is candidate *data*: an APK, an AAB and their evidence, produced on a
+# different runner by candidate Gradle. This is the boundary that data crosses,
+# so everything about the incoming directory is treated as hostile until proven
+# otherwise:
+#
+#   * exactly the closed inventory, no more and no fewer files;
+#   * every entry a regular file — no symlink, no directory, no device node,
+#     nothing that could redirect a later read or write outside the tree;
+#   * no name that could traverse, hide, or collide;
+#   * nothing executable: this job runs none of it, and a file that need not be
+#     executable must not be;
+#   * no empty file;
+#   * a producer-side SHA256SUMS covering exactly the payload, rechecked here;
+#   * the admitted source commit, matching the one the controller admitted.
+#
+# What this cannot prove, stated plainly: GitHub Actions artifacts carry no
+# signature or provenance a consumer job can verify, so "these bytes came from
+# the producer job in this run" rests on the platform's artifact scoping, not on
+# cryptography. What it does prove is that the bytes are internally consistent,
+# match the checksums the producer recorded, and name the commit the controller
+# admitted — which is protected-main ancestry, already verified.
+#
+# Usage:
+#   scripts/admit-unsigned-android-artifact.sh --directory DIR --source-sha SHA
+
+DIRECTORY=""
+SOURCE_SHA=""
+
+# The producer promises exactly these names. Payload first, then the two
+# metadata files, which are verified rather than checksummed by themselves.
+PAYLOAD=(
+  "app-release-unsigned.apk"
+  "app-release.aab"
+  "mapping.txt"
+  "native-debug-symbols.zip"
+  "release-runtime-dependencies.txt"
+  "tracker-scan-summary.json"
+)
+CHECKSUM_FILE="SHA256SUMS"
+SOURCE_FILE="source-sha"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --directory) DIRECTORY="${2:-}"; shift 2 ;;
+    --source-sha) SOURCE_SHA="${2:-}"; shift 2 ;;
+    *) echo "ERROR: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+[ -n "$DIRECTORY" ] || { echo "ERROR: --directory is required" >&2; exit 2; }
+[ -n "$SOURCE_SHA" ] || { echo "ERROR: --source-sha is required" >&2; exit 2; }
+printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$' \
+  || { echo "ERROR: --source-sha is not a 40-hex commit id" >&2; exit 2; }
+command -v sha256sum >/dev/null 2>&1 || { echo "ERROR: sha256sum is required" >&2; exit 2; }
+
+refuse() {
+  echo "Refusing the unsigned build: $*" >&2
+  exit 1
+}
+
+[ -d "$DIRECTORY" ] || refuse "the artifact directory does not exist"
+
+# ── 1. Exactly the closed inventory ───────────────────────────────────
+#
+# `find -mindepth 1` sees every entry at any depth, so a nested directory or a
+# stray file anywhere under the tree is caught, not just at the top level.
+
+EXPECTED="$(printf '%s\n' "${PAYLOAD[@]}" "$CHECKSUM_FILE" "$SOURCE_FILE" | LC_ALL=C sort)"
+ACTUAL="$(find "$DIRECTORY" -mindepth 1 -printf '%P\n' | LC_ALL=C sort)"
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  echo "Refusing the unsigned build: the artifact is not the closed inventory" >&2
+  echo "  expected:" >&2
+  printf '%s\n' "$EXPECTED" | sed 's/^/    /' >&2
+  echo "  actual:" >&2
+  printf '%s\n' "$ACTUAL" | sed 's/^/    /' >&2
+  exit 1
+fi
+
+# ── 2. What each entry is ─────────────────────────────────────────────
+
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  path="$DIRECTORY/$name"
+  case "$name" in
+    */*|.*|*..*) refuse "'${name}' is not a plain top-level file name" ;;
+  esac
+  [ -L "$path" ] && refuse "'${name}' is a symbolic link"
+  [ -f "$path" ] || refuse "'${name}' is not a regular file"
+  [ -s "$path" ] || refuse "'${name}' is empty"
+  mode="$(stat -c '%a' -- "$path")"
+  [ "$mode" = "644" ] \
+    || refuse "'${name}' has mode ${mode}, expected exactly 644 for data-only input"
+done <<< "$ACTUAL"
+
+# ── 3. The commit the producer says it built ──────────────────────────
+
+RECORDED_SHA="$(tr -d ' \t\r\n' < "$DIRECTORY/$SOURCE_FILE")"
+[ "$RECORDED_SHA" = "$SOURCE_SHA" ] \
+  || refuse "the artifact records source ${RECORDED_SHA}, not the admitted ${SOURCE_SHA}"
+
+# ── 4. The producer's checksums, over exactly the payload ─────────────
+#
+# The manifest must name the payload and nothing else: a checksum line for a
+# file that is not in the inventory, or a payload file with no line, both mean
+# the manifest and the tree disagree.
+
+MANIFEST_NAMES="$(sed -n 's/^[0-9a-f]\{64\}  \(.*\)$/\1/p' "$DIRECTORY/$CHECKSUM_FILE" | LC_ALL=C sort)"
+PAYLOAD_NAMES="$(printf '%s\n' "${PAYLOAD[@]}" | LC_ALL=C sort)"
+[ "$MANIFEST_NAMES" = "$PAYLOAD_NAMES" ] \
+  || refuse "${CHECKSUM_FILE} does not cover exactly the payload files"
+[ "$(wc -l < "$DIRECTORY/$CHECKSUM_FILE")" -eq "${#PAYLOAD[@]}" ] \
+  || refuse "${CHECKSUM_FILE} contains malformed or duplicate records"
+
+( cd "$DIRECTORY" && sha256sum --check --strict --quiet "$CHECKSUM_FILE" ) \
+  || refuse "the artifact bytes do not match the checksums the producer recorded"
+
+echo "Unsigned build admitted for ${SOURCE_SHA}:"
+echo "  ${#PAYLOAD[@]} payload files, closed inventory, checksums verified"

--- a/scripts/attach-umbrella-release-assets.sh
+++ b/scripts/attach-umbrella-release-assets.sh
@@ -131,6 +131,61 @@ api() {
     "$@" "${API}${path}"
 }
 
+# POST a JSON document and return GitHub's HTTP status on stdout.
+#
+# The media type is the whole point of this function existing. curl sends `-d`
+# as application/x-www-form-urlencoded unless told otherwise, and the Accept
+# header only describes the response, so a JSON body sent through the plain
+# `api` helper reaches GitHub as form fields. That is what happened to
+# v0.5.4-beta: six draft-creation POSTs across two lanes were rejected, none
+# returned an `.id`, and the tag ended up with no release at all.
+#
+# The body goes through a file rather than argv: it is not secret, but a request
+# document belongs on disk under this run's private WORKDIR, not in a process
+# listing. The token stays in a header, as everywhere else in this script.
+# Exactly three digits on stdout, always. On a transport failure curl both
+# writes `000` through `-w` *and* exits non-zero, so a `|| printf '000'`
+# fallback appends a second one and the caller reports `HTTP 000000`. The status
+# is therefore taken from the write-out alone and then validated; anything that
+# is not three digits — including the empty string from a curl that died before
+# writing — becomes the single canonical `000`.
+api_post_json() {
+  local path="$1" body="$2" out="$3" request="$WORKDIR/request.json" status
+  printf '%s' "$body" > "$request"
+  # curl does not create the -o file when it never connects, and the caller's
+  # diagnostic reads it either way. An empty file yields the fixed
+  # "unparseable response" label instead of a missing-path error.
+  : > "$out"
+  status="$(curl -sS -o "$out" -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    -H "Content-Type: application/json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    --data-binary "@${request}" \
+    "${API}${path}")" || true
+  if ! printf '%s' "$status" | grep -Eq '^[0-9]{3}$'; then
+    status="000"
+  fi
+  printf '%s' "$status"
+}
+
+# What a failed creation is allowed to say out loud.
+#
+# GitHub's error bodies carry a short human `.message` ("Validation Failed",
+# "Not Found", "Bad credentials"), which is exactly the diagnostic the last run
+# needed and did not have. Nothing else is echoed: no response headers, no other
+# response field, no request. The message is stripped of control characters and
+# truncated, so a hostile or malformed body cannot flood the log or smuggle
+# terminal escapes into it.
+sanitized_api_message() {
+  local body="$1" message
+  if ! message="$(jq -er '.message | select(type == "string")' "$body" 2>/dev/null)"; then
+    printf 'unparseable response'
+    return 0
+  fi
+  printf '%s' "$message" | tr -c '[:print:]' ' ' | cut -c1-200
+}
+
 local_digest() {
   sha256sum "$1" | cut -d' ' -f1
 }
@@ -209,6 +264,7 @@ assert_release_identity() {
 revalidate "pre"
 
 RELEASE_ID=""
+CREATE_STATUS="none"
 for attempt in $(seq 1 "$ATTEMPTS"); do
   if find_release; then
     RELEASE_ID="$(jq -r '.id' "$WORKDIR/matches.json")"
@@ -220,20 +276,25 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
   # releases, so the identity is re-proved here rather than inherited from the
   # check at the top of the script.
   revalidate "before-create"
-  api POST "/repos/${GITHUB_REPOSITORY}/releases" \
-    -d "$(jq -n --arg tag "$TAG" --arg target "$EXPECTED_COMMIT" \
+  CREATE_STATUS="$(api_post_json "/repos/${GITHUB_REPOSITORY}/releases" \
+    "$(jq -n --arg tag "$TAG" --arg target "$EXPECTED_COMMIT" \
       '{tag_name: $tag, target_commitish: $target, name: ("SilentSuite " + $tag), draft: true}')" \
-    > "$WORKDIR/created.json" || true
+    "$WORKDIR/created.json")"
   if jq -e '.id? // empty' "$WORKDIR/created.json" >/dev/null 2>&1; then
     RELEASE_ID="$(jq -r '.id' "$WORKDIR/created.json")"
     break
   fi
-  echo "release lookup/create attempt ${attempt} did not settle; retrying in ${RETRY_DELAY}s" >&2
+  # A losing sibling in the create/create race sees 422 here and finds the
+  # winner's draft on the next lookup, so this is a retry, not a failure — but
+  # it says why, which the run that produced no draft at all could not.
+  echo "draft creation attempt ${attempt} did not settle: HTTP ${CREATE_STATUS}: $(sanitized_api_message "$WORKDIR/created.json")" >&2
+  echo "retrying in ${RETRY_DELAY}s" >&2
   sleep "$RETRY_DELAY"
 done
 
 if [ -z "$RELEASE_ID" ] || ! printf '%s' "$RELEASE_ID" | grep -Eq '^[0-9]+$'; then
   echo "ERROR: could not resolve a single draft release for ${TAG} within ${ATTEMPTS} attempts" >&2
+  echo "       last creation attempt: HTTP ${CREATE_STATUS}: $(sanitized_api_message "$WORKDIR/created.json")" >&2
   exit 1
 fi
 

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -61,7 +61,8 @@ PRODUCTION_WORKFLOW = WORKFLOW_DIR / "deploy-server.yml"
 PRODUCTION_ENVIRONMENT = "server-production"
 
 DISPATCH_EVENT_TYPE = "silentsuite_release"
-ALLOWED_JOB = "build-release"
+ALLOWED_JOB = "sign-release"
+UNSIGNED_JOB = "build-unsigned-release"
 POLICY_JOB = "signing-policy"
 REVALIDATION_JOB = "revalidate-signing"
 CONSCRYPT_JOB = "conscrypt-r28"
@@ -73,6 +74,8 @@ IDENTITY_HELPER = Path("scripts/verify-release-identity.sh")
 ATTACHMENT_HELPER = Path("scripts/attach-umbrella-release-assets.sh")
 READINESS_HELPER = Path("scripts/verify-umbrella-release-readiness.py")
 KEYSTORE_HELPER = Path("scripts/verify-android-release-keystore.sh")
+ARTIFACT_ADMISSION_HELPER = Path("scripts/admit-unsigned-android-artifact.sh")
+SIGNING_HELPER = Path("scripts/sign-android-release.sh")
 # The developer upload certificate the signed build must produce. It is pinned
 # here as well as in the helper so that changing which key the project ships
 # under cannot pass as a routine script edit.
@@ -80,6 +83,7 @@ EXPECTED_UPLOAD_CERT_SHA256 = (
     "8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79"
 )
 RELEASE_ASSET_ARTIFACT = "silentsuite-android-release-assets-${{ inputs.source_sha }}"
+UNSIGNED_ARTIFACT = "silentsuite-android-unsigned-${{ inputs.source_sha }}"
 
 # The server lane's irreversible act and the check that must immediately precede
 # it. `publish_alias` returns early when the alias already exists, so verifying
@@ -95,6 +99,8 @@ ALIAS_REVALIDATION_HELPER = "trusted/scripts/verify-release-identity.sh"
 TRUSTED_HELPERS = (
     "verify-release-identity.sh",
     "verify-android-release-keystore.sh",
+    "admit-unsigned-android-artifact.sh",
+    "sign-android-release.sh",
     "attach-umbrella-release-assets.sh",
     "verify-umbrella-release-readiness.py",
     "check-android-signing-boundary.py",
@@ -190,17 +196,11 @@ EXPECTED_RELEASE_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
     "Decode release keystore": {
         "KEYSTORE_BASE64": "${{ secrets.ANDROID_KEYSTORE_BASE64 }}",
     },
-    "Build signed release APK and AAB": {
+    "Verify the release keystore before signing": {
         "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
         "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
     },
-    "Verify the release keystore before Gradle": {
-        "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
-        "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
-    },
-    "Capture release dependency graph and generate signed-release splits": {
-        "BUNDLETOOL_VERSION": "1.18.1",
-        "BUNDLETOOL_SHA256": "675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c",
+    "Sign the admitted APK and AAB": {
         "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
         "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
     },
@@ -209,8 +209,34 @@ EXPECTED_RELEASE_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
 # the "a step environment is reviewed or absent" rule intact now that the
 # admitted tag reaches the job as an input rather than as github.ref_name.
 EXPECTED_RELEASE_PLAIN_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
-    "Rename Android artifacts for release": {"RELEASE_TAG": "${{ inputs.release_tag }}"},
     "Stage the closed release-asset set": {"RELEASE_TAG": "${{ inputs.release_tag }}"},
+    "Admit the unsigned build": {"SOURCE_SHA": "${{ inputs.source_sha }}"},
+    "Fetch the pinned bundletool": {
+        "BUNDLETOOL_VERSION": "1.18.1",
+        "BUNDLETOOL_SHA256": "675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c",
+    },
+}
+EXPECTED_BUILD_TOOLS_INSTALL_STEP = {
+    "name": "Install the exact Android signing tools",
+    "run": """set -euo pipefail
+SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+[ -f "$SDKMANAGER" ] && [ -x "$SDKMANAGER" ] \\
+  || { echo "fixed Android sdkmanager is missing or not executable" >&2; exit 1; }
+CANONICAL_ANDROID_HOME="$(readlink -f -- "$ANDROID_HOME")"
+CANONICAL_SDKMANAGER="$(readlink -f -- "$SDKMANAGER")"
+case "$CANONICAL_SDKMANAGER" in
+  "$CANONICAL_ANDROID_HOME"/*) ;;
+  *) echo "fixed Android sdkmanager resolves outside ANDROID_HOME" >&2; exit 1 ;;
+esac
+"$SDKMANAGER" "build-tools;36.0.0"
+BUILD_TOOLS="$ANDROID_HOME/build-tools/36.0.0"
+[ -d "$BUILD_TOOLS" ] \\
+  || { echo "build-tools;36.0.0 was not installed at its exact path" >&2; exit 1; }
+for tool in zipalign apksigner; do
+  [ -f "$BUILD_TOOLS/$tool" ] && [ -x "$BUILD_TOOLS/$tool" ] \\
+    || { echo "build-tools;36.0.0/$tool is missing or not executable" >&2; exit 1; }
+done
+""",
 }
 # The umbrella-draft attachment lock, shared by all three component lanes.
 # Reviewed as an exact literal so a release cannot be quietly re-scoped: a
@@ -250,18 +276,9 @@ SECRET_REFERENCE = re.compile(r"secrets\.\s*([A-Za-z_][A-Za-z0-9_-]*)")
 # clean sweep remove it.
 EXPECTED_RELEASE_CHECKOUTS: list[dict[str, Any]] = [
     {
-        "name": "Checkout",
-        "uses": CHECKOUT_ACTION,
-        "with": {"ref": "${{ inputs.source_sha }}", "persist-credentials": "false"},
-    },
-    {
         "name": "Check out the trusted controller revision",
         "uses": CHECKOUT_ACTION,
-        "with": {
-            "ref": TRUSTED_REF,
-            "path": ".release-trusted",
-            "persist-credentials": "false",
-        },
+        "with": {"ref": TRUSTED_REF, "clean": "true", "persist-credentials": "false"},
     },
 ]
 
@@ -279,7 +296,7 @@ def _revalidation_step(name: str, stage: str) -> dict[str, Any]:
         },
         "run": (
             "set -euo pipefail\n"
-            'bash "$GITHUB_WORKSPACE/.release-trusted/scripts/verify-release-identity.sh" \\\n'
+            'bash "$GITHUB_WORKSPACE/scripts/verify-release-identity.sh" \\\n'
             '  --tag "$RELEASE_TAG" \\\n'
             '  --commit "$SOURCE_SHA" \\\n'
             f"  --stage {stage}\n"
@@ -290,17 +307,14 @@ def _revalidation_step(name: str, stage: str) -> dict[str, Any]:
 # The keystore must be proven readable, correctly aliased and bound to the
 # reviewed certificate between decoding it and handing it to Gradle.
 KEYSTORE_DECODE_STEP = "Decode release keystore"
-KEYSTORE_VERIFY_STEP = "Verify the release keystore before Gradle"
-KEYSTORE_CONSUMER_STEP = "Build signed release APK and AAB"
+KEYSTORE_VERIFY_STEP = "Verify the release keystore before signing"
+KEYSTORE_CONSUMER_STEP = "Sign the admitted APK and AAB"
 
 # revalidation step name -> the step name it must immediately precede.
 RELEASE_MUTATION_BOUNDARIES: dict[str, str] = {
     "Revalidate the release identity before decoding signing material": "Decode release keystore",
     "Revalidate the release identity before publishing signed artifacts": (
-        "Upload signed tracker verification evidence"
-    ),
-    "Revalidate the release identity before publishing signed release outputs": (
-        "Upload signed release APK, AAB, and native debug symbols"
+        "Upload signed split evidence"
     ),
     "Revalidate the release identity before the attachment handoff": (
         "Publish the closed release-asset set to the attachment job"
@@ -314,10 +328,6 @@ EXPECTED_RELEASE_REVALIDATION_STEPS: dict[str, dict[str, Any]] = {
     "Revalidate the release identity before publishing signed artifacts": _revalidation_step(
         "Revalidate the release identity before publishing signed artifacts",
         "android-signed-artifact-egress",
-    ),
-    "Revalidate the release identity before publishing signed release outputs": _revalidation_step(
-        "Revalidate the release identity before publishing signed release outputs",
-        "android-release-output-egress",
     ),
     "Revalidate the release identity before the attachment handoff": _revalidation_step(
         "Revalidate the release identity before the attachment handoff",
@@ -440,12 +450,9 @@ EXPECTED_COMPONENT_INPUTS = {
 }
 
 EXPECTED_SECRET_STEP_SHA256 = {
-    "Verify the release keystore before Gradle": "443aeb93567e5668e6ed7e0f210fbf663f9b2241d680079f43365569625e1cd9",
     "Decode release keystore": "d0893a6a12d2aa1b8add481df288b4f70e91d9eaa1d6c4f92c4b4ff696c538b7",
-    "Build signed release APK and AAB": "e9e02db295ff745dfe2ead024747b996b246ddb2fc2cc0f195ed2244b1a86776",
-    "Capture release dependency graph and generate signed-release splits": (
-        "69ded7eab4c4ff48deff2da950aacf8e627da05373ffa507f358fbcc986a7a6a"
-    ),
+    "Verify the release keystore before signing": "f0e6e9ad363f19af8682bfa48c7d9f42cc89b8bd199b03cd57b2a3156d7ef881",
+    "Sign the admitted APK and AAB": "70ee6491fc048b35aa47860c854ed590d732082ab72930cc02e3470d471545a8",
 }
 # Signing steps and the two reviewed plain-environment steps are the only steps
 # in the release job permitted to carry an environment at all.
@@ -456,16 +463,19 @@ REVIEWED_RELEASE_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
 }
 # Covers the whole reviewed signing job: the explicit literal checks state the
 # intent, this digest makes any other edit to the job fail closed as well.
-EXPECTED_RELEASE_JOB_SHA256 = "9d58d8a0bfcd0d4cd21e61552caaddd3702652a5471dae7ea2d96f13acd8062c"
+EXPECTED_RELEASE_JOB_SHA256 = "77295dce0752b35f290310f641c1d8b1eaf3a2b3db78445c90679b75459f105e"
+EXPECTED_UNSIGNED_JOB_SHA256 = "b20d7ce02bb1de96741fda2320c3b5993b63ff55ffec314ea534b83129f52823"
 # Same treatment for the one job that can write a release. It carries the write
 # credential, the attachment helper and the umbrella lock, so every byte of it
 # is reviewed.
-EXPECTED_ATTACHMENT_JOB_SHA256 = "1d58283e8697f63a21627dc6ea037e5d2d0e1de50d5c72d6c9eb8781599a2cca"
+EXPECTED_ATTACHMENT_JOB_SHA256 = "a7ca21a04a0f403520773be23fb89aa9a39b6ebc91c74d970dc23f8312be5a0e"
 EXPECTED_CONTROLLER_ADMIT_SHA256 = "6423d79810b64d292382c9bccab15a7b0ed342a6ff6e7272972502a868a3d958"
 # The helpers those jobs execute. Hashing the step is not enough: the step text
 # is stable while the file it runs is what reaches the network and the API.
 EXPECTED_IDENTITY_HELPER_SHA256 = "855c557e36e8fb55979e6877b02808d1ed0e40dafb9e8b7195e711f76d4b5da7"
 EXPECTED_ATTACHMENT_HELPER_SHA256 = "f37f415e7ec9439fe2e16c7e68a32a7ff0f8927de77eb2266480549e93aca875"
+EXPECTED_ARTIFACT_ADMISSION_SHA256 = "5c810ac880a6f91c334dc108c456927a70dbbbd6284016f14fd11a4ea01c4b4e"
+EXPECTED_SIGNING_HELPER_SHA256 = "4956cc84f364a951b72e35ed95581e2322ecbedef863bcd4e4daa1c2fcc34dbd"
 EXPECTED_KEYSTORE_HELPER_SHA256 = "b9b0c8046a85209754c5e206b9cc1778036d2366d0709caf9a60fbf741f5c9b6"
 EXPECTED_READINESS_HELPER_SHA256 = "c75ebfba772c4f7bd6559161f64df3127c9c390bf1e5a81e39236ba47cc6e26f"
 # The Conscrypt producer exists twice: unprivileged CI builds it from the
@@ -483,7 +493,6 @@ ALLOWED_RELEASE_JOB_KEYS = {
     "runs-on",
     "environment",
     "permissions",
-    "defaults",
     "steps",
 }
 ALLOWED_ATTACHMENT_JOB_KEYS = {
@@ -1158,6 +1167,8 @@ def check(root: Path) -> list[str]:
         (ATTACHMENT_HELPER, EXPECTED_ATTACHMENT_HELPER_SHA256),
         (READINESS_HELPER, EXPECTED_READINESS_HELPER_SHA256),
         (KEYSTORE_HELPER, EXPECTED_KEYSTORE_HELPER_SHA256),
+        (ARTIFACT_ADMISSION_HELPER, EXPECTED_ARTIFACT_ADMISSION_SHA256),
+        (SIGNING_HELPER, EXPECTED_SIGNING_HELPER_SHA256),
     ):
         path = root / helper
         if not path.is_file():
@@ -1315,10 +1326,10 @@ def check(root: Path) -> list[str]:
             f"{ALLOWED_JOB} must not carry an event guard; this lane is reachable only through "
             "the protected controller"
         )
-    if release.get("needs") != [POLICY_JOB, CONSCRYPT_JOB, REVALIDATION_JOB]:
+    if release.get("needs") != [POLICY_JOB, CONSCRYPT_JOB, REVALIDATION_JOB, UNSIGNED_JOB]:
         violations.append(
-            f"{ALLOWED_JOB} must require successful {POLICY_JOB}, {CONSCRYPT_JOB} and "
-            f"{REVALIDATION_JOB}"
+            f"{ALLOWED_JOB} must require successful {POLICY_JOB}, {CONSCRYPT_JOB}, "
+            f"{REVALIDATION_JOB} and {UNSIGNED_JOB}"
         )
     if release.get("permissions") != {"contents": "read"}:
         violations.append(
@@ -1362,6 +1373,95 @@ def check(root: Path) -> list[str]:
                 f"{release_step_names[guard_index + 1 : guard_index + 2]}"
             )
 
+    # The unsigned producer runs candidate Gradle. It must therefore hold
+    # nothing a compromise could take: no protected environment, no signing
+    # secret, no workflow token, and no write permission. This is the half of
+    # the split that makes the fresh-runner boundary meaningful.
+    unsigned = jobs.get(UNSIGNED_JOB)
+    if not isinstance(unsigned, Mapping):
+        violations.append(f"{ROOT_WORKFLOW} must define the {UNSIGNED_JOB} job")
+    else:
+        if semantic_sha256(unsigned) != EXPECTED_UNSIGNED_JOB_SHA256:
+            violations.append(
+                f"{UNSIGNED_JOB} must match the exact reviewed producer specification"
+            )
+        if environment_name(unsigned) is not None:
+            violations.append(f"{UNSIGNED_JOB} must not bind a deployment environment")
+        if signing_references(unsigned):
+            violations.append(f"{UNSIGNED_JOB} must never reference Android signing secrets")
+        if unsigned.get("permissions") != {"contents": "read"}:
+            violations.append(f"{UNSIGNED_JOB} permissions must be exactly contents: read")
+        unsigned_body = "\n".join(strings(unsigned))
+        if WORKFLOW_TOKEN in unsigned_body:
+            violations.append(f"{UNSIGNED_JOB} must not carry the workflow token")
+        for marker in RELEASE_WRITE_MARKERS:
+            if marker in unsigned_body:
+                violations.append(f"{UNSIGNED_JOB} must not be able to write a release: {marker}")
+        if UNSIGNED_ARTIFACT not in unsigned_body:
+            violations.append(f"{UNSIGNED_JOB} must publish {UNSIGNED_ARTIFACT}")
+        if unsigned.get("needs") != [POLICY_JOB, CONSCRYPT_JOB]:
+            violations.append(
+                f"{UNSIGNED_JOB} must require successful {POLICY_JOB} and {CONSCRYPT_JOB}"
+            )
+
+    # The signing job must never see candidate code. Its only checkout is the
+    # protected revision; no Gradle, no candidate script, no candidate path.
+    release_body = "\n".join(strings(release))
+    for candidate_marker in ("./gradlew", "gradlew", "inputs.source_sha }}\n          persist"):
+        if candidate_marker in release_body:
+            violations.append(
+                f"{ALLOWED_JOB} must not execute candidate build tooling ({candidate_marker})"
+            )
+    if UNSIGNED_ARTIFACT not in release_body:
+        violations.append(f"{ALLOWED_JOB} must consume {UNSIGNED_ARTIFACT}")
+    if str(ARTIFACT_ADMISSION_HELPER) not in release_body:
+        violations.append(
+            f"{ALLOWED_JOB} must admit the unsigned build through {ARTIFACT_ADMISSION_HELPER}"
+        )
+    if str(SIGNING_HELPER) not in release_body:
+        violations.append(f"{ALLOWED_JOB} must sign through {SIGNING_HELPER}")
+    admit_index = (
+        release_step_names.index("Admit the unsigned build")
+        if "Admit the unsigned build" in release_step_names
+        else -1
+    )
+    decode_index = (
+        release_step_names.index(KEYSTORE_DECODE_STEP)
+        if KEYSTORE_DECODE_STEP in release_step_names
+        else -1
+    )
+    if admit_index < 0 or decode_index < 0 or admit_index > decode_index:
+        violations.append(
+            f"{ALLOWED_JOB} must admit the candidate artifact before the keystore is decoded"
+        )
+
+    # The signing helper resolves its tools by absolute path under a verified
+    # root; a PATH lookup is what a poisoned producer would aim at.
+    signing_helper_path = root / SIGNING_HELPER
+    if signing_helper_path.is_file():
+        signing_code = "\n".join(
+            line
+            for line in signing_helper_path.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        for required in (
+            'ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION}',
+            'JAVA_HOME}/bin/jarsigner',
+            "--ks-pass \"env:KSTOREPWD\"",
+            "-storepass:env KSTOREPWD",
+            EXPECTED_UPLOAD_CERT_SHA256,
+            '"$ZIPALIGN" -P 16 -f 4',
+            '"$ZIPALIGN" -c -P 16 4',
+            'canonical="$(readlink -f -- "$tool")"',
+            "resolves outside its trusted root",
+        ):
+            if required not in signing_code:
+                violations.append(f"{SIGNING_HELPER} must contain {required!r}")
+        if "$(command -v" in signing_code:
+            violations.append(f"{SIGNING_HELPER} must not resolve tools through PATH")
+        if '"$ZIPALIGN" -p' in signing_code or '"$ZIPALIGN" -c -p' in signing_code:
+            violations.append(f"{SIGNING_HELPER} must not use deprecated zipalign -p")
+
     # The keystore preflight sits exactly between the decode and Gradle. A
     # verifier that ran earlier would check a file that did not exist yet; one
     # that ran later would be reporting on a store Gradle had already opened.
@@ -1388,7 +1488,7 @@ def check(root: Path) -> list[str]:
         verify_body = "\n".join(strings(verify_step))
         if str(KEYSTORE_HELPER) not in verify_body:
             violations.append(f"{ALLOWED_JOB} must verify the keystore with {KEYSTORE_HELPER}")
-        if ".release-trusted/" not in verify_body:
+        if '"$GITHUB_WORKSPACE/scripts/' not in verify_body:
             violations.append(
                 f"{ALLOWED_JOB} must run the keystore verifier from the trusted controller "
                 "checkout, not the candidate tree"
@@ -1486,8 +1586,10 @@ def check(root: Path) -> list[str]:
         violations.append(f"{ALLOWED_JOB} must bind the {ENVIRONMENT_NAME} environment")
     if release.get("runs-on") != "ubuntu-latest":
         violations.append(f"{ALLOWED_JOB} must run exactly on GitHub-hosted ubuntu-latest")
-    if release.get("defaults") != {"run": {"working-directory": "android"}}:
-        violations.append(f"{ALLOWED_JOB} must use the exact Android working-directory defaults")
+    if "defaults" in release:
+        violations.append(
+            f"{ALLOWED_JOB} must not declare defaults; it has no candidate tree to run in"
+        )
     # The umbrella lock belongs on the attachment job. Leaving it here would put
     # the signing job back in the shared write domain it no longer belongs to.
     if "concurrency" in release:
@@ -1514,6 +1616,20 @@ def check(root: Path) -> list[str]:
     if not isinstance(release_steps, list):
         violations.append(f"{ALLOWED_JOB} steps must be a sequence")
     else:
+        install_steps = [
+            step for step in release_steps
+            if isinstance(step, Mapping)
+            and step.get("name") == EXPECTED_BUILD_TOOLS_INSTALL_STEP["name"]
+        ]
+        if install_steps != [EXPECTED_BUILD_TOOLS_INSTALL_STEP]:
+            violations.append(
+                f"{ALLOWED_JOB} must install and check exact build-tools;36.0.0 "
+                "with the reviewed fixed-path step"
+            )
+        elif release_step_names.index(EXPECTED_BUILD_TOOLS_INSTALL_STEP["name"]) > decode_index:
+            violations.append(
+                f"{ALLOWED_JOB} must install Android signing tools before decoding the keystore"
+            )
         for step in release_steps:
             if not isinstance(step, Mapping):
                 violations.append(f"{ALLOWED_JOB} steps must contain only mappings")

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -72,6 +72,13 @@ ENVIRONMENT_NAME = "android-release"
 IDENTITY_HELPER = Path("scripts/verify-release-identity.sh")
 ATTACHMENT_HELPER = Path("scripts/attach-umbrella-release-assets.sh")
 READINESS_HELPER = Path("scripts/verify-umbrella-release-readiness.py")
+KEYSTORE_HELPER = Path("scripts/verify-android-release-keystore.sh")
+# The developer upload certificate the signed build must produce. It is pinned
+# here as well as in the helper so that changing which key the project ships
+# under cannot pass as a routine script edit.
+EXPECTED_UPLOAD_CERT_SHA256 = (
+    "8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79"
+)
 RELEASE_ASSET_ARTIFACT = "silentsuite-android-release-assets-${{ inputs.source_sha }}"
 
 # The server lane's irreversible act and the check that must immediately precede
@@ -87,6 +94,7 @@ ALIAS_REVALIDATION_HELPER = "trusted/scripts/verify-release-identity.sh"
 # executed only through a checkout of the protected controller revision.
 TRUSTED_HELPERS = (
     "verify-release-identity.sh",
+    "verify-android-release-keystore.sh",
     "attach-umbrella-release-assets.sh",
     "verify-umbrella-release-readiness.py",
     "check-android-signing-boundary.py",
@@ -186,6 +194,10 @@ EXPECTED_RELEASE_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
         "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
         "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
     },
+    "Verify the release keystore before Gradle": {
+        "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
+        "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
+    },
     "Capture release dependency graph and generate signed-release splits": {
         "BUNDLETOOL_VERSION": "1.18.1",
         "BUNDLETOOL_SHA256": "675786493983787ffa11550bdb7c0715679a44e1643f3ff980a529e9c822595c",
@@ -274,6 +286,12 @@ def _revalidation_step(name: str, stage: str) -> dict[str, Any]:
         ),
     }
 
+
+# The keystore must be proven readable, correctly aliased and bound to the
+# reviewed certificate between decoding it and handing it to Gradle.
+KEYSTORE_DECODE_STEP = "Decode release keystore"
+KEYSTORE_VERIFY_STEP = "Verify the release keystore before Gradle"
+KEYSTORE_CONSUMER_STEP = "Build signed release APK and AAB"
 
 # revalidation step name -> the step name it must immediately precede.
 RELEASE_MUTATION_BOUNDARIES: dict[str, str] = {
@@ -422,7 +440,8 @@ EXPECTED_COMPONENT_INPUTS = {
 }
 
 EXPECTED_SECRET_STEP_SHA256 = {
-    "Decode release keystore": "44c1231395b5f7347980a05fa641b0e7d866451e10ddb88958e61459f649ffba",
+    "Verify the release keystore before Gradle": "443aeb93567e5668e6ed7e0f210fbf663f9b2241d680079f43365569625e1cd9",
+    "Decode release keystore": "d0893a6a12d2aa1b8add481df288b4f70e91d9eaa1d6c4f92c4b4ff696c538b7",
     "Build signed release APK and AAB": "e9e02db295ff745dfe2ead024747b996b246ddb2fc2cc0f195ed2244b1a86776",
     "Capture release dependency graph and generate signed-release splits": (
         "69ded7eab4c4ff48deff2da950aacf8e627da05373ffa507f358fbcc986a7a6a"
@@ -437,7 +456,7 @@ REVIEWED_RELEASE_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
 }
 # Covers the whole reviewed signing job: the explicit literal checks state the
 # intent, this digest makes any other edit to the job fail closed as well.
-EXPECTED_RELEASE_JOB_SHA256 = "2789fa4a1277514497c625a87e3c091894c47b797101b1d08fb320eaabf1a01c"
+EXPECTED_RELEASE_JOB_SHA256 = "9d58d8a0bfcd0d4cd21e61552caaddd3702652a5471dae7ea2d96f13acd8062c"
 # Same treatment for the one job that can write a release. It carries the write
 # credential, the attachment helper and the umbrella lock, so every byte of it
 # is reviewed.
@@ -445,8 +464,9 @@ EXPECTED_ATTACHMENT_JOB_SHA256 = "1d58283e8697f63a21627dc6ea037e5d2d0e1de50d5c72
 EXPECTED_CONTROLLER_ADMIT_SHA256 = "6423d79810b64d292382c9bccab15a7b0ed342a6ff6e7272972502a868a3d958"
 # The helpers those jobs execute. Hashing the step is not enough: the step text
 # is stable while the file it runs is what reaches the network and the API.
-EXPECTED_IDENTITY_HELPER_SHA256 = "5782b71552a0e08c3d011cab58112bd5998d92e561cbf4c78875ca147248c9e9"
-EXPECTED_ATTACHMENT_HELPER_SHA256 = "4ca8ca30a843abbb8305bdd63a8e04541c8791cb4bc04e0c6006e7474e463ebf"
+EXPECTED_IDENTITY_HELPER_SHA256 = "855c557e36e8fb55979e6877b02808d1ed0e40dafb9e8b7195e711f76d4b5da7"
+EXPECTED_ATTACHMENT_HELPER_SHA256 = "f37f415e7ec9439fe2e16c7e68a32a7ff0f8927de77eb2266480549e93aca875"
+EXPECTED_KEYSTORE_HELPER_SHA256 = "b9b0c8046a85209754c5e206b9cc1778036d2366d0709caf9a60fbf741f5c9b6"
 EXPECTED_READINESS_HELPER_SHA256 = "c75ebfba772c4f7bd6559161f64df3127c9c390bf1e5a81e39236ba47cc6e26f"
 # The Conscrypt producer exists twice: unprivileged CI builds it from the
 # triggering ref, the release lane builds it from the admitted commit. Both are
@@ -1137,6 +1157,7 @@ def check(root: Path) -> list[str]:
         (IDENTITY_HELPER, EXPECTED_IDENTITY_HELPER_SHA256),
         (ATTACHMENT_HELPER, EXPECTED_ATTACHMENT_HELPER_SHA256),
         (READINESS_HELPER, EXPECTED_READINESS_HELPER_SHA256),
+        (KEYSTORE_HELPER, EXPECTED_KEYSTORE_HELPER_SHA256),
     ):
         path = root / helper
         if not path.is_file():
@@ -1339,6 +1360,100 @@ def check(root: Path) -> list[str]:
                 f"{ALLOWED_JOB} must revalidate the release identity immediately before "
                 f"{guarded_name!r}; {guard_name!r} is followed by "
                 f"{release_step_names[guard_index + 1 : guard_index + 2]}"
+            )
+
+    # The keystore preflight sits exactly between the decode and Gradle. A
+    # verifier that ran earlier would check a file that did not exist yet; one
+    # that ran later would be reporting on a store Gradle had already opened.
+    if KEYSTORE_VERIFY_STEP in release_step_names:
+        decode = release_step_names.index(KEYSTORE_DECODE_STEP) if KEYSTORE_DECODE_STEP in release_step_names else -1
+        verify = release_step_names.index(KEYSTORE_VERIFY_STEP)
+        consume = (
+            release_step_names.index(KEYSTORE_CONSUMER_STEP)
+            if KEYSTORE_CONSUMER_STEP in release_step_names
+            else -1
+        )
+        if decode < 0 or verify != decode + 1:
+            violations.append(
+                f"{ALLOWED_JOB} must verify the keystore immediately after {KEYSTORE_DECODE_STEP!r}"
+            )
+        if consume < 0 or consume != verify + 1:
+            violations.append(
+                f"{ALLOWED_JOB} must run {KEYSTORE_CONSUMER_STEP!r} immediately after the "
+                "keystore verification"
+            )
+        verify_step = next(
+            step for step in release_step_list if step.get("name") == KEYSTORE_VERIFY_STEP
+        )
+        verify_body = "\n".join(strings(verify_step))
+        if str(KEYSTORE_HELPER) not in verify_body:
+            violations.append(f"{ALLOWED_JOB} must verify the keystore with {KEYSTORE_HELPER}")
+        if ".release-trusted/" not in verify_body:
+            violations.append(
+                f"{ALLOWED_JOB} must run the keystore verifier from the trusted controller "
+                "checkout, not the candidate tree"
+            )
+    else:
+        violations.append(f"{ALLOWED_JOB} must define the {KEYSTORE_VERIFY_STEP!r} step")
+
+    # The reviewed certificate is pinned in both the helper and this policy, so
+    # a change of signing identity cannot pass as an ordinary script edit.
+    keystore_helper_path = root / KEYSTORE_HELPER
+    if keystore_helper_path.is_file():
+        keystore_source = keystore_helper_path.read_text(encoding="utf-8")
+        # Argument-vector rules are about what the script *executes*. The
+        # comments deliberately name the two constructs being avoided, so they
+        # are stripped before the executable text is scanned.
+        keystore_code = "\n".join(
+            line for line in keystore_source.splitlines() if not line.lstrip().startswith("#")
+        )
+        if EXPECTED_UPLOAD_CERT_SHA256 not in keystore_source:
+            violations.append(
+                f"{KEYSTORE_HELPER} must pin the reviewed upload certificate "
+                f"{EXPECTED_UPLOAD_CERT_SHA256}"
+            )
+        if "-storepass:env" not in keystore_code:
+            violations.append(
+                f"{KEYSTORE_HELPER} must take the store password through the environment, "
+                "never as an argument"
+            )
+        # The alias must not reach *any* child process's argument vector, and
+        # `ps` on a shared runner shows arguments. `keytool -alias` and
+        # `awk -v alias=` are the two ways it previously could.
+        for argv_leak in ("-alias ", "-v alias=", "-v ALIAS="):
+            if argv_leak in keystore_code:
+                violations.append(
+                    f"{KEYSTORE_HELPER} must not pass the signing alias in a child argument "
+                    f"vector ({argv_leak.strip()})"
+                )
+        if 'ENVIRON["KEY_ALIAS"]' not in keystore_code:
+            violations.append(
+                f"{KEYSTORE_HELPER} must read the alias from the environment, not an argument"
+            )
+        # keytool's labels are translated. Without a pinned locale the parser
+        # silently matches nothing on a non-English runner.
+        for flag in ("-J-Duser.language=en", "-J-Duser.country=US"):
+            if flag not in keystore_code:
+                violations.append(
+                    f"{KEYSTORE_HELPER} must pin keytool's locale with {flag} so its labels "
+                    "are machine-readable"
+                )
+        # The expected fingerprint is validated before it can reach a log line.
+        if "^[0-9a-f]{64}$" not in keystore_code:
+            violations.append(
+                f"{KEYSTORE_HELPER} must validate the expected fingerprint as 64 hex characters"
+            )
+        # An override must not be reachable from the environment: an earlier
+        # step in the signed job writes $GITHUB_ENV, so a variable is candidate
+        # controllable while a reviewed step's `run` text is not.
+        if "EXPECTED_CERT_SHA256:-" in keystore_code:
+            violations.append(
+                f"{KEYSTORE_HELPER} must not take the expected fingerprint from the "
+                "environment; $GITHUB_ENV is writable by an earlier candidate step"
+            )
+        if "--expect-sha256" in verify_body:
+            violations.append(
+                f"{ALLOWED_JOB} must not override the reviewed upload certificate"
             )
 
     # The workflow token is admissible only inside those reviewed steps. Any

--- a/scripts/sign-android-release.sh
+++ b/scripts/sign-android-release.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sign the admitted unsigned Android build, and prove what signed it.
+#
+# This runs in the signing job, on a fresh runner that has never checked out or
+# executed candidate code. Everything it executes is either a JDK tool, an
+# Android SDK build-tool, or the pinned bundletool jar — each resolved by an
+# absolute path under a fixed, verified root rather than through PATH, because
+# PATH is exactly what a compromised producer would reach for.
+#
+# Why post-build signing at all: Gradle's signing config makes candidate build
+# scripts a party to the keystore. Signing the finished APK and AAB with the
+# standard tools keeps the key in a job where no candidate byte executes.
+#
+#   APK  zipalign (alignment must precede signing) then apksigner
+#   AAB  jarsigner, the documented upload-signing path for app bundles
+#   both then re-read, and their signer certificate compared to the pin
+#
+# Secret handling:
+#   * the store password reaches apksigner as `env:KSTOREPWD` and jarsigner as
+#     `-storepass:env KSTOREPWD` — never an argument, never on disk;
+#   * bundletool has no environment password form, so it gets a file created
+#     under `umask 077` inside the caller's private directory, removed on exit;
+#   * the alias is an unavoidable positional/`--ks-key-alias` argument to
+#     jarsigner, apksigner and bundletool. That is stated rather than claimed
+#     otherwise: it is the tools' interface, and it matches the pre-existing
+#     reviewed behaviour. The password never joins it.
+#
+# Environment:
+#   UNSIGNED_DIR   admitted producer output (read only)
+#   OUTPUT_DIR     where signed artefacts and evidence are written
+#   KEYSTORE_PATH  decoded, already verified store
+#   KSTOREPWD      store password
+#   KEY_ALIAS      signing alias
+#   ANDROID_HOME   Android SDK root
+#   BUNDLETOOL_JAR pinned, checksum-verified bundletool jar
+#   JAVA_HOME      JDK root providing jarsigner/keytool
+
+BUILD_TOOLS_VERSION="36.0.0"
+EXPECTED_CERT_SHA256="8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79"
+KEYTOOL_LOCALE=(-J-Duser.language=en -J-Duser.country=US)
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --expect-sha256) EXPECTED_CERT_SHA256="${2:-}"; shift 2 ;;
+    --build-tools-version) BUILD_TOOLS_VERSION="${2:-}"; shift 2 ;;
+    *) echo "ERROR: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+: "${UNSIGNED_DIR:?UNSIGNED_DIR must be set}"
+: "${OUTPUT_DIR:?OUTPUT_DIR must be set}"
+: "${KEYSTORE_PATH:?KEYSTORE_PATH must be set}"
+: "${KSTOREPWD:?KSTOREPWD must be set}"
+: "${KEY_ALIAS:?KEY_ALIAS must be set}"
+: "${ANDROID_HOME:?ANDROID_HOME must be set}"
+: "${BUNDLETOOL_JAR:?BUNDLETOOL_JAR must be set}"
+: "${JAVA_HOME:?JAVA_HOME must be set}"
+export KSTOREPWD
+
+refuse() {
+  echo "Refusing to sign: $*" >&2
+  exit 1
+}
+
+EXPECTED_CERT_SHA256="$(printf '%s' "$EXPECTED_CERT_SHA256" | tr '[:upper:]' '[:lower:]')"
+printf '%s' "$EXPECTED_CERT_SHA256" | grep -Eq '^[0-9a-f]{64}$' \
+  || refuse "the expected certificate fingerprint is not 64 hexadecimal characters"
+printf '%s' "$BUILD_TOOLS_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  || refuse "the build-tools version is not a dotted release number"
+
+# ── Fixed tool paths, never PATH ──────────────────────────────────────
+
+BUILD_TOOLS="${ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION}"
+ZIPALIGN="${BUILD_TOOLS}/zipalign"
+APKSIGNER="${BUILD_TOOLS}/apksigner"
+JARSIGNER="${JAVA_HOME}/bin/jarsigner"
+KEYTOOL="${JAVA_HOME}/bin/keytool"
+JAVA="${JAVA_HOME}/bin/java"
+
+CANONICAL_BUILD_TOOLS="$(readlink -f -- "$BUILD_TOOLS")" \
+  || refuse "the fixed build-tools root cannot be resolved"
+CANONICAL_JAVA_HOME="$(readlink -f -- "$JAVA_HOME")" \
+  || refuse "JAVA_HOME cannot be resolved"
+[ -d "$CANONICAL_BUILD_TOOLS" ] || refuse "the fixed build-tools root is missing"
+[ -d "$CANONICAL_JAVA_HOME" ] || refuse "JAVA_HOME is missing"
+
+require_tool_beneath() {
+  local tool="$1" root="$2" canonical
+  [ -f "$tool" ] || refuse "required tool ${tool} is missing at its fixed path"
+  [ -x "$tool" ] || refuse "required tool ${tool} is not executable"
+  canonical="$(readlink -f -- "$tool")" \
+    || refuse "required tool ${tool} cannot be resolved"
+  case "$canonical" in
+    "$root"/*) ;;
+    *) refuse "required tool ${tool} resolves outside its trusted root" ;;
+  esac
+}
+
+require_tool_beneath "$ZIPALIGN" "$CANONICAL_BUILD_TOOLS"
+require_tool_beneath "$APKSIGNER" "$CANONICAL_BUILD_TOOLS"
+require_tool_beneath "$JARSIGNER" "$CANONICAL_JAVA_HOME"
+require_tool_beneath "$KEYTOOL" "$CANONICAL_JAVA_HOME"
+require_tool_beneath "$JAVA" "$CANONICAL_JAVA_HOME"
+[ -f "$BUNDLETOOL_JAR" ] || refuse "the pinned bundletool jar is missing"
+
+# ── Inputs and outputs ────────────────────────────────────────────────
+
+UNSIGNED_APK="${UNSIGNED_DIR}/app-release-unsigned.apk"
+UNSIGNED_AAB="${UNSIGNED_DIR}/app-release.aab"
+for input in "$UNSIGNED_APK" "$UNSIGNED_AAB"; do
+  [ -f "$input" ] || refuse "admitted input ${input##*/} is missing"
+done
+
+mkdir -p "$OUTPUT_DIR"
+SIGNED_APK="${OUTPUT_DIR}/app-release.apk"
+SIGNED_AAB="${OUTPUT_DIR}/app-release.aab"
+ALIGNED_APK="${OUTPUT_DIR}/app-release-aligned.apk"
+
+WORKDIR="$(umask 077; mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Read the SHA-256 of the certificate a tool reports, normalised for comparison.
+leaf_fingerprint() {
+  grep -m1 -oE 'SHA-?256(:| digest:)[[:space:]]*(([0-9A-Fa-f]{2}:){31}[0-9A-Fa-f]{2}|[0-9a-f]{64})' \
+    | sed -E 's/^SHA-?256(:| digest:)[[:space:]]*//' \
+    | tr -d ': \t' \
+    | tr '[:upper:]' '[:lower:]'
+}
+
+require_pinned_certificate() {
+  local label="$1" observed="$2"
+  printf '%s' "$observed" | grep -Eq '^[0-9a-f]{64}$' \
+    || refuse "no SHA-256 signer certificate could be read from the signed ${label}"
+  if [ "$observed" != "$EXPECTED_CERT_SHA256" ]; then
+    echo "Refusing to sign: the signed ${label} does not carry the reviewed upload key" >&2
+    echo "  expected SHA-256: ${EXPECTED_CERT_SHA256}" >&2
+    echo "  observed SHA-256: ${observed}" >&2
+    exit 1
+  fi
+  echo "  ${label}: signer certificate ${observed}"
+}
+
+# ── APK: align, then sign ─────────────────────────────────────────────
+#
+# zipalign must run before apksigner: aligning a signed APK would invalidate
+# the signature, and apksigner deliberately preserves existing alignment.
+
+"$ZIPALIGN" -P 16 -f 4 "$UNSIGNED_APK" "$ALIGNED_APK"
+"$ZIPALIGN" -c -P 16 4 "$ALIGNED_APK" || refuse "the aligned APK failed zipalign verification"
+
+"$APKSIGNER" sign \
+  --ks "$KEYSTORE_PATH" \
+  --ks-key-alias "$KEY_ALIAS" \
+  --ks-pass "env:KSTOREPWD" \
+  --key-pass "env:KSTOREPWD" \
+  --out "$SIGNED_APK" \
+  "$ALIGNED_APK"
+rm -f "$ALIGNED_APK"
+
+# ── AAB: jarsigner ────────────────────────────────────────────────────
+
+"$JARSIGNER" -keystore "$KEYSTORE_PATH" -storepass:env KSTOREPWD \
+  -signedjar "$SIGNED_AAB" "$UNSIGNED_AAB" "$KEY_ALIAS" >/dev/null
+
+# ── Prove what signed them ────────────────────────────────────────────
+
+echo "Signed with the reviewed upload key:"
+require_pinned_certificate "APK" \
+  "$("$APKSIGNER" verify --print-certs "$SIGNED_APK" 2>/dev/null | leaf_fingerprint || true)"
+require_pinned_certificate "AAB" \
+  "$("$KEYTOOL" "${KEYTOOL_LOCALE[@]}" -printcert -jarfile "$SIGNED_AAB" 2>/dev/null | leaf_fingerprint || true)"
+
+"$JARSIGNER" -verify -strict "$SIGNED_AAB" >/dev/null \
+  || refuse "the signed AAB did not verify"
+
+# ── Signed split evidence ─────────────────────────────────────────────
+#
+# bundletool takes only `pass:` or `file:`, so the password goes to a private
+# file inside this run's 0700 workdir and is removed with it.
+
+PASSWORD_FILE="$WORKDIR/bundletool-password"
+( umask 077; printf '%s' "$KSTOREPWD" > "$PASSWORD_FILE" )
+
+"$JAVA" -jar "$BUNDLETOOL_JAR" build-apks \
+  --bundle "$SIGNED_AAB" \
+  --output "${OUTPUT_DIR}/signed-release.apks" \
+  --mode universal \
+  --ks="$KEYSTORE_PATH" \
+  --ks-key-alias="$KEY_ALIAS" \
+  --ks-pass="file:${PASSWORD_FILE}" \
+  --key-pass="file:${PASSWORD_FILE}"
+rm -f "$PASSWORD_FILE"
+
+echo "  signed universal split set written"

--- a/scripts/verify-android-release-keystore.sh
+++ b/scripts/verify-android-release-keystore.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prove the decoded Android release keystore is the one this project signs with,
+# before Gradle is allowed to open it.
+#
+# v0.5.4-beta's signed build decoded the environment secret and then died inside
+# `:app:packageRelease` with `KeytoolException: Failed to read key from
+# .../silentsuite-release.jks: Tag number over 30 is not supported` — a DER
+# parse failure, i.e. the bytes on disk were not a readable JKS at all. That was
+# discovered after twenty minutes of native build work, from a Gradle stack
+# trace, with no statement of what the store actually contained. This runs
+# immediately after the decode and answers the question directly.
+#
+# What it proves, all fail-closed:
+#   1. the keystore path is a non-empty regular file;
+#   2. the store opens with the configured password;
+#   3. the configured alias exists in it;
+#   4. that alias is a PrivateKeyEntry, not a trusted certificate;
+#   5. its leaf certificate is exactly the reviewed developer upload key.
+#
+# Secret handling, deliberate:
+#   * the store password is read by keytool from the environment through
+#     `-storepass:env`, so it is never an argument and never on disk;
+#   * the alias is read by awk from ENVIRON, and matched in this script, so it
+#     never reaches any child process's argument vector either — `ps` on a
+#     shared runner shows arguments, not environments;
+#   * keytool's own output is captured into a shell variable, never written to
+#     disk and never echoed — recognised failures are reported as fixed labels;
+#   * the only values printed are the expected and observed SHA-256 certificate
+#     fingerprints, which are public: they are in every published APK.
+#
+# Why the expected fingerprint is an argument and not an environment variable:
+# an earlier step in the signed job writes to `$GITHUB_ENV`, so a variable is
+# reachable by candidate build code running before this check. A step's `run`
+# text is byte-pinned by scripts/check-android-signing-boundary.py, so an
+# argument is not. The reviewed workflow passes none, and the compiled-in
+# constant is used.
+#
+# Usage:
+#   scripts/verify-android-release-keystore.sh [--expect-sha256 <64-hex>]
+#
+# Environment:
+#   KEYSTORE_PATH  path to the decoded store (not secret)
+#   KSTOREPWD      store password (never printed, never in any argv)
+#   KEY_ALIAS      expected alias (never printed, never in any argv)
+
+# The developer upload certificate. Changing this is changing which key the
+# project ships under, so it is a reviewed constant, pinned by
+# scripts/check-android-signing-boundary.py.
+EXPECTED_CERT_SHA256="8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79"
+
+# Deterministic, machine-readable keytool output. Without these the labels this
+# script parses ("Alias name:", "Entry type:", "SHA256:") are translated — a
+# German-locale runner prints "Keystore-Typ" and nothing matches. Both flags are
+# ordinary non-secret JVM options.
+KEYTOOL_LOCALE=(-J-Duser.language=en -J-Duser.country=US)
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --expect-sha256) EXPECTED_CERT_SHA256="${2:-}"; shift 2 ;;
+    *) echo "ERROR: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+: "${KEYSTORE_PATH:?KEYSTORE_PATH must be set}"
+: "${KSTOREPWD:?KSTOREPWD must be set}"
+: "${KEY_ALIAS:?KEY_ALIAS must be set}"
+
+# keytool reads the password from the environment and awk reads the alias from
+# it; both must therefore actually be exported, not merely set in this shell.
+export KSTOREPWD KEY_ALIAS
+
+command -v keytool >/dev/null 2>&1 || {
+  echo "ERROR: keytool is required to verify the release keystore" >&2
+  exit 2
+}
+
+refuse() {
+  echo "Refusing to sign: $*" >&2
+  exit 1
+}
+
+# Normalise then validate, before the value can reach a log line. An expected
+# fingerprint carrying control characters or the wrong length is a broken
+# invocation, not something to compare against and print.
+EXPECTED_CERT_SHA256="$(printf '%s' "$EXPECTED_CERT_SHA256" | tr '[:upper:]' '[:lower:]')"
+printf '%s' "$EXPECTED_CERT_SHA256" | grep -Eq '^[0-9a-f]{64}$' \
+  || refuse "the expected certificate fingerprint is not 64 hexadecimal characters"
+
+# ── 1. The file itself ────────────────────────────────────────────────
+
+[ -f "$KEYSTORE_PATH" ] || refuse "the keystore path is not a regular file"
+[ -s "$KEYSTORE_PATH" ] || refuse "the decoded keystore is empty"
+
+# ── 2. The store opens ────────────────────────────────────────────────
+#
+# Captured, never echoed. keytool does not print the password back, but its
+# diagnostics are still mapped to fixed labels rather than forwarded verbatim,
+# so no future keytool release can surprise this log.
+
+LISTING=""
+if ! LISTING="$(keytool "${KEYTOOL_LOCALE[@]}" -list -v \
+    -keystore "$KEYSTORE_PATH" -storepass:env KSTOREPWD 2>&1)"; then
+  case "$LISTING" in
+    *"password was incorrect"*|*"Keystore was tampered with"*)
+      refuse "the store password was rejected by the keystore" ;;
+    *"Tag number over"*|*"Invalid keystore format"*|*"DerInputStream"*|*"Short read"*\
+    |*"EOFException"*|*"not a valid"*|*"Unrecognized keystore"*)
+      # This is the v0.5.4-beta shape: a truncated or otherwise mangled base64
+      # decode produces bytes that are not DER, and Gradle only says so from
+      # inside :app:packageRelease twenty minutes later.
+      refuse "the decoded bytes are not a readable keystore (DER/format error)" ;;
+    *)
+      refuse "keytool could not read the keystore" ;;
+  esac
+fi
+
+# ── 3/4. The configured alias, and what kind of entry it is ───────────
+#
+# `keytool -alias "$KEY_ALIAS"` and `awk -v alias="$KEY_ALIAS"` would both put
+# the alias into a child process's argument vector. Reading it from ENVIRON
+# keeps it out of every argv while still matching exactly. Only the matching
+# block is examined; no alias is ever printed.
+
+ENTRY="$(
+  printf '%s\n' "$LISTING" | awk '
+    BEGIN { alias = ENVIRON["KEY_ALIAS"] }
+    /^Alias name: / {
+      capturing = (substr($0, 13) == alias)
+      if (capturing) { print; next }
+    }
+    /^Alias name: / { next }
+    capturing { print }
+  '
+)"
+
+[ -n "$ENTRY" ] || refuse "the configured signing alias is not present in the keystore"
+
+case "$ENTRY" in
+  *"Entry type: PrivateKeyEntry"*) ;;
+  *) refuse "the configured signing alias is not a PrivateKeyEntry" ;;
+esac
+
+# ── 5. The leaf certificate ───────────────────────────────────────────
+#
+# The first SHA256 fingerprint in the entry is Certificate[1], the signing leaf.
+
+OBSERVED="$(
+  printf '%s\n' "$ENTRY" \
+    | grep -m1 -oE 'SHA256:[[:space:]]*([0-9A-Fa-f]{2}:){31}[0-9A-Fa-f]{2}' \
+    | tr -d ' \t' \
+    | sed 's/^SHA256://' \
+    | tr -d ':' \
+    | tr '[:upper:]' '[:lower:]' || true
+)"
+
+printf '%s' "$OBSERVED" | grep -Eq '^[0-9a-f]{64}$' \
+  || refuse "no SHA-256 certificate fingerprint was found for the signing alias"
+
+if [ "$OBSERVED" != "$EXPECTED_CERT_SHA256" ]; then
+  echo "Refusing to sign: the signing certificate is not the reviewed upload key" >&2
+  echo "  expected SHA-256: ${EXPECTED_CERT_SHA256}" >&2
+  echo "  observed SHA-256: ${OBSERVED}" >&2
+  exit 1
+fi
+
+echo "Release keystore verified before Gradle:"
+echo "  store opens, configured alias present, entry is a PrivateKeyEntry"
+echo "  certificate SHA-256: ${OBSERVED}"

--- a/scripts/verify-release-identity.sh
+++ b/scripts/verify-release-identity.sh
@@ -110,17 +110,24 @@ api_get() {
       if [ "$mode" = "token" ] && [ -z "${GITHUB_TOKEN:-}" ]; then
         continue
       fi
+      # curl writes `000` through -w on a transport failure *and* exits
+      # non-zero, so `|| echo 000` appended a second one: the status became
+      # `000000`, which matched neither the success test nor the retry case
+      # below, and reported nonsense. Take the write-out alone, then validate.
       if [ "$mode" = "token" ]; then
         status="$(curl -sS -o "$destination" -w '%{http_code}' \
           -H "Authorization: Bearer ${GITHUB_TOKEN:-}" \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          "${API}${path}" || echo 000)"
+          "${API}${path}")" || true
       else
         status="$(curl -sS -o "$destination" -w '%{http_code}' \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          "${API}${path}" || echo 000)"
+          "${API}${path}")" || true
+      fi
+      if ! printf '%s' "$status" | grep -Eq '^[0-9]{3}$'; then
+        status="000"
       fi
       if [ "$status" = "200" ]; then
         return 0

--- a/tests/github_api_stub.py
+++ b/tests/github_api_stub.py
@@ -73,6 +73,9 @@ def default_state(tag: str = "v1.2.3", commit: str = "a" * 40) -> dict:
         "tag_moves_after": None,
         "moved_sha": "f" * 40,
         "tag_reads": 0,
+        # Every Content-Type the release-creation endpoint refused, so a test
+        # can assert *why* a request failed rather than only that it did.
+        "rejected_media_types": [],
     }
 
 
@@ -229,8 +232,39 @@ class _Handler(BaseHTTPRequestHandler):
         if path == f"{prefix}/releases":
             status = self._override("create_release")
             if status:
-                return self._send(status, {"message": "forced"})
-            payload = json.loads(body.decode("utf-8"))
+                return self._send(status, self.state.get("create_release_body", {"message": "forced"}))
+            # GitHub parses a request body by its declared media type. curl's
+            # `-d` defaults to application/x-www-form-urlencoded, so a JSON
+            # document sent without this header arrives as one nonsense form
+            # field and the release is rejected — the exact defect that left
+            # v0.5.4-beta with no draft. Modelled faithfully so the regression
+            # cannot come back unnoticed.
+            content_type = self.headers.get("Content-Type", "")
+            if content_type.split(";")[0].strip().lower() != "application/json":
+                self.state["rejected_media_types"].append(content_type)
+                return self._send(
+                    400,
+                    {
+                        "message": "Body should be a JSON object",
+                        "documentation_url": "https://docs.github.com/rest",
+                    },
+                )
+            try:
+                payload = json.loads(body.decode("utf-8"))
+                if not isinstance(payload, dict):
+                    raise ValueError("not an object")
+            except (ValueError, UnicodeDecodeError):
+                return self._send(400, {"message": "Problems parsing JSON"})
+            # A tag may hold exactly one release; a losing sibling in the
+            # create/create race gets GitHub's 422, not a second draft.
+            if any(r["tag_name"] == payload.get("tag_name") for r in self.state["releases"]):
+                return self._send(
+                    422,
+                    {
+                        "message": "Validation Failed",
+                        "errors": [{"resource": "Release", "code": "already_exists"}],
+                    },
+                )
             release = {
                 "id": self.state["next_release_id"],
                 "tag_name": payload["tag_name"],

--- a/tests/test_android_conscrypt_r28.py
+++ b/tests/test_android_conscrypt_r28.py
@@ -80,7 +80,7 @@ def test_release_builds_fail_closed_without_rebuilt_conscrypt_aar():
         (
             RELEASE_WORKFLOW,
             "conscrypt-r28-${{ inputs.source_sha }}",
-            ("build-release",),
+            ("build-unsigned-release",),
         ),
     ],
     ids=("ci", "release"),
@@ -117,7 +117,7 @@ def test_workflow_builds_conscrypt_once_without_secrets_and_reuses_exact_run_art
 def test_final_apk_and_aab_gates_require_conscrypt_ndk_r28_identity():
     for path, job_name, step_name in (
         (CI_WORKFLOW, "build-pr", "Verify unsigned release native libraries"),
-        (RELEASE_WORKFLOW, "build-release", "Verify release native libraries"),
+        (RELEASE_WORKFLOW, "build-unsigned-release", "Verify unsigned release native libraries"),
     ):
         jobs = workflow_jobs(path)
         run = {step["name"]: step for step in jobs[job_name]["steps"]}[step_name]["run"]

--- a/tests/test_android_release_keystore.py
+++ b/tests/test_android_release_keystore.py
@@ -368,29 +368,31 @@ def build_release_steps() -> list[dict]:
     workflow = yaml.load(
         ANDROID_RELEASE_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader
     )
-    return workflow["jobs"]["build-release"]["steps"]
+    return workflow["jobs"]["sign-release"]["steps"]
 
 
-def test_the_verifier_runs_between_the_decode_and_gradle():
+def test_the_verifier_runs_between_the_decode_and_signing():
+    """Nothing may sit between the store being written and it being proven."""
+
     names = [step.get("name") for step in build_release_steps()]
     decode = names.index("Decode release keystore")
-    verify_index = names.index("Verify the release keystore before Gradle")
-    gradle = names.index("Build signed release APK and AAB")
+    verify_index = names.index("Verify the release keystore before signing")
+    signing = names.index("Sign the admitted APK and AAB")
 
-    assert verify_index == decode + 1, names[decode : gradle + 1]
-    assert gradle == verify_index + 1, names[decode : gradle + 1]
+    assert verify_index == decode + 1, names[decode : signing + 1]
+    assert signing == verify_index + 1, names[decode : signing + 1]
 
 
 def test_the_verifier_runs_trusted_code_with_only_the_signing_secrets():
     step = next(
-        s for s in build_release_steps() if s.get("name") == "Verify the release keystore before Gradle"
+        s for s in build_release_steps() if s.get("name") == "Verify the release keystore before signing"
     )
     assert step["env"] == {
         "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
         "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
     }
-    assert ".release-trusted/scripts/verify-android-release-keystore.sh" in step["run"]
-    assert "android/scripts" not in step["run"]
+    assert '"$GITHUB_WORKSPACE/scripts/verify-android-release-keystore.sh"' in step["run"]
+    assert "unsigned/" not in step["run"], "the verifier is trusted code, not candidate data"
 
 
 def test_the_decode_step_is_hardened_and_fails_closed():
@@ -440,7 +442,7 @@ def test_an_ambient_environment_variable_cannot_relax_the_expected_certificate(s
 
 def test_the_reviewed_workflow_supplies_no_override():
     step = next(
-        s for s in build_release_steps() if s.get("name") == "Verify the release keystore before Gradle"
+        s for s in build_release_steps() if s.get("name") == "Verify the release keystore before signing"
     )
     assert "--expect-sha256" not in step["run"]
 

--- a/tests/test_android_release_keystore.py
+++ b/tests/test_android_release_keystore.py
@@ -1,0 +1,591 @@
+"""Behavioural contract for the pre-Gradle Android keystore verifier.
+
+v0.5.4-beta's signed build decoded the environment secret and then died inside
+`:app:packageRelease` with `KeytoolException: Failed to read key from
+.../silentsuite-release.jks: Tag number over 30 is not supported`. The bytes on
+disk were not a readable keystore, and nothing said so until Gradle had already
+spent twenty minutes building. `scripts/verify-android-release-keystore.sh` is
+the check that now runs between the decode and Gradle.
+
+Reading it proves very little, so every case here builds a real keystore with
+`keytool` and runs the real script against it: a good store, a wrong password, a
+missing alias, a certificate-only entry, an unexpected certificate, and a
+truncated store — the shape the release actually hit.
+
+No secret is embedded anywhere. Passwords are generated per test, passed only
+through the environment, and asserted absent from both the output and the
+argument vector the script hands to keytool.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import secrets
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts" / "verify-android-release-keystore.sh"
+ANDROID_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-android.yml"
+
+# The reviewed developer upload certificate. Nothing here can produce it — these
+# tests generate throwaway keys — so the fingerprint is overridden per case and
+# the constant is asserted to be what the shipped helper and policy pin.
+EXPECTED_UPLOAD_CERT_SHA256 = "8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79"
+
+ALIAS = "silentsuite-upload"
+FINGERPRINT = re.compile(r"SHA256:\s*((?:[0-9A-Fa-f]{2}:){31}[0-9A-Fa-f]{2})")
+
+keytool_required = pytest.mark.skipif(
+    shutil.which("keytool") is None, reason="keytool (JDK) is not installed"
+)
+
+
+def keytool(*arguments: str, password: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["keytool", *arguments],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "SILENTSUITE_TEST_STOREPASS": password},
+    )
+
+
+def make_keystore(path: Path, password: str, alias: str = ALIAS) -> None:
+    result = keytool(
+        "-genkeypair",
+        "-keystore", str(path),
+        "-storetype", "JKS",
+        "-alias", alias,
+        "-keyalg", "RSA",
+        "-keysize", "2048",
+        "-validity", "1",
+        "-dname", "CN=SilentSuite Test Upload",
+        "-storepass:env", "SILENTSUITE_TEST_STOREPASS",
+        "-keypass:env", "SILENTSUITE_TEST_STOREPASS",
+        password=password,
+    )
+    assert result.returncode == 0, result.stderr
+    assert path.is_file() and path.stat().st_size > 0
+
+
+def fingerprint_of(path: Path, password: str) -> str:
+    result = keytool(
+        "-list", "-v", "-keystore", str(path),
+        "-storepass:env", "SILENTSUITE_TEST_STOREPASS",
+        password=password,
+    )
+    assert result.returncode == 0, result.stderr
+    match = FINGERPRINT.search(result.stdout)
+    assert match, result.stdout
+    return match.group(1).replace(":", "").lower()
+
+
+def verify(
+    keystore: Path,
+    password: str,
+    *,
+    alias: str = ALIAS,
+    expected: str | None = None,
+    path_override: str | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    environment = {
+        **os.environ,
+        "KEYSTORE_PATH": path_override if path_override is not None else str(keystore),
+        "KSTOREPWD": password,
+        "KEY_ALIAS": alias,
+        **(extra_env or {}),
+    }
+    command = ["bash", str(VERIFIER)]
+    if expected is not None:
+        command += ["--expect-sha256", expected]
+    return subprocess.run(command, capture_output=True, text=True, env=environment)
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    password = secrets.token_urlsafe(24)
+    path = tmp_path / "silentsuite-release.jks"
+    make_keystore(path, password)
+    return {"path": path, "password": password, "fingerprint": fingerprint_of(path, password)}
+
+
+# ── The one path that signs ───────────────────────────────────────────
+
+
+@keytool_required
+def test_a_matching_keystore_is_accepted(store):
+    result = verify(store["path"], store["password"], expected=store["fingerprint"])
+
+    assert result.returncode == 0, result.stderr
+    assert "Release keystore verified before Gradle" in result.stdout
+    assert "PrivateKeyEntry" in result.stdout
+    assert store["fingerprint"] in result.stdout
+
+
+# ── Everything that must fail before Gradle ───────────────────────────
+
+
+@keytool_required
+def test_a_truncated_store_is_refused(store, tmp_path: Path):
+    """The v0.5.4-beta shape: a mangled decode that is not DER at all."""
+
+    broken = tmp_path / "broken.jks"
+    broken.write_bytes(store["path"].read_bytes()[:400])
+
+    result = verify(broken, store["password"], expected=store["fingerprint"])
+
+    assert result.returncode == 1
+    assert "Refusing to sign" in result.stderr
+    assert "keystore" in result.stderr
+
+
+@keytool_required
+def test_random_bytes_are_refused_as_a_der_format_error(store, tmp_path: Path):
+    garbage = tmp_path / "garbage.jks"
+    garbage.write_bytes(secrets.token_bytes(4096))
+
+    result = verify(garbage, store["password"], expected=store["fingerprint"])
+
+    assert result.returncode == 1
+    assert "not a readable keystore" in result.stderr
+
+
+@keytool_required
+def test_a_wrong_store_password_is_refused(store):
+    result = verify(store["path"], secrets.token_urlsafe(24), expected=store["fingerprint"])
+
+    assert result.returncode == 1
+    assert "store password was rejected" in result.stderr
+
+
+@keytool_required
+def test_a_missing_alias_is_refused(store):
+    result = verify(
+        store["path"], store["password"], alias="not-present", expected=store["fingerprint"]
+    )
+
+    assert result.returncode == 1
+    assert "alias is not present" in result.stderr
+
+
+@keytool_required
+def test_a_certificate_only_entry_is_refused(store, tmp_path: Path):
+    """A trustedCertEntry cannot sign, and must not be mistaken for a key."""
+
+    certificate = tmp_path / "upload.cer"
+    export = keytool(
+        "-exportcert", "-alias", ALIAS, "-keystore", str(store["path"]),
+        "-storepass:env", "SILENTSUITE_TEST_STOREPASS", "-file", str(certificate),
+        password=store["password"],
+    )
+    assert export.returncode == 0, export.stderr
+
+    cert_only = tmp_path / "cert-only.jks"
+    imported = keytool(
+        "-importcert", "-noprompt", "-alias", ALIAS, "-file", str(certificate),
+        "-keystore", str(cert_only), "-storetype", "JKS",
+        "-storepass:env", "SILENTSUITE_TEST_STOREPASS",
+        password=store["password"],
+    )
+    assert imported.returncode == 0, imported.stderr
+
+    result = verify(cert_only, store["password"], expected=store["fingerprint"])
+
+    assert result.returncode == 1
+    assert "not a PrivateKeyEntry" in result.stderr
+
+
+@keytool_required
+def test_an_unexpected_certificate_is_refused_and_both_fingerprints_reported(store):
+    other = "b" * 64
+
+    result = verify(store["path"], store["password"], expected=other)
+
+    assert result.returncode == 1
+    assert "not the reviewed upload key" in result.stderr
+    assert f"expected SHA-256: {other}" in result.stderr
+    assert f"observed SHA-256: {store['fingerprint']}" in result.stderr
+
+
+@keytool_required
+def test_an_empty_store_is_refused_before_keytool_runs(store, tmp_path: Path):
+    empty = tmp_path / "empty.jks"
+    empty.touch()
+
+    result = verify(empty, store["password"], expected=store["fingerprint"])
+
+    assert result.returncode == 1
+    assert "decoded keystore is empty" in result.stderr
+
+
+@keytool_required
+def test_a_missing_store_is_refused(store, tmp_path: Path):
+    result = verify(
+        store["path"],
+        store["password"],
+        expected=store["fingerprint"],
+        path_override=str(tmp_path / "absent.jks"),
+    )
+
+    assert result.returncode == 1
+    assert "not a regular file" in result.stderr
+
+
+@pytest.mark.parametrize("missing", ["KEYSTORE_PATH", "KSTOREPWD", "KEY_ALIAS"])  # noqa: PT006
+def test_a_missing_input_fails_closed(tmp_path: Path, missing: str):
+    environment = {
+        **os.environ,
+        "KEYSTORE_PATH": str(tmp_path / "x.jks"),
+        "KSTOREPWD": "unused",
+        "KEY_ALIAS": ALIAS,
+    }
+    environment.pop(missing)
+    result = subprocess.run(
+        ["bash", str(VERIFIER)], capture_output=True, text=True, env=environment
+    )
+
+    assert result.returncode != 0
+    assert missing in result.stderr
+
+
+# ── Secret handling ───────────────────────────────────────────────────
+
+
+@keytool_required
+@pytest.mark.parametrize(
+    "case", ["good", "wrong-password", "wrong-alias", "wrong-certificate", "corrupt"]
+)
+def test_no_outcome_ever_prints_the_password_or_alias(store, tmp_path: Path, case: str):
+    password = store["password"]
+    keystore = store["path"]
+    expected = store["fingerprint"]
+    alias = ALIAS
+    if case == "wrong-password":
+        password = secrets.token_urlsafe(24)
+    elif case == "wrong-alias":
+        alias = "some-other-alias"
+    elif case == "wrong-certificate":
+        expected = "c" * 64
+    elif case == "corrupt":
+        keystore = tmp_path / "corrupt.jks"
+        keystore.write_bytes(store["path"].read_bytes()[:200])
+
+    result = verify(keystore, password, alias=alias, expected=expected)
+    combined = result.stdout + result.stderr
+
+    assert password not in combined, f"{case}: the store password reached the log"
+    assert store["password"] not in combined, f"{case}: the real password reached the log"
+    assert alias not in combined, f"{case}: the signing alias reached the log"
+    assert ALIAS not in combined, f"{case}: the real alias reached the log"
+
+
+@keytool_required
+def test_the_password_and_alias_never_reach_the_keytool_argument_vector(store, tmp_path: Path):
+    """A shim records exactly what the verifier hands to keytool, then execs it.
+
+    `ps` on a shared runner shows the argument vector of every process, so
+    "the password is not an argument" has to be proven, not asserted in prose.
+    """
+
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    record = tmp_path / "argv.log"
+    real = shutil.which("keytool")
+    (shim_dir / "keytool").write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$@" >> {record}\n'
+        f'exec {real} "$@"\n',
+        encoding="utf-8",
+    )
+    (shim_dir / "keytool").chmod(0o755)
+
+    result = verify(
+        store["path"],
+        store["password"],
+        expected=store["fingerprint"],
+        extra_env={"PATH": f"{shim_dir}:{os.environ['PATH']}"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    recorded = record.read_text(encoding="utf-8")
+    assert recorded, "the shim captured no keytool invocation"
+    assert store["password"] not in recorded, "the store password was passed as an argument"
+    assert ALIAS not in recorded, "the signing alias was passed as an argument"
+    # The password is named, not spelled: keytool reads it from the environment.
+    assert "-storepass:env" in recorded
+    assert "KSTOREPWD" in recorded
+
+
+def executable_text(path: Path) -> str:
+    """Source with comments stripped: these rules are about what runs.
+
+    The comments deliberately name the two constructs being avoided.
+    """
+
+    return "\n".join(
+        line for line in path.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+def test_the_verifier_never_writes_key_material_or_passwords_to_disk():
+    source = executable_text(VERIFIER)
+    assert "-storepass:env KSTOREPWD" in source
+    assert "-storepass " not in source, "a literal password argument would land in `ps`"
+    assert "-keypass" not in source
+    assert "-alias " not in source, "the alias is matched in-shell, not passed to keytool"
+    # keytool's own output is held in a variable and never persisted or echoed.
+    # keytool's output is held in a shell variable, matched against fixed
+    # patterns, and never echoed or persisted.
+    assert 'LISTING="$(keytool' in source
+    for leak in ('echo "$LISTING"', 'echo "${LISTING}"', '"$LISTING" >', '"$LISTING" >>'):
+        assert leak not in source, f"keytool output must not be forwarded: {leak}"
+    assert 'EXPECTED_CERT_SHA256:-' not in source, (
+        "the expected fingerprint must not fall back to an ambient variable"
+    )
+    # The only place it is consumed is the failure classifier and the awk split.
+    assert 'case "$LISTING" in' in source
+    assert 'printf \'%s\\n\' "$LISTING" | awk' in source
+
+
+def test_the_verifier_pins_the_reviewed_upload_certificate():
+    source = VERIFIER.read_text(encoding="utf-8")
+    assert EXPECTED_UPLOAD_CERT_SHA256 in source
+    policy = (ROOT / "scripts" / "check-android-signing-boundary.py").read_text(encoding="utf-8")
+    assert EXPECTED_UPLOAD_CERT_SHA256 in policy, "the policy must pin the same certificate"
+
+
+# ── Wiring: decode, then verify, then Gradle ──────────────────────────
+
+
+def build_release_steps() -> list[dict]:
+    workflow = yaml.load(
+        ANDROID_RELEASE_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader
+    )
+    return workflow["jobs"]["build-release"]["steps"]
+
+
+def test_the_verifier_runs_between_the_decode_and_gradle():
+    names = [step.get("name") for step in build_release_steps()]
+    decode = names.index("Decode release keystore")
+    verify_index = names.index("Verify the release keystore before Gradle")
+    gradle = names.index("Build signed release APK and AAB")
+
+    assert verify_index == decode + 1, names[decode : gradle + 1]
+    assert gradle == verify_index + 1, names[decode : gradle + 1]
+
+
+def test_the_verifier_runs_trusted_code_with_only_the_signing_secrets():
+    step = next(
+        s for s in build_release_steps() if s.get("name") == "Verify the release keystore before Gradle"
+    )
+    assert step["env"] == {
+        "KSTOREPWD": "${{ secrets.ANDROID_KEYSTORE_PASSWORD }}",
+        "KEY_ALIAS": "${{ secrets.ANDROID_KEY_ALIAS }}",
+    }
+    assert ".release-trusted/scripts/verify-android-release-keystore.sh" in step["run"]
+    assert "android/scripts" not in step["run"]
+
+
+def test_the_decode_step_is_hardened_and_fails_closed():
+    step = next(s for s in build_release_steps() if s.get("name") == "Decode release keystore")
+    run = step["run"]
+    assert "umask 077" in run, "the store must not be world-readable on a shared runner"
+    assert "printf '%s'" in run, "echo mangles a value with backslashes or a leading dash"
+    assert "echo \"$KEYSTORE_BASE64\"" not in run
+    assert "set -euo pipefail" in run
+    # A failing decode must not leave a truncated file behind unremarked.
+    assert "is not valid base64" in run
+    assert "-s \"$KEYSTORE_FILE\"" in run
+    assert "-f \"$KEYSTORE_FILE\"" in run
+
+
+def test_the_keystore_is_still_cleaned_up():
+    steps = build_release_steps()
+    cleanup = next(s for s in steps if s.get("name") == "Cleanup keystore")
+    assert cleanup["if"] == "always()"
+    assert 'rm -rf "$RUNNER_TEMP/keystore"' in cleanup["run"]
+    assert [s.get("name") for s in steps][-1] == "Cleanup keystore"
+
+
+# ── The expected fingerprint is not environment-controllable ──────────
+
+
+@keytool_required
+def test_an_ambient_environment_variable_cannot_relax_the_expected_certificate(store):
+    """An earlier step in the signed job writes `$GITHUB_ENV`.
+
+    That makes any environment variable reachable by candidate build code
+    running before this check, while a reviewed step's `run` text is byte-pinned
+    by the signing-boundary policy. So the override is an argument, and an
+    ambient variable of the same name must have no effect at all.
+    """
+
+    result = verify(
+        store["path"],
+        store["password"],
+        extra_env={"EXPECTED_CERT_SHA256": store["fingerprint"]},
+    )
+
+    assert result.returncode == 1
+    assert f"expected SHA-256: {EXPECTED_UPLOAD_CERT_SHA256}" in result.stderr
+    assert f"observed SHA-256: {store['fingerprint']}" in result.stderr
+
+
+def test_the_reviewed_workflow_supplies_no_override():
+    step = next(
+        s for s in build_release_steps() if s.get("name") == "Verify the release keystore before Gradle"
+    )
+    assert "--expect-sha256" not in step["run"]
+
+
+@keytool_required
+@pytest.mark.parametrize(
+    "value",
+    ["", "abc", "g" * 64, "a" * 63, "a" * 65, "a" * 63 + "\n", "\x1b[31m" + "a" * 58],
+)
+def test_a_malformed_expected_fingerprint_is_refused_before_it_is_logged(store, value: str):
+    result = verify(store["path"], store["password"], expected=value)
+
+    assert result.returncode == 1
+    assert "not 64 hexadecimal characters" in result.stderr
+    assert "\x1b" not in result.stderr
+    assert "observed SHA-256" not in result.stderr, "nothing is compared or printed"
+
+
+@keytool_required
+def test_an_uppercase_expected_fingerprint_is_normalised(store):
+    result = verify(store["path"], store["password"], expected=store["fingerprint"].upper())
+
+    assert result.returncode == 0, result.stderr
+
+
+# ── Deterministic keytool output ──────────────────────────────────────
+
+
+@keytool_required
+def test_a_hostile_default_jvm_locale_cannot_break_the_parser(store):
+    """keytool translates its labels; the parser matches English ones.
+
+    `JAVA_TOOL_OPTIONS` sets the JVM's default locale from the environment, so
+    this is the real failure mode on a non-English runner. The explicit `-J-D`
+    flags come later on the command line and win.
+    """
+
+    german = {"JAVA_TOOL_OPTIONS": "-Duser.language=de -Duser.country=DE"}
+
+    # Without the flags, the labels this script parses do not appear at all.
+    raw = keytool(
+        "-list", "-v", "-keystore", str(store["path"]),
+        "-storepass:env", "SILENTSUITE_TEST_STOREPASS",
+        password=store["password"],
+    )
+    localised = subprocess.run(
+        ["keytool", "-list", "-v", "-keystore", str(store["path"]),
+         "-storepass:env", "SILENTSUITE_TEST_STOREPASS"],
+        capture_output=True, text=True,
+        env={**os.environ, "SILENTSUITE_TEST_STOREPASS": store["password"], **german},
+    )
+    assert "Alias name:" in raw.stdout
+    if "Alias name:" in localised.stdout:
+        pytest.skip("this JDK has no German resource bundle to translate with")
+
+    result = verify(
+        store["path"], store["password"], expected=store["fingerprint"], extra_env=german
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert store["fingerprint"] in result.stdout
+
+
+def test_the_verifier_pins_keytools_locale():
+    source = VERIFIER.read_text(encoding="utf-8")
+    assert "-J-Duser.language=en" in source
+    assert "-J-Duser.country=US" in source
+    assert 'KEYTOOL_LOCALE=(' in source
+    assert '"${KEYTOOL_LOCALE[@]}"' in source
+
+
+# ── Nothing secret reaches any child argument vector ──────────────────
+
+
+def spawned_commands(source: str) -> set[str]:
+    """External commands the verifier can execute, from its executable text."""
+
+    code = "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+    found = set()
+    for name in ("keytool", "awk", "grep", "sed", "tr", "cut", "printf", "cat", "head"):
+        if re.search(rf"(?:^|[|(\s$]){name}\s", code, re.MULTILINE):
+            found.add(name)
+    return found
+
+
+@keytool_required
+def test_no_process_the_verifier_spawns_receives_the_alias_or_password(store, tmp_path: Path):
+    """Every PATH-resolved command it runs is shimmed and its argv recorded.
+
+    `ps` shows arguments to any user on the machine, so "the alias is not an
+    argument" has to be observed across every child, not just keytool. Shell
+    builtins cannot leak to an argv at all, so PATH coverage is the whole
+    external surface.
+    """
+
+    names = spawned_commands(VERIFIER.read_text(encoding="utf-8"))
+    assert "keytool" in names and "awk" in names, names
+
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    record = tmp_path / "argv.log"
+    shimmed = {}
+    for name in sorted(names):
+        real = shutil.which(name)
+        if real is None:  # a builtin such as printf may have no binary
+            continue
+        shimmed[name] = real
+        (shim_dir / name).write_text(
+            "#!/usr/bin/env bash\n"
+            f'printf "%s\\n" "{name}" "$@" >> {record}\n'
+            f'exec {real} "$@"\n',
+            encoding="utf-8",
+        )
+        (shim_dir / name).chmod(0o755)
+    assert "keytool" in shimmed and "awk" in shimmed, shimmed
+
+    result = verify(
+        store["path"],
+        store["password"],
+        expected=store["fingerprint"],
+        extra_env={"PATH": f"{shim_dir}:{os.environ['PATH']}"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    recorded = record.read_text(encoding="utf-8")
+    assert recorded, "no child process was observed"
+    observed = {line for line in recorded.splitlines() if line in shimmed}
+    assert "keytool" in observed and "awk" in observed, sorted(observed)
+    assert store["password"] not in recorded, "the store password reached a child argv"
+    assert ALIAS not in recorded, "the signing alias reached a child argv"
+    # The password is named, not spelled; the alias is not mentioned at all.
+    assert "-storepass:env" in recorded
+    assert "KSTOREPWD" in recorded
+    assert "-v alias=" not in recorded
+
+
+def test_the_alias_is_read_from_the_environment_not_an_argument():
+    code = "\n".join(
+        line for line in VERIFIER.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    assert 'ENVIRON["KEY_ALIAS"]' in code
+    for argv_leak in ("-v alias=", "-v ALIAS=", "-alias "):
+        assert argv_leak not in code, f"the alias must not be passed as {argv_leak.strip()}"
+    # Both values must actually be exported for keytool and awk to see them.
+    assert "export KSTOREPWD KEY_ALIAS" in code

--- a/tests/test_android_release_static.py
+++ b/tests/test_android_release_static.py
@@ -48,7 +48,15 @@ def job_steps(job: str) -> dict[str, dict[str, object]]:
 
 
 def release_steps() -> dict[str, dict[str, object]]:
-    return job_steps("build-release")
+    """Steps of the signing job — where the release assets are produced."""
+
+    return job_steps("sign-release")
+
+
+def unsigned_steps() -> dict[str, dict[str, object]]:
+    """Steps of the candidate producer, which builds but never signs."""
+
+    return job_steps("build-unsigned-release")
 
 
 def attachment_steps() -> dict[str, dict[str, object]]:
@@ -103,16 +111,15 @@ def test_android_release_checksum_generation_matches_uploads():
     bundle_checksum = f"silentsuite-android-{tag}-bundle.sha256"
     symbols_checksum = f"silentsuite-android-{tag}-native-debug-symbols.sha256"
 
-    rename_run = steps["Rename Android artifacts for release"]["run"]
-    assert checksum_outputs(rename_run) == {
+    stage_run = steps["Stage the closed release-asset set"]["run"]
+    assert checksum_outputs(stage_run) == {
         apk: installer_checksum,
         aab: bundle_checksum,
         symbols: symbols_checksum,
     }
 
-    # The signed job stages exactly the six renamed assets into one closed
+    # The signing job stages exactly the six versioned assets into one closed
     # directory; it no longer attaches them itself.
-    stage_run = steps["Stage the closed release-asset set"]["run"]
     for name in (apk, installer_checksum, aab, bundle_checksum, symbols, symbols_checksum):
         assert name in stage_run, name
 
@@ -144,8 +151,7 @@ def test_android_release_checksum_generation_matches_uploads():
 
 def test_android_release_checksum_sidecars_do_not_match_orion_apk_filter():
     steps = release_steps()
-    rename_run = steps["Rename Android artifacts for release"]["run"]
-    sidecars = checksum_outputs(rename_run).values()
+    sidecars = checksum_outputs(steps["Stage the closed release-asset set"]["run"]).values()
 
     def looks_installable(name: str) -> bool:
         lowered_name = name.lower()
@@ -188,7 +194,7 @@ def test_release_build_type_does_not_claim_agp_emits_symbol_zip():
     assert "native-debug-symbols" not in release
 
 
-@pytest.mark.parametrize("job", ["build-pr", "build-release"])
+@pytest.mark.parametrize("job", ["build-pr", "build-unsigned-release"])
 def test_native_symbol_verification_gates_both_release_builds(job: str):
     run = job_steps(job)["Verify release native debug symbols"]["run"]
     assert "scripts/verify-native-debug-symbols.py" in run
@@ -203,7 +209,7 @@ def test_native_symbol_verification_gates_both_release_builds(job: str):
     )
 
 
-@pytest.mark.parametrize("job", ["build-pr", "build-release"])
+@pytest.mark.parametrize("job", ["build-pr", "build-unsigned-release"])
 def test_manual_symbol_packaging_precedes_verification(job: str):
     steps = job_steps(job)
     ordered = list(steps)
@@ -227,23 +233,25 @@ def test_release_symbols_upload_is_gated_by_verifier_and_release_attach():
     the attach step's fail_on_unmatched_files; if-no-files-found stays only
     as defense in depth.
     """
+    produced = unsigned_steps()
+    produced_order = list(produced)
+    assert produced_order.index("Verify release native debug symbols") < produced_order.index(
+        "Stage the closed unsigned handoff"
+    )
+    handoff = produced["Publish the unsigned build to the signing job"]
+    assert handoff["with"]["if-no-files-found"] == "error"
+
+    # Release assets leave the signing job as a closed artifact instead of being
+    # attached there; the inventory re-assertion downstream is what now fails
+    # closed if the symbols ZIP is missing.
     steps = release_steps()
     ordered = list(steps)
-    upload = steps["Upload signed release APK, AAB, and native debug symbols"]
-    assert SYMBOLS_ZIP_BUILD_PATH in upload["with"]["path"].splitlines()
-    assert upload["with"]["if-no-files-found"] == "error"
-    assert ordered.index("Verify release native debug symbols") < ordered.index(
-        "Upload signed release APK, AAB, and native debug symbols"
-    )
-    # Release assets leave this job as a closed artifact instead of being
-    # attached here; the inventory re-assertion downstream is what now fails
-    # closed if the symbols ZIP is missing.
     stage_run = steps["Stage the closed release-asset set"]["run"]
     assert "native-debug-symbols.zip" in stage_run
     artifact = steps["Publish the closed release-asset set to the attachment job"]
     assert artifact["with"]["if-no-files-found"] == "error"
-    assert ordered.index("Verify release native debug symbols") < ordered.index(
-        "Stage the closed release-asset set"
+    assert ordered.index("Stage the closed release-asset set") < ordered.index(
+        "Publish the closed release-asset set to the attachment job"
     )
     inventory = attachment_steps()["Re-assert the closed asset inventory"]["run"]
     assert "native-debug-symbols.zip" in inventory
@@ -296,7 +304,7 @@ def test_release_job_hash_constant_matches_workflow():
     spec.loader.exec_module(checker)
     workflow = checker.load_workflow(ANDROID_RELEASE_WORKFLOW)
     assert (
-        checker.semantic_sha256(workflow["jobs"]["build-release"])
+        checker.semantic_sha256(workflow["jobs"]["sign-release"])
         == checker.EXPECTED_RELEASE_JOB_SHA256
     )
 

--- a/tests/test_android_security_static.py
+++ b/tests/test_android_security_static.py
@@ -40,24 +40,22 @@ def test_android_resources_do_not_reference_tourguide_owned_white():
 
 
 def test_bundletool_uses_a_private_temporary_password_file():
-    workflow = ANDROID_RELEASE_WORKFLOW.read_text(encoding="utf-8")
-    release_step = workflow.split(
-        "      - name: Capture release dependency graph and generate signed-release splits\n",
-        1,
-    )[1].split("\n      - name:", 1)[0]
+    """bundletool takes only `pass:` or `file:`, so the file must be private.
 
-    assert "--ks-pass=env:" not in release_step
-    assert "--key-pass=env:" not in release_step
+    The signing now happens in a trusted helper rather than inline YAML, but the
+    handling contract is unchanged.
+    """
+
+    release_step = (ROOT / "scripts/sign-android-release.sh").read_text(encoding="utf-8")
+
     assert "umask 077" in release_step
-    assert 'BUNDLETOOL_PASSWORD_FILE="$RUNNER_TEMP/keystore/bundletool-password"' in release_step
-    assert 'printf \'%s\' "$KSTOREPWD" > "$BUNDLETOOL_PASSWORD_FILE"' in release_step
-    assert "unset KSTOREPWD" in release_step
-    assert '--ks-pass="file:$BUNDLETOOL_PASSWORD_FILE"' in release_step
-    assert '--key-pass="file:$BUNDLETOOL_PASSWORD_FILE"' in release_step
-    assert release_step.index(
-        'printf \'%s\' "$KSTOREPWD" > "$BUNDLETOOL_PASSWORD_FILE"'
-    ) < release_step.index("unset KSTOREPWD") < release_step.index(
-        'java -jar "$RUNNER_TEMP/bundletool.jar" build-apks'
+    assert 'PASSWORD_FILE="$WORKDIR/bundletool-password"' in release_step
+    assert 'printf \'%s\' "$KSTOREPWD" > "$PASSWORD_FILE"' in release_step
+    assert 'rm -f "$PASSWORD_FILE"' in release_step
+    assert '--ks-pass="file:${PASSWORD_FILE}"' in release_step
+    assert '--key-pass="file:${PASSWORD_FILE}"' in release_step
+    assert release_step.index('printf \'%s\' "$KSTOREPWD" > "$PASSWORD_FILE"') < release_step.index(
+        "build-apks"
     )
 
 

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -29,6 +29,7 @@ CONSCRYPT_BUILD_SCRIPT = Path("android/scripts/build-conscrypt-android-r28.sh")
 IDENTITY_HELPER = Path("scripts/verify-release-identity.sh")
 ATTACHMENT_HELPER = Path("scripts/attach-umbrella-release-assets.sh")
 READINESS_HELPER = Path("scripts/verify-umbrella-release-readiness.py")
+KEYSTORE_HELPER = Path("scripts/verify-android-release-keystore.sh")
 
 RELEASE_NEEDS = "    needs: [signing-policy, conscrypt-r28, revalidate-signing]\n"
 RELEASE_CHECKOUT = (
@@ -85,7 +86,7 @@ def fixture_root(tmp_path: Path) -> Path:
     # The control plane executes these with network and API access, so the
     # policy pins their bytes; the fixture must carry them for the digest
     # checks to be real.
-    for helper in (IDENTITY_HELPER, ATTACHMENT_HELPER, READINESS_HELPER):
+    for helper in (IDENTITY_HELPER, ATTACHMENT_HELPER, READINESS_HELPER, KEYSTORE_HELPER):
         (root / helper).parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(ROOT / helper, root / helper)
     return root

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -30,38 +30,25 @@ IDENTITY_HELPER = Path("scripts/verify-release-identity.sh")
 ATTACHMENT_HELPER = Path("scripts/attach-umbrella-release-assets.sh")
 READINESS_HELPER = Path("scripts/verify-umbrella-release-readiness.py")
 KEYSTORE_HELPER = Path("scripts/verify-android-release-keystore.sh")
+ARTIFACT_ADMISSION_HELPER = Path("scripts/admit-unsigned-android-artifact.sh")
+SIGNING_HELPER = Path("scripts/sign-android-release.sh")
 
-RELEASE_NEEDS = "    needs: [signing-policy, conscrypt-r28, revalidate-signing]\n"
-RELEASE_CHECKOUT = (
-    "      - name: Checkout\n"
-    "        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n"
-    "        with:\n"
-    "          ref: ${{ inputs.source_sha }}\n"
-    "          persist-credentials: false\n"
+RELEASE_NEEDS = (
+    "    needs: [signing-policy, conscrypt-r28, revalidate-signing, build-unsigned-release]\n"
 )
-TRUSTED_CHECKOUT = (
-    "      # Second, and into its own directory: the candidate checkout above cleans\n"
-    "      # the workspace root, so the trusted verifier has to land after it and\n"
-    "      # outside it. Nothing in the Android build reads from this path.\n"
+RELEASE_CHECKOUT = (
     "      - name: Check out the trusted controller revision\n"
     "        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n"
     "        with:\n"
     "          ref: ${{ github.sha }}\n"
-    "          path: .release-trusted\n"
+    "          clean: true\n"
     "          persist-credentials: false\n"
 )
-RELEASE_JOB_HEAD = (
-    "    defaults:\n"
-    "      run:\n"
-    "        working-directory: android\n"
-    "\n"
-    "    steps:\n"
-    + RELEASE_CHECKOUT
-    + "\n"
-    + TRUSTED_CHECKOUT
-    + "\n"
-    "      - name: Set up JDK 17\n"
-)
+# The same trusted checkout text appears in `revalidate-signing` and
+# `attach-release-assets`. Only the signing job follows it with the JDK setup,
+# so this is the anchor that addresses it unambiguously.
+SIGN_JOB_CHECKOUT = RELEASE_CHECKOUT + "\n      - name: Set up JDK 17\n"
+RELEASE_JOB_HEAD = "    steps:\n" + SIGN_JOB_CHECKOUT
 POLICY_STEP = """      - name: Enforce Android signing boundary
         run: python "$GITHUB_WORKSPACE/scripts/check-android-signing-boundary.py"
 """
@@ -86,7 +73,14 @@ def fixture_root(tmp_path: Path) -> Path:
     # The control plane executes these with network and API access, so the
     # policy pins their bytes; the fixture must carry them for the digest
     # checks to be real.
-    for helper in (IDENTITY_HELPER, ATTACHMENT_HELPER, READINESS_HELPER, KEYSTORE_HELPER):
+    for helper in (
+        IDENTITY_HELPER,
+        ATTACHMENT_HELPER,
+        READINESS_HELPER,
+        KEYSTORE_HELPER,
+        ARTIFACT_ADMISSION_HELPER,
+        SIGNING_HELPER,
+    ):
         (root / helper).parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(ROOT / helper, root / helper)
     return root
@@ -815,7 +809,7 @@ jobs:
 """,
         encoding="utf-8",
     )
-    assert_rejected(run_checker(root), "binds android-release outside build-release")
+    assert_rejected(run_checker(root), "binds android-release outside sign-release")
 
 
 def test_android_environment_comparison_is_case_insensitive(tmp_path: Path) -> None:
@@ -832,7 +826,7 @@ jobs:
 """,
         encoding="utf-8",
     )
-    assert_rejected(run_checker(root), "binds android-release outside build-release")
+    assert_rejected(run_checker(root), "binds android-release outside sign-release")
 
 
 def test_dynamic_environment_outside_release_is_rejected(tmp_path: Path) -> None:
@@ -849,7 +843,7 @@ jobs:
 """,
         encoding="utf-8",
     )
-    assert_rejected(run_checker(root), "uses a dynamic environment outside build-release")
+    assert_rejected(run_checker(root), "uses a dynamic environment outside sign-release")
 
 
 def test_binding_the_production_environment_outside_its_lane_is_rejected(tmp_path: Path) -> None:
@@ -897,7 +891,7 @@ def test_workflow_level_environment_is_rejected(tmp_path: Path) -> None:
 def test_release_requires_successful_policy_job(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     mutate(root / ROOT_WORKFLOW, RELEASE_NEEDS, "")
-    assert_rejected(run_checker(root), "build-release must require successful signing-policy")
+    assert_rejected(run_checker(root), "sign-release must require successful signing-policy")
 
 
 def test_release_needs_must_be_exact(tmp_path: Path) -> None:
@@ -907,21 +901,22 @@ def test_release_needs_must_be_exact(tmp_path: Path) -> None:
         RELEASE_NEEDS,
         "    needs: [signing-policy, conscrypt-r28, revalidate-signing, attacker]\n",
     )
-    assert_rejected(run_checker(root), "build-release must require successful signing-policy")
+    assert_rejected(run_checker(root), "sign-release must require successful signing-policy")
 
 
 def test_dropping_the_pre_signing_revalidation_is_rejected(tmp_path: Path) -> None:
-    """A tag that moved during the build must not reach the keystore."""
+    """A tag that moved during the unsigned build must not reach the keystore."""
 
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
         RELEASE_NEEDS,
-        "    needs: [signing-policy, conscrypt-r28]\n",
+        "    needs: [signing-policy, conscrypt-r28, build-unsigned-release]\n",
     )
     assert_rejected(
         run_checker(root),
-        "build-release must require successful signing-policy, conscrypt-r28 and revalidate-signing",
+        "sign-release must require successful signing-policy, conscrypt-r28, "
+        "revalidate-signing and build-unsigned-release",
     )
 
 
@@ -960,11 +955,11 @@ def test_a_reintroduced_event_guard_on_the_signing_job_is_rejected(tmp_path: Pat
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        "  build-release:\n    name: Build (signed, admitted release)\n",
-        "  build-release:\n    name: Build (signed, admitted release)\n"
+        "  sign-release:\n    name: Sign (admitted release)\n",
+        "  sign-release:\n    name: Sign (admitted release)\n"
         "    if: startsWith(github.ref, 'refs/tags/v')\n",
     )
-    assert_rejected(run_checker(root), "build-release must not carry an event guard")
+    assert_rejected(run_checker(root), "sign-release must not carry an event guard")
 
 
 def test_release_job_must_use_github_hosted_runner(tmp_path: Path) -> None:
@@ -1019,14 +1014,17 @@ def test_release_job_cannot_define_job_env(tmp_path: Path) -> None:
     assert_rejected(run_checker(root), "must not define job-level env")
 
 
-def test_release_job_cannot_override_default_shell(tmp_path: Path) -> None:
+def test_declaring_defaults_on_the_signing_job_is_rejected(tmp_path: Path) -> None:
+    """It has no candidate tree, so an `android` working directory is a smell."""
+
     root = fixture_root(tmp_path)
-    mutate_last(
+    mutate(
         root / ROOT_WORKFLOW,
-        "      run:\n        working-directory: android\n",
-        "      run:\n        working-directory: android\n        shell: bash -c 'exit 0' {0}\n",
+        "  sign-release:\n    name: Sign (admitted release)\n",
+        "  sign-release:\n    name: Sign (admitted release)\n"
+        "    defaults:\n      run:\n        working-directory: android\n",
     )
-    assert_rejected(run_checker(root), "must use the exact Android working-directory defaults")
+    assert_rejected(run_checker(root), "sign-release must not declare defaults")
 
 
 def test_release_job_cannot_continue_on_error(tmp_path: Path) -> None:
@@ -1082,14 +1080,13 @@ def test_release_step_environment_is_exact(tmp_path: Path) -> None:
 
 
 def test_an_unreviewed_plain_step_environment_is_rejected(tmp_path: Path) -> None:
-    """Only the reviewed tag-passing steps may carry a non-secret environment."""
+    """Only the reviewed steps may carry an environment at all."""
 
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        "      - name: Make gradlew executable\n        run: chmod +x gradlew\n",
-        "      - name: Make gradlew executable\n        env:\n          BASH_ENV: attacker\n"
-        "        run: chmod +x gradlew\n",
+        "      - name: Fetch the pinned bundletool\n        env:\n",
+        "      - name: Fetch the pinned bundletool\n        env:\n          BASH_ENV: attacker\n",
     )
     assert_rejected(run_checker(root), "must use its exact reviewed environment")
 
@@ -1098,22 +1095,18 @@ def test_secret_bearing_step_cannot_be_replaced_by_pinned_action(tmp_path: Path)
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        """      - name: Build signed release APK and AAB
+        """      - name: Sign the admitted APK and AAB
         env:
           KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         run: |
-          ./gradlew assembleRelease bundleRelease --no-daemon \\
-            -PrequireEtebase16Kb=true \\
-            -PrequireConscryptR28=true \\
-            -PsigningStoreLocation="$KEYSTORE_PATH" \\
-            -PsigningKeyAlias="$KEY_ALIAS"
 """,
-        """      - name: Build signed release APK and AAB
+        """      - name: Sign the admitted APK and AAB
         env:
           KSTOREPWD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
         uses: attacker/release-secret-recorder@0123456789012345678901234567890123456789
+        run: |
 """,
     )
     assert_rejected(run_checker(root), "must match its exact reviewed execution")
@@ -1123,18 +1116,19 @@ def test_secret_bearing_step_command_is_immutable(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        '            -PsigningKeyAlias="$KEY_ALIAS"\n',
-        '            -PsigningKeyAlias="$KEY_ALIAS"\n          curl https://attacker.invalid/\n',
+        '          bash "$GITHUB_WORKSPACE/scripts/sign-android-release.sh"\n',
+        '          bash "$GITHUB_WORKSPACE/scripts/sign-android-release.sh"\n'
+        "          curl https://attacker.invalid/\n",
     )
     assert_rejected(run_checker(root), "must match its exact reviewed execution")
 
 
-def test_earlier_release_step_cannot_poison_secret_execution_environment(tmp_path: Path) -> None:
+def test_earlier_signing_step_cannot_poison_the_execution_environment(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     mutate_last(
         root / ROOT_WORKFLOW,
-        "      - name: Make gradlew executable\n        run: chmod +x gradlew\n",
-        "      - name: Make gradlew executable\n        run: |\n          chmod +x gradlew\n"
+        '          echo "$BUNDLETOOL_SHA256  $RUNNER_TEMP/bundletool.jar" | sha256sum --check --strict\n',
+        '          echo "$BUNDLETOOL_SHA256  $RUNNER_TEMP/bundletool.jar" | sha256sum --check --strict\n'
         "          echo 'BASH_ENV=attacker' >> \"$GITHUB_ENV\"\n",
     )
     assert_rejected(run_checker(root), "must match the exact reviewed release-job specification")
@@ -1144,9 +1138,10 @@ def test_release_secret_cannot_move_into_action_input(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        RELEASE_CHECKOUT,
+        SIGN_JOB_CHECKOUT,
         RELEASE_CHECKOUT.rstrip("\n")
-        + "\n          token: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+        + "\n          token: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n"
+        + "\n      - name: Set up JDK 17\n",
     )
     assert_rejected(run_checker(root), "references signing secrets outside reviewed step environments")
 
@@ -1162,7 +1157,7 @@ def test_release_job_cannot_invoke_local_action(tmp_path: Path) -> None:
             "      - name: Set up JDK 17\n",
         ),
     )
-    assert_rejected(run_checker(root), "build-release must not invoke local actions")
+    assert_rejected(run_checker(root), "sign-release must not invoke local actions")
 
 
 def test_mutable_action_in_the_release_lane_is_rejected(tmp_path: Path) -> None:
@@ -1188,19 +1183,23 @@ def test_mutable_action_in_android_sibling_workflow_is_rejected(tmp_path: Path) 
     )
 
 
-def test_a_foreign_credential_in_the_signed_release_job_is_rejected(tmp_path: Path) -> None:
+def test_a_foreign_credential_in_the_signing_job_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
         "          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}\n"
-        "        run: |\n          ./gradlew assembleRelease",
+        "        run: |\n"
+        "          set -euo pipefail\n"
+        '          UNSIGNED_DIR="$GITHUB_WORKSPACE/unsigned" \\',
         "          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}\n"
         "          SETTINGS_READ: ${{ secrets.SOME_ADMIN_READ_TOKEN }}\n"
-        "        run: |\n          ./gradlew assembleRelease",
+        "        run: |\n"
+        "          set -euo pipefail\n"
+        '          UNSIGNED_DIR="$GITHUB_WORKSPACE/unsigned" \\',
     )
     assert_rejected(
         run_checker(root),
-        "build-release must not carry any credential beyond the reviewed signing secrets",
+        "sign-release must not carry any credential beyond the reviewed signing secrets",
     )
 
 
@@ -1225,15 +1224,14 @@ def test_moving_the_umbrella_lock_onto_the_signing_job_is_rejected(tmp_path: Pat
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        "    environment: android-release\n    permissions:\n      contents: read\n    defaults:\n",
+        "    environment: android-release\n    permissions:\n      contents: read\n",
         "    environment: android-release\n    permissions:\n      contents: read\n"
         "    concurrency:\n      group: umbrella-release-${{ github.event.client_payload.release_tag }}\n"
-        "      cancel-in-progress: false\n      queue: max\n"
-        "    defaults:\n",
+        "      cancel-in-progress: false\n      queue: max\n",
     )
     assert_rejected(
         run_checker(root),
-        "build-release must not declare concurrency; the umbrella lock belongs to",
+        "sign-release must not declare concurrency; the umbrella lock belongs to",
     )
 
 
@@ -1246,7 +1244,7 @@ def test_granting_the_signing_job_write_permission_is_rejected(tmp_path: Path) -
     )
     result = run_checker(root)
     assert result.returncode == 1
-    assert "build-release permissions must be exactly contents: read" in result.stdout
+    assert "sign-release permissions must be exactly contents: read" in result.stdout
     assert "holds signing material and must declare read-only permissions" in result.stdout
 
 
@@ -1254,12 +1252,12 @@ def test_persisting_the_checkout_credential_in_the_signing_job_is_rejected(tmp_p
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        RELEASE_CHECKOUT,
-        RELEASE_CHECKOUT.replace("          persist-credentials: false\n", ""),
+        SIGN_JOB_CHECKOUT,
+        SIGN_JOB_CHECKOUT.replace("          persist-credentials: false\n", ""),
     )
     assert_rejected(
         run_checker(root),
-        "build-release must check out the admitted commit and then the trusted controller "
+        "sign-release must check out the admitted commit and then the trusted controller "
         "revision, in that order, both with persist-credentials: false",
     )
 
@@ -1268,12 +1266,12 @@ def test_checking_out_a_floating_ref_in_the_signing_job_is_rejected(tmp_path: Pa
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        RELEASE_CHECKOUT,
-        RELEASE_CHECKOUT.replace("          ref: ${{ inputs.source_sha }}\n", "          ref: main\n"),
+        SIGN_JOB_CHECKOUT,
+        SIGN_JOB_CHECKOUT.replace("          ref: ${{ github.sha }}\n", "          ref: main\n"),
     )
     assert_rejected(
         run_checker(root),
-        "build-release must check out the admitted commit and then the trusted controller "
+        "sign-release must check out the admitted commit and then the trusted controller "
         "revision, in that order, both with persist-credentials: false",
     )
 
@@ -1630,7 +1628,7 @@ def test_turning_the_owner_gate_into_a_skipping_job_condition_is_rejected(tmp_pa
 ANDROID_GUARDS = {
     "Revalidate the release identity before decoding signing material": "Decode release keystore",
     "Revalidate the release identity before publishing signed artifacts": (
-        "Upload signed tracker verification evidence"
+        "Upload signed split evidence"
     ),
     "Revalidate the release identity before the attachment handoff": (
         "Publish the closed release-asset set to the attachment job"
@@ -1684,11 +1682,11 @@ def test_pointing_a_revalidation_at_the_candidate_tree_is_rejected(tmp_path: Pat
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        '          bash "$GITHUB_WORKSPACE/.release-trusted/scripts/verify-release-identity.sh" \\\n'
+        '          bash "$GITHUB_WORKSPACE/scripts/verify-release-identity.sh" \\\n'
         '            --tag "$RELEASE_TAG" \\\n'
         '            --commit "$SOURCE_SHA" \\\n'
         "            --stage android-signing-material\n",
-        '          bash "$GITHUB_WORKSPACE/scripts/verify-release-identity.sh" \\\n'
+        '          bash "$GITHUB_WORKSPACE/unsigned/verify-release-identity.sh" \\\n'
         '            --tag "$RELEASE_TAG" \\\n'
         '            --commit "$SOURCE_SHA" \\\n'
         "            --stage android-signing-material\n",
@@ -1700,51 +1698,85 @@ def test_pointing_a_revalidation_at_the_candidate_tree_is_rejected(tmp_path: Pat
 
 def test_removing_the_trusted_checkout_from_the_signing_job_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
+    mutate(root / ROOT_WORKFLOW, SIGN_JOB_CHECKOUT, "      - name: Set up JDK 17\n")
+    result = run_checker(root)
+    assert result.returncode == 1
+    assert "must check out the admitted commit and then the trusted controller revision" in result.stdout
+
+
+def test_adding_a_candidate_checkout_to_the_signing_job_is_rejected(tmp_path: Path) -> None:
+    """The whole point of the split: no candidate byte on the signing runner."""
+
+    root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        "      - name: Check out the trusted controller revision\n"
+        SIGN_JOB_CHECKOUT,
+        RELEASE_CHECKOUT
+        + "\n      - name: Checkout the candidate\n"
         "        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1\n"
         "        with:\n"
-        "          ref: ${{ github.sha }}\n"
-        "          path: .release-trusted\n"
-        "          persist-credentials: false\n\n",
-        "",
+        "          ref: ${{ inputs.source_sha }}\n"
+        "          path: candidate\n"
+        "          persist-credentials: false\n"
+        + "\n      - name: Set up JDK 17\n",
     )
     result = run_checker(root)
     assert result.returncode == 1
     assert "must check out the admitted commit and then the trusted controller revision" in result.stdout
 
 
-def test_checking_the_trusted_copy_out_before_the_candidate_is_rejected(tmp_path: Path) -> None:
-    """The candidate checkout cleans the workspace root; order is load-bearing."""
+def test_running_candidate_gradle_in_the_signing_job_is_rejected(tmp_path: Path) -> None:
+    """Gradle is the candidate's own code; it must never share this runner."""
 
-    root = fixture_root(tmp_path)
-    workflow = root / ROOT_WORKFLOW
-    text = workflow.read_text(encoding="utf-8")
-    start = text.index(RELEASE_CHECKOUT)
-    end = text.index("      - name: Set up JDK 17", start)
-    workflow.write_text(
-        text[:start] + TRUSTED_CHECKOUT + "\n" + RELEASE_CHECKOUT + "\n" + text[end:],
-        encoding="utf-8",
-    )
-    assert_rejected(
-        run_checker(root),
-        "must check out the admitted commit and then the trusted controller revision",
-    )
-
-
-def test_handing_the_workflow_token_to_candidate_gradle_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     mutate(
         root / ROOT_WORKFLOW,
-        "      - name: Build signed release APK and AAB\n        env:\n",
-        "      - name: Build signed release APK and AAB\n        env:\n"
+        "      - name: Sign the admitted APK and AAB\n",
+        "      - name: Rebuild with Gradle\n"
+        "        run: ./gradlew assembleRelease\n"
+        "\n      - name: Sign the admitted APK and AAB\n",
+    )
+    result = run_checker(root)
+    assert result.returncode == 1
+    assert "must not execute candidate build tooling" in result.stdout
+
+
+def test_drifting_the_exact_android_build_tools_install_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / ROOT_WORKFLOW,
+        '"$SDKMANAGER" "build-tools;36.0.0"\n',
+        '"$SDKMANAGER" "build-tools;35.0.0"\n',
+    )
+    assert_rejected(
+        run_checker(root),
+        "must install and check exact build-tools;36.0.0 with the reviewed fixed-path step",
+    )
+
+
+def test_downgrading_native_library_alignment_to_deprecated_p_is_rejected(
+    tmp_path: Path,
+) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / SIGNING_HELPER,
+        '"$ZIPALIGN" -P 16 -f 4',
+        '"$ZIPALIGN" -p -f 4',
+    )
+    assert_rejected(run_checker(root), "must not use deprecated zipalign -p")
+
+
+def test_handing_the_workflow_token_to_an_unreviewed_step_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / ROOT_WORKFLOW,
+        "      - name: Fetch the pinned bundletool\n        env:\n",
+        "      - name: Fetch the pinned bundletool\n        env:\n"
         "          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n",
     )
     result = run_checker(root)
     assert result.returncode == 1
     assert "may name the workflow token only in its reviewed revalidation steps" in result.stdout
-    assert "holds signing material and can also write a release" in result.stdout
 
 
 def test_a_token_at_signing_job_scope_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_android_unsigned_artifact_admission.py
+++ b/tests/test_android_unsigned_artifact_admission.py
@@ -1,0 +1,529 @@
+"""Behavioural contract for the candidate/trusted artifact boundary.
+
+The signing job runs on a fresh runner and never checks out or executes
+candidate code. What it does consume is candidate *data*: an APK, an AAB and
+their evidence, produced by candidate Gradle on a different machine. This is
+the only thing that crosses, so every case here hands
+`scripts/admit-unsigned-android-artifact.sh` a real directory in a real
+adversarial shape and asserts it refuses before the keystore would be decoded.
+
+The static half additionally pins how `scripts/sign-android-release.sh` reaches
+its tools: by absolute path under a verified root, never through PATH, because
+PATH is exactly what a compromised producer would aim at if it could.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+ADMIT = ROOT / "scripts" / "admit-unsigned-android-artifact.sh"
+SIGNER = ROOT / "scripts" / "sign-android-release.sh"
+ANDROID_RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-android.yml"
+
+SOURCE_SHA = "a" * 40
+OTHER_SHA = "b" * 40
+
+PAYLOAD = {
+    "app-release-unsigned.apk": b"unsigned-apk-bytes",
+    "app-release.aab": b"unsigned-aab-bytes",
+    "mapping.txt": b"com.example -> a:\n",
+    "native-debug-symbols.zip": b"symbols-zip-bytes",
+    "release-runtime-dependencies.txt": b"+--- androidx.core:core\n",
+    "tracker-scan-summary.json": b'{"trackers": []}\n',
+}
+
+
+def build_artifact(directory: Path, *, payload: dict[str, bytes] | None = None,
+                   source_sha: str = SOURCE_SHA, checksums: str | None = None) -> Path:
+    """A well-formed producer handoff, which each case then damages."""
+
+    payload = PAYLOAD if payload is None else payload
+    directory.mkdir(parents=True, exist_ok=True)
+    for name, data in payload.items():
+        (directory / name).write_bytes(data)
+        (directory / name).chmod(0o644)
+    (directory / "source-sha").write_text(f"{source_sha}\n", encoding="utf-8")
+    if checksums is None:
+        checksums = "".join(
+            f"{hashlib.sha256(data).hexdigest()}  {name}\n"
+            for name, data in payload.items()
+        )
+    (directory / "SHA256SUMS").write_text(checksums, encoding="utf-8")
+    (directory / "SHA256SUMS").chmod(0o644)
+    (directory / "source-sha").chmod(0o644)
+    return directory
+
+
+def admit(directory: Path, *, source_sha: str = SOURCE_SHA) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(ADMIT), "--directory", str(directory), "--source-sha", source_sha],
+        capture_output=True,
+        text=True,
+        env={**os.environ},
+    )
+
+
+@pytest.fixture
+def artifact(tmp_path: Path) -> Path:
+    return build_artifact(tmp_path / "unsigned")
+
+
+# ── The one shape that is admitted ────────────────────────────────────
+
+
+def test_a_well_formed_handoff_is_admitted(artifact: Path):
+    result = admit(artifact)
+
+    assert result.returncode == 0, result.stderr
+    assert f"Unsigned build admitted for {SOURCE_SHA}" in result.stdout
+    assert "6 payload files" in result.stdout
+
+
+# ── Substitution and confusion ────────────────────────────────────────
+
+
+def test_a_handoff_built_from_another_commit_is_refused(tmp_path: Path):
+    directory = build_artifact(tmp_path / "unsigned", source_sha=OTHER_SHA)
+
+    result = admit(directory)
+
+    assert result.returncode != 0
+    assert f"records source {OTHER_SHA}, not the admitted {SOURCE_SHA}" in result.stderr
+
+
+@pytest.mark.parametrize("missing", sorted(PAYLOAD))
+def test_a_missing_payload_file_is_refused(tmp_path: Path, missing: str):
+    directory = build_artifact(tmp_path / "unsigned")
+    (directory / missing).unlink()
+
+    result = admit(directory)
+
+    assert result.returncode != 0
+    assert "is not the closed inventory" in result.stderr
+
+
+def test_an_unexpected_extra_file_is_refused(artifact: Path):
+    (artifact / "surprise.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    result = admit(artifact)
+
+    assert result.returncode != 0
+    assert "is not the closed inventory" in result.stderr
+    assert "surprise.sh" in result.stderr
+
+
+def test_a_nested_directory_is_refused(artifact: Path):
+    """`find -mindepth 1` sees the whole tree, not just its top level."""
+
+    (artifact / "nested").mkdir()
+    (artifact / "nested" / "payload.so").write_bytes(b"x")
+
+    result = admit(artifact)
+
+    assert result.returncode != 0
+    assert "is not the closed inventory" in result.stderr
+
+
+def test_a_symlinked_payload_is_refused(artifact: Path):
+    """A link would let a later read escape the artifact directory."""
+
+    target = artifact.parent / "outside.apk"
+    target.write_bytes(b"outside")
+    (artifact / "app-release-unsigned.apk").unlink()
+    (artifact / "app-release-unsigned.apk").symlink_to(target)
+
+    result = admit(artifact)
+
+    assert result.returncode != 0
+    assert "is a symbolic link" in result.stderr
+
+
+def test_an_executable_payload_is_refused(artifact: Path):
+    """Nothing here is meant to run, so nothing here may be executable."""
+
+    (artifact / "mapping.txt").chmod(0o755)
+
+    result = admit(artifact)
+
+    assert result.returncode != 0
+    assert "expected exactly 644" in result.stderr
+
+
+@pytest.mark.parametrize("mode", [0o600, 0o640, 0o664, 0o755])
+def test_every_noncanonical_input_mode_is_refused(artifact: Path, mode: int):
+    target = artifact / "mapping.txt"
+    target.chmod(mode)
+
+    result = admit(artifact)
+
+    assert result.returncode != 0
+    assert "expected exactly 644" in result.stderr
+
+
+@pytest.mark.parametrize("empty", sorted(PAYLOAD))
+def test_an_empty_payload_file_is_refused(tmp_path: Path, empty: str):
+    payload = dict(PAYLOAD)
+    payload[empty] = b""
+    directory = build_artifact(tmp_path / "unsigned", payload=payload)
+
+    result = admit(directory)
+
+    assert result.returncode != 0
+    assert "is empty" in result.stderr
+
+
+# ── Checksum integrity ────────────────────────────────────────────────
+
+
+def test_a_tampered_payload_is_refused(artifact: Path):
+    (artifact / "app-release.aab").write_bytes(b"swapped-aab-bytes")
+
+    result = admit(artifact)
+
+    assert result.returncode != 0
+    assert "do not match the checksums the producer recorded" in result.stderr
+
+
+def test_a_manifest_that_omits_a_payload_file_is_refused(tmp_path: Path):
+    partial = "".join(
+        f"{hashlib.sha256(data).hexdigest()}  {name}\n"
+        for name, data in PAYLOAD.items()
+        if name != "mapping.txt"
+    )
+    directory = build_artifact(tmp_path / "unsigned", checksums=partial)
+
+    result = admit(directory)
+
+    assert result.returncode != 0
+    assert "does not cover exactly the payload files" in result.stderr
+
+
+def test_a_manifest_naming_a_file_outside_the_inventory_is_refused(tmp_path: Path):
+    extra = "".join(
+        f"{hashlib.sha256(data).hexdigest()}  {name}\n" for name, data in PAYLOAD.items()
+    ) + f"{'0' * 64}  ../escape.apk\n"
+    directory = build_artifact(tmp_path / "unsigned", checksums=extra)
+
+    result = admit(directory)
+
+    assert result.returncode != 0
+    assert "does not cover exactly the payload files" in result.stderr
+
+
+def test_a_manifest_with_duplicate_records_is_refused(tmp_path: Path):
+    doubled = "".join(
+        f"{hashlib.sha256(data).hexdigest()}  {name}\n" for name, data in PAYLOAD.items()
+    )
+    doubled += f"{hashlib.sha256(PAYLOAD['mapping.txt']).hexdigest()}  mapping.txt\n"
+    directory = build_artifact(tmp_path / "unsigned", checksums=doubled)
+
+    result = admit(directory)
+
+    assert result.returncode != 0
+    # A repeated record makes the manifest's name list differ from the payload's,
+    # so it is caught by the coverage comparison before the record-count check.
+    assert "SHA256SUMS" in result.stderr
+    assert "Refusing the unsigned build" in result.stderr
+
+
+def test_a_missing_directory_is_refused(tmp_path: Path):
+    result = admit(tmp_path / "absent")
+
+    assert result.returncode != 0
+    assert "does not exist" in result.stderr
+
+
+@pytest.mark.parametrize("sha", ["", "abc", "A" * 40, "g" * 40, "a" * 39])
+def test_a_malformed_admitted_sha_is_refused(artifact: Path, sha: str):
+    result = admit(artifact, source_sha=sha)
+
+    assert result.returncode != 0
+    assert "40-hex commit id" in result.stderr or "required" in result.stderr
+
+
+# ── The signing helper's tool resolution ──────────────────────────────
+
+
+def executable_text(path: Path) -> str:
+    return "\n".join(
+        line for line in path.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+def test_the_signer_resolves_every_tool_by_absolute_path():
+    """A poisoned producer cannot reach a job it never shares, but the signer
+    still refuses to take a tool from PATH — the boundary is stated in code."""
+
+    code = executable_text(SIGNER)
+    for fixed in (
+        'BUILD_TOOLS="${ANDROID_HOME}/build-tools/${BUILD_TOOLS_VERSION}"',
+        'ZIPALIGN="${BUILD_TOOLS}/zipalign"',
+        'APKSIGNER="${BUILD_TOOLS}/apksigner"',
+        'JARSIGNER="${JAVA_HOME}/bin/jarsigner"',
+        'KEYTOOL="${JAVA_HOME}/bin/keytool"',
+    ):
+        assert fixed in code, fixed
+    assert "$(command -v" not in code, "no tool may be resolved through PATH"
+    # setup-java may expose in-root symlinks. Canonical containment accepts
+    # those while rejecting a link that escapes either trusted root.
+    assert 'canonical="$(readlink -f -- "$tool")"' in code
+    assert '"$root"/*)' in code
+    assert "resolves outside its trusted root" in code
+
+
+def test_the_signer_keeps_the_password_out_of_every_argument_vector():
+    code = executable_text(SIGNER)
+    assert '--ks-pass "env:KSTOREPWD"' in code
+    assert '--key-pass "env:KSTOREPWD"' in code
+    assert "-storepass:env KSTOREPWD" in code
+    assert "-storepass " not in code, "a literal password argument would land in `ps`"
+    # bundletool has no env form, so the file is private and removed.
+    assert 'umask 077; printf \'%s\' "$KSTOREPWD" > "$PASSWORD_FILE"' in code
+    assert 'rm -f "$PASSWORD_FILE"' in code
+
+
+def test_the_signer_aligns_before_it_signs():
+    """zipalign after apksigner would invalidate the signature it just made."""
+
+    code = executable_text(SIGNER)
+    assert '"$ZIPALIGN" -p' not in code
+    assert '"$ZIPALIGN" -c -p' not in code
+    align = code.index('"$ZIPALIGN" -P 16 -f 4')
+    sign = code.index('"$APKSIGNER" sign')
+    assert align < sign
+    assert '"$ZIPALIGN" -c -P 16 4' in code, "the alignment must be verified, not assumed"
+
+
+def test_the_signer_proves_the_pinned_certificate_on_both_outputs():
+    code = executable_text(SIGNER)
+    assert "8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79" in code
+    assert 'require_pinned_certificate "APK"' in code
+    assert 'require_pinned_certificate "AAB"' in code
+    assert '"$APKSIGNER" verify --print-certs' in code
+    assert "-printcert -jarfile" in code
+    assert '"$JARSIGNER" -verify -strict' in code
+    assert "-J-Duser.language=en" in code, "keytool labels must not be locale-dependent"
+
+
+def test_the_signer_validates_its_inputs_before_using_them():
+    code = executable_text(SIGNER)
+    assert "^[0-9a-f]{64}$" in code, "the expected fingerprint is validated"
+    assert "^[0-9]+\\.[0-9]+\\.[0-9]+$" in code, "the build-tools version is validated"
+    assert "EXPECTED_CERT_SHA256:-" not in code, (
+        "an ambient variable must not relax the pinned certificate"
+    )
+
+
+def signer_preflight(tmp_path: Path, *, escaping_zipalign: bool = False):
+    android_home = tmp_path / "android-sdk"
+    build_tools = android_home / "build-tools" / "36.0.0"
+    java_home = tmp_path / "jdk"
+    build_tools.mkdir(parents=True)
+    (java_home / "bin").mkdir(parents=True)
+
+    for directory, names in (
+        (build_tools, ("zipalign.real", "apksigner")),
+        (java_home / "bin", ("jarsigner.real", "keytool", "java")),
+    ):
+        for name in names:
+            path = directory / name
+            path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            path.chmod(0o755)
+    (build_tools / "zipalign").symlink_to(
+        "/bin/true" if escaping_zipalign else "zipalign.real"
+    )
+    (java_home / "bin" / "jarsigner").symlink_to("jarsigner.real")
+    bundletool = tmp_path / "bundletool.jar"
+    bundletool.write_bytes(b"pinned test placeholder")
+
+    return subprocess.run(
+        ["bash", str(SIGNER)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "ANDROID_HOME": str(android_home),
+            "JAVA_HOME": str(java_home),
+            "UNSIGNED_DIR": str(tmp_path / "unsigned"),
+            "OUTPUT_DIR": str(tmp_path / "signed"),
+            "KEYSTORE_PATH": str(tmp_path / "release.jks"),
+            "KSTOREPWD": "test-password",
+            "KEY_ALIAS": "test-alias",
+            "BUNDLETOOL_JAR": str(bundletool),
+        },
+    )
+
+
+def test_in_root_tool_symlinks_are_accepted(tmp_path: Path):
+    result = signer_preflight(tmp_path)
+    assert result.returncode != 0
+    assert "admitted input app-release-unsigned.apk is missing" in result.stderr
+    assert "resolves outside its trusted root" not in result.stderr
+
+
+def test_a_tool_symlink_escaping_its_fixed_root_is_rejected(tmp_path: Path):
+    result = signer_preflight(tmp_path, escaping_zipalign=True)
+    assert result.returncode != 0
+    assert "zipalign resolves outside its trusted root" in result.stderr
+
+
+def test_signer_end_to_end_with_generated_jks_when_exact_sdk_fixtures_exist(
+    tmp_path: Path,
+):
+    """Runtime proof for the signing runner.
+
+    A local developer machine is never mutated to satisfy this test. CI can
+    point SILENTSUITE_SIGNING_E2E_FIXTURES at a directory containing a minimal
+    valid app-release-unsigned.apk and app-release.aab, and BUNDLETOOL_JAR at
+    the already checksum-verified jar. The test then generates its own JKS and
+    exercises alignment, APK/AAB signing, certificate pinning, verification,
+    and bundletool split generation through the real helper.
+    """
+
+    android_home = os.environ.get("ANDROID_HOME")
+    java_home = os.environ.get("JAVA_HOME")
+    fixtures_value = os.environ.get("SILENTSUITE_SIGNING_E2E_FIXTURES")
+    bundletool_value = os.environ.get("BUNDLETOOL_JAR")
+    if not all((android_home, java_home, fixtures_value, bundletool_value)):
+        pytest.skip("exact SDK/JDK, bundletool, and valid signing fixtures are not configured")
+
+    build_tools = Path(android_home) / "build-tools" / "36.0.0"
+    keytool = Path(java_home) / "bin" / "keytool"
+    required = (
+        build_tools / "zipalign",
+        build_tools / "apksigner",
+        keytool,
+        Path(java_home) / "bin" / "jarsigner",
+        Path(java_home) / "bin" / "java",
+        Path(bundletool_value),
+    )
+    if not all(path.is_file() and (path == Path(bundletool_value) or os.access(path, os.X_OK))
+               for path in required):
+        pytest.skip("exact build-tools;36.0.0 signing toolchain is unavailable")
+
+    fixtures = Path(fixtures_value)
+    fixture_apk = fixtures / "app-release-unsigned.apk"
+    fixture_aab = fixtures / "app-release.aab"
+    if not fixture_apk.is_file() or not fixture_aab.is_file():
+        pytest.skip("minimal valid APK/AAB fixtures are unavailable")
+
+    unsigned = tmp_path / "unsigned"
+    unsigned.mkdir()
+    shutil.copy2(fixture_apk, unsigned / fixture_apk.name)
+    shutil.copy2(fixture_aab, unsigned / fixture_aab.name)
+    keystore = tmp_path / "generated.jks"
+    password = "temporary-test-password"
+    alias = "temporary-test-key"
+    subprocess.run(
+        [
+            str(keytool), "-genkeypair", "-storetype", "JKS",
+            "-keystore", str(keystore), "-storepass", password,
+            "-keypass", password, "-alias", alias, "-keyalg", "RSA",
+            "-keysize", "2048", "-validity", "2",
+            "-dname", "CN=SilentSuite signing test",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    listed = subprocess.run(
+        [
+            str(keytool), "-J-Duser.language=en", "-J-Duser.country=US",
+            "-list", "-v", "-keystore", str(keystore),
+            "-storepass", password, "-alias", alias,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    match = re.search(r"SHA256:\s*((?:[0-9A-F]{2}:){31}[0-9A-F]{2})", listed)
+    assert match, listed
+    fingerprint = match.group(1).replace(":", "").lower()
+
+    output = tmp_path / "signed"
+    result = subprocess.run(
+        ["bash", str(SIGNER), "--expect-sha256", fingerprint],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "ANDROID_HOME": android_home,
+            "JAVA_HOME": java_home,
+            "UNSIGNED_DIR": str(unsigned),
+            "OUTPUT_DIR": str(output),
+            "KEYSTORE_PATH": str(keystore),
+            "KSTOREPWD": password,
+            "KEY_ALIAS": alias,
+            "BUNDLETOOL_JAR": bundletool_value,
+        },
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    for name in ("app-release.apk", "app-release.aab", "signed-release.apks"):
+        assert (output / name).is_file() and (output / name).stat().st_size > 0
+
+
+# ── Wiring ────────────────────────────────────────────────────────────
+
+
+def android_jobs() -> dict:
+    return yaml.load(
+        ANDROID_RELEASE_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader
+    )["jobs"]
+
+
+def test_the_producer_publishes_exactly_the_admitted_inventory():
+    """The names the producer stages are the names the admitter demands."""
+
+    producer = android_jobs()["build-unsigned-release"]
+    staged = next(
+        s for s in producer["steps"] if s["name"] == "Stage the closed unsigned handoff"
+    )["run"]
+    for name in (*PAYLOAD, "source-sha", "SHA256SUMS"):
+        assert name in staged, f"the producer never stages {name}"
+    assert '[ -s "$payload" ]' in staged, "the producer must reject empty payloads"
+    assert "chmod 0644 ./*" in staged, "the producer must normalize data-only modes"
+    admitter = ADMIT.read_text(encoding="utf-8")
+    for name in PAYLOAD:
+        assert f'"{name}"' in admitter, f"the admitter does not require {name}"
+
+
+def test_the_two_jobs_run_on_separate_runners_and_share_only_the_artifact():
+    jobs = android_jobs()
+    producer, signer = jobs["build-unsigned-release"], jobs["sign-release"]
+    assert producer["runs-on"] == signer["runs-on"] == "ubuntu-latest"
+    # No cache is shared into the signing job: a poisoned Gradle cache would be
+    # candidate-controlled state crossing the boundary.
+    signer_uses = [s.get("uses", "") for s in signer["steps"]]
+    assert not any("actions/cache" in u for u in signer_uses)
+    downloads = [
+        s["with"]["name"] for s in signer["steps"] if "download-artifact" in s.get("uses", "")
+    ]
+    assert downloads == ["silentsuite-android-unsigned-${{ inputs.source_sha }}"]
+
+
+def test_the_signing_job_installs_and_checks_the_exact_build_tools_before_secrets():
+    signer = android_jobs()["sign-release"]
+    names = [step["name"] for step in signer["steps"]]
+    install = next(
+        step for step in signer["steps"]
+        if step["name"] == "Install the exact Android signing tools"
+    )
+    assert names.index(install["name"]) < names.index("Decode release keystore")
+    assert install.get("env") is None
+    run = install["run"]
+    assert 'SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"' in run
+    assert '"$SDKMANAGER" "build-tools;36.0.0"' in run
+    assert 'BUILD_TOOLS="$ANDROID_HOME/build-tools/36.0.0"' in run
+    assert "for tool in zipalign apksigner" in run
+    assert "readlink -f" in run
+    assert "sudo" not in run

--- a/tests/test_self_host_release_workflows.py
+++ b/tests/test_self_host_release_workflows.py
@@ -1234,7 +1234,7 @@ def test_the_attachment_helper_revalidates_before_each_individual_write():
     assert 'revalidate "before-upload:${asset}"' in helper
     lines = [line.strip() for line in helper.splitlines()]
     # Immediately before the two POST bodies, not merely somewhere above them.
-    create = lines.index('api POST "/repos/${GITHUB_REPOSITORY}/releases" \\')
+    create = lines.index('CREATE_STATUS="$(api_post_json "/repos/${GITHUB_REPOSITORY}/releases" \\')
     assert lines[create - 1] == 'revalidate "before-create"'
     upload = lines.index('echo "  ${asset}: uploading"')
     assert lines[upload - 1] == 'revalidate "before-upload:${asset}"'

--- a/tests/test_self_host_release_workflows.py
+++ b/tests/test_self_host_release_workflows.py
@@ -1021,7 +1021,7 @@ def test_only_the_signed_android_job_binds_a_deployment_environment():
         for job_name, job in load(path).get("jobs", {}).items():
             if job.get("environment") is not None:
                 owners.append(f"{path.name}:{job_name}")
-    assert owners == ["release-android.yml:build-release"]
+    assert owners == ["release-android.yml:sign-release"]
 
 
 def test_every_workflow_action_is_pinned_to_an_immutable_commit():
@@ -1148,13 +1148,8 @@ ANDROID_MUTATION_BOUNDARIES = [
     ),
     (
         "Revalidate the release identity before publishing signed artifacts",
-        "Upload signed tracker verification evidence",
+        "Upload signed split evidence",
         "android-signed-artifact-egress",
-    ),
-    (
-        "Revalidate the release identity before publishing signed release outputs",
-        "Upload signed release APK, AAB, and native debug symbols",
-        "android-release-output-egress",
     ),
     (
         "Revalidate the release identity before the attachment handoff",
@@ -1172,33 +1167,63 @@ def test_each_android_irreversible_step_is_immediately_preceded_by_a_revalidatio
 ):
     """Immediately: an inserted step would reopen the window this closes."""
 
-    names = step_names(ANDROID["jobs"]["build-release"])
+    names = step_names(ANDROID["jobs"]["sign-release"])
     assert guard in names, guard
     assert guarded in names, guarded
     assert names[names.index(guard) + 1] == guarded, (
         f"{guard!r} must sit directly before {guarded!r}, found "
         f"{names[names.index(guard) + 1]!r}"
     )
-    step = step_named(ANDROID["jobs"]["build-release"], guard)
+    step = step_named(ANDROID["jobs"]["sign-release"], guard)
     assert f"--stage {stage}" in step["run"]
 
 
-def test_the_android_revalidations_run_trusted_code_not_the_candidate_tree():
-    job = ANDROID["jobs"]["build-release"]
+def test_the_android_signing_job_never_checks_out_candidate_code():
+    """The fresh-runner boundary: no candidate byte reaches this job."""
+
+    job = ANDROID["jobs"]["sign-release"]
     assert checkouts(job) == [
-        {"ref": "${{ inputs.source_sha }}", "persist-credentials": "false"},
-        {"ref": TRUSTED_REF, "path": ".release-trusted", "persist-credentials": "false"},
+        {"ref": TRUSTED_REF, "clean": "true", "persist-credentials": "false"}
     ]
+    body = "\n".join(str(step.get("run", "")) for step in steps(job))
+    assert "gradlew" not in body, "candidate Gradle must not run beside the keystore"
     for guard, _, _ in ANDROID_MUTATION_BOUNDARIES:
         run = step_named(job, guard)["run"]
-        assert '"$GITHUB_WORKSPACE/.release-trusted/scripts/verify-release-identity.sh"' in run
-        assert "android/scripts" not in run
+        assert '"$GITHUB_WORKSPACE/scripts/verify-release-identity.sh"' in run
+
+
+def test_the_unsigned_producer_holds_nothing_worth_taking():
+    """Candidate Gradle runs here, on a runner with no secret and no token."""
+
+    job = ANDROID["jobs"]["build-unsigned-release"]
+    assert job["permissions"] == {"contents": "read"}
+    assert "environment" not in job
+    body = ANDROID_WORKFLOW.read_text(encoding="utf-8")
+    producer = body.split("  build-unsigned-release:", 1)[1].split("\n  sign-release:", 1)[0]
+    for forbidden in (
+        "ANDROID_KEYSTORE_BASE64",
+        "ANDROID_KEYSTORE_PASSWORD",
+        "ANDROID_KEY_ALIAS",
+        "secrets.GITHUB_TOKEN",
+        "android-release",
+    ):
+        assert forbidden not in producer, f"the unsigned producer must not reference {forbidden}"
+    assert "silentsuite-android-unsigned-${{ inputs.source_sha }}" in producer
+
+
+def test_the_signing_job_admits_the_candidate_artifact_before_decoding():
+    job = ANDROID["jobs"]["sign-release"]
+    names = step_names(job)
+    assert names.index("Admit the unsigned build") < names.index("Decode release keystore")
+    admit = step_named(job, "Admit the unsigned build")["run"]
+    assert "scripts/admit-unsigned-android-artifact.sh" in admit
+    assert '--source-sha "$SOURCE_SHA"' in admit
 
 
 def test_only_the_android_revalidation_steps_receive_the_workflow_token():
     """Candidate Gradle and candidate scripts must never see it."""
 
-    job = ANDROID["jobs"]["build-release"]
+    job = ANDROID["jobs"]["sign-release"]
     carriers = [
         step.get("name")
         for step in steps(job)

--- a/tests/test_umbrella_release_attachment.py
+++ b/tests/test_umbrella_release_attachment.py
@@ -11,7 +11,9 @@ against a live stand-in for the GitHub API in exactly those states.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -406,3 +408,295 @@ def test_an_identical_rerun_revalidates_but_performs_no_write(stub, assets: Path
     log = request_log(stub)
     assert [event for event in log if event != "revalidate"] == []
     assert log.count("revalidate") == 2, "an unchanged rerun still brackets its reads"
+
+
+# ── Draft creation media type ─────────────────────────────────────────
+#
+# v0.5.4-beta produced no GitHub release at all: six draft-creation POSTs across
+# the self-host and Bridge lanes were rejected and none returned an `.id`. The
+# body was JSON, but curl's `-d` declares application/x-www-form-urlencoded and
+# the `Accept` header only describes the response, so GitHub parsed the document
+# as form fields. These cases pin both halves — the old request must fail, the
+# new one must succeed — and the diagnostics that make the next such failure
+# legible without leaking anything.
+
+
+def create_release_directly(stub: GitHubStub, *, content_type: str | None) -> tuple[int, str]:
+    """Replay one draft-creation POST with a chosen media type, via curl."""
+
+    body = json.dumps(
+        {
+            "tag_name": TAG,
+            "target_commitish": COMMIT,
+            "name": f"SilentSuite {TAG}",
+            "draft": True,
+        }
+    )
+    command = [
+        "curl", "-sS", "-o", "/dev/stdout", "-w", "\\n%{http_code}", "-X", "POST",
+        "-H", "Authorization: Bearer test-token",
+        "-H", "Accept: application/vnd.github+json",
+        "-H", "X-GitHub-Api-Version: 2022-11-28",
+    ]
+    if content_type is not None:
+        command += ["-H", f"Content-Type: {content_type}"]
+    command += ["-d", body, f"{stub.url}/repos/{stub.state['repository']}/releases"]
+    result = subprocess.run(command, capture_output=True, text=True, check=True)
+    payload, _, status = result.stdout.rpartition("\n")
+    return int(status), payload
+
+
+def test_the_pre_fix_form_encoded_request_is_rejected(stub):
+    """curl's default media type is what broke the release."""
+
+    status, payload = create_release_directly(stub, content_type=None)
+
+    assert status == 400
+    assert "id" not in json.loads(payload)
+    assert stub.state["releases"] == []
+    assert stub.state["rejected_media_types"] == ["application/x-www-form-urlencoded"]
+
+
+def test_an_explicit_json_media_type_creates_the_draft(stub):
+    status, payload = create_release_directly(stub, content_type="application/json")
+
+    assert status == 201
+    assert json.loads(payload)["tag_name"] == TAG
+    assert stub.state["rejected_media_types"] == []
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    ["application/x-www-form-urlencoded", "text/plain", "application/vnd.github+json"],
+)
+def test_only_the_exact_json_media_type_is_accepted(stub, content_type: str):
+    """`application/vnd.github+json` describes the response, not the request."""
+
+    status, _ = create_release_directly(stub, content_type=content_type)
+
+    assert status == 400
+    assert stub.state["releases"] == []
+
+
+def test_the_helper_declares_the_json_media_type_on_the_creation_post(stub, assets: Path):
+    assert attach(stub, assets).returncode == 0
+
+    assert stub.state["rejected_media_types"] == [], "the helper sent a body GitHub cannot parse"
+    assert len(stub.state["releases"]) == 1
+
+
+@pytest.mark.parametrize("status", [401, 403, 404, 422, 500, 502, 503])
+def test_a_failed_creation_reports_the_status_and_the_sanitized_message(
+    stub, assets: Path, status: int
+):
+    stub.state["fail"]["create_release"] = status
+    stub.state["create_release_body"] = {"message": "Validation Failed", "errors": ["private"]}
+
+    result = attach(stub, assets)
+
+    assert result.returncode != 0
+    assert f"HTTP {status}: Validation Failed" in result.stderr
+    assert "could not resolve a single draft release" in result.stderr
+    # Only `.message` — never another response field, never a header.
+    assert "private" not in result.stderr
+    assert "errors" not in result.stderr
+    assert stub.state["releases"] == []
+
+
+def test_an_unparseable_response_is_labelled_rather_than_dumped(stub, assets: Path):
+    stub.state["fail"]["create_release"] = 502
+    stub.state["create_release_body"] = "<html><body>bad gateway</body></html>"
+
+    result = attach(stub, assets)
+
+    assert result.returncode != 0
+    assert "HTTP 502: unparseable response" in result.stderr
+    assert "html" not in result.stderr.lower()
+
+
+def test_a_hostile_api_message_is_bounded_and_stripped(stub, assets: Path):
+    stub.state["fail"]["create_release"] = 422
+    stub.state["create_release_body"] = {"message": "\x1b[31mboom\x1b[0m " + "A" * 500}
+
+    result = attach(stub, assets)
+
+    assert result.returncode != 0
+    assert "\x1b" not in result.stderr, "terminal escapes must not reach the log"
+    longest = max(len(line) for line in result.stderr.splitlines())
+    assert longest < 320, f"an unbounded message reached the log ({longest} chars)"
+
+
+def test_no_diagnostic_ever_prints_the_token(stub, assets: Path):
+    stub.state["fail"]["create_release"] = 401
+    stub.state["create_release_body"] = {"message": "Bad credentials"}
+
+    result = attach(stub, assets)
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "test-token" not in combined
+    assert "Authorization" not in combined
+    assert "Bearer" not in combined
+
+
+def test_a_sibling_that_wins_the_creation_race_is_joined_not_duplicated(stub, assets: Path):
+    """The loser's 422 is a retry signal, not a second draft."""
+
+    winner = stub.add_release(TAG, target=COMMIT)
+
+    result = attach(stub, assets)
+
+    assert result.returncode == 0, result.stderr
+    assert [r["id"] for r in stub.state["releases"]] == [winner["id"]]
+    assert set(uploaded(stub, winner["id"])) == {
+        "server-image.json",
+        f"silentsuite-self-host-{TAG}.tar.gz",
+    }
+
+
+def test_a_second_creation_for_the_same_tag_is_refused_by_the_api(stub):
+    """The stub enforces GitHub's one-release-per-tag rule, so a duplicate
+    draft cannot be manufactured by a test and pass unnoticed."""
+
+    assert create_release_directly(stub, content_type="application/json")[0] == 201
+    status, payload = create_release_directly(stub, content_type="application/json")
+
+    assert status == 422
+    assert json.loads(payload)["message"] == "Validation Failed"
+    assert len(stub.state["releases"]) == 1
+
+
+def test_the_request_body_never_reaches_the_process_arguments(stub, assets: Path):
+    """The document goes through a file under the run's private workdir."""
+
+    helper = ATTACH.read_text(encoding="utf-8")
+    assert '--data-binary "@${request}"' in helper
+    assert '-H "Content-Type: application/json"' in helper
+    # And the only other POST body — an asset — is already a file upload.
+    assert '--data-binary "@${DIRECTORY}/${asset}"' in helper
+
+
+def test_a_transport_failure_reports_exactly_one_canonical_status(assets: Path, tmp_path: Path):
+    """curl writes `000` through -w *and* exits non-zero on a dead endpoint.
+
+    A `|| printf '000'` fallback therefore concatenated, and the helper reported
+    `HTTP 000000`. The status is now taken from the write-out and validated to
+    exactly three digits.
+    """
+
+    # Port 1 on loopback refuses immediately: no listener, no DNS, no timeout.
+    dead = "http://127.0.0.1:1"
+    environment = {
+        **os.environ,
+        "GITHUB_API_URL": dead,
+        "GITHUB_UPLOAD_URL_BASE": dead,
+        "GITHUB_REPOSITORY": "silent-suite/silentsuite",
+        "GITHUB_TOKEN": "test-token",
+    }
+    environment.pop("GITHUB_REF", None)
+    result = subprocess.run(
+        [
+            "bash", str(ATTACH),
+            "--tag", TAG,
+            "--expected-commit", COMMIT,
+            "--directory", str(assets),
+            "--attempts", "1",
+            "--retry-delay", "0",
+            "--asset", "server-image.json",
+        ],
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "000000" not in combined, "the status was concatenated again"
+    for impossible in ("HTTP 0000", "HTTP  ", "HTTP :"):
+        assert impossible not in combined
+    assert "test-token" not in combined
+    assert "Bearer" not in combined
+
+
+def test_a_transport_failure_inside_the_creation_step_reports_http_000(
+    stub, assets: Path, tmp_path: Path
+):
+    """Identity checks pass, then the creation POST cannot connect.
+
+    A curl stand-in fails only the release-creation call, so the run reaches the
+    diagnostic under test instead of stopping at the first identity read.
+    """
+
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    real_curl = shutil.which("curl")
+    (shim_dir / "curl").write_text(
+        "#!/usr/bin/env bash\n"
+        "for argument in \"$@\"; do\n"
+        "  if [[ \"$argument\" == *'/releases' && \"$*\" == *'-X POST'* ]]; then\n"
+        "    for previous in \"$@\"; do\n"
+        "      if [[ \"$previous\" == '%{http_code}' ]]; then printf '000'; fi\n"
+        "    done\n"
+        "    exit 7\n"
+        "  fi\n"
+        "done\n"
+        f"exec {real_curl} \"$@\"\n",
+        encoding="utf-8",
+    )
+    (shim_dir / "curl").chmod(0o755)
+
+    environment = {
+        **os.environ,
+        **stub.environment(),
+        "GITHUB_TOKEN": "test-token",
+        "PATH": f"{shim_dir}:{os.environ['PATH']}",
+    }
+    environment.pop("GITHUB_REF", None)
+    result = subprocess.run(
+        [
+            "bash", str(ATTACH),
+            "--tag", TAG,
+            "--expected-commit", COMMIT,
+            "--directory", str(assets),
+            "--attempts", "1",
+            "--retry-delay", "0",
+            "--asset", "server-image.json",
+        ],
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+
+    assert result.returncode != 0
+    assert "HTTP 000: unparseable response" in result.stderr, result.stderr
+    assert "000000" not in result.stderr
+    assert "test-token" not in result.stdout + result.stderr
+    assert stub.state["releases"] == [], "nothing was created"
+
+
+def executable_lines(path: Path) -> str:
+    """Source with comments removed: these rules are about what runs."""
+
+    return "\n".join(
+        line for line in path.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+@pytest.mark.parametrize(
+    "script",
+    ["attach-umbrella-release-assets.sh", "verify-release-identity.sh"],
+)
+def test_no_curl_status_is_taken_from_a_concatenating_fallback(script: str):
+    """Both helpers read `%{http_code}`; both had the same defect."""
+
+    code = executable_lines(ROOT / "scripts" / script)
+    assert "'^[0-9]{3}$'" in code, "the write-out must be validated to three digits"
+    assert 'status="000"' in code
+    for fallback in ("|| printf '000'", "|| echo 000"):
+        assert fallback not in code, f"{script}: {fallback} concatenates with curl's own 000"
+
+
+def test_the_creation_response_file_always_exists_for_the_diagnostic():
+    code = executable_lines(ATTACH)
+    assert ': > "$out"' in code, "curl does not create -o when it never connects"


### PR DESCRIPTION
## Root causes

The first real `v0.5.4-beta` controller runs failed closed before an umbrella draft became usable:

- the shared attachment helper sent a JSON release-creation body with curl's default form media type;
- the live Android environment keystore decoded to unreadable bytes;
- candidate Gradle/native code shared a passwordless-sudo runner with later signing secrets and trusted tools;
- API transport failures could concatenate curl's `000` status.

## What this changes

### Shared draft creation

- sends release creation as `Content-Type: application/json`
- normalizes transport failures to one three-digit status
- logs only a bounded, sanitized GitHub `message`
- preserves live tag/ruleset revalidation, sole-draft lookup, idempotent attachment, sibling preservation, readback, and manual publication

### Fresh-runner Android signing boundary

- builds APK/AAB and all candidate/native evidence in `build-unsigned-release`, with no protected environment or signing secrets
- emits an exact SHA-bound, checksummed, data-only unsigned artifact
- signs on a separate fresh GitHub-hosted runner that checks out only protected controller code
- rejects missing, extra, nested, symlinked, executable, empty, wrong-mode, wrong-SHA, duplicate or checksum-mismatched handoff files before decoding the keystore
- installs exact Android build-tools 36.0.0 before secrets
- decodes and validates the JKS fail-closed, requiring the reviewed `PrivateKeyEntry` and upload certificate
- uses fixed trusted tool roots, with canonical containment for legitimate in-root symlinks
- aligns native-library APK contents with `zipalign -P 16` before `apksigner`
- signs AAB with `jarsigner`, generates signed split evidence with pinned bundletool, and verifies both final signer fingerprints
- keeps passwords out of process argv and output; preserves unconditional cleanup
- leaves the attachment writer separate and signing-secret free

## Verification

- 980 repository tests passed, plus 26 subtests
- one real-SDK end-to-end signing test correctly skipped locally because this coordinator has no Android SDK/bundletool fixture; GitHub Actions supplies that runtime evidence
- 396 focused release/signing/workflow tests passed in the final coordinator run
- generated temporary JKS tests cover valid, corrupt, truncated, wrong-password, wrong-alias, certificate-only, wrong-certificate and locale cases
- adversarial unsigned-handoff tests cover inventory, traversal, symlink, mode, emptiness, SHA and checksum failures
- release control-plane and Android signing-boundary checker passed
- live server-image registry material contract passed
- immutable action-pin, workflow YAML and shell checks passed
- hosted production deployment, controller, server-image, Bridge and readiness workflows remain unchanged

## Operational prerequisite

Canonical JKS custody remains offline on the owner laptop. Before another controller dispatch, it must be verified against upload certificate SHA-256 `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79` and the protected `android-release` secrets re-uploaded through stdin-only commands.

## Boundaries

This PR does not move the immutable tag, create/publish a release, move GHCR `latest`, change GitHub settings/secrets, upload stores, or deploy hosted production.