### PR TITLE
fix: verify AAB integrity without PKI strictness

### DIFF
--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -495,7 +495,7 @@ EXPECTED_CONTROLLER_ADMIT_SHA256 = "6423d79810b64d292382c9bccab15a7b0ed342a6ff6e
 EXPECTED_IDENTITY_HELPER_SHA256 = "855c557e36e8fb55979e6877b02808d1ed0e40dafb9e8b7195e711f76d4b5da7"
 EXPECTED_ATTACHMENT_HELPER_SHA256 = "f37f415e7ec9439fe2e16c7e68a32a7ff0f8927de77eb2266480549e93aca875"
 EXPECTED_ARTIFACT_ADMISSION_SHA256 = "5c810ac880a6f91c334dc108c456927a70dbbbd6284016f14fd11a4ea01c4b4e"
-EXPECTED_SIGNING_HELPER_SHA256 = "4956cc84f364a951b72e35ed95581e2322ecbedef863bcd4e4daa1c2fcc34dbd"
+EXPECTED_SIGNING_HELPER_SHA256 = "b7eb3fb80dfc9e802ab526575d8b13fb33bc086abdbaa348e7cbee21d26253ff"
 EXPECTED_KEYSTORE_HELPER_SHA256 = "b9b0c8046a85209754c5e206b9cc1778036d2366d0709caf9a60fbf741f5c9b6"
 EXPECTED_READINESS_HELPER_SHA256 = "c75ebfba772c4f7bd6559161f64df3127c9c390bf1e5a81e39236ba47cc6e26f"
 # The Conscrypt producer exists twice: unprivileged CI builds it from the
@@ -1510,6 +1510,8 @@ def check(root: Path) -> list[str]:
             '"$ZIPALIGN" -c -P 16 4',
             'canonical="$(readlink -f -- "$tool")"',
             "resolves outside its trusted root",
+            '"$JARSIGNER" -verify "$SIGNED_AAB"',
+            '-printcert -jarfile "$SIGNED_AAB"',
         ):
             if required not in signing_code:
                 violations.append(f"{SIGNING_HELPER} must contain {required!r}")
@@ -1517,6 +1519,10 @@ def check(root: Path) -> list[str]:
             violations.append(f"{SIGNING_HELPER} must not resolve tools through PATH")
         if '"$ZIPALIGN" -p' in signing_code or '"$ZIPALIGN" -c -p' in signing_code:
             violations.append(f"{SIGNING_HELPER} must not use deprecated zipalign -p")
+        if '"$JARSIGNER" -verify -strict' in signing_code:
+            violations.append(
+                f"{SIGNING_HELPER} must not apply public-PKI strict policy to AAB integrity"
+            )
 
     # The keystore preflight sits exactly between the decode and Gradle. A
     # verifier that ran earlier would check a file that did not exist yet; one

--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -495,7 +495,7 @@ EXPECTED_CONTROLLER_ADMIT_SHA256 = "6423d79810b64d292382c9bccab15a7b0ed342a6ff6e
 EXPECTED_IDENTITY_HELPER_SHA256 = "855c557e36e8fb55979e6877b02808d1ed0e40dafb9e8b7195e711f76d4b5da7"
 EXPECTED_ATTACHMENT_HELPER_SHA256 = "f37f415e7ec9439fe2e16c7e68a32a7ff0f8927de77eb2266480549e93aca875"
 EXPECTED_ARTIFACT_ADMISSION_SHA256 = "5c810ac880a6f91c334dc108c456927a70dbbbd6284016f14fd11a4ea01c4b4e"
-EXPECTED_SIGNING_HELPER_SHA256 = "b7eb3fb80dfc9e802ab526575d8b13fb33bc086abdbaa348e7cbee21d26253ff"
+EXPECTED_SIGNING_HELPER_SHA256 = "6e36285e5837ac13eb8ef20e1a34d07eb88b857c1acaffbaff6af458ed94ade5"
 EXPECTED_KEYSTORE_HELPER_SHA256 = "b9b0c8046a85209754c5e206b9cc1778036d2366d0709caf9a60fbf741f5c9b6"
 EXPECTED_READINESS_HELPER_SHA256 = "c75ebfba772c4f7bd6559161f64df3127c9c390bf1e5a81e39236ba47cc6e26f"
 # The Conscrypt producer exists twice: unprivileged CI builds it from the
@@ -1510,7 +1510,9 @@ def check(root: Path) -> list[str]:
             '"$ZIPALIGN" -c -P 16 4',
             'canonical="$(readlink -f -- "$tool")"',
             "resolves outside its trusted root",
-            '"$JARSIGNER" -verify "$SIGNED_AAB"',
+            '"$JARSIGNER" -verify -strict \\\n'
+            '  -keystore "$KEYSTORE_PATH" -storepass:env KSTOREPWD',
+            "grep -Fxq 'jar verified.' \"$JARSIGNER_VERIFY_LOG\"",
             '-printcert -jarfile "$SIGNED_AAB"',
         ):
             if required not in signing_code:
@@ -1519,9 +1521,9 @@ def check(root: Path) -> list[str]:
             violations.append(f"{SIGNING_HELPER} must not resolve tools through PATH")
         if '"$ZIPALIGN" -p' in signing_code or '"$ZIPALIGN" -c -p' in signing_code:
             violations.append(f"{SIGNING_HELPER} must not use deprecated zipalign -p")
-        if '"$JARSIGNER" -verify -strict' in signing_code:
+        if '"$JARSIGNER" -verify "$SIGNED_AAB"' in signing_code:
             violations.append(
-                f"{SIGNING_HELPER} must not apply public-PKI strict policy to AAB integrity"
+                f"{SIGNING_HELPER} must not use unparsed plain AAB verification"
             )
 
     # The keystore preflight sits exactly between the decode and Gradle. A

--- a/scripts/sign-android-release.sh
+++ b/scripts/sign-android-release.sh
@@ -172,8 +172,18 @@ require_pinned_certificate "APK" \
 require_pinned_certificate "AAB" \
   "$("$KEYTOOL" "${KEYTOOL_LOCALE[@]}" -printcert -jarfile "$SIGNED_AAB" 2>/dev/null | leaf_fingerprint || true)"
 
-"$JARSIGNER" -verify -strict "$SIGNED_AAB" >/dev/null \
-  || refuse "the signed AAB did not verify"
+# `-strict` turns public-PKI chain and timestamp warnings into failures. The
+# upload certificate is deliberately self-signed, so those warnings are not
+# the trust decision here: the exact certificate pin above is. Plain verify
+# still fails when the JAR signature or any signed entry has been damaged.
+JARSIGNER_VERIFY_LOG="$WORKDIR/jarsigner-verify.log"
+if ! "$JARSIGNER" -verify "$SIGNED_AAB" >"$JARSIGNER_VERIFY_LOG" 2>&1; then
+  echo "Refusing to sign: the signed AAB failed cryptographic integrity verification" >&2
+  echo "  jarsigner diagnostic (sanitized, first 4096 bytes):" >&2
+  head -c 4096 "$JARSIGNER_VERIFY_LOG" | LC_ALL=C tr -cd '\11\12\15\40-\176' >&2
+  echo >&2
+  exit 1
+fi
 
 # ── Signed split evidence ─────────────────────────────────────────────
 #

--- a/scripts/sign-android-release.sh
+++ b/scripts/sign-android-release.sh
@@ -172,12 +172,17 @@ require_pinned_certificate "APK" \
 require_pinned_certificate "AAB" \
   "$("$KEYTOOL" "${KEYTOOL_LOCALE[@]}" -printcert -jarfile "$SIGNED_AAB" 2>/dev/null | leaf_fingerprint || true)"
 
-# `-strict` turns public-PKI chain and timestamp warnings into failures. The
-# upload certificate is deliberately self-signed, so those warnings are not
-# the trust decision here: the exact certificate pin above is. Plain verify
-# still fails when the JAR signature or any signed entry has been damaged.
+# Strict verification is required because plain `jarsigner -verify` exits zero
+# for an unsigned JAR. The already preflighted JKS is also the explicit trust
+# store: it trusts the deliberately self-signed, exactly pinned upload
+# certificate while strict mode rejects unsigned entries, integrity failures,
+# and algorithm-policy errors. JDK 17 still exits zero for a wholly unsigned
+# JAR even in strict mode, so require its locale-stabilized verified result too.
 JARSIGNER_VERIFY_LOG="$WORKDIR/jarsigner-verify.log"
-if ! "$JARSIGNER" -verify "$SIGNED_AAB" >"$JARSIGNER_VERIFY_LOG" 2>&1; then
+if ! "$JARSIGNER" -verify -strict \
+  -keystore "$KEYSTORE_PATH" -storepass:env KSTOREPWD \
+  "${KEYTOOL_LOCALE[@]}" "$SIGNED_AAB" >"$JARSIGNER_VERIFY_LOG" 2>&1 \
+  || ! grep -Fxq 'jar verified.' "$JARSIGNER_VERIFY_LOG"; then
   echo "Refusing to sign: the signed AAB failed cryptographic integrity verification" >&2
   echo "  jarsigner diagnostic (sanitized, first 4096 bytes):" >&2
   head -c 4096 "$JARSIGNER_VERIFY_LOG" | LC_ALL=C tr -cd '\11\12\15\40-\176' >&2

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -110,6 +110,42 @@ def test_repository_workflows_satisfy_the_release_and_signing_boundary() -> None
     assert "boundary check passed" in result.stdout
 
 
+def test_aab_integrity_cannot_reintroduce_public_pki_strict_policy(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / SIGNING_HELPER,
+        '"$JARSIGNER" -verify "$SIGNED_AAB"',
+        '"$JARSIGNER" -verify -strict "$SIGNED_AAB"',
+    )
+    assert_rejected(run_checker(root), "must not apply public-PKI strict policy")
+
+
+def test_aab_integrity_verification_cannot_be_removed(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / SIGNING_HELPER,
+        'if ! "$JARSIGNER" -verify "$SIGNED_AAB"',
+        'if ! /bin/true',
+    )
+    assert_rejected(
+        run_checker(root),
+        'must contain \'"$JARSIGNER" -verify "$SIGNED_AAB"\'',
+    )
+
+
+def test_aab_certificate_pin_extraction_cannot_be_removed(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / SIGNING_HELPER,
+        '-printcert -jarfile "$SIGNED_AAB"',
+        '-printcert -file "$SIGNED_AAB"',
+    )
+    assert_rejected(
+        run_checker(root),
+        'must contain \'-printcert -jarfile "$SIGNED_AAB"\'',
+    )
+
+
 def test_the_unmutated_fixture_is_clean(tmp_path: Path) -> None:
     """Every rejection below must be caused by its own mutation, not the copy."""
 

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -110,27 +110,47 @@ def test_repository_workflows_satisfy_the_release_and_signing_boundary() -> None
     assert "boundary check passed" in result.stdout
 
 
-def test_aab_integrity_cannot_reintroduce_public_pki_strict_policy(tmp_path: Path) -> None:
+def test_aab_integrity_cannot_remove_explicit_keystore_trust(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
-    mutate(
+    mutate_last(
         root / SIGNING_HELPER,
-        '"$JARSIGNER" -verify "$SIGNED_AAB"',
-        '"$JARSIGNER" -verify -strict "$SIGNED_AAB"',
+        '-keystore "$KEYSTORE_PATH" -storepass:env KSTOREPWD',
+        '-keystore "$KEYSTORE_PATH"',
     )
-    assert_rejected(run_checker(root), "must not apply public-PKI strict policy")
+    assert_rejected(run_checker(root), '"$JARSIGNER" -verify -strict')
 
 
 def test_aab_integrity_verification_cannot_be_removed(tmp_path: Path) -> None:
     root = fixture_root(tmp_path)
     mutate(
         root / SIGNING_HELPER,
-        'if ! "$JARSIGNER" -verify "$SIGNED_AAB"',
+        'if ! "$JARSIGNER" -verify -strict',
         'if ! /bin/true',
     )
     assert_rejected(
         run_checker(root),
-        'must contain \'"$JARSIGNER" -verify "$SIGNED_AAB"\'',
+        'must contain \'"$JARSIGNER" -verify -strict',
     )
+
+
+def test_aab_integrity_cannot_fall_back_to_plain_verify(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / SIGNING_HELPER,
+        '"$JARSIGNER" -verify -strict \\',
+        '"$JARSIGNER" -verify "$SIGNED_AAB"; /bin/true \\',
+    )
+    assert_rejected(run_checker(root), "must not use unparsed plain AAB verification")
+
+
+def test_aab_integrity_cannot_remove_verified_result_check(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    mutate(
+        root / SIGNING_HELPER,
+        "grep -Fxq 'jar verified.' \"$JARSIGNER_VERIFY_LOG\"",
+        "/bin/true",
+    )
+    assert_rejected(run_checker(root), "grep -Fxq")
 
 
 def test_aab_certificate_pin_extraction_cannot_be_removed(tmp_path: Path) -> None:

--- a/tests/test_android_unsigned_artifact_admission.py
+++ b/tests/test_android_unsigned_artifact_admission.py
@@ -20,6 +20,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 import zipfile
 from pathlib import Path
 
@@ -313,8 +314,10 @@ def test_the_signer_proves_the_pinned_certificate_on_both_outputs():
     assert 'require_pinned_certificate "AAB"' in code
     assert '"$APKSIGNER" verify --print-certs' in code
     assert "-printcert -jarfile" in code
-    assert '"$JARSIGNER" -verify "$SIGNED_AAB"' in code
-    assert '"$JARSIGNER" -verify -strict' not in code
+    assert '"$JARSIGNER" -verify -strict' in code
+    assert '-keystore "$KEYSTORE_PATH" -storepass:env KSTOREPWD' in code
+    assert "grep -Fxq 'jar verified.' \"$JARSIGNER_VERIFY_LOG\"" in code
+    assert '"$JARSIGNER" -verify "$SIGNED_AAB"' not in code
     assert "failed cryptographic integrity verification" in code
     assert 'head -c 4096 "$JARSIGNER_VERIFY_LOG"' in code
     assert "-J-Duser.language=en" in code, "keytool labels must not be locale-dependent"
@@ -394,6 +397,19 @@ def jdk_signing_fixture(tmp_path: Path, *, mode: str, expected: str | None = Non
     java_home = tmp_path / "jdk"
     bin_dir = java_home / "bin"
     bin_dir.mkdir(parents=True)
+    argv_log = tmp_path / "jarsigner.argv"
+    tamper_script = tmp_path / "tamper-signed-entry.py"
+    tamper_script.write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        "path = Path(os.environ['TAMPER_AAB'])\n"
+        "data = bytearray(path.read_bytes())\n"
+        "marker = b'minimal signed-entry fixture'\n"
+        "offset = data.index(marker)\n"
+        "data[offset] ^= 1\n"
+        "path.write_bytes(data)\n",
+        encoding="utf-8",
+    )
     (bin_dir / "java").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     (bin_dir / "java").chmod(0o755)
     (bin_dir / "keytool").write_text(
@@ -408,7 +424,8 @@ def jdk_signing_fixture(tmp_path: Path, *, mode: str, expected: str | None = Non
         )
         + f'{shlex.quote(keytool_real)} "$@"\n'
         'status=$?\n'
-        + ('printf x >> "$TAMPER_AAB"\n' if mode == "tampered" else "")
+        + (f'{shlex.quote(sys.executable)} {shlex.quote(str(tamper_script))}\n'
+           if mode == "tampered" else "")
         + "exit $status\n",
         encoding="utf-8",
     )
@@ -422,13 +439,16 @@ def jdk_signing_fixture(tmp_path: Path, *, mode: str, expected: str | None = Non
             '    shift\n'
             "  done\n"
             "fi\n"
+            f'printf "%s\\n" "$@" >> {shlex.quote(str(argv_log))}\n'
             f'exec {shlex.quote(jarsigner_real)} "$@"\n'
         )
         (bin_dir / "jarsigner").write_text(jarsigner_body, encoding="utf-8")
         (bin_dir / "jarsigner").chmod(0o755)
     else:
         (bin_dir / "jarsigner").write_text(
-            f"#!/bin/sh\nexec {shlex.quote(jarsigner_real)} \"$@\"\n", encoding="utf-8"
+            "#!/bin/sh\n"
+            f'printf "%s\\n" "$@" >> {shlex.quote(str(argv_log))}\n'
+            f'exec {shlex.quote(jarsigner_real)} "$@"\n', encoding="utf-8"
         )
         (bin_dir / "jarsigner").chmod(0o755)
 
@@ -500,6 +520,9 @@ def jdk_signing_fixture(tmp_path: Path, *, mode: str, expected: str | None = Non
         },
     )
     assert password not in result.stdout + result.stderr
+    recorded_argv = argv_log.read_text(encoding="utf-8")
+    assert password not in recorded_argv
+    assert "-storepass:env\nKSTOREPWD" in recorded_argv
     return result
 
 

--- a/tests/test_android_unsigned_artifact_admission.py
+++ b/tests/test_android_unsigned_artifact_admission.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import shlex
 import shutil
 import subprocess
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -311,7 +313,10 @@ def test_the_signer_proves_the_pinned_certificate_on_both_outputs():
     assert 'require_pinned_certificate "AAB"' in code
     assert '"$APKSIGNER" verify --print-certs' in code
     assert "-printcert -jarfile" in code
-    assert '"$JARSIGNER" -verify -strict' in code
+    assert '"$JARSIGNER" -verify "$SIGNED_AAB"' in code
+    assert '"$JARSIGNER" -verify -strict' not in code
+    assert "failed cryptographic integrity verification" in code
+    assert 'head -c 4096 "$JARSIGNER_VERIFY_LOG"' in code
     assert "-J-Duser.language=en" in code, "keytool labels must not be locale-dependent"
 
 
@@ -377,6 +382,150 @@ def test_a_tool_symlink_escaping_its_fixed_root_is_rejected(tmp_path: Path):
     assert "zipalign resolves outside its trusted root" in result.stderr
 
 
+def jdk_signing_fixture(tmp_path: Path, *, mode: str, expected: str | None = None):
+    """Exercise the AAB checks with real JDK signing tools and inert SDK peers."""
+
+    java = shutil.which("java")
+    keytool_real = shutil.which("keytool")
+    jarsigner_real = shutil.which("jarsigner")
+    if not all((java, keytool_real, jarsigner_real)):
+        pytest.skip("local JDK signing tools are unavailable")
+
+    java_home = tmp_path / "jdk"
+    bin_dir = java_home / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "java").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (bin_dir / "java").chmod(0o755)
+    (bin_dir / "keytool").write_text(
+        "#!/bin/sh\n"
+        + (
+            'for arg in "$@"; do\n'
+            '  if [ "$arg" = "-printcert" ]; then\n'
+            "    printf 'SHA256: %s\\n' \"$FIXTURE_CERT\"; exit 0\n"
+            "  fi\n"
+            "done\n"
+            if mode == "unsigned" else ""
+        )
+        + f'{shlex.quote(keytool_real)} "$@"\n'
+        'status=$?\n'
+        + ('printf x >> "$TAMPER_AAB"\n' if mode == "tampered" else "")
+        + "exit $status\n",
+        encoding="utf-8",
+    )
+    (bin_dir / "keytool").chmod(0o755)
+    if mode == "unsigned":
+        jarsigner_body = (
+            "#!/bin/sh\n"
+            'if [ "${1:-}" = "-keystore" ]; then\n'
+            '  while [ "$#" -gt 0 ]; do\n'
+            '    if [ "$1" = "-signedjar" ]; then cp "$3" "$2"; exit 0; fi\n'
+            '    shift\n'
+            "  done\n"
+            "fi\n"
+            f'exec {shlex.quote(jarsigner_real)} "$@"\n'
+        )
+        (bin_dir / "jarsigner").write_text(jarsigner_body, encoding="utf-8")
+        (bin_dir / "jarsigner").chmod(0o755)
+    else:
+        (bin_dir / "jarsigner").write_text(
+            f"#!/bin/sh\nexec {shlex.quote(jarsigner_real)} \"$@\"\n", encoding="utf-8"
+        )
+        (bin_dir / "jarsigner").chmod(0o755)
+
+    android_home = tmp_path / "android-sdk"
+    build_tools = android_home / "build-tools" / "36.0.0"
+    build_tools.mkdir(parents=True)
+    (build_tools / "zipalign").write_text(
+        '#!/bin/sh\ncase "$1" in -c) exit 0;; *) cp "$5" "$6";; esac\n',
+        encoding="utf-8",
+    )
+    (build_tools / "apksigner").write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "sign" ]; then\n'
+        '  while [ "$1" != "--out" ]; do shift; done; cp "$3" "$2"\n'
+        "else\n"
+        "  printf 'Signer #1 certificate SHA-256 digest: %s\\n' \"$FIXTURE_CERT\"\n"
+        "fi\n",
+        encoding="utf-8",
+    )
+    for tool in (build_tools / "zipalign", build_tools / "apksigner"):
+        tool.chmod(0o755)
+
+    password = "temporary-fixture-password"
+    alias = "fixture-key"
+    keystore = tmp_path / "fixture.jks"
+    fixture_env = {**os.environ, "KSTOREPWD": password}
+    subprocess.run(
+        [
+            str(bin_dir / "keytool"), "-genkeypair", "-storetype", "JKS",
+            "-keystore", str(keystore), "-storepass:env", "KSTOREPWD",
+            "-keypass:env", "KSTOREPWD", "-alias", alias, "-keyalg", "RSA",
+            "-keysize", "2048", "-validity", "2",
+            "-dname", "CN=SilentSuite AAB integrity fixture",
+        ],
+        check=True, capture_output=True, text=True, env=fixture_env,
+    )
+    listed = subprocess.run(
+        [
+            str(bin_dir / "keytool"), "-J-Duser.language=en", "-J-Duser.country=US",
+            "-list", "-v", "-keystore", str(keystore),
+            "-storepass:env", "KSTOREPWD", "-alias", alias,
+        ],
+        check=True, capture_output=True, text=True, env=fixture_env,
+    ).stdout
+    match = re.search(r"SHA256:\s*((?:[0-9A-F]{2}:){31}[0-9A-F]{2})", listed)
+    assert match, listed
+    fingerprint = match.group(1).replace(":", "").lower()
+
+    unsigned = tmp_path / "unsigned"
+    unsigned.mkdir()
+    (unsigned / "app-release-unsigned.apk").write_bytes(b"minimal apk fixture")
+    with zipfile.ZipFile(unsigned / "app-release.aab", "w") as bundle:
+        bundle.writestr("BundleConfig.pb", b"minimal signed-entry fixture")
+    output = tmp_path / "signed"
+    bundletool = tmp_path / "bundletool.jar"
+    bundletool.write_bytes(b"inert fixture")
+    result = subprocess.run(
+        ["bash", str(SIGNER), "--expect-sha256", expected or fingerprint],
+        capture_output=True,
+        text=True,
+        env={
+            **fixture_env,
+            "ANDROID_HOME": str(android_home), "JAVA_HOME": str(java_home),
+            "UNSIGNED_DIR": str(unsigned), "OUTPUT_DIR": str(output),
+            "KEYSTORE_PATH": str(keystore), "KEY_ALIAS": alias,
+            "BUNDLETOOL_JAR": str(bundletool),
+            "FIXTURE_CERT": expected or fingerprint,
+            "TAMPER_AAB": str(output / "app-release.aab"),
+        },
+    )
+    assert password not in result.stdout + result.stderr
+    return result
+
+
+def test_valid_self_signed_pinned_aab_passes_integrity(tmp_path: Path):
+    result = jdk_signing_fixture(tmp_path, mode="valid")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_byte_tampered_signed_aab_fails_integrity(tmp_path: Path):
+    result = jdk_signing_fixture(tmp_path, mode="tampered")
+    assert result.returncode != 0
+    assert "failed cryptographic integrity verification" in result.stderr
+
+
+def test_wrong_aab_signing_certificate_fails_the_pin(tmp_path: Path):
+    result = jdk_signing_fixture(tmp_path, mode="valid", expected="0" * 64)
+    assert result.returncode != 0
+    assert "does not carry the reviewed upload key" in result.stderr
+
+
+def test_unsigned_aab_fails_integrity(tmp_path: Path):
+    result = jdk_signing_fixture(tmp_path, mode="unsigned")
+    assert result.returncode != 0
+    assert "failed cryptographic integrity verification" in result.stderr
+
+
 def test_signer_end_to_end_with_generated_jks_when_exact_sdk_fixtures_exist(
     tmp_path: Path,
 ):
@@ -427,24 +576,26 @@ def test_signer_end_to_end_with_generated_jks_when_exact_sdk_fixtures_exist(
     subprocess.run(
         [
             str(keytool), "-genkeypair", "-storetype", "JKS",
-            "-keystore", str(keystore), "-storepass", password,
-            "-keypass", password, "-alias", alias, "-keyalg", "RSA",
+            "-keystore", str(keystore), "-storepass:env", "KSTOREPWD",
+            "-keypass:env", "KSTOREPWD", "-alias", alias, "-keyalg", "RSA",
             "-keysize", "2048", "-validity", "2",
             "-dname", "CN=SilentSuite signing test",
         ],
         check=True,
         capture_output=True,
         text=True,
+        env={**os.environ, "KSTOREPWD": password},
     )
     listed = subprocess.run(
         [
             str(keytool), "-J-Duser.language=en", "-J-Duser.country=US",
             "-list", "-v", "-keystore", str(keystore),
-            "-storepass", password, "-alias", alias,
+            "-storepass:env", "KSTOREPWD", "-alias", alias,
         ],
         check=True,
         capture_output=True,
         text=True,
+        env={**os.environ, "KSTOREPWD": password},
     ).stdout
     match = re.search(r"SHA256:\s*((?:[0-9A-F]{2}:){31}[0-9A-F]{2})", listed)
     assert match, listed
@@ -467,6 +618,7 @@ def test_signer_end_to_end_with_generated_jks_when_exact_sdk_fixtures_exist(
             "BUNDLETOOL_JAR": bundletool_value,
         },
     )
+    assert password not in result.stdout + result.stderr
     assert result.returncode == 0, result.stdout + result.stderr
     for name in ("app-release.apk", "app-release.aab", "signed-release.apks"):
         assert (output / name).is_file() and (output / name).stat().st_size > 0


### PR DESCRIPTION
## Root cause

The fresh release signing runner successfully decoded and verified the protected JKS, signed APK and AAB, and observed the exact reviewed certificate on both files. Its initial `jarsigner -verify -strict` lacked an explicit truststore, so the deliberately self-signed upload certificate was treated as untrusted.

A subsequent plain-verification candidate was rejected by CI because Java returns success for wholly unsigned JARs and trailing bytes outside a ZIP do not alter signed entries.

## Final fix

- verifies AAB integrity with `jarsigner -verify -strict`
- supplies the already verified JKS as the explicit truststore using `-storepass:env KSTOREPWD`
- requires the locale-stabilized exact `jar verified.` result, so unsigned AABs cannot pass on jarsigner exit status alone
- retains independent `keytool -printcert -jarfile` extraction and exact certificate pinning
- preserves APK verification unchanged
- emits only bounded, sanitized diagnostics on integrity failure
- pins the complete signing helper and prevents fallback to unparsed plain verification

## Verification

- 994 repository tests passed, plus 26 subtests in the corrected implementation pass
- exact-head GitHub CI is fully green
- real JDK behavioral tests prove:
  - valid self-signed/pinned AAB passes with explicit trust
  - unsigned AAB fails
  - corruption inside a signed ZIP entry fails
  - wrong signer certificate fails the exact pin
  - password is absent from argv and output
- release control-plane and signing-boundary checker passed
- no workflow, attachment, release, tag, registry, store or production boundary changed

## Runtime evidence

Run `33307305456`, job `99247676021` proved both outputs carried certificate SHA-256 `8035a4ff1511e2045c579c905d26e93af6009b239e741ef78542ae04e7a7ca79`. Final release-controller runtime proof remains the only residual.