### PR TITLE
fix: canonicalize Bridge release checksums

### DIFF
--- a/scripts/check-android-signing-boundary.py
+++ b/scripts/check-android-signing-boundary.py
@@ -73,6 +73,7 @@ ENVIRONMENT_NAME = "android-release"
 IDENTITY_HELPER = Path("scripts/verify-release-identity.sh")
 ATTACHMENT_HELPER = Path("scripts/attach-umbrella-release-assets.sh")
 READINESS_HELPER = Path("scripts/verify-umbrella-release-readiness.py")
+BRIDGE_STAGING_HELPER = Path("scripts/stage-bridge-release-assets.sh")
 KEYSTORE_HELPER = Path("scripts/verify-android-release-keystore.sh")
 ARTIFACT_ADMISSION_HELPER = Path("scripts/admit-unsigned-android-artifact.sh")
 SIGNING_HELPER = Path("scripts/sign-android-release.sh")
@@ -504,6 +505,7 @@ EXPECTED_ARTIFACT_ADMISSION_SHA256 = "5c810ac880a6f91c334dc108c456927a70dbbbd628
 EXPECTED_SIGNING_HELPER_SHA256 = "6e36285e5837ac13eb8ef20e1a34d07eb88b857c1acaffbaff6af458ed94ade5"
 EXPECTED_KEYSTORE_HELPER_SHA256 = "b9b0c8046a85209754c5e206b9cc1778036d2366d0709caf9a60fbf741f5c9b6"
 EXPECTED_READINESS_HELPER_SHA256 = "c75ebfba772c4f7bd6559161f64df3127c9c390bf1e5a81e39236ba47cc6e26f"
+EXPECTED_BRIDGE_STAGING_HELPER_SHA256 = "b9dd8980fa763c485caa5ac999b2ba9f9d187a9545e02e3cc580425fc223e0b6"
 # The Conscrypt producer exists twice: unprivileged CI builds it from the
 # triggering ref, the release lane builds it from the admitted commit. Both are
 # pinned so neither can drift into an unreviewed native toolchain.
@@ -1302,6 +1304,7 @@ def check(root: Path) -> list[str]:
         (IDENTITY_HELPER, EXPECTED_IDENTITY_HELPER_SHA256),
         (ATTACHMENT_HELPER, EXPECTED_ATTACHMENT_HELPER_SHA256),
         (READINESS_HELPER, EXPECTED_READINESS_HELPER_SHA256),
+        (BRIDGE_STAGING_HELPER, EXPECTED_BRIDGE_STAGING_HELPER_SHA256),
         (KEYSTORE_HELPER, EXPECTED_KEYSTORE_HELPER_SHA256),
         (ARTIFACT_ADMISSION_HELPER, EXPECTED_ARTIFACT_ADMISSION_SHA256),
         (SIGNING_HELPER, EXPECTED_SIGNING_HELPER_SHA256),

--- a/scripts/stage-bridge-release-assets.sh
+++ b/scripts/stage-bridge-release-assets.sh
@@ -1,17 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Flatten the per-platform bridge build artifacts into one directory and derive
-# the combined SHA256SUMS.txt the release carries.
-#
-# Kept out of the workflow so the attachment lanes run reviewed, syntax-checked
-# repository code rather than inline YAML, and so the real-tag and manual-dispatch
-# lanes cannot drift apart.
-#
-# Every staged name is checked against a conservative asset grammar before it is
-# accepted: the attachment helper passes names straight into a URL query and a
-# local path, so a stray traversal or shell-significant character has no business
-# reaching it.
+# Flatten the five per-platform Bridge artifacts, verify every producer checksum,
+# and rewrite accepted GNU text/binary records into the one canonical release
+# representation consumed by the readiness gate.
 #
 # Usage:
 #   scripts/stage-bridge-release-assets.sh <downloaded-artifact-dir> <staging-dir>
@@ -27,10 +19,20 @@ if [ -e "$STAGING" ]; then
   echo "ERROR: staging directory '$STAGING' already exists" >&2
   exit 1
 fi
-mkdir -p "$STAGING"
+mkdir -m 0755 "$STAGING"
 
-while IFS= read -r file; do
-  name="$(basename -- "$file")"
+# Artifact directories are expected, but every leaf must be a regular file.
+# In particular, do not let find silently omit producer-created symlinks.
+while IFS= read -r entry; do
+  if [ -d "$entry" ] && [ ! -L "$entry" ]; then
+    continue
+  fi
+  if [ ! -f "$entry" ] || [ -L "$entry" ]; then
+    echo "ERROR: refusing non-regular or symlink artifact: $entry" >&2
+    exit 1
+  fi
+
+  name="$(basename -- "$entry")"
   if ! printf '%s' "$name" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
     echo "ERROR: refusing to stage asset with unexpected name: $name" >&2
     exit 1
@@ -39,16 +41,105 @@ while IFS= read -r file; do
     echo "ERROR: two build artifacts are both named '$name'" >&2
     exit 1
   fi
-  mv "$file" "$STAGING/$name"
-done < <(find "$SOURCE" -type f | LC_ALL=C sort)
+  mv "$entry" "$STAGING/$name"
+done < <(find "$SOURCE" -mindepth 1 -print | LC_ALL=C sort)
 
-if ! ls "$STAGING"/*.sha256 >/dev/null 2>&1; then
-  echo "ERROR: no per-asset checksum files were staged" >&2
-  exit 1
-fi
+# Python is already a pinned runner dependency in the release job. Use byte
+# parsing here so NULs, CRLF, missing final LF, and extra records cannot be
+# normalized accidentally by shell text handling.
+python3 - "$STAGING" <<'PY'
+from __future__ import annotations
 
-# Deterministic order, so the manifest does not depend on artifact arrival.
-( cd "$STAGING" && cat $(ls *.sha256 | LC_ALL=C sort) > SHA256SUMS.txt )
+import hashlib
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+staging = Path(sys.argv[1])
+payloads = (
+    "silentsuite-bridge-linux-arm64",
+    "silentsuite-bridge-linux-x86_64",
+    "silentsuite-bridge-macos-arm64",
+    "silentsuite-bridge-macos-x86_64",
+    "silentsuite-bridge-windows-x86_64.exe",
+)
+expected = {name for payload in payloads for name in (payload, f"{payload}.sha256")}
+actual = {entry.name for entry in staging.iterdir()}
+if actual != expected:
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    raise SystemExit(
+        f"ERROR: bridge payload/sidecar inventory mismatch; missing={missing}, extra={extra}"
+    )
+
+safe_name = re.compile(rb"[A-Za-z0-9][A-Za-z0-9._-]*")
+record = re.compile(rb"([0-9A-Fa-f]{64}) ([ *])(.+)\n")
+canonical: list[bytes] = []
+
+for payload_name in sorted(payloads):
+    payload = staging / payload_name
+    sidecar = staging / f"{payload_name}.sha256"
+    for path, kind in ((payload, "payload"), (sidecar, "sidecar")):
+        metadata = path.stat(follow_symlinks=False)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise SystemExit(f"ERROR: {kind} is not a regular non-symlink file: {path.name}")
+    if payload.stat().st_size == 0:
+        raise SystemExit(f"ERROR: payload is empty: {payload_name}")
+
+    raw = sidecar.read_bytes()
+    match = record.fullmatch(raw)
+    if match is None:
+        raise SystemExit(f"ERROR: malformed checksum record: {sidecar.name}")
+    recorded_name = match.group(3)
+    if safe_name.fullmatch(recorded_name) is None:
+        raise SystemExit(f"ERROR: checksum records an unsafe top-level name: {sidecar.name}")
+    if recorded_name.decode("ascii") != payload_name:
+        raise SystemExit(
+            f"ERROR: {sidecar.name} records the wrong filename: {recorded_name!r}"
+        )
+
+    actual_digest = hashlib.sha256(payload.read_bytes()).hexdigest()
+    if match.group(1).decode("ascii").lower() != actual_digest:
+        raise SystemExit(f"ERROR: checksum mismatch for {payload_name}")
+    rendered = f"{actual_digest}  {payload_name}\n".encode("ascii")
+
+    temporary = sidecar.with_name(f".{sidecar.name}.canonical.{os.getpid()}")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+    try:
+        with os.fdopen(descriptor, "wb") as output:
+            output.write(rendered)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, sidecar)
+        os.chmod(sidecar, 0o644)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+    canonical.append(rendered)
+
+manifest = staging / "SHA256SUMS.txt"
+temporary = staging / f".{manifest.name}.tmp.{os.getpid()}"
+descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+try:
+    with os.fdopen(descriptor, "wb") as output:
+        output.write(b"".join(canonical))
+        output.flush()
+        os.fsync(output.fileno())
+    os.replace(temporary, manifest)
+    os.chmod(manifest, 0o644)
+finally:
+    if temporary.exists():
+        temporary.unlink()
+
+covered = {
+    line.split(b"  ", 1)[1].removesuffix(b"\n").decode("ascii")
+    for line in manifest.read_bytes().splitlines(keepends=True)
+}
+if covered != set(payloads):
+    raise SystemExit("ERROR: SHA256SUMS.txt does not cover exactly the Bridge payloads")
+PY
 
 echo "== staged release assets =="
 ls -l "$STAGING"

--- a/tests/test_android_signing_boundary_static.py
+++ b/tests/test_android_signing_boundary_static.py
@@ -29,6 +29,7 @@ CONSCRYPT_BUILD_SCRIPT = Path("android/scripts/build-conscrypt-android-r28.sh")
 IDENTITY_HELPER = Path("scripts/verify-release-identity.sh")
 ATTACHMENT_HELPER = Path("scripts/attach-umbrella-release-assets.sh")
 READINESS_HELPER = Path("scripts/verify-umbrella-release-readiness.py")
+BRIDGE_STAGING_HELPER = Path("scripts/stage-bridge-release-assets.sh")
 KEYSTORE_HELPER = Path("scripts/verify-android-release-keystore.sh")
 ARTIFACT_ADMISSION_HELPER = Path("scripts/admit-unsigned-android-artifact.sh")
 SIGNING_HELPER = Path("scripts/sign-android-release.sh")
@@ -77,6 +78,7 @@ def fixture_root(tmp_path: Path) -> Path:
         IDENTITY_HELPER,
         ATTACHMENT_HELPER,
         READINESS_HELPER,
+        BRIDGE_STAGING_HELPER,
         KEYSTORE_HELPER,
         ARTIFACT_ADMISSION_HELPER,
         SIGNING_HELPER,
@@ -649,6 +651,16 @@ def test_mutating_the_readiness_helper_bytes_is_rejected(tmp_path: Path) -> None
     helper = root / READINESS_HELPER
     helper.write_text(helper.read_text(encoding="utf-8") + "\n# unreviewed\n", encoding="utf-8")
     assert_rejected(run_checker(root), f"{READINESS_HELPER} must match its exact reviewed digest")
+
+
+def test_mutating_the_bridge_staging_helper_bytes_is_rejected(tmp_path: Path) -> None:
+    root = fixture_root(tmp_path)
+    helper = root / BRIDGE_STAGING_HELPER
+    helper.write_text(helper.read_text(encoding="utf-8") + "\n# unreviewed\n", encoding="utf-8")
+    assert_rejected(
+        run_checker(root),
+        f"{BRIDGE_STAGING_HELPER} must match its exact reviewed digest",
+    )
 
 
 def test_a_missing_helper_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_self_host_release_admission.py
+++ b/tests/test_self_host_release_admission.py
@@ -14,6 +14,7 @@ that has been disabled, relaxed, or given a bypass actor.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 from pathlib import Path
@@ -472,12 +473,15 @@ def test_local_ancestry_refuses_a_commit_off_protected_main(lane):
 # ── Bridge asset staging ──────────────────────────────────────────────
 
 
-def stage(tmp_path: Path, names: dict[str, str]):
+def stage(tmp_path: Path, names: dict[str, str | bytes]):
     source = tmp_path / "artifacts"
     for relative, content in names.items():
         target = source / relative
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(content, encoding="utf-8")
+        if isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(content, encoding="utf-8")
     return subprocess.run(
         ["bash", str(STAGE), str(source), str(tmp_path / "flat")],
         capture_output=True,
@@ -485,67 +489,117 @@ def stage(tmp_path: Path, names: dict[str, str]):
     )
 
 
-def test_staging_flattens_and_builds_a_deterministic_manifest(tmp_path: Path):
-    result = stage(
-        tmp_path,
-        {
-            "b/silentsuite-bridge-macos-arm64": "m\n",
-            "b/silentsuite-bridge-macos-arm64.sha256": "bbb  silentsuite-bridge-macos-arm64\n",
-            "a/silentsuite-bridge-linux-x86_64": "l\n",
-            "a/silentsuite-bridge-linux-x86_64.sha256": "aaa  silentsuite-bridge-linux-x86_64\n",
-        },
-    )
+BRIDGE_PAYLOADS = (
+    "silentsuite-bridge-linux-arm64",
+    "silentsuite-bridge-linux-x86_64",
+    "silentsuite-bridge-macos-arm64",
+    "silentsuite-bridge-macos-x86_64",
+    "silentsuite-bridge-windows-x86_64.exe",
+)
+
+
+def valid_bridge_tree(*, windows_binary_marker: bool = False) -> dict[str, bytes]:
+    files: dict[str, bytes] = {}
+    for index, name in enumerate(BRIDGE_PAYLOADS):
+        payload = f"payload-{index}-{name}\n".encode()
+        digest = hashlib.sha256(payload).hexdigest()
+        marker = "*" if windows_binary_marker and name.endswith(".exe") else " "
+        files[f"artifact-{index}/{name}"] = payload
+        files[f"artifact-{index}/{name}.sha256"] = f"{digest.upper()} {marker}{name}\n".encode()
+    return files
+
+
+def test_staging_verifies_all_platforms_and_builds_a_deterministic_manifest(tmp_path: Path):
+    result = stage(tmp_path, valid_bridge_tree(windows_binary_marker=True))
 
     assert result.returncode == 0, result.stderr
-    manifest = (tmp_path / "flat" / "SHA256SUMS.txt").read_text()
-    assert manifest == (
-        "aaa  silentsuite-bridge-linux-x86_64\nbbb  silentsuite-bridge-macos-arm64\n"
-    ), "the manifest order must not depend on artifact arrival"
+    flat = tmp_path / "flat"
+    records = [(flat / f"{name}.sha256").read_text() for name in sorted(BRIDGE_PAYLOADS)]
+    assert (flat / "SHA256SUMS.txt").read_text() == "".join(records)
+    assert all(record.split()[0].islower() for record in records)
+    assert records[-1].endswith("  silentsuite-bridge-windows-x86_64.exe\n")
+
+
+@pytest.mark.parametrize(
+    ("replacement", "message"),
+    [
+        (lambda digest, name: f"{digest}  {name}", "malformed checksum record"),
+        (lambda digest, name: f"{digest}  {name}\r\n", "unsafe top-level name"),
+        (lambda digest, name: f"{digest}  {name}\n{digest}  {name}\n", "malformed checksum record"),
+        (lambda digest, name: f"{digest}   {name}\n", "unsafe top-level name"),
+        (lambda digest, name: f"{digest}  ../{name}\n", "unsafe top-level name"),
+        (lambda digest, name: f"{digest}  wrong-name\n", "wrong filename"),
+        (lambda digest, name: f"{'0' * 64}  {name}\n", "checksum mismatch"),
+        (lambda digest, name: f"{digest}\t {name}\n", "malformed checksum record"),
+        (lambda digest, name: f"{digest}  {name}\x00\n", "unsafe top-level name"),
+    ],
+)
+def test_staging_refuses_malformed_or_untrusted_checksum_records(tmp_path, replacement, message):
+    files = valid_bridge_tree()
+    name = BRIDGE_PAYLOADS[0]
+    payload = files[f"artifact-0/{name}"]
+    files[f"artifact-0/{name}.sha256"] = replacement(
+        hashlib.sha256(payload).hexdigest(), name
+    ).encode()
+    result = stage(tmp_path, files)
+
+    assert result.returncode != 0
+    assert message in result.stderr
 
 
 def test_staging_refuses_an_asset_name_that_could_escape_its_directory(tmp_path: Path):
-    result = stage(
-        tmp_path,
-        {
-            "a/.hidden-asset": "x\n",
-            "a/silentsuite-bridge-linux-x86_64.sha256": "aaa  silentsuite-bridge-linux-x86_64\n",
-        },
-    )
+    files = valid_bridge_tree()
+    files["a/.hidden-asset"] = b"x\n"
+    result = stage(tmp_path, files)
 
     assert result.returncode != 0
     assert "unexpected name" in result.stderr
 
 
 def test_staging_refuses_two_artifacts_with_the_same_name(tmp_path: Path):
-    result = stage(
-        tmp_path,
-        {
-            "a/silentsuite-bridge-linux-x86_64": "one\n",
-            "b/silentsuite-bridge-linux-x86_64": "two\n",
-            "a/silentsuite-bridge-linux-x86_64.sha256": "aaa  silentsuite-bridge-linux-x86_64\n",
-        },
-    )
+    files = valid_bridge_tree()
+    files["duplicate/silentsuite-bridge-linux-x86_64"] = b"two\n"
+    result = stage(tmp_path, files)
 
     assert result.returncode != 0
     assert "both named" in result.stderr
 
 
-def test_staging_refuses_to_produce_an_empty_checksum_manifest(tmp_path: Path):
-    result = stage(tmp_path, {"a/silentsuite-bridge-linux-x86_64": "l\n"})
+def test_staging_refuses_missing_and_orphan_assets(tmp_path: Path):
+    files = valid_bridge_tree()
+    del files["artifact-0/silentsuite-bridge-linux-arm64.sha256"]
+    files["orphan.sha256"] = b"0" * 64 + b"  orphan\n"
+    result = stage(tmp_path, files)
 
     assert result.returncode != 0
-    assert "no per-asset checksum files" in result.stderr
+    assert "inventory mismatch" in result.stderr
 
 
 def test_staging_refuses_to_reuse_an_existing_directory(tmp_path: Path):
     (tmp_path / "flat").mkdir()
-    result = stage(
-        tmp_path,
-        {"a/silentsuite-bridge-linux-x86_64.sha256": "aaa  silentsuite-bridge-linux-x86_64\n"},
-    )
+    result = stage(tmp_path, valid_bridge_tree())
 
     assert result.returncode != 0
     assert "already exists" in result.stderr
+
+
+def test_staging_refuses_empty_payloads_and_symlinks(tmp_path: Path):
+    files = valid_bridge_tree()
+    name = BRIDGE_PAYLOADS[0]
+    files[f"artifact-0/{name}"] = b""
+    assert "payload is empty" in stage(tmp_path, files).stderr
+
+    source = tmp_path / "symlink-artifacts"
+    source.mkdir()
+    (source / "target").write_bytes(b"payload")
+    (source / "link").symlink_to("target")
+    result = subprocess.run(
+        ["bash", str(STAGE), str(source), str(tmp_path / "symlink-flat")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "symlink artifact" in result.stderr
 
 
 # ── Bridge artifact acquisition: the real mixed run ───────────────────
@@ -599,6 +653,17 @@ REAL_RUN_ARTIFACTS: dict[str, dict[str, str]] = {
         "org/conscrypt/conscrypt-android/2.6.3-r28/conscrypt-android-2.6.3-r28.aar": "aar\n",
     },
 }
+
+# Keep the historical tree shape, but make its producer sidecars cryptographically
+# valid now that staging verifies rather than blindly concatenating them.
+for _artifact_files in REAL_RUN_ARTIFACTS.values():
+    for _relative_name in tuple(_artifact_files):
+        if _relative_name.endswith(".sha256"):
+            _payload_name = _relative_name.removesuffix(".sha256")
+            _payload = _artifact_files[_payload_name].encode()
+            _artifact_files[_relative_name] = (
+                f"{hashlib.sha256(_payload).hexdigest()}  {_payload_name}\n"
+            )
 
 
 def workflow_expected_inventory() -> list[str]:
@@ -697,13 +762,9 @@ def test_a_missing_bridge_producer_fails_the_closed_inventory(tmp_path: Path):
     source = materialise(tmp_path, artifacts)
     staging = tmp_path / "flat"
 
-    assert run_staging(source, staging).returncode == 0
-    staged = sorted(entry.name for entry in staging.iterdir())
-    assert staged != workflow_expected_inventory()
-    assert set(workflow_expected_inventory()) - set(staged) == {
-        "silentsuite-bridge-macos-arm64",
-        "silentsuite-bridge-macos-arm64.sha256",
-    }
+    result = run_staging(source, staging)
+    assert result.returncode != 0
+    assert "inventory mismatch" in result.stderr
 
 
 def test_a_duplicated_bridge_producer_is_refused_by_the_helper(tmp_path: Path):
@@ -733,9 +794,6 @@ def test_an_unexpected_extra_bridge_asset_fails_the_closed_inventory(tmp_path: P
     # It matches the acquisition pattern, so the filter alone does not stop it;
     # the closed inventory is what does.
     assert fnmatch.fnmatch("silentsuite-bridge-freebsd-x86_64", BRIDGE_PATTERN)
-    assert run_staging(source, staging).returncode == 0
-    staged = sorted(entry.name for entry in staging.iterdir())
-    assert set(staged) - set(workflow_expected_inventory()) == {
-        "silentsuite-bridge-freebsd-x86_64",
-        "silentsuite-bridge-freebsd-x86_64.sha256",
-    }
+    result = run_staging(source, staging)
+    assert result.returncode != 0
+    assert "inventory mismatch" in result.stderr


### PR DESCRIPTION
## Root cause

A clean controller run completed every build/sign/attachment lane and produced the exact 20-asset draft. Readiness then rejected the Windows Bridge checksum sidecar because the Windows producer emitted valid GNU binary-marker syntax:

```text
<hash> *silentsuite-bridge-windows-x86_64.exe
```

The release contract requires one canonical cross-platform form:

```text
<hash>  silentsuite-bridge-windows-x86_64.exe
```

The trusted staging helper previously concatenated producer sidecars without validating their filename or digest.

## Fix

- requires exactly five Bridge payload/sidecar pairs
- accepts one exact GNU text or binary-marker checksum record
- validates safe filename and exact sidecar/payload name binding
- rejects symlinks, non-regular/empty files, malformed/extra records, traversal and digest mismatch
- recomputes every payload SHA-256
- atomically rewrites lowercase canonical `<hash>  <name>\n` sidecars
- builds deterministic `SHA256SUMS.txt` covering exactly the five Bridge payloads
- pins the trusted staging helper bytes in the release boundary checker

## Verification

- 1,013 repository tests passed, plus 26 subtests
- Windows `*` marker normalization and all platform pairs covered
- malformed, wrong-name/hash, non-LF, extra/missing/orphan, duplicate, traversal, NUL, symlink and empty cases rejected
- release control-plane/signing-boundary checker passed
- workflow YAML/action pins and shell syntax passed
- readiness, attachment, workflows, tags, registry, stores and production boundaries unchanged

## Runtime evidence

Run `33319370013` completed all component and attachment jobs. Readiness found the sole draft and exact 20 assets, then failed only on the noncanonical Windows sidecar record.
