### PR TITLE
fix: grant Android release secret capabilities

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -40,6 +40,19 @@ on:
         description: The admitted 40-hex source commit.
         required: true
         type: string
+    # These declarations are capabilities, not repository-scoped fallback
+    # values. The controller grants only these names; the sign-release job's
+    # android-release binding supplies the protected environment values.
+    secrets:
+      ANDROID_KEYSTORE_BASE64:
+        description: Base64-encoded Android release keystore.
+        required: true
+      ANDROID_KEYSTORE_PASSWORD:
+        description: Password for the Android release keystore.
+        required: true
+      ANDROID_KEY_ALIAS:
+        description: Alias of the Android release signing key.
+        required: true
 
 permissions: {}
 

--- a/.github/workflows/release-controller.yml
+++ b/.github/workflows/release-controller.yml
@@ -176,6 +176,13 @@ jobs:
     with:
       release_tag: ${{ needs.admit.outputs.tag }}
       source_sha: ${{ needs.admit.outputs.commit }}
+    # Named grants establish only the reusable-workflow capability. The called
+    # signing job binds android-release, whose environment secrets override
+    # these same-name caller values; no repository-scoped copies are required.
+    secrets:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
 
   bridge:
     name: Bridge

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -436,6 +436,9 @@ EXPECTED_CALLER_INPUTS = {
     "release_tag": "${{ needs.admit.outputs.tag }}",
     "source_sha": "${{ needs.admit.outputs.commit }}",
 }
+EXPECTED_ANDROID_CALLER_SECRETS = {
+    name: f"${{{{ secrets.{name} }}}}" for name in SIGNING_SECRETS
+}
 EXPECTED_COMPONENT_INPUTS = {
     "release_tag": {
         "description": "The admitted immutable release tag.",
@@ -446,6 +449,20 @@ EXPECTED_COMPONENT_INPUTS = {
         "description": "The admitted 40-hex source commit.",
         "required": "true",
         "type": "string",
+    },
+}
+EXPECTED_ANDROID_CALLABLE_SECRETS = {
+    "ANDROID_KEYSTORE_BASE64": {
+        "description": "Base64-encoded Android release keystore.",
+        "required": "true",
+    },
+    "ANDROID_KEYSTORE_PASSWORD": {
+        "description": "Password for the Android release keystore.",
+        "required": "true",
+    },
+    "ANDROID_KEY_ALIAS": {
+        "description": "Alias of the Android release signing key.",
+        "required": "true",
     },
 }
 
@@ -464,6 +481,9 @@ REVIEWED_RELEASE_STEP_ENVIRONMENTS: dict[str, dict[str, str]] = {
 # Covers the whole reviewed signing job: the explicit literal checks state the
 # intent, this digest makes any other edit to the job fail closed as well.
 EXPECTED_RELEASE_JOB_SHA256 = "77295dce0752b35f290310f641c1d8b1eaf3a2b3db78445c90679b75459f105e"
+# The Android caller is the only controller job allowed to grant secrets. Pin
+# its entire semantic job after reviewing the exact three-name capability map.
+EXPECTED_CONTROLLER_ANDROID_JOB_SHA256 = "8caa709d1d1680daff0e2e53438072c113c265cfdd8fcb6064f9f2cc808df237"
 EXPECTED_UNSIGNED_JOB_SHA256 = "b20d7ce02bb1de96741fda2320c3b5993b63ff55ffec314ea534b83129f52823"
 # Same treatment for the one job that can write a release. It carries the write
 # credential, the attachment helper and the umbrella lock, so every byte of it
@@ -851,8 +871,9 @@ def check_control_plane(
                 )
 
     # 4. Each component lane is called from this protected revision, with the
-    #    admitted pair, under a declared permission ceiling, and with no secret
-    #    handed across the call boundary.
+    #    admitted pair and under a declared permission ceiling. Android alone
+    #    receives the exact named signing capabilities required by its called
+    #    workflow; no sibling lane receives any secret.
     for job_name, expected in EXPECTED_CONTROLLER_CALLERS.items():
         job = controller_jobs.get(job_name)
         if not isinstance(job, Mapping):
@@ -872,10 +893,19 @@ def check_control_plane(
             violations.append(
                 f"{CONTROLLER_WORKFLOW} job {job_name} must pass exactly the admitted tag and commit"
             )
-        if "secrets" in job:
+        if job_name == "android":
+            if job.get("secrets") != EXPECTED_ANDROID_CALLER_SECRETS:
+                violations.append(
+                    f"{CONTROLLER_WORKFLOW} job android must grant exactly the three Android "
+                    "signing secrets, each from its same-name secrets context value"
+                )
+            if semantic_sha256(job) != EXPECTED_CONTROLLER_ANDROID_JOB_SHA256:
+                violations.append(
+                    f"{CONTROLLER_WORKFLOW} job android must match its exact reviewed whole-job digest"
+                )
+        elif "secrets" in job:
             violations.append(
-                f"{CONTROLLER_WORKFLOW} job {job_name} must not pass secrets across the call "
-                "boundary; environment secrets belong to the called job that binds the environment"
+                f"{CONTROLLER_WORKFLOW} job {job_name} must not receive any secrets"
             )
         needs = job.get("needs")
         needs = [needs] if isinstance(needs, str) else (needs or [])
@@ -907,7 +937,13 @@ def check_control_plane(
         declared = call.get("inputs") if isinstance(call, Mapping) else None
         if declared != EXPECTED_COMPONENT_INPUTS:
             violations.append(f"{relative} must accept exactly the admitted tag and commit")
-        if isinstance(call, Mapping) and "secrets" in call:
+        declared_secrets = call.get("secrets") if isinstance(call, Mapping) else None
+        if relative == ROOT_WORKFLOW:
+            if declared_secrets != EXPECTED_ANDROID_CALLABLE_SECRETS:
+                violations.append(
+                    f"{relative} must declare exactly the three Android signing secrets as required"
+                )
+        elif declared_secrets is not None:
             violations.append(f"{relative} must not declare callable secrets")
         if workflow.get("permissions") != {}:
             violations.append(f"{relative} must grant no default permissions")
@@ -1094,6 +1130,18 @@ def check(root: Path) -> list[str]:
         loaded[relative] = workflow
         jobs = as_mapping(workflow.get("jobs"), f"{relative} jobs", violations)
         workflow_scope = {key: value for key, value in workflow.items() if key != "jobs"}
+        # The Android workflow_call declaration contains secret *names* as its
+        # least-privilege interface. It is reviewed exactly below and is not a
+        # secret value reference or an exposure at workflow scope.
+        if relative == ROOT_WORKFLOW:
+            workflow_scope = dict(workflow_scope)
+            root_triggers = dict(triggers(workflow_scope))
+            root_call = root_triggers.get("workflow_call")
+            if isinstance(root_call, Mapping):
+                root_call = dict(root_call)
+                root_call.pop("secrets", None)
+                root_triggers["workflow_call"] = root_call
+                workflow_scope["on"] = root_triggers
 
         scope_refs = signing_references(workflow_scope)
         if scope_refs:
@@ -1113,7 +1161,10 @@ def check(root: Path) -> list[str]:
                 continue
             refs = signing_references(raw_job)
             env = environment_name(raw_job)
-            is_allowed = relative == ROOT_WORKFLOW and job_name == ALLOWED_JOB
+            is_allowed = (
+                (relative == ROOT_WORKFLOW and job_name == ALLOWED_JOB)
+                or (relative == CONTROLLER_WORKFLOW and job_name == "android")
+            )
             if refs and not is_allowed:
                 violations.append(
                     f"{relative} job {job_name} references Android signing secrets: "
@@ -1225,6 +1276,11 @@ def check(root: Path) -> list[str]:
     for relative, workflow in loaded.items():
         for job_name, raw_job in (workflow.get("jobs") or {}).items():
             if not isinstance(raw_job, Mapping) or not signing_references(raw_job):
+                continue
+            if relative == CONTROLLER_WORKFLOW and job_name == "android":
+                # A reusable-workflow call job does not run steps or receive
+                # secret values itself. Its exact same-name grant is validated
+                # above; the called environment-bound signing job receives it.
                 continue
             scanned = dict(raw_job)
             if relative == ROOT_WORKFLOW and job_name == ALLOWED_JOB:

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -222,19 +222,86 @@ def test_widening_a_caller_permission_ceiling_is_rejected(tmp_path: Path) -> Non
     assert_rejected(run_checker(root), "job bridge must declare exactly")
 
 
-def test_passing_secrets_across_the_call_boundary_is_rejected(tmp_path: Path) -> None:
+def test_removing_an_android_callable_secret_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / ROOT_WORKFLOW,
+        "      ANDROID_KEY_ALIAS:\n"
+        "        description: Alias of the Android release signing key.\n"
+        "        required: true\n",
+        "",
+    )
+    assert_rejected(run_checker(root), "must declare exactly the three Android signing secrets")
+
+
+def test_removing_an_android_caller_secret_grant_is_rejected(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     mutate(
         root / CONTROLLER,
-        "    uses: ./.github/workflows/release-android.yml\n",
-        "    uses: ./.github/workflows/release-android.yml\n"
+        "      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}\n",
+        "",
+    )
+    assert_rejected(run_checker(root), "job android must grant exactly the three Android signing secrets")
+
+
+def test_adding_a_fourth_android_callable_secret_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / ROOT_WORKFLOW,
+        "    secrets:\n",
         "    secrets:\n"
-        "      KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}\n",
+        "      EXTRA_SIGNING_SECRET:\n"
+        "        description: Must never be admitted.\n"
+        "        required: true\n",
+    )
+    assert_rejected(run_checker(root), "must declare exactly the three Android signing secrets")
+
+
+def test_mapping_an_android_grant_from_the_wrong_secret_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / CONTROLLER,
+        "      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}\n",
+        "      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}\n",
+    )
+    assert_rejected(run_checker(root), "job android must grant exactly the three Android signing secrets")
+
+
+def test_mapping_an_android_grant_under_the_wrong_name_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / CONTROLLER,
+        "      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}\n",
+        "      ANDROID_KEY_NAME: ${{ secrets.ANDROID_KEY_ALIAS }}\n",
+    )
+    assert_rejected(run_checker(root), "job android must grant exactly the three Android signing secrets")
+
+
+def test_adding_a_fourth_android_caller_grant_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / CONTROLLER,
+        "    secrets:\n      ANDROID_KEYSTORE_BASE64:",
+        "    secrets:\n"
+        "      EXTRA_SIGNING_SECRET: ${{ secrets.EXTRA_SIGNING_SECRET }}\n"
+        "      ANDROID_KEYSTORE_BASE64:",
+    )
+    assert_rejected(run_checker(root), "job android must grant exactly the three Android signing secrets")
+
+
+def test_exposing_android_signing_secrets_to_another_lane_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / CONTROLLER,
+        "    uses: ./.github/workflows/release-bridge.yml\n",
+        "    uses: ./.github/workflows/release-bridge.yml\n"
+        "    secrets:\n"
+        "      ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}\n",
     )
     result = run_checker(root)
     assert result.returncode == 1
-    assert "must not pass secrets across the call boundary" in result.stdout
-    assert "job android references Android signing secrets" in result.stdout
+    assert "job bridge must not receive any secrets" in result.stdout
+    assert "job bridge references Android signing secrets" in result.stdout
 
 
 def test_a_component_lane_running_without_admission_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_self_host_release_workflows.py
+++ b/tests/test_self_host_release_workflows.py
@@ -45,6 +45,11 @@ NATIVE_RUNNERS = {"ubuntu-24.04": "linux/amd64", "ubuntu-24.04-arm": "linux/arm6
 SMOKE_SCRIPT = "scripts/self-host-image-smoke.sh"
 TRUSTED_REF = "${{ github.sha }}"
 UMBRELLA_GROUP = "umbrella-release-${{ github.event.client_payload.release_tag }}"
+ANDROID_SIGNING_SECRET_NAMES = {
+    "ANDROID_KEYSTORE_BASE64",
+    "ANDROID_KEYSTORE_PASSWORD",
+    "ANDROID_KEY_ALIAS",
+}
 
 PRODUCTION_MARKERS = (
     "server-production",
@@ -309,7 +314,12 @@ def test_each_component_lane_is_called_locally_with_the_admitted_pair(job, targe
         "release_tag": "${{ needs.admit.outputs.tag }}",
         "source_sha": "${{ needs.admit.outputs.commit }}",
     }
-    assert "secrets" not in lane, "environment secrets belong to the called job"
+    if job == "android":
+        assert lane["secrets"] == {
+            name: f"${{{{ secrets.{name} }}}}" for name in ANDROID_SIGNING_SECRET_NAMES
+        }
+    else:
+        assert "secrets" not in lane
 
 
 @pytest.mark.parametrize("path", COMPONENT_WORKFLOWS, ids=lambda p: p.name)
@@ -329,7 +339,12 @@ def test_component_lanes_are_reachable_only_by_that_call(path):
             "type": "string",
         },
     }
-    assert "secrets" not in workflow["on"]["workflow_call"]
+    if path == ANDROID_WORKFLOW:
+        declarations = workflow["on"]["workflow_call"]["secrets"]
+        assert set(declarations) == ANDROID_SIGNING_SECRET_NAMES
+        assert all(value["required"] == "true" for value in declarations.values())
+    else:
+        assert "secrets" not in workflow["on"]["workflow_call"]
 
 
 def test_the_bridge_build_is_shared_with_an_unprivileged_dispatch_lane():


### PR DESCRIPTION
## Root cause

The fresh `sign-release` job correctly entered `android-release`, but the reusable workflow had not declared the signing secret names and the controller had not granted those capabilities. GitHub therefore evaluated `secrets.ANDROID_KEYSTORE_BASE64` as empty even though the protected environment contained a freshly verified value.

## Fix

- declares exactly three required reusable-workflow secrets:
  - `ANDROID_KEYSTORE_BASE64`
  - `ANDROID_KEYSTORE_PASSWORD`
  - `ANDROID_KEY_ALIAS`
- grants exactly those same-name capabilities from the protected controller's Android caller
- relies on the called job's `environment: android-release` binding to supply/override with the protected environment values
- does not restore repository-scoped copies and does not use `secrets: inherit`
- prevents any secret grant to Bridge, server or readiness lanes
- pins the complete controller Android caller and updates adversarial boundary contracts

## Verification

- 986 repository tests passed, plus 26 subtests
- one real-SDK signing test remains correctly skipped locally
- release control-plane and Android signing-boundary checker passed
- workflow YAML and immutable action-pin checks passed
- live server-image registry material contract passed
- attachment helper, hosted deployment, server-image, Bridge and readiness lanes remain unchanged

## Operational boundary

The Actions integration is denied release creation for the owner-protected immutable tag (`403 Resource not accessible by integration`). The owner-authenticated release process will pre-create the draft after this correction merges; workflows will then append and verify assets idempotently. This PR does not create or publish a release, move `latest`, change secrets/settings, upload stores, or deploy production.
