### PR TITLE
fix: make self-host backups fail closed

### DIFF
--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -26,6 +26,7 @@ on:
       - 'scripts/lock-server-requirements.py'
       - 'scripts/stage-bridge-release-assets.sh'
       - 'tests/test_self_host_*.py'
+      - 'tests/fixtures/self-host-backup/**'
       - 'tests/test_umbrella_release_*.py'
       - 'tests/test_server_image_verifier.py'
       - 'tests/test_reusable_workflow_caller_permissions.py'
@@ -60,6 +61,7 @@ on:
       - 'scripts/lock-server-requirements.py'
       - 'scripts/stage-bridge-release-assets.sh'
       - 'tests/test_self_host_*.py'
+      - 'tests/fixtures/self-host-backup/**'
       - 'tests/test_umbrella_release_*.py'
       - 'tests/test_server_image_verifier.py'
       - 'tests/test_reusable_workflow_caller_permissions.py'
@@ -196,6 +198,8 @@ jobs:
             self-host/install.sh \
             self-host/update.sh \
             self-host/verify.sh \
+            self-host/backup.sh \
+            tests/fixtures/self-host-backup/harness.sh \
             self-host/close-signups.sh \
             scripts/self-host-image-smoke.sh \
             scripts/self-host-compose-effective-check.sh \
@@ -226,6 +230,33 @@ jobs:
         env:
           SILENTSUITE_REQUIRE_REGISTRY_CONTRACT: '1'
         run: python -m pytest tests/test_self_host_server_image_materials.py -q
+
+  self-host-backup-behaviour:
+    name: Self-Host Backup Behaviour (amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Read-only, credential-free, GitHub-hosted. The fixture starts throwaway
+    # Compose stacks from the PostgreSQL digest this repository already pins,
+    # and removes every container and volume it created. Nothing is pushed,
+    # published or deployed.
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Proves the properties a static test cannot: the physical volume is
+      # resolved from the live container under a default and a custom Compose
+      # project name, the backup is exact and checksummed over real sentinel
+      # data, the old guessed-name volumes are untouched, unchanged-manifest
+      # corruption and concurrent drift are detected, the unauthenticated
+      # manifest boundary is explicit, and invalid identities are refused before
+      # any backup directory exists.
+      - name: Run the self-host backup behaviour fixture
+        run: tests/fixtures/self-host-backup/harness.sh
 
   self-host-image:
     name: Self-Host Image (${{ matrix.platform }})

--- a/apps/docs/self-hosting/backup-and-restore.md
+++ b/apps/docs/self-hosting/backup-and-restore.md
@@ -1,44 +1,100 @@
-# Backup & Restore
+# Backup & Recovery
 
-Protect your self-hosted SilentSuite data with regular backups.
+Protect your self-hosted SilentSuite data with regular, verified backups.
 
-## What to Back Up
+## What Gets Backed Up
 
 | Item | Why |
 |---|---|
 | **PostgreSQL database** | All encrypted sync data and user accounts |
-| **Server data volume** | Server secret key and media files. **If you lose the secret key, existing encrypted data becomes unrecoverable.** |
-| **`.env` file** | Contains all passwords and configuration |
+| **Server data volume** | Media files and, when `secret_file` is under `/data` (the default), the server secret key. **If you lose the secret key, existing encrypted data becomes unrecoverable.** |
+| **`.env` and `etebase-server.ini`** | Every password and configuration value the stack runs with |
+| **`docker-compose.yml`** (and your override, if you have one) | The stack definition your data was produced by |
 
 ---
 
-## Back Up the Database
+## Never Type a Volume Name from Documentation
+
+Docker creates a named volume silently when it does not exist. A command like
+`docker run -v some_name:/data ... tar czf ...` therefore *succeeds* against a
+brand-new empty volume if `some_name` is not the volume your server is really
+using — and hands you an empty archive that looks like a backup.
+
+Compose derives the physical volume name from the project name, which depends on
+your directory name, `COMPOSE_PROJECT_NAME`, or a `name:` key. No document can
+know it. Use the bundled helper, which reads the volume out of the live
+container that is actually mounting it.
+
+## Inspect What This Install Is Really Using
 
 ```bash
-docker exec silentsuite-postgres pg_dump -U silentsuite silentsuite > backup-$(date +%Y%m%d-%H%M%S).sql
+cd silentsuite-server
+./backup.sh inspect
 ```
 
-## Back Up the Server Data Volume
+This is read-only. It prints the Compose project, the two containers, the server
+image ID, and the physical volume mounted at `/data` and at
+`/var/lib/postgresql/data`.
+
+## Take a Verified Backup
 
 ```bash
-mkdir -p backups
-docker run --rm \
-  -v self-host_server_data:/data \
-  -v $(pwd)/backups:/backup \
-  alpine tar czf /backup/server-data-$(date +%Y%m%d-%H%M%S).tar.gz -C /data .
+./backup.sh backup ~/silentsuite-backups/$(date +%Y%m%d-%H%M%S)
 ```
 
-> **Note:** The volume name depends on the directory name where `docker-compose.yml` lives. If you cloned to the default location, it will be `self-host_server_data`. Check with `docker volume ls | grep server_data`.
+The destination must not already exist. The helper writes into a private
+`.partial` sibling directory and renames it into place only after every check
+passes; on any failure it removes the partial directory, so a failed run never
+leaves something that looks like a backup.
 
-## Back Up the .env File
+Before it writes anything it proves the identity of the stack: exactly one
+`server` and one `postgres` container, exactly one mount at each expected path,
+two distinct named volumes carrying this project's Compose labels, the default
+`local` driver with local scope and no driver options. Bind mounts, anonymous
+volumes, shared or redirected volumes, custom drivers and ambiguous or missing
+identities are all refused.
+
+It then:
+
+- runs a real `pg_dump` inside the admitted database container, using that
+  container's own configured credentials (they are never printed);
+- proves `django_migrations` actually contains rows, so an empty database cannot
+  pass as a successful backup;
+- archives the admitted server-data volume **read-only** using the exact image ID
+  the server container is already running — nothing is pulled, and no mutable
+  helper tag is involved;
+- proves the archive contains at least one real file, and that the `secret_file`
+  configured in `etebase-server.ini` is inside it when that path lives under
+  `/data`;
+- copies `.env`, `etebase-server.ini`, `docker-compose.yml` (and
+  `docker-compose.override.yml` / `server-image.json` when present) with private
+  permissions;
+- writes `backup-metadata.txt` and a `SHA256SUMS` manifest covering every other
+  file in the backup;
+- re-checks the container, volume and image identity after collecting everything,
+  and only then renames the directory into place.
+
+The backup directory always contains your `.env`; it contains the server secret
+key when `secret_file` is under `/data`. Keep it private and encrypted at rest.
+
+If `secret_file` points somewhere outside `/data`, that file is operator-managed:
+the helper does not read host paths, and you must back it up yourself.
+
+## Re-check a Backup Later
 
 ```bash
-cp .env backups/.env.backup
+./backup.sh verify ~/silentsuite-backups/20260101-020000
 ```
+
+This enforces the manifest grammar and exact file inventory, validates the
+backup's metadata and secret scope, and checks that every file still matches
+`SHA256SUMS`. It catches corruption or edits while the manifest is unchanged,
+plus changes made during one verification run. Because `SHA256SUMS` is stored
+beside the backup and is not independently authenticated, verification does not
+prove who created the backup and cannot detect a deliberate edit accompanied by
+a correctly recomputed manifest.
 
 ## Automated Backups
-
-Set up a daily cron job:
 
 ```bash
 crontab -e
@@ -47,53 +103,44 @@ crontab -e
 Add:
 
 ```
-# SilentSuite daily backup at 2:00 AM
-0 2 * * * cd /path/to/silentsuite/self-host && docker exec silentsuite-postgres pg_dump -U silentsuite silentsuite > /path/to/backups/silentsuite-$(date +\%Y\%m\%d).sql
+# SilentSuite verified backup daily at 2:00 AM
+0 2 * * * cd /path/to/silentsuite-server && ./backup.sh backup /path/to/backups/$(date +\%Y\%m\%d-\%H\%M\%S) >> /path/to/backups/backup.log 2>&1
 ```
 
-For off-site backups, use `rsync`, `rclone`, or your preferred tool to copy the backup directory to another server.
+Copy the backup directories off-site with `rsync`, `rclone`, or your preferred
+tool. Backups you have never verified are not backups — run `./backup.sh verify`
+against a copy periodically.
 
 ---
 
-## Restore the Database
+## Recovery
 
-```bash
-# Stop all services
-docker compose down
+**Automated restore is not supported yet.** This release ships a verified,
+non-destructive backup path only. There is no `restore` command, no automated
+volume deletion, and no automated reset — a wrong restore destroys the data it
+was meant to save, and the safe procedure depends on your specific install.
 
-# Remove the existing database volume
-docker volume rm self-host_pgdata
+If you need to recover:
 
-# Start only PostgreSQL
-docker compose up -d postgres
+1. **Stop making it worse.** Take and preserve a fresh copy of whatever data
+   still exists before touching anything. Keep every existing backup.
+2. **Verify your backups** with `./backup.sh verify` before relying on one.
+3. **Use PostgreSQL- and storage-specific recovery procedures**, with
+   expert assistance, against the dump and archive in the backup directory.
+   Treat the restore target as an install whose data you are willing to lose.
 
-# Wait for it to be ready
-sleep 10
-docker compose exec postgres pg_isready -U silentsuite
-
-# Restore the backup
-docker exec -i silentsuite-postgres psql -U silentsuite silentsuite < backup-20260101-020000.sql
-
-# Start the server
-docker compose up -d
-```
-
-## Restore the Server Data Volume
+To stop the stack without deleting any data:
 
 ```bash
 docker compose down
-
-docker volume rm self-host_server_data
-docker volume create self-host_server_data
-
-docker run --rm \
-  -v self-host_server_data:/data \
-  -v $(pwd)/backups:/backup \
-  alpine tar xzf /backup/server-data-20260101-020000.tar.gz -C /data
-
-docker compose up -d
 ```
 
-## Test Your Backups
+That preserves both volumes; `docker compose up -d` resumes where you left off.
 
-Backups you've never restored from are not backups. Periodically verify by restoring to a test instance.
+## Rolling Back an Image
+
+Starting an older server image does **not** reverse Django migrations that have
+already been applied to your database. A schema migrated forward is not made
+backward-compatible by changing the image back. A full rollback generally
+requires a logical database dump taken *before* the migration ran — that is what
+`./backup.sh backup` produces, so take one before any version move.

--- a/apps/docs/self-hosting/quick-start.md
+++ b/apps/docs/self-hosting/quick-start.md
@@ -98,9 +98,13 @@ cloudflared tunnel --url http://localhost:3735
 
 **Nginx Proxy Manager** or other Docker-based proxies:
 
-If your reverse proxy runs in Docker, connect it to the SilentSuite network:
+If your reverse proxy runs in Docker, connect it to the SilentSuite network. The
+network's physical name depends on your Compose project, so read it off the
+running server container rather than typing one from documentation:
 ```bash
-docker network connect silentsuite-server_silentsuite <proxy_container>
+docker inspect --format '{{range $net, $_ := .NetworkSettings.Networks}}{{$net}}{{"\n"}}{{end}}' silentsuite-server
+# Replace these two placeholders with an exact name printed above and your proxy container.
+docker network connect NETWORK_NAME PROXY_CONTAINER_NAME
 ```
 Then use `silentsuite-server:3735` as the upstream instead of `localhost:3735`.
 Set `TRUSTED_PROXY_IPS` in `.env` to the proxy container's exact IP so the server

--- a/apps/docs/self-hosting/troubleshooting.md
+++ b/apps/docs/self-hosting/troubleshooting.md
@@ -83,7 +83,7 @@ docker compose up -d --force-recreate server
 **Fixes:**
 
 - Confirm PostgreSQL is healthy: `docker compose ps postgres`
-- Confirm `DATABASE_PASSWORD` in `.env` matches what was used when the database was first initialized. If the database volume already exists, changing the password in `.env` alone won't update the database. You must either recreate the volume (`docker compose down -v` -- **this deletes all data**) or alter the password inside PostgreSQL.
+- Confirm `DATABASE_PASSWORD` in `.env` matches what was used when the database was first initialized. If the database volume already exists, changing the password in `.env` alone won't update the database. Change the password inside PostgreSQL instead; recreating the database volume would destroy every account and sync row, and this release does not automate that.
 
 ### Server Takes a Long Time to Start
 
@@ -103,7 +103,7 @@ If it's still not healthy after 2 minutes, check the logs for errors.
 
 **Fixes:**
 
-- Recreating volumes usually resolves this: `docker compose down -v && docker compose up -d` (**deletes all data**).
+- Check ownership inside the volume rather than recreating it: recreating a data volume deletes every account and sync row, and this release does not automate that.
 - On SELinux-enabled systems, add the `:z` flag to volume mounts in `docker-compose.yml`.
 
 ### Cannot Connect from the Web App
@@ -129,10 +129,15 @@ docker compose restart server
 docker compose up -d --force-recreate server
 ```
 
-## Reset Everything
+## Stop the Stack
 
 ```bash
-# WARNING: This deletes ALL data (users, encrypted sync data, everything)
-docker compose down -v
-./install.sh
+docker compose down
 ```
+
+This stops and removes the containers and leaves both data volumes intact;
+`docker compose up -d` resumes where you left off. There is no supported reset
+command: automated volume deletion is not supported, and re-running `install.sh`
+is not an upgrade or reset path — it refuses to touch an existing installation.
+If you are recovering from data loss, take and verify a backup first
+([Backup & Recovery](./backup-and-restore.md)).

--- a/apps/docs/self-hosting/uninstalling.md
+++ b/apps/docs/self-hosting/uninstalling.md
@@ -4,31 +4,51 @@ How to remove SilentSuite from your server.
 
 ## Stop Without Deleting Data
 
-If you only want to stop the services but keep your data for later:
+If you only want to stop the services but preserve your data for later:
 
 ```bash
+cd silentsuite-server
 docker compose down
 ```
 
-The data volumes will persist. Run `docker compose up -d` to start again.
+The data volumes will persist and the stack will resume where it left off when
+you run `docker compose up -d` again. This is the supported stop path.
 
 ## Complete Removal
 
-To completely remove SilentSuite and all its data:
+Automated deletion of your data volumes is **not** supported by this release, and
+no command here removes them. Docker volume names are project-dependent, and a
+guessed name deletes the wrong thing as easily as the right one.
+
+Start in the installation directory. Record its exact canonical path, inspect
+the volume names, and take and preserve a verified backup:
 
 ```bash
-# Stop and remove all containers and volumes
-docker compose down -v
-
-# Remove the Docker images. Both are pinned by digest, and `latest` is never
-# published for the server image, so remove them by the references you actually
-# pulled — list them with `docker image ls`.
-docker image rm postgres@sha256:7c688148e5e156d0e86df7ba8ae5a05a2386aaec1e2ad8e6d11bdf10504b1fb7
-docker image ls --filter 'reference=ghcr.io/silent-suite/silentsuite-server' --format '{{.ID}}' | xargs -r docker image rm
-
-# Remove the cloned repository
-cd ..
-rm -rf silentsuite
+pwd -P  # write down and inspect this exact path before continuing
+./backup.sh backup ~/silentsuite-final-backup
+./backup.sh verify ~/silentsuite-final-backup
+./backup.sh inspect  # record the two exact volume names before removing this directory
 ```
 
-> **Warning:** `docker compose down -v` deletes all data volumes. This is irreversible. [Back up](./backup-and-restore.md) first if you want to keep your data.
+Then stop the stack and remove the parts that are safe to remove automatically:
+
+```bash
+# Stop and remove the containers (volumes are left alone)
+docker compose down
+
+# Remove the Docker images (the silentsuite-server tag/digest may differ — list yours with `docker image ls`)
+docker image rm postgres@sha256:7c688148e5e156d0e86df7ba8ae5a05a2386aaec1e2ad8e6d11bdf10504b1fb7
+docker image ls --filter 'reference=ghcr.io/silent-suite/silentsuite-server' --format '{{.ID}}' | xargs -r docker image rm
+```
+
+The installation directory and two data volumes still exist at this point.
+Leave the directory, inspect the canonical installation path you recorded, and
+deliberately remove that exact path yourself. Do not guess its name. The
+inspection output recorded before removing it identifies the volumes. Deleting
+the directory or volumes is an irreversible manual step you take yourself,
+against those exact identities, once you are certain the backup you kept is one
+you can live with.
+
+If you set up a reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel)
+yourself, that's outside the SilentSuite stack — remove its config and any
+certificates it provisioned separately.

--- a/docs/self-hosting/backup-and-restore.md
+++ b/docs/self-hosting/backup-and-restore.md
@@ -1,90 +1,146 @@
-# Backup & Restore
+# Backup & Recovery
 
-Protect your self-hosted SilentSuite data with regular backups.
+Protect your self-hosted SilentSuite data with regular, verified backups.
 
-## What to Back Up
+## What Gets Backed Up
 
-There are three things to back up:
-
-1. **The PostgreSQL database** -- contains all encrypted sync data and user accounts.
-2. **The server data volume** -- stores the server's secret key and media files.
-3. **The `.env` file** -- contains all your secrets and configuration.
+| Item | Why |
+|---|---|
+| **PostgreSQL database** | All encrypted sync data and user accounts |
+| **Server data volume** | Media files and, when `secret_file` is under `/data` (the default), the server secret key. **If you lose the secret key, existing encrypted data becomes unrecoverable.** |
+| **`.env` and `etebase-server.ini`** | Every password and configuration value the stack runs with |
+| **`docker-compose.yml`** (and your override, if you have one) | The stack definition your data was produced by |
 
 ---
 
-## Back Up the Database
+## Never Type a Volume Name from Documentation
 
-Create a full PostgreSQL dump:
+Docker creates a named volume silently when it does not exist. A command like
+`docker run -v some_name:/data ... tar czf ...` therefore *succeeds* against a
+brand-new empty volume if `some_name` is not the volume your server is really
+using — and hands you an empty archive that looks like a backup.
 
-```bash
-docker exec silentsuite-postgres pg_dump -U silentsuite silentsuite > backup-$(date +%Y%m%d-%H%M%S).sql
-```
+Compose derives the physical volume name from the project name, which depends on
+your directory name, `COMPOSE_PROJECT_NAME`, or a `name:` key. No document can
+know it. Use the bundled helper, which reads the volume out of the live
+container that is actually mounting it.
 
-## Back Up the Server Data Volume
-
-```bash
-docker run --rm \
-  -v self-host_server_data:/data \
-  -v $(pwd)/backups:/backup \
-  alpine tar czf /backup/server-data-$(date +%Y%m%d-%H%M%S).tar.gz -C /data .
-```
-
-## Back Up the .env File
-
-Your `.env` file contains all secrets. Keep a secure, encrypted copy:
+## Inspect What This Install Is Really Using
 
 ```bash
-cp .env backups/.env.backup
+cd silentsuite-server
+./backup.sh inspect
 ```
+
+This is read-only. It prints the Compose project, the two containers, the server
+image ID, and the physical volume mounted at `/data` and at
+`/var/lib/postgresql/data`.
+
+## Take a Verified Backup
+
+```bash
+./backup.sh backup ~/silentsuite-backups/$(date +%Y%m%d-%H%M%S)
+```
+
+The destination must not already exist. The helper writes into a private
+`.partial` sibling directory and renames it into place only after every check
+passes; on any failure it removes the partial directory, so a failed run never
+leaves something that looks like a backup.
+
+Before it writes anything it proves the identity of the stack: exactly one
+`server` and one `postgres` container, exactly one mount at each expected path,
+two distinct named volumes carrying this project's Compose labels, the default
+`local` driver with local scope and no driver options. Bind mounts, anonymous
+volumes, shared or redirected volumes, custom drivers and ambiguous or missing
+identities are all refused.
+
+It then:
+
+- runs a real `pg_dump` inside the admitted database container, using that
+  container's own configured credentials (they are never printed);
+- proves `django_migrations` actually contains rows, so an empty database cannot
+  pass as a successful backup;
+- archives the admitted server-data volume **read-only** using the exact image ID
+  the server container is already running — nothing is pulled, and no mutable
+  helper tag is involved;
+- proves the archive contains at least one real file, and that the `secret_file`
+  configured in `etebase-server.ini` is inside it when that path lives under
+  `/data`;
+- copies `.env`, `etebase-server.ini`, `docker-compose.yml` (and
+  `docker-compose.override.yml` / `server-image.json` when present) with private
+  permissions;
+- writes `backup-metadata.txt` and a `SHA256SUMS` manifest covering every other
+  file in the backup;
+- re-checks the container, volume and image identity after collecting everything,
+  and only then renames the directory into place.
+
+The backup directory always contains your `.env`; it contains the server secret
+key when `secret_file` is under `/data`. Keep it private and encrypted at rest.
+
+If `secret_file` points somewhere outside `/data`, that file is operator-managed:
+the helper does not read host paths, and you must back it up yourself.
+
+## Re-check a Backup Later
+
+```bash
+./backup.sh verify ~/silentsuite-backups/20260101-020000
+```
+
+This enforces the manifest grammar and exact file inventory, validates the
+backup's metadata and secret scope, and checks that every file still matches
+`SHA256SUMS`. It catches corruption or edits while the manifest is unchanged,
+plus changes made during one verification run. Because `SHA256SUMS` is stored
+beside the backup and is not independently authenticated, verification does not
+prove who created the backup and cannot detect a deliberate edit accompanied by
+a correctly recomputed manifest.
 
 ## Automated Backups
 
-For production deployments, set up a cron job:
-
 ```bash
-# Run a full backup daily at 2:00 AM
-0 2 * * * cd /path/to/silentsuite/self-host && docker exec silentsuite-postgres pg_dump -U silentsuite silentsuite > /path/to/backups/silentsuite-$(date +\%Y\%m\%d).sql
+crontab -e
 ```
+
+Add:
+
+```
+# SilentSuite verified backup daily at 2:00 AM
+0 2 * * * cd /path/to/silentsuite-server && ./backup.sh backup /path/to/backups/$(date +\%Y\%m\%d-\%H\%M\%S) >> /path/to/backups/backup.log 2>&1
+```
+
+Copy the backup directories off-site with `rsync`, `rclone`, or your preferred
+tool. Backups you have never verified are not backups — run `./backup.sh verify`
+against a copy periodically.
 
 ---
 
-## Restore the Database
+## Recovery
 
-To restore from a backup, stop the stack, replace the database, and restart:
+**Automated restore is not supported yet.** This release ships a verified,
+non-destructive backup path only. There is no `restore` command, no automated
+volume deletion, and no automated reset — a wrong restore destroys the data it
+was meant to save, and the safe procedure depends on your specific install.
 
-```bash
-# Stop all services
-docker compose down
+If you need to recover:
 
-# Remove the existing database volume
-docker volume rm self-host_pgdata
+1. **Stop making it worse.** Take and preserve a fresh copy of whatever data
+   still exists before touching anything. Keep every existing backup.
+2. **Verify your backups** with `./backup.sh verify` before relying on one.
+3. **Use PostgreSQL- and storage-specific recovery procedures**, with
+   expert assistance, against the dump and archive in the backup directory.
+   Treat the restore target as an install whose data you are willing to lose.
 
-# Start only PostgreSQL
-docker compose up -d postgres
-
-# Wait for it to be healthy
-sleep 10
-docker compose exec postgres pg_isready -U silentsuite
-
-# Restore the backup
-docker exec -i silentsuite-postgres psql -U silentsuite silentsuite < backup-20260101-020000.sql
-
-# Start the rest of the stack
-docker compose up -d
-```
-
-## Restore the Server Data Volume
+To stop the stack without deleting any data:
 
 ```bash
 docker compose down
-
-docker volume rm self-host_server_data
-docker volume create self-host_server_data
-
-docker run --rm \
-  -v self-host_server_data:/data \
-  -v $(pwd)/backups:/backup \
-  alpine tar xzf /backup/server-data-20260101-020000.tar.gz -C /data
-
-docker compose up -d
 ```
+
+That preserves both volumes; `docker compose up -d` resumes where you left off.
+
+## Rolling Back an Image
+
+Starting an older server image does **not** reverse Django migrations that have
+already been applied to your database. A schema migrated forward is not made
+backward-compatible by changing the image back. A full rollback generally
+requires a logical database dump taken *before* the migration ran — that is what
+`./backup.sh backup` produces, so take one before any version move.

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -65,7 +65,7 @@ TLS is your reverse proxy's responsibility — these are not SilentSuite-server 
 **Fixes:**
 
 - Confirm PostgreSQL is healthy: `docker compose ps postgres`
-- Confirm the `DATABASE_PASSWORD` in `.env` matches what was used when the database was first initialized. If the database volume already exists, changing the password in `.env` will not update the database. You must either recreate the volume or alter the password inside PostgreSQL.
+- Confirm the `DATABASE_PASSWORD` in `.env` matches what was used when the database was first initialized. If the database volume already exists, changing the password in `.env` will not update the database. Change the password inside PostgreSQL instead; recreating the database volume would destroy every account and sync row, and this release does not automate that.
 
 ### "Permission Denied" Errors
 
@@ -73,7 +73,7 @@ TLS is your reverse proxy's responsibility — these are not SilentSuite-server 
 
 **Fixes:**
 
-- Ensure the data volumes are owned by the correct users. Recreating volumes usually fixes this.
+- Check ownership inside the volume rather than recreating it: recreating a data volume deletes every account and sync row, and this release does not automate that.
 - On SELinux-enabled systems, you may need to add the `:z` flag to volume mounts.
 
 ### Server Not Accepting Connections
@@ -97,3 +97,16 @@ docker compose restart server
 # Recreate a service (picks up .env changes)
 docker compose up -d --force-recreate server
 ```
+
+## Stop the Stack
+
+```bash
+docker compose down
+```
+
+This stops and removes the containers and leaves both data volumes intact;
+`docker compose up -d` resumes where you left off. There is no supported reset
+command: automated volume deletion is not supported, and re-running `install.sh`
+is not an upgrade or reset path — it refuses to touch an existing installation.
+If you are recovering from data loss, take and verify a backup first
+([Backup & Recovery](./backup-and-restore.md)).

--- a/docs/self-hosting/uninstalling.md
+++ b/docs/self-hosting/uninstalling.md
@@ -2,35 +2,53 @@
 
 How to remove SilentSuite from your server.
 
-## Complete Removal
-
-To completely remove SilentSuite and all its data:
-
-```bash
-# Stop and remove the containers
-cd silentsuite-server
-docker compose down
-
-# Remove all data volumes (THIS DELETES ALL DATA)
-docker volume rm self-host_pgdata self-host_server_data
-
-# Remove the Docker images (the silentsuite-server tag/digest may differ — list yours with `docker image ls`)
-docker image rm postgres@sha256:7c688148e5e156d0e86df7ba8ae5a05a2386aaec1e2ad8e6d11bdf10504b1fb7
-docker image ls --filter 'reference=ghcr.io/silent-suite/silentsuite-server' --format '{{.ID}}' | xargs -r docker image rm
-
-# Remove the install directory
-cd ..
-rm -rf silentsuite-server
-```
-
-If you set up a reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel) yourself, that's outside the SilentSuite stack — remove its config and any certificates it provisioned separately.
-
 ## Stop Without Deleting Data
 
 If you only want to stop the services but preserve your data for later:
 
 ```bash
+cd silentsuite-server
 docker compose down
 ```
 
-The data volumes will persist and the stack will resume where it left off when you run `docker compose up -d` again.
+The data volumes will persist and the stack will resume where it left off when
+you run `docker compose up -d` again. This is the supported stop path.
+
+## Complete Removal
+
+Automated deletion of your data volumes is **not** supported by this release, and
+no command here removes them. Docker volume names are project-dependent, and a
+guessed name deletes the wrong thing as easily as the right one.
+
+Start in the installation directory. Record its exact canonical path, inspect
+the volume names, and take and preserve a verified backup:
+
+```bash
+pwd -P  # write down and inspect this exact path before continuing
+./backup.sh backup ~/silentsuite-final-backup
+./backup.sh verify ~/silentsuite-final-backup
+./backup.sh inspect  # record the two exact volume names before removing this directory
+```
+
+Then stop the stack and remove the parts that are safe to remove automatically:
+
+```bash
+# Stop and remove the containers (volumes are left alone)
+docker compose down
+
+# Remove the Docker images (the silentsuite-server tag/digest may differ — list yours with `docker image ls`)
+docker image rm postgres@sha256:7c688148e5e156d0e86df7ba8ae5a05a2386aaec1e2ad8e6d11bdf10504b1fb7
+docker image ls --filter 'reference=ghcr.io/silent-suite/silentsuite-server' --format '{{.ID}}' | xargs -r docker image rm
+```
+
+The installation directory and two data volumes still exist at this point.
+Leave the directory, inspect the canonical installation path you recorded, and
+deliberately remove that exact path yourself. Do not guess its name. The
+inspection output recorded before removing it identifies the volumes. Deleting
+the directory or volumes is an irreversible manual step you take yourself,
+against those exact identities, once you are certain the backup you kept is one
+you can live with.
+
+If you set up a reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel)
+yourself, that's outside the SilentSuite stack — remove its config and any
+certificates it provisioned separately.

--- a/scripts/selfhost_release_contract.py
+++ b/scripts/selfhost_release_contract.py
@@ -30,6 +30,7 @@ SUPPORTED_PLATFORMS = ("linux/amd64", "linux/arm64")
 BUNDLE_SOURCE_FILES = (
     ".env.example",
     "SELF-HOSTING.md",
+    "backup.sh",
     "close-signups.sh",
     "docker-compose.yml",
     "install.sh",

--- a/self-host/SELF-HOSTING.md
+++ b/self-host/SELF-HOSTING.md
@@ -446,45 +446,90 @@ before you ran it.
 
 The advanced Django admin panel is disabled by default in self-host installs (`ETEBASE_DISABLE_DJANGO_ADMIN=true`) because normal operators do not need it exposed on the public sync domain. If you need it for recovery or advanced maintenance, set `ETEBASE_DISABLE_DJANGO_ADMIN=false` in `.env`, recreate the server container, and protect `/admin/` with your reverse proxy or Cloudflare Access before exposing it.
 
-## Backup and Restore
+## Backup and Recovery
 
-### Backup
+### Never type a volume name from documentation
 
-```bash
-# Database
-docker exec silentsuite-postgres pg_dump -U silentsuite silentsuite > backup.sql
+Docker creates a named volume silently when it does not exist, so
+`docker run -v some_name:/data ... tar czf ...` succeeds against a brand-new
+empty volume whenever `some_name` is not the one your server is really using —
+and produces an empty archive that looks like a backup. Compose derives the
+physical volume name from the project name, which depends on your directory,
+`COMPOSE_PROJECT_NAME`, or a `name:` key, so no document can know it.
 
-# Server data (secret key, media)
-docker run --rm \
-  -v self-host_server_data:/data \
-  -v $(pwd)/backups:/backup \
-  alpine tar czf /backup/server-data.tar.gz -C /data .
+`./backup.sh` reads the volume out of the live container that is mounting it.
 
-# Environment file
-cp .env backups/.env.backup
-```
-
-### Restore
+### Inspect
 
 ```bash
-# Database
-docker compose down
-docker volume rm self-host_pgdata
-docker compose up -d postgres
-sleep 10
-docker exec -i silentsuite-postgres psql -U silentsuite silentsuite < backup.sql
-docker compose up -d
-
-# Server data
-docker compose down
-docker volume rm self-host_server_data
-docker volume create self-host_server_data
-docker run --rm \
-  -v self-host_server_data:/data \
-  -v $(pwd)/backups:/backup \
-  alpine tar xzf /backup/server-data.tar.gz -C /data
-docker compose up -d
+./backup.sh inspect
 ```
+
+Read-only. Prints the Compose project, both containers, the server image ID, and
+the physical volume mounted at `/data` and `/var/lib/postgresql/data`.
+
+### Back up
+
+```bash
+./backup.sh backup ~/silentsuite-backups/$(date +%Y%m%d-%H%M%S)
+```
+
+The destination must not exist. Work happens in a private `.partial` sibling
+that is removed on any failure and renamed into place only after every check
+passes, so a failed run never leaves something that looks like a backup.
+
+Admission requires exactly one `server` and one `postgres` container, exactly one
+mount at each expected target, two distinct named volumes carrying this
+project's Compose labels, the default `local` driver with local scope and no
+driver options. Bind mounts, anonymous, shared or redirected volumes, custom
+drivers and ambiguous identities are refused. The run then takes a real
+`pg_dump` using the database container's own credentials (never printed), proves
+`django_migrations` has rows, archives the server-data volume read-only using the
+exact image ID the server container is already running, proves the archive holds
+a real file and contains the configured `secret_file` when that path is under
+`/data`, copies `.env`, `etebase-server.ini`, `docker-compose.yml` (plus
+`docker-compose.override.yml` and `server-image.json` when present) with private
+permissions, and writes `backup-metadata.txt` and a `SHA256SUMS` manifest. The
+container, volume and image identities are re-checked after collection.
+
+A `secret_file` outside `/data` is operator-managed; the helper does not read
+host paths and you must back it up yourself.
+
+The backup directory always contains your `.env`; it contains the server secret
+key when `secret_file` is under `/data`. Keep it private and encrypted at rest.
+
+```bash
+./backup.sh verify ~/silentsuite-backups/20260101-020000
+```
+
+This enforces the manifest grammar and exact file inventory, validates the
+backup's metadata and secret scope, and checks that every file still matches
+`SHA256SUMS`. It catches corruption or edits while the manifest is unchanged,
+plus changes made during one verification run. Because `SHA256SUMS` is stored
+beside the backup and is not independently authenticated, verification does not
+prove who created the backup and cannot detect a deliberate edit accompanied by
+a correctly recomputed manifest.
+
+### Recovery
+
+**Automated restore is not supported yet.** There is no restore command, no
+automated volume deletion, and no automated reset. If you need to recover:
+preserve whatever data still exists and every backup you hold, verify a backup
+with `./backup.sh verify`, and use PostgreSQL- and storage-specific recovery
+procedures with expert assistance against the dump and archive inside it.
+
+To stop the stack without deleting data:
+
+```bash
+docker compose down
+```
+
+Both volumes persist; `docker compose up -d` resumes where you left off.
+
+Starting an older server image does **not** reverse Django migrations already
+applied to your database. A full rollback generally requires a logical dump
+taken *before* the migration ran — take one with `./backup.sh backup` before any
+version move.
 
 ## Troubleshooting
 
@@ -502,7 +547,7 @@ docker compose up -d --force-recreate server
 
 ### Database connection errors
 - Verify PostgreSQL is healthy: `docker compose ps`
-- Check that `DATABASE_PASSWORD` in `.env` matches the original value (changing it after first run requires a volume reset or manual password change in PostgreSQL)
+- Check that `DATABASE_PASSWORD` in `.env` matches the original value (after first run, change the password inside PostgreSQL; recreating the database volume would destroy every account and sync row)
 
 ### Server won't start: SILENTSUITE_SERVER_IMAGE is not set
 Compose refuses to start without a verified image digest. Copy `indexDigest`
@@ -510,15 +555,15 @@ from `server-image.json` in your install directory into `.env` as
 `SILENTSUITE_SERVER_IMAGE=ghcr.io/silent-suite/silentsuite-server@sha256:...`,
 or re-install into a fresh directory from a published release.
 
-### Reset everything
+### Stopping the stack
 ```bash
-docker compose down -v   # WARNING: Deletes all data!
-rm -rf silentsuite-server
-curl -fsSL https://raw.githubusercontent.com/silent-suite/silentsuite/main/self-host/install.sh | bash
+docker compose down
 ```
-The installer refuses to use a path that already exists — even an empty
-directory — so the old one must be removed first. Everything in it, including
-your credentials, is gone at that point.
+This removes the containers and leaves both data volumes intact. There is no
+supported reset command: automated volume deletion is not supported, and
+re-running `install.sh` is not an upgrade or reset path — it refuses to touch an
+existing installation. Take and verify a backup before any maintenance you are
+unsure about.
 
 ## Security Notes
 

--- a/self-host/backup.sh
+++ b/self-host/backup.sh
@@ -1,0 +1,925 @@
+#!/usr/bin/env bash
+# SilentSuite self-host backup helper.
+#
+# Three non-destructive commands only:
+#
+#   ./backup.sh inspect            read-only identity report for this install
+#   ./backup.sh backup DEST        verified backup into a new directory DEST
+#   ./backup.sh verify DEST        re-check an existing backup's checksums
+#
+# There is deliberately no restore, reset, prune or delete command. Restoring a
+# PostgreSQL database and a server-data volume is an irreversible, install-
+# specific operation; see SELF-HOSTING.md for what is and is not supported.
+#
+# The whole point of this script is that it never guesses a Docker volume name.
+# `docker run -v NAME:/data ...` creates NAME when it does not exist, so a
+# guessed Compose-generated name (the old docs guessed `self-host_server_data`)
+# can archive a brand-new empty volume and report success. Every physical volume
+# used here is read out of the live container that is actually mounting it.
+
+set -euo pipefail
+
+umask 077
+
+readonly SCHEMA_VERSION=1
+readonly SERVER_SERVICE=server
+readonly POSTGRES_SERVICE=postgres
+readonly SERVER_TARGET=/data
+readonly POSTGRES_TARGET=/var/lib/postgresql/data
+readonly SERVER_VOLUME_LABEL=server_data
+readonly POSTGRES_VOLUME_LABEL=pgdata
+
+readonly LABEL_PROJECT=com.docker.compose.project
+readonly LABEL_SERVICE=com.docker.compose.service
+readonly LABEL_VOLUME=com.docker.compose.volume
+
+readonly DUMP_NAME=database.sql
+readonly ARCHIVE_NAME=server-data.tar.gz
+readonly METADATA_NAME=backup-metadata.txt
+readonly CHECKSUM_NAME=SHA256SUMS
+readonly REQUIRED_CONFIG=(.env etebase-server.ini docker-compose.yml)
+readonly OPTIONAL_CONFIG=(docker-compose.override.yml server-image.json)
+
+PARTIAL_DIR=""
+DEST_DIR=""
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+# A partial directory is never left behind, and a run that was interrupted or
+# failed must never exit 0 — a "backup" that reports success without renaming
+# anything into place is exactly the failure mode this script exists to prevent.
+cleanup() {
+  status=$?
+  signal="${1:-}"
+  if [ -n "$PARTIAL_DIR" ] && [ -d "$PARTIAL_DIR" ]; then
+    rm -rf -- "$PARTIAL_DIR"
+  fi
+  # The claimed final name is an empty directory this run created; rmdir gives
+  # it back and refuses if anything unexpectedly ended up inside it.
+  if [ -n "$DEST_DIR" ] && [ -d "$DEST_DIR" ]; then
+    rmdir -- "$DEST_DIR" 2>/dev/null || true
+  fi
+  if [ -n "$signal" ]; then
+    echo "ERROR: interrupted by SIG$signal; nothing was kept" >&2
+    exit 1
+  fi
+  [ "$status" -ne 0 ] || status=1
+  exit "$status"
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  ./backup.sh inspect
+  ./backup.sh backup <destination-directory>
+  ./backup.sh verify <backup-directory>
+
+Run from the SilentSuite install directory (the one holding docker-compose.yml).
+USAGE
+  exit 2
+}
+
+# ── Strict field grammar ──────────────────────────────────────────────
+#
+# Every value below is read from a Docker --format template, so a hostile or
+# merely surprising label must not be able to smuggle a delimiter, a newline or
+# a control character into the metadata file or into a later shell word.
+
+is_safe_token() {
+  case "$1" in
+    "" | *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  return 0
+}
+
+require_token() {
+  is_safe_token "$1" || die "$2 is empty or contains characters outside [A-Za-z0-9._-]"
+}
+
+require_digits() {
+  case "$1" in
+    "" | *[!0-9]*) die "$2 is not a plain decimal number" ;;
+  esac
+}
+
+# Exactly "sha256:" plus 64 lowercase hex. A glob prefix match is not enough:
+# `sha256:deadbeefzz...` would pass one, and the image ID is what pins the only
+# container image this script is allowed to run.
+require_image_id() {
+  case "$1" in
+    sha256:*) ;;
+    *) die "$2 is not a sha256 image ID" ;;
+  esac
+  hex="${1#sha256:}"
+  [ "${#hex}" -eq 64 ] || die "$2 is not a 64-hex sha256 image ID"
+  case "$hex" in
+    *[!0-9a-f]*) die "$2 is not a 64-hex sha256 image ID" ;;
+  esac
+}
+
+compose() {
+  docker compose "$@"
+}
+
+# ── Identity admission ────────────────────────────────────────────────
+#
+# `docker compose` resolves the project the same way the operator's own
+# `docker compose up` does — COMPOSE_PROJECT_NAME, the top-level `name:`, or the
+# directory. Asking it, instead of reconstructing a project prefix lexically, is
+# what keeps custom project names and docker-compose.override.yml working.
+
+# --all deliberately: a stopped duplicate is an ambiguous identity, and listing
+# only running containers would hide it and then happily back up the survivor.
+single_service_container() {
+  service="$1"
+  ids="$(compose ps --all --quiet "$service" 2>/dev/null || true)"
+  [ -n "$ids" ] || die "no container found for the '$service' service (is the stack installed?)"
+  count="$(printf '%s\n' "$ids" | grep -c .)"
+  [ "$count" -eq 1 ] || die "expected exactly one '$service' container, found $count"
+  id="$(printf '%s\n' "$ids" | head -n 1)"
+  require_token "$id" "the '$service' container ID"
+  printf '%s\n' "$id"
+}
+
+# Prints "<project> <volume-name>" for the single named-volume mount the given
+# container has at the given target path.
+container_identity() {
+  cid="$1"
+  service="$2"
+  target="$3"
+
+  state="$(docker inspect --format '{{.State.Running}}' "$cid")"
+  [ "$state" = "true" ] || die "the '$service' container is not running"
+
+  project="$(docker inspect --format "{{index .Config.Labels \"$LABEL_PROJECT\"}}" "$cid")"
+  labelled="$(docker inspect --format "{{index .Config.Labels \"$LABEL_SERVICE\"}}" "$cid")"
+  require_token "$project" "the Compose project label on the '$service' container"
+  [ "$labelled" = "$service" ] ||
+    die "the '$service' container carries Compose service label '$labelled'"
+
+  # One line per mount: type name destination. A bind mount has an empty .Name,
+  # which collapses the line to two fields and is rejected below.
+  mounts="$(docker inspect \
+    --format '{{range .Mounts}}{{.Type}} {{.Name}} {{.Destination}}{{println}}{{end}}' "$cid")"
+
+  found=0
+  volume=""
+  while IFS=' ' read -r mtype mname mdest extra; do
+    [ -n "$mtype" ] || continue
+    [ -z "$extra" ] || die "a mount on the '$service' container has an unparseable descriptor"
+    [ "$mdest" = "$target" ] || continue
+    found=$((found + 1))
+    [ "$mtype" = "volume" ] ||
+      die "'$service' mounts a $mtype at $target; only a named volume can be backed up safely"
+    require_token "$mname" "the volume name mounted at $target"
+    volume="$mname"
+  done <<MOUNTS
+$mounts
+MOUNTS
+
+  [ "$found" -eq 1 ] ||
+    die "expected exactly one mount at $target on '$service', found $found"
+
+  printf '%s %s\n' "$project" "$volume"
+}
+
+# Proves the physical volume is a plain, unshared, option-free local volume that
+# Compose created for this project under the expected logical name.
+assert_volume_admissible() {
+  name="$1"
+  project="$2"
+  logical="$3"
+
+  line="$(docker volume inspect --format \
+    "{{.Driver}} {{.Scope}} {{len .Options}} {{index .Labels \"$LABEL_PROJECT\"}} {{index .Labels \"$LABEL_VOLUME\"}}" \
+    "$name" 2>/dev/null)" || die "volume '$name' could not be inspected"
+
+  # shellcheck disable=SC2086
+  set -- $line
+  [ "$#" -eq 5 ] || die "volume '$name' has an unparseable descriptor"
+  driver="$1"; scope="$2"; options="$3"; vproject="$4"; vlogical="$5"
+
+  [ "$driver" = "local" ] || die "volume '$name' uses the '$driver' driver; only 'local' is supported"
+  [ "$scope" = "local" ] || die "volume '$name' has '$scope' scope; only 'local' is supported"
+  require_digits "$options" "the option count for volume '$name'"
+  [ "$options" -eq 0 ] || die "volume '$name' carries driver options; refusing to guess their meaning"
+  [ "$vproject" = "$project" ] ||
+    die "volume '$name' belongs to Compose project '$vproject', not '$project'"
+  [ "$vlogical" = "$logical" ] ||
+    die "volume '$name' carries logical Compose volume name '$vlogical', expected '$logical'"
+}
+
+# Sets PROJECT, SERVER_CID, POSTGRES_CID, SERVER_VOLUME, POSTGRES_VOLUME, IMAGE_ID.
+resolve_identity() {
+  SERVER_CID="$(single_service_container "$SERVER_SERVICE")"
+  POSTGRES_CID="$(single_service_container "$POSTGRES_SERVICE")"
+
+  # Captured in two steps: a command substitution that dies inside `read` would
+  # not fail the pipeline, and a fail-open identity check is the whole bug class
+  # this script exists to close.
+  server_line="$(container_identity "$SERVER_CID" "$SERVER_SERVICE" "$SERVER_TARGET")"
+  postgres_line="$(container_identity "$POSTGRES_CID" "$POSTGRES_SERVICE" "$POSTGRES_TARGET")"
+  read -r PROJECT SERVER_VOLUME <<< "$server_line"
+  read -r pg_project POSTGRES_VOLUME <<< "$postgres_line"
+  require_token "$PROJECT" "the Compose project name"
+  require_token "$SERVER_VOLUME" "the server data volume name"
+  require_token "$POSTGRES_VOLUME" "the database volume name"
+
+  [ "$PROJECT" = "$pg_project" ] ||
+    die "the server and postgres containers belong to different Compose projects"
+  [ "$SERVER_VOLUME" != "$POSTGRES_VOLUME" ] ||
+    die "the server and database resolve to the same volume '$SERVER_VOLUME'"
+
+  assert_volume_admissible "$SERVER_VOLUME" "$PROJECT" "$SERVER_VOLUME_LABEL"
+  assert_volume_admissible "$POSTGRES_VOLUME" "$PROJECT" "$POSTGRES_VOLUME_LABEL"
+
+  # The archiving container reuses the exact image the admitted server container
+  # is already running, by immutable local ID. Nothing is pulled, and no mutable
+  # helper tag (`alpine`, `alpine:latest`, ...) can be substituted underneath.
+  IMAGE_ID="$(docker inspect --format '{{.Image}}' "$SERVER_CID")"
+  require_image_id "$IMAGE_ID" "the server container's image ID"
+  local_id="$(docker image inspect --format '{{.Id}}' "$IMAGE_ID" 2>/dev/null)" ||
+    die "the server container's image is not present locally"
+  [ "$local_id" = "$IMAGE_ID" ] || die "the server container's image ID is ambiguous locally"
+}
+
+identity_fingerprint() {
+  printf '%s|%s|%s|%s|%s|%s\n' \
+    "$PROJECT" "$SERVER_CID" "$POSTGRES_CID" "$SERVER_VOLUME" "$POSTGRES_VOLUME" "$IMAGE_ID"
+}
+
+cmd_inspect() {
+  resolve_identity
+  cat <<REPORT
+Compose project:      $PROJECT
+Server service:       $SERVER_SERVICE
+  container:          $SERVER_CID
+  image ID:           $IMAGE_ID
+  volume at $SERVER_TARGET:    $SERVER_VOLUME
+Database service:     $POSTGRES_SERVICE
+  container:          $POSTGRES_CID
+  volume at $POSTGRES_TARGET: $POSTGRES_VOLUME
+
+These are the physical volume names this install is actually using. Never type a
+volume name from documentation into a docker command: Docker creates a missing
+named volume silently, and the result looks like a successful empty backup.
+REPORT
+}
+
+# ── Shared archive and secret_file grammar ────────────────────────────
+#
+# Backup and verify have to ask the same two questions of the same two
+# artefacts, with one grammar. A second, looser parser in the verifier is
+# exactly how a backup written under one set of rules gets blessed under
+# another: the metadata file and the manifest are both recomputable by whoever
+# holds the directory, so the only evidence about the secret key is the
+# etebase-server.ini that was backed up next to the archive, and the archive.
+
+# Regular-file member names of a `tar -tvz` listing read on stdin. A tar of an
+# empty volume still lists "./", and a directory or a symlink is not the secret
+# key an operator thinks they have.
+archive_regular_members() {
+  awk '{ if (substr($0, 1, 1) != "-") next; p = index($0, $5); print substr($0, p + length($5) + 1) }'
+}
+
+# Reads regular-file member names on stdin. `tar -C /data .` records "./name";
+# a listing that records the same member without that prefix names the same
+# file, and nothing else counts as membership.
+assert_archived_member() {
+  relative="$1"
+  message="$2"
+  grep -Fxq -e "./$relative" -e "$relative" || die "$message"
+}
+
+# Sets SECRET_FILE_VALUE to the single effective [global] secret_file
+# declaration in the given etebase-server.ini. Only the [global] section is the
+# effective declaration. A secret_file under some other section is not what the
+# server reads, and treating it as such would "prove" the wrong file was
+# archived.
+read_secret_file_declaration() {
+  ini="$1"
+  [ -f "$ini" ] && [ ! -L "$ini" ] ||
+    die "'$ini' is not a regular file; the effective secret_file cannot be read"
+
+  global_sections="$(grep -c -E '^[[:space:]]*\[global\][[:space:]]*$' "$ini" || true)"
+  require_digits "$global_sections" "the [global] section count"
+  [ "$global_sections" -eq 1 ] ||
+    die "etebase-server.ini must contain exactly one [global] section"
+  global_body="$(awk '
+    /^[[:space:]]*\[/ { in_global = ($0 ~ /^[[:space:]]*\[global\][[:space:]]*$/); next }
+    in_global { print }
+  ' "$ini")"
+  declarations="$(printf '%s\n' "$global_body" |
+    grep -c -E '^[[:space:]]*secret_file[[:space:]]*=' || true)"
+  require_digits "$declarations" "the secret_file declaration count"
+  [ "$declarations" -le 1 ] ||
+    die "etebase-server.ini declares secret_file $declarations times in [global]; resolve the ambiguity first"
+  [ "$declarations" -eq 1 ] ||
+    die "etebase-server.ini's [global] section does not declare secret_file"
+
+  SECRET_FILE_VALUE="$(printf '%s\n' "$global_body" |
+    sed -n -E 's/^[[:space:]]*secret_file[[:space:]]*=[[:space:]]*//p' |
+    sed -e 's/[[:space:]]*$//')"
+}
+
+# Sets SECRET_FILE_SCOPE from a declared value, plus SECRET_FILE_RELATIVE when
+# that value lives in the server volume. `archived` and `external` are the only
+# two scopes a declaration can resolve to, and therefore the only two a backup
+# can record: the key is either a member of the archived volume, or it is an
+# operator-managed file that this helper never reads from the host.
+classify_secret_file() {
+  value="$1"
+  SECRET_FILE_RELATIVE=""
+  case "$value" in
+    *[[:cntrl:]]*) die "etebase-server.ini's secret_file contains control characters" ;;
+  esac
+  case "$value" in
+    /*) ;;
+    *) die "etebase-server.ini's secret_file is not an absolute path; resolve it first" ;;
+  esac
+  # One path grammar for both scopes. A malformed path is not more acceptable
+  # because it points outside the volume: `/data/../etc/key` and `/srv//key` are
+  # unresolvable claims either way, and classifying one of them would decide
+  # where the key lives on the strength of a string nobody can read twice the
+  # same way.
+  case "$value" in
+    *//* | */. | */./* | *.. | *../* | */..* | *' '* | *"	"*)
+      die "etebase-server.ini's secret_file path is ambiguous; resolve it first"
+      ;;
+  esac
+  case "$value" in
+    "$SERVER_TARGET")
+      die "etebase-server.ini's secret_file names $SERVER_TARGET itself, not a file in it"
+      ;;
+    "$SERVER_TARGET"/*) ;;
+    *)
+      # Operator-managed path outside the server volume. Not read from the host:
+      # what is or is not at that path on this machine says nothing about what a
+      # backup directory contains.
+      SECRET_FILE_SCOPE=external
+      return 0
+      ;;
+  esac
+  SECRET_FILE_RELATIVE="${value#"$SERVER_TARGET"/}"
+  SECRET_FILE_SCOPE=archived
+}
+
+# ── Backup ────────────────────────────────────────────────────────────
+
+# The destination is claimed the way the installer claims an install directory:
+# through a canonicalised, trusted parent, with an atomic mkdir that cannot
+# follow a symlink planted between the check and the write.
+assert_trusted_parent() {
+  parent="$1"
+  uid="$(id -u)"
+  [ -d "$parent" ] || die "parent directory '$parent' does not exist; create it yourself first"
+  resolved="$(CDPATH='' cd -P -- "$parent" 2>/dev/null && pwd -P)" || resolved=""
+  [ -n "$resolved" ] && [ -d "$resolved" ] ||
+    die "parent directory '$parent' does not resolve to a real directory"
+  if [ -n "${PARENT_CANONICAL:-}" ] && [ "$resolved" != "$PARENT_CANONICAL" ]; then
+    die "'$parent' now resolves to '$resolved', not '$PARENT_CANONICAL'; a path component changed"
+  fi
+  # Owned by this user and writable by nobody else: the two properties that make
+  # the mkdir below a claim rather than a hope, and that keep another local user
+  # from reading a backup directory full of secrets.
+  [ -n "$(find "$resolved" -maxdepth 0 -uid "$uid" ! -perm /022 -print 2>/dev/null)" ] ||
+    die "'$resolved' must be owned by UID $uid and must not be group- or world-writable"
+  PARENT_REAL="$resolved"
+}
+
+claim_destination() {
+  dest="$1"
+  case "$dest" in
+    "" | -*) die "destination must be a plain path" ;;
+    */) dest="${dest%/}" ;;
+  esac
+  name="$(basename -- "$dest")"
+  case "$name" in
+    "" | "." | ".." | */*) die "destination must name a new directory" ;;
+  esac
+
+  PARENT_CANONICAL=""
+  assert_trusted_parent "$(dirname -- "$dest")"
+  PARENT_CANONICAL="$PARENT_REAL"
+
+  # Address the destination only through the canonical parent from here on; the
+  # path as typed may run through a symlink that is re-pointed mid-run.
+  if [ "$PARENT_REAL" = "/" ]; then
+    DEST_DIR="/$name"
+  else
+    DEST_DIR="$PARENT_REAL/$name"
+  fi
+  PARTIAL_TARGET="$DEST_DIR.partial"
+
+  [ ! -e "$DEST_DIR" ] && [ ! -L "$DEST_DIR" ] ||
+    die "destination '$DEST_DIR' already exists; this helper only ever creates a new directory"
+  [ ! -e "$PARTIAL_TARGET" ] && [ ! -L "$PARTIAL_TARGET" ] ||
+    die "a previous attempt left '$PARTIAL_TARGET' behind; inspect and remove it yourself"
+
+  # Claim the final name now, atomically and empty. Anything that appears at
+  # that name later is not this run's directory, and the rename below will fail
+  # rather than write into or over it.
+  mkdir -- "$DEST_DIR" 2>/dev/null ||
+    die "'$DEST_DIR' appeared while the destination was being validated; nothing was written"
+  mkdir -- "$PARTIAL_TARGET" 2>/dev/null || {
+    rmdir -- "$DEST_DIR" 2>/dev/null || true
+    die "'$PARTIAL_TARGET' appeared while the destination was being validated"
+  }
+  PARTIAL_DIR="$PARTIAL_TARGET"
+  chmod 700 -- "$DEST_DIR" "$PARTIAL_DIR"
+  [ ! -L "$PARTIAL_DIR" ] && [ -d "$PARTIAL_DIR" ] ||
+    die "'$PARTIAL_DIR' is not the directory this helper just created"
+}
+
+# rename(2) over a directory succeeds only when the target is an empty directory
+# we own — which is exactly the placeholder claimed above. -T is what makes this
+# a replacement instead of a move *into* the destination, so a directory that
+# gained content in the meantime fails closed instead of being nested into.
+finalise_destination() {
+  assert_trusted_parent "$PARENT_CANONICAL"
+  [ -d "$DEST_DIR" ] && [ ! -L "$DEST_DIR" ] ||
+    die "'$DEST_DIR' is no longer the empty directory this helper claimed"
+
+  # Publication and its acknowledgement are one signal-safe transition. A
+  # signal before this point still cleans the private partial and empty claim.
+  # Across the rename, state update, trap retirement and truthful success
+  # output, INT/TERM are ignored so cleanup can never describe a published
+  # backup as a failed attempt. EXIT remains armed until the rename succeeds.
+  trap '' INT TERM
+  if ! mv -T -- "$PARTIAL_DIR" "$DEST_DIR"; then
+    trap 'cleanup INT' INT
+    trap 'cleanup TERM' TERM
+    die "could not put the backup in place at '$DEST_DIR'; nothing was kept"
+  fi
+  PARTIAL_DIR=""
+  trap - EXIT
+
+  echo "Backup complete: $DEST_DIR"
+  echo "  database dump, server-data archive, configuration, metadata, $CHECKSUM_NAME"
+  echo "  server data volume: $SERVER_VOLUME (project $PROJECT)"
+  # Only the archived scope can promise the key. The external branch never reads
+  # the operator's host path, so claiming the key is here would be false in
+  # exactly the case where an operator most needs the truth.
+  case "$SECRET_FILE_SCOPE" in
+    archived)
+      echo "  keep this directory private; it contains your .env and your server secret key"
+      ;;
+    *)
+      echo "  keep this directory private; it contains your .env"
+      echo "  your server secret key is NOT in this backup: secret_file is outside"
+      echo "  $SERVER_TARGET, is operator-managed, and must be backed up separately"
+      ;;
+  esac
+  trap - INT TERM
+}
+
+# The credentials live in the postgres container's own environment. They are
+# expanded inside the container and never enter this script, its arguments, its
+# output or the metadata file.
+dump_database() {
+  docker exec "$POSTGRES_CID" sh -c \
+    'exec pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" --no-owner --no-privileges' \
+    > "$PARTIAL_DIR/$DUMP_NAME" || die "pg_dump failed"
+  [ -s "$PARTIAL_DIR/$DUMP_NAME" ] || die "the database dump is empty"
+}
+
+# A dump of a freshly created empty database is a valid file. Requiring applied
+# migration rows in the live database is the cheapest proof that the admitted
+# volume is the one holding a real installation.
+count_migrations() {
+  rows="$(docker exec "$POSTGRES_CID" sh -c \
+    'exec psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atqc "select count(*) from django_migrations"')" ||
+    die "could not count django_migrations rows in the live database"
+  rows="$(printf '%s' "$rows" | tr -d '[:space:]')"
+  require_digits "$rows" "the django_migrations row count"
+  [ "$rows" -gt 0 ] || die "django_migrations is empty; this is not an initialised SilentSuite database"
+  MIGRATION_ROWS="$rows"
+}
+
+# The archive is streamed to this process's stdout and written by the host user
+# who owns the partial directory. Binding the partial directory into the
+# container instead would ask an image running as its own non-host UID to create
+# a file in a 0700 host directory, which is both a permission problem and an
+# unnecessary write path into the operator's filesystem. The data volume goes in
+# read-only; the image is the immutable local ID already admitted.
+archive_server_volume() {
+  docker run --rm \
+    --network none \
+    --read-only \
+    --cap-drop ALL \
+    --security-opt no-new-privileges \
+    --entrypoint tar \
+    --mount "type=volume,src=$SERVER_VOLUME,dst=$SERVER_TARGET,readonly,volume-nocopy" \
+    "$IMAGE_ID" \
+    -czf - -C "$SERVER_TARGET" . > "$PARTIAL_DIR/$ARCHIVE_NAME" ||
+    die "archiving the server data volume failed"
+  [ -s "$PARTIAL_DIR/$ARCHIVE_NAME" ] || die "the server data archive is empty"
+
+  ARCHIVE_REGULAR_FILES="$PARTIAL_DIR/.regular-files"
+  tar -tvzf "$PARTIAL_DIR/$ARCHIVE_NAME" | archive_regular_members \
+    > "$ARCHIVE_REGULAR_FILES" || die "the server data archive could not be listed"
+  ARCHIVE_FILES="$(grep -c . "$ARCHIVE_REGULAR_FILES" || true)"
+  require_digits "$ARCHIVE_FILES" "the archived regular-file count"
+  [ "$ARCHIVE_FILES" -gt 0 ] ||
+    die "the server data archive contains no regular files; the volume looks empty"
+}
+
+# etebase-server.ini may point the server's secret key at a path inside /data.
+# When it does, that file has to be inside the archive, or the "backup" is
+# missing the one thing that cannot be regenerated.
+assert_secret_file_archived() {
+  read_secret_file_declaration "$PARTIAL_DIR/etebase-server.ini"
+  classify_secret_file "$SECRET_FILE_VALUE"
+  [ "$SECRET_FILE_SCOPE" = archived ] || return 0
+
+  # Membership is proven against the regular-file listing, so a directory or a
+  # symlink carrying the right name cannot stand in for the secret key.
+  assert_archived_member "$SECRET_FILE_RELATIVE" \
+    "the configured secret_file is not archived as a regular file" \
+    < "$ARCHIVE_REGULAR_FILES"
+}
+
+# Configuration is copied, never followed: a symlink at .env would silently pull
+# an arbitrary host file into a backup directory the operator then treats as
+# theirs, and a fifo or device is not configuration at all.
+#
+# GNU dd opens the source itself with O_NOFOLLOW. O_NONBLOCK prevents a raced
+# fifo from hanging the helper, and count_bytes bounds a raced device to the
+# size of the admitted regular file. The pathname identity must still be the
+# same after the copy, and the destination must be a plain regular file, before
+# the name can enter the config inventory.
+copy_config_file() {
+  name="$1"
+  source_before="$(stat --format='%d:%i:%f:%s:%y' -- "$name")" ||
+    die "could not inspect configuration file '$name'"
+  IFS=: read -r _ _ source_mode source_size _ <<< "$source_before"
+  require_digits "$source_size" "the size of configuration file '$name'"
+  [ $((0x$source_mode & 0xf000)) -eq $((0x8000)) ] ||
+    die "'$name' is not a regular file"
+
+  dd if="$name" of="$PARTIAL_DIR/$name" count="$source_size" \
+    iflag=nofollow,nonblock,count_bytes status=none ||
+    die "'$name' changed while it was being opened; refusing to copy it"
+
+  source_after="$(stat --format='%d:%i:%f:%s:%y' -- "$name")" ||
+    die "'$name' disappeared while it was being copied"
+  [ "$source_before" = "$source_after" ] ||
+    die "'$name' changed while it was being copied; refusing to keep it"
+  [ ! -L "$PARTIAL_DIR/$name" ] ||
+    die "'$name' became a symlink while it was being copied; refusing to keep it"
+  [ -f "$PARTIAL_DIR/$name" ] ||
+    die "the copy of '$name' is not a regular file; refusing to keep it"
+  [ "$(stat --format='%s' -- "$PARTIAL_DIR/$name")" = "$source_size" ] ||
+    die "the copy of '$name' is incomplete; refusing to keep it"
+  chmod 600 -- "$PARTIAL_DIR/$name"
+  CONFIG_FILES="${CONFIG_FILES:+$CONFIG_FILES,}$name"
+}
+
+collect_config() {
+  CONFIG_FILES=""
+  for name in "${REQUIRED_CONFIG[@]}"; do
+    [ -e "$name" ] || [ -L "$name" ] ||
+      die "required configuration file '$name' is missing from this directory"
+    copy_config_file "$name"
+  done
+  for name in "${OPTIONAL_CONFIG[@]}"; do
+    [ -e "$name" ] || [ -L "$name" ] || continue
+    copy_config_file "$name"
+  done
+}
+
+write_metadata() {
+  dump_bytes="$(wc -c < "$PARTIAL_DIR/$DUMP_NAME" | tr -d '[:space:]')"
+  archive_bytes="$(wc -c < "$PARTIAL_DIR/$ARCHIVE_NAME" | tr -d '[:space:]')"
+  require_digits "$dump_bytes" "the database dump size"
+  require_digits "$archive_bytes" "the server data archive size"
+
+  # A successful run resolves the scope to one of exactly two values. Recording
+  # anything else — including a placeholder — would hand the verifier a scope it
+  # cannot cross-check against the config and the archive.
+  case "${SECRET_FILE_SCOPE:-}" in
+    archived | external) ;;
+    *) die "the secret_file scope was not resolved; refusing to write metadata" ;;
+  esac
+
+  # Closed key set, one strict key=value per line, no secrets, no database user
+  # or database name, no raw label or option dumps.
+  cat > "$PARTIAL_DIR/$METADATA_NAME" <<META
+schema_version=$SCHEMA_VERSION
+created_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+compose_project=$PROJECT
+server_volume=$SERVER_VOLUME
+postgres_volume=$POSTGRES_VOLUME
+server_image_id=$IMAGE_ID
+database_dump=$DUMP_NAME
+database_dump_bytes=$dump_bytes
+migration_rows=$MIGRATION_ROWS
+server_data_archive=$ARCHIVE_NAME
+server_data_archive_bytes=$archive_bytes
+server_data_files=$ARCHIVE_FILES
+secret_file_scope=$SECRET_FILE_SCOPE
+config_files=$CONFIG_FILES
+META
+  chmod 600 -- "$PARTIAL_DIR/$METADATA_NAME"
+}
+
+write_checksums() {
+  rm -f -- "$ARCHIVE_REGULAR_FILES"
+  ( cd "$PARTIAL_DIR" &&
+    find . -maxdepth 1 -type f ! -name "$CHECKSUM_NAME" -printf '%P\n' |
+      LC_ALL=C sort |
+      xargs -r sha256sum -- > "$CHECKSUM_NAME" )
+  chmod 600 -- "$PARTIAL_DIR/$CHECKSUM_NAME"
+  [ -s "$PARTIAL_DIR/$CHECKSUM_NAME" ] || die "the checksum manifest is empty"
+}
+
+cmd_backup() {
+  [ "$#" -eq 1 ] || usage
+  dest="$1"
+
+  [ -f docker-compose.yml ] ||
+    die "run this from the SilentSuite install directory (no docker-compose.yml here)"
+
+  resolve_identity
+  before="$(identity_fingerprint)"
+
+  trap cleanup EXIT
+  trap 'cleanup INT' INT
+  trap 'cleanup TERM' TERM
+  claim_destination "$dest"
+
+  collect_config
+  count_migrations
+  dump_database
+  archive_server_volume
+  assert_secret_file_archived
+  write_metadata
+  write_checksums
+
+  # Everything was collected against one identity; prove it is still that
+  # identity — same containers, same volumes, same image — before the directory
+  # becomes a backup an operator will trust.
+  resolve_identity
+  [ "$(identity_fingerprint)" = "$before" ] ||
+    die "the running stack changed identity during the backup; nothing was kept"
+
+  finalise_destination
+}
+
+# ── Verify ────────────────────────────────────────────────────────────
+#
+# Verification is read-only. It proves internal manifest consistency and catches
+# corruption or edits while the adjacent manifest is unchanged, not authenticity.
+
+# Exactly "<64 lowercase hex><two spaces><plain basename>" per line. A name that
+# starts with "-" would be read as an option by the checker, and a name carrying
+# "/" or ".." would reach outside the backup directory.
+assert_checksum_grammar() {
+  file="$1"
+  [ -s "$file" ] || die "$CHECKSUM_NAME is empty"
+  [ "$(tail -c 1 "$file" | od -An -tu1 | tr -d '[:space:]')" = "10" ] ||
+    die "$CHECKSUM_NAME does not end with a newline"
+  lines="$(grep -c '' "$file" || true)"
+  require_digits "$lines" "the manifest line count"
+  matching="$(grep -c -E '^[0-9a-f]{64}  [A-Za-z0-9._][A-Za-z0-9._-]*$' "$file" || true)"
+  require_digits "$matching" "the manifest record count"
+  [ "$lines" -eq "$matching" ] ||
+    die "$CHECKSUM_NAME contains a record outside '<64 hex><two spaces><plain name>'"
+  if grep -q '\.\.' "$file"; then
+    die "$CHECKSUM_NAME names a path outside the backup directory"
+  fi
+  names="$(sed -e 's/^[0-9a-f]\{64\}  //' "$file")"
+  sorted_names="$(printf '%s\n' "$names" | LC_ALL=C sort)"
+  [ "$names" = "$sorted_names" ] ||
+    die "$CHECKSUM_NAME records are not in canonical filename order"
+  duplicates="$(printf '%s\n' "$names" | LC_ALL=C sort | uniq -d | grep -c . || true)"
+  require_digits "$duplicates" "the duplicate manifest name count"
+  [ "$duplicates" -eq 0 ] || die "$CHECKSUM_NAME lists the same file more than once"
+}
+
+# The metadata file is a closed grammar, not a bag of keys: the exact key set, in
+# the exact order, with a value shape per key. Anything else is a file that was
+# edited, generated by something else, or truncated.
+assert_metadata_grammar() {
+  file="$1"
+  META_CONFIG_FILES=""
+  META_DATABASE_DUMP_BYTES=""
+  META_ARCHIVE_BYTES=""
+  META_ARCHIVE_FILES=""
+  META_SERVER_VOLUME=""
+  META_POSTGRES_VOLUME=""
+  META_SECRET_FILE_SCOPE=""
+  expected="schema_version created_utc compose_project server_volume postgres_volume \
+server_image_id database_dump database_dump_bytes migration_rows server_data_archive \
+server_data_archive_bytes server_data_files secret_file_scope config_files"
+  # shellcheck disable=SC2086
+  set -- $expected
+  while IFS= read -r line; do
+    [ "$#" -gt 0 ] || die "$METADATA_NAME has more lines than the backup metadata grammar defines"
+    key="$1"
+    shift
+    case "$line" in
+      "$key="*) ;;
+      *) die "$METADATA_NAME line does not start with the expected key '$key='" ;;
+    esac
+    value="${line#"$key="}"
+    case "$key" in
+      schema_version)
+        [ "$value" = "$SCHEMA_VERSION" ] || die "$METADATA_NAME declares an unsupported schema version"
+        ;;
+      created_utc)
+        printf '%s\n' "$value" |
+          grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' ||
+          die "$METADATA_NAME has a malformed created_utc"
+        ;;
+      server_image_id) require_image_id "$value" "$METADATA_NAME's server_image_id" ;;
+      database_dump)
+        [ "$value" = "$DUMP_NAME" ] || die "$METADATA_NAME names an unexpected database dump"
+        ;;
+      server_data_archive)
+        [ "$value" = "$ARCHIVE_NAME" ] || die "$METADATA_NAME names an unexpected server-data archive"
+        ;;
+      database_dump_bytes | migration_rows | server_data_archive_bytes | server_data_files)
+        require_digits "$value" "$METADATA_NAME's $key"
+        [ "$value" -gt 0 ] || die "$METADATA_NAME records $key as zero"
+        case "$key" in
+          database_dump_bytes) META_DATABASE_DUMP_BYTES="$value" ;;
+          server_data_archive_bytes) META_ARCHIVE_BYTES="$value" ;;
+          server_data_files) META_ARCHIVE_FILES="$value" ;;
+        esac
+        ;;
+      secret_file_scope)
+        # Backup generation can only ever produce these two. A third value the
+        # verifier tolerates is a free hiding place: metadata and checksums can
+        # both be recomputed, so a scope nothing cross-checks would conceal a
+        # secret key that is not in this directory at all.
+        case "$value" in
+          archived | external) ;;
+          *) die "$METADATA_NAME has an unknown secret_file_scope; only archived and external are ever written" ;;
+        esac
+        META_SECRET_FILE_SCOPE="$value"
+        ;;
+      config_files)
+        case "$value" in
+          .env,etebase-server.ini,docker-compose.yml | \
+          .env,etebase-server.ini,docker-compose.yml,docker-compose.override.yml | \
+          .env,etebase-server.ini,docker-compose.yml,server-image.json | \
+          .env,etebase-server.ini,docker-compose.yml,docker-compose.override.yml,server-image.json)
+            META_CONFIG_FILES="$value"
+            ;;
+          *) die "$METADATA_NAME has a malformed or non-canonical config_files list" ;;
+        esac
+        ;;
+      compose_project) require_token "$value" "$METADATA_NAME's $key" ;;
+      server_volume)
+        require_token "$value" "$METADATA_NAME's $key"
+        META_SERVER_VOLUME="$value"
+        ;;
+      postgres_volume)
+        require_token "$value" "$METADATA_NAME's $key"
+        META_POSTGRES_VOLUME="$value"
+        ;;
+      *) require_token "$value" "$METADATA_NAME's $key" ;;
+    esac
+  done < "$file"
+  [ "$#" -eq 0 ] || die "$METADATA_NAME is missing keys: $*"
+  [ "$META_SERVER_VOLUME" != "$META_POSTGRES_VOLUME" ] ||
+    die "$METADATA_NAME records one shared server/database volume"
+}
+
+# One canonical snapshot ties every pathname to its directory entry and file
+# identity. Nanosecond mtime, size and mode catch in-place writes; device and
+# inode catch replacement; the directory identity and sorted inventory catch a
+# swapped directory or added/removed entry. Content is rechecked separately.
+backup_identity_snapshot() {
+  dir="$1"
+  stat --format='directory %d:%i:%f:%s:%y' -- "$dir" || return 1
+  find "$dir" -mindepth 1 -maxdepth 1 -exec \
+    stat --format='entry %d:%i:%f:%s:%y:%n' -- {} + | LC_ALL=C sort
+}
+
+cmd_verify() {
+  [ "$#" -eq 1 ] || usage
+  dir="$1"
+  [ -d "$dir" ] || die "'$dir' is not a directory"
+  [ ! -L "$dir" ] || die "'$dir' is a symlink; refusing to verify through it"
+  [ -f "$dir/$CHECKSUM_NAME" ] && [ ! -L "$dir/$CHECKSUM_NAME" ] ||
+    die "'$dir' has no regular $CHECKSUM_NAME"
+  [ -f "$dir/$METADATA_NAME" ] && [ ! -L "$dir/$METADATA_NAME" ] ||
+    die "'$dir' has no regular $METADATA_NAME"
+
+  unexpected="$(find "$dir" -mindepth 1 -maxdepth 1 ! -type f -print -quit)"
+  [ -z "$unexpected" ] ||
+    die "'$dir' contains a non-regular or nested entry; refusing an ambiguous inventory"
+
+  assert_checksum_grammar "$dir/$CHECKSUM_NAME"
+
+  # Exact inventory. Deleting a manifest line must be detected, so the listed
+  # set and the present set must be equal, not merely overlapping.
+  listed="$(sed -e 's/^[0-9a-f]\{64\}  //' "$dir/$CHECKSUM_NAME" | LC_ALL=C sort)"
+  present="$( ( cd "$dir" && find . -maxdepth 1 ! -name . -printf '%y %P\n' ) |
+    sed -n 's/^f //p' | grep -Fxv "$CHECKSUM_NAME" | LC_ALL=C sort)"
+  [ "$listed" = "$present" ] ||
+    die "'$dir' does not match its manifest: files were added, removed or renamed"
+
+  verified_snapshot="$(backup_identity_snapshot "$dir")" ||
+    die "'$dir' changed while its file identities were being recorded"
+  manifest_digest="$(sha256sum -- "$dir/$CHECKSUM_NAME")" ||
+    die "could not fingerprint $CHECKSUM_NAME"
+
+  ( cd "$dir" && sha256sum --quiet --check -- "$CHECKSUM_NAME" >/dev/null ) ||
+    die "'$dir' failed checksum verification"
+
+  assert_metadata_grammar "$dir/$METADATA_NAME"
+
+  expected="$(
+    {
+      printf '%s\n' "$DUMP_NAME" "$ARCHIVE_NAME" "$METADATA_NAME"
+      printf '%s\n' "$META_CONFIG_FILES" | tr ',' '\n'
+    } | LC_ALL=C sort
+  )"
+  [ "$listed" = "$expected" ] ||
+    die "'$dir' does not contain the exact inventory declared by $METADATA_NAME"
+
+  actual_dump_bytes="$(wc -c < "$dir/$DUMP_NAME" | tr -d '[:space:]')"
+  actual_archive_bytes="$(wc -c < "$dir/$ARCHIVE_NAME" | tr -d '[:space:]')"
+  [ "$actual_dump_bytes" = "$META_DATABASE_DUMP_BYTES" ] ||
+    die "$METADATA_NAME's database dump size does not match the file"
+  [ "$actual_archive_bytes" = "$META_ARCHIVE_BYTES" ] ||
+    die "$METADATA_NAME's server-data archive size does not match the file"
+  # tar's own exit status is the only proof the archive is structurally whole:
+  # a truncated or corrupt archive can list every expected member before it
+  # fails, and a manifest can be recomputed around it. Listing and counting are
+  # therefore separate statements, so that the `|| true` which excuses grep's
+  # "no matches" exit 1 can never also excuse a failed tar.
+  archive_listing="$(tar -tvzf "$dir/$ARCHIVE_NAME")" ||
+    die "'$dir' has a server-data archive that could not be listed; it is truncated or corrupt"
+  actual_archive_files="$(printf '%s\n' "$archive_listing" | grep -c '^-' || true)"
+  require_digits "$actual_archive_files" "the verified archive's regular-file count"
+  [ "$actual_archive_files" = "$META_ARCHIVE_FILES" ] ||
+    die "$METADATA_NAME's server-data file count does not match the archive"
+
+  # The recorded scope is a claim by whoever wrote the metadata; the semantic
+  # scope is what the backed-up etebase-server.ini actually says, read with the
+  # same grammar the server and the backup path use. Both the config and the
+  # archive matched the manifest above, so this cross-check enforces the
+  # semantic scope that any internally consistent backup must satisfy.
+  read_secret_file_declaration "$dir/etebase-server.ini"
+  classify_secret_file "$SECRET_FILE_VALUE"
+  if [ "$SECRET_FILE_SCOPE" = archived ]; then
+    archive_members="$(printf '%s\n' "$archive_listing" | archive_regular_members)"
+    assert_archived_member "$SECRET_FILE_RELATIVE" \
+      "etebase-server.ini declares a secret_file under $SERVER_TARGET that the archive does not hold as a regular file" \
+      <<< "$archive_members"
+  fi
+  [ "$META_SECRET_FILE_SCOPE" = "$SECRET_FILE_SCOPE" ] ||
+    die "$METADATA_NAME records secret_file_scope=$META_SECRET_FILE_SCOPE, but etebase-server.ini resolves to $SECRET_FILE_SCOPE"
+
+  # Re-read all content against the pinned manifest, then require the manifest,
+  # every entry identity and the directory inventory to be exactly what the
+  # semantic checks above observed. Nothing mutable is read after this point.
+  ( cd "$dir" && sha256sum --quiet --check -- "$CHECKSUM_NAME" >/dev/null ) ||
+    die "'$dir' changed during verification"
+  [ "$(sha256sum -- "$dir/$CHECKSUM_NAME")" = "$manifest_digest" ] ||
+    die "$CHECKSUM_NAME changed during verification"
+  final_snapshot="$(backup_identity_snapshot "$dir")" ||
+    die "'$dir' changed while its file identities were revalidated"
+  [ "$final_snapshot" = "$verified_snapshot" ] ||
+    die "'$dir' changed during verification"
+
+  echo "Backup verified: $dir"
+  # The same honesty the backup path owes an operator: an external key is not in
+  # this directory, and a verified backup must not let anyone believe it is.
+  case "$SECRET_FILE_SCOPE" in
+    archived)
+      echo "  the configured secret_file is present in $ARCHIVE_NAME"
+      ;;
+    *)
+      echo "  your server secret key is NOT in this backup: secret_file is outside"
+      echo "  $SERVER_TARGET, is operator-managed, and must be backed up separately"
+      ;;
+  esac
+}
+
+# ── Entry point ───────────────────────────────────────────────────────
+
+[ "$#" -ge 1 ] || usage
+action="$1"
+shift
+
+case "$action" in
+  inspect)
+    command -v docker >/dev/null 2>&1 || die "docker is not installed or not on PATH"
+    [ "$#" -eq 0 ] || usage
+    cmd_inspect
+    ;;
+  backup)
+    command -v docker >/dev/null 2>&1 || die "docker is not installed or not on PATH"
+    cmd_backup "$@"
+    ;;
+  verify) cmd_verify "$@" ;;
+  *) usage ;;
+esac

--- a/self-host/install.sh
+++ b/self-host/install.sh
@@ -622,6 +622,7 @@ done < "$MEMBER_LIST"
 EXPECTED_MEMBERS="$(printf '%s\n' \
   .env.example \
   SELF-HOSTING.md \
+  backup.sh \
   close-signups.sh \
   docker-compose.yml \
   install.sh \
@@ -767,10 +768,10 @@ echo ""
 echo "Creating install directory: $INSTALL_DIR"
 claim_target
 
-for file in docker-compose.yml install.sh SELF-HOSTING.md update.sh verify.sh close-signups.sh success.html .env.example "$MANIFEST_NAME"; do
+for file in docker-compose.yml install.sh SELF-HOSTING.md update.sh verify.sh close-signups.sh backup.sh success.html .env.example "$MANIFEST_NAME"; do
   cp "$BUNDLE_ROOT/$file" "$INSTALL_DIR/$file"
 done
-chmod +x "$INSTALL_DIR/install.sh" "$INSTALL_DIR/update.sh" "$INSTALL_DIR/verify.sh" "$INSTALL_DIR/close-signups.sh"
+chmod +x "$INSTALL_DIR/install.sh" "$INSTALL_DIR/update.sh" "$INSTALL_DIR/verify.sh" "$INSTALL_DIR/close-signups.sh" "$INSTALL_DIR/backup.sh"
 
 cd "$INSTALL_DIR"
 

--- a/tests/fixtures/self-host-backup/harness.sh
+++ b/tests/fixtures/self-host-backup/harness.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+# Behavioural fixture for self-host/backup.sh.
+#
+# Runs a throwaway Compose stack on a GitHub-hosted AMD64 runner and proves the
+# properties a static test cannot: that the helper resolves the physical volume
+# from the live container under both a default and a custom project name, that
+# it produces an exact, checksummed, non-empty backup, that it leaves the old
+# guessed-name volumes strictly alone, and that bind, shared, redirected and
+# option-bearing identities are refused before any backup directory exists.
+#
+# Everything it creates is suffixed with a random token and removed on exit. It
+# needs no credentials, writes no packages and touches nothing outside its own
+# temporary directory, project names and volumes.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+HELPER="$ROOT/self-host/backup.sh"
+
+# The same immutable PostgreSQL identity self-host/docker-compose.yml pins. It
+# stands in for both fixture services: it has pg_dump, psql and a tar, so the
+# whole fixture runs on one image and never resolves a mutable tag.
+IMAGE="postgres@sha256:7c688148e5e156d0e86df7ba8ae5a05a2386aaec1e2ad8e6d11bdf10504b1fb7"
+
+SUFFIX="$$-$(date +%s)"
+WORK="$(mktemp -d)"
+PROJECTS=()
+VOLUMES=()
+FAILURES=0
+
+cleanup() {
+  status=$?
+  # Each entry is "<install dir>|<project or empty>"; the stack is torn down
+  # from the directory that defined it so Compose sees the same project.
+  for entry in "${PROJECTS[@]:-}"; do
+    [ -n "$entry" ] || continue
+    stack_dir="${entry%%|*}"
+    stack_project="${entry#*|}"
+    [ -d "$stack_dir" ] || continue
+    if [ -n "$stack_project" ]; then
+      ( cd "$stack_dir" && COMPOSE_PROJECT_NAME="$stack_project" \
+        docker compose down -v --remove-orphans ) >/dev/null 2>&1 || true
+    else
+      ( cd "$stack_dir" && docker compose down -v --remove-orphans ) >/dev/null 2>&1 || true
+    fi
+  done
+  for volume in "${VOLUMES[@]:-}"; do
+    [ -n "$volume" ] || continue
+    docker volume rm -f "$volume" >/dev/null 2>&1 || true
+  done
+  rm -rf -- "$WORK"
+  exit "$status"
+}
+trap cleanup EXIT
+
+note() { printf '\n=== %s\n' "$*"; }
+pass() { printf 'ok   %s\n' "$*"; }
+fail() { printf 'FAIL %s\n' "$*" >&2; FAILURES=$((FAILURES + 1)); }
+check() { if [ "$1" = "$2" ]; then pass "$3"; else fail "$3 (expected '$2', got '$1')"; fi; }
+
+# ── Fixture stack ─────────────────────────────────────────────────────
+
+write_install_dir() {
+  # $1 install dir, $2 variant
+  dir="$1"
+  variant="$2"
+  mkdir -p "$dir"
+
+  server_mount="      - server_data:/data"
+  volume_block=$'volumes:\n  pgdata:\n  server_data:'
+
+  case "$variant" in
+    valid) ;;
+    bind)
+      mkdir -p "$WORK/bind-$SUFFIX"
+      server_mount="      - $WORK/bind-$SUFFIX:/data"
+      ;;
+    shared)
+      # One physical volume behind both logical mounts.
+      server_mount="      - pgdata:/data"
+      ;;
+    redirected)
+      external="ss-external-$SUFFIX"
+      docker volume create "$external" >/dev/null
+      VOLUMES+=("$external")
+      volume_block=$'volumes:\n  pgdata:\n  server_data:\n    name: '"$external"$'\n    external: true'
+      ;;
+    options)
+      mkdir -p "$WORK/opts-$SUFFIX"
+      volume_block=$'volumes:\n  pgdata:\n  server_data:\n    driver_opts:\n      type: none\n      device: '"$WORK/opts-$SUFFIX"$'\n      o: bind'
+      ;;
+    *) echo "unknown variant $variant" >&2; exit 2 ;;
+  esac
+
+  cat > "$dir/docker-compose.yml" <<COMPOSE
+services:
+  postgres:
+    image: $IMAGE
+    environment:
+      POSTGRES_DB: fixturedb
+      POSTGRES_USER: fixtureuser
+      POSTGRES_PASSWORD: fixture-password-not-a-secret
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  server:
+    image: $IMAGE
+    entrypoint: ["sleep", "infinity"]
+    volumes:
+$server_mount
+
+$volume_block
+COMPOSE
+
+  printf 'DATABASE_PASSWORD=fixture-password-not-a-secret\n' > "$dir/.env"
+  cat > "$dir/etebase-server.ini" <<'INI'
+[global]
+secret_file = /data/secret.txt
+debug = false
+INI
+  cp "$HELPER" "$dir/backup.sh"
+  chmod +x "$dir/backup.sh"
+}
+
+start_stack() {
+  # $1 install dir, $2 project name ("" for the Compose default)
+  dir="$1"
+  project="$2"
+  PROJECTS+=("$dir|$project")
+  if [ -n "$project" ]; then
+    ( cd "$dir" && COMPOSE_PROJECT_NAME="$project" docker compose up -d >/dev/null )
+  else
+    ( cd "$dir" && docker compose up -d >/dev/null )
+  fi
+}
+
+wait_for_database() {
+  dir="$1"; project="$2"
+  for _ in $(seq 1 60); do
+    if run_compose "$dir" "$project" exec -T postgres pg_isready -U fixtureuser -d fixturedb >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "the fixture database never became ready" >&2
+  return 1
+}
+
+run_compose() {
+  dir="$1"; project="$2"; shift 2
+  if [ -n "$project" ]; then
+    ( cd "$dir" && COMPOSE_PROJECT_NAME="$project" docker compose "$@" )
+  else
+    ( cd "$dir" && docker compose "$@" )
+  fi
+}
+
+run_helper() {
+  dir="$1"; project="$2"; shift 2
+  if [ -n "$project" ]; then
+    ( cd "$dir" && COMPOSE_PROJECT_NAME="$project" ./backup.sh "$@" )
+  else
+    ( cd "$dir" && ./backup.sh "$@" )
+  fi
+}
+
+seed_sentinels() {
+  dir="$1"; project="$2"
+  # A real django_migrations table with real rows: the helper refuses a database
+  # that has none, so this is what separates a backup from an empty success.
+  run_compose "$dir" "$project" exec -T postgres psql -U fixtureuser -d fixturedb -q <<'SQL'
+CREATE TABLE IF NOT EXISTS django_migrations (id serial primary key, app text, name text);
+INSERT INTO django_migrations (app, name) VALUES ('etebase_fastapi', '0001_initial'), ('myauth', '0001_initial');
+CREATE TABLE IF NOT EXISTS sentinel_rows (value text);
+INSERT INTO sentinel_rows (value) VALUES ('fixture-sentinel-row');
+SQL
+  # A non-empty server-data volume, including the secret_file the ini declares.
+  run_compose "$dir" "$project" exec -T server sh -c \
+    'printf fixture-secret-key > /data/secret.txt && printf sentinel > /data/media-sentinel.bin'
+}
+
+# ── Decoys ────────────────────────────────────────────────────────────
+#
+# The exact names the old documentation guessed. Nothing in this run may touch
+# them, and the helper must never resolve to one.
+
+DECOYS=("self-host_server_data" "self-host_pgdata")
+setup_decoys() {
+  for decoy in "${DECOYS[@]}"; do
+    if docker volume inspect "$decoy" >/dev/null 2>&1; then
+      echo "refusing to run: a volume named '$decoy' already exists on this host" >&2
+      exit 2
+    fi
+    docker volume create "$decoy" >/dev/null
+    VOLUMES+=("$decoy")
+    docker run --rm --network none -v "$decoy:/d" --entrypoint sh "$IMAGE" \
+      -c 'printf decoy-untouched > /d/decoy.txt' >/dev/null
+  done
+}
+
+assert_decoys_untouched() {
+  for decoy in "${DECOYS[@]}"; do
+    listing="$(docker run --rm --network none -v "$decoy:/d:ro" --entrypoint sh "$IMAGE" \
+      -c 'ls -A /d' | tr '\n' ' ' | sed 's/ *$//')"
+    check "$listing" "decoy.txt" "decoy volume $decoy still holds only its marker"
+    content="$(docker run --rm --network none -v "$decoy:/d:ro" --entrypoint cat "$IMAGE" /d/decoy.txt)"
+    check "$content" "decoy-untouched" "decoy volume $decoy content unchanged"
+  done
+}
+
+# ── Positive runs ─────────────────────────────────────────────────────
+
+metadata_value() {
+  sed -n "s/^$2=//p" "$1/backup-metadata.txt"
+}
+
+run_positive_case() {
+  label="$1"; dirname="$2"; project="$3"; optional_extra="$4"
+  note "positive: $label"
+  dir="$WORK/$dirname"
+  write_install_dir "$dir" valid
+  if [ "$optional_extra" = "yes" ]; then
+    printf '{"schemaVersion":1}\n' > "$dir/server-image.json"
+    printf 'services:\n  server:\n    environment:\n      FIXTURE_OVERRIDE: admitted\n' > \
+      "$dir/docker-compose.override.yml"
+  fi
+  start_stack "$dir" "$project"
+  wait_for_database "$dir" "$project"
+  seed_sentinels "$dir" "$project"
+
+  dest="$dir/backup-out"
+  if run_helper "$dir" "$project" backup "$dest" >/dev/null; then
+    pass "$label: backup succeeded"
+  else
+    fail "$label: backup failed"
+    return 0
+  fi
+
+  expected_project="${project:-$(basename "$dir")}"
+  # Compose normalises project names to lowercase.
+  expected_project="$(printf '%s' "$expected_project" | tr '[:upper:]' '[:lower:]')"
+
+  inventory="$(find "$dest" -maxdepth 1 -type f -printf '%P\n' | LC_ALL=C sort | tr '\n' ' ' | sed 's/ *$//')"
+  if [ "$optional_extra" = "yes" ]; then
+    expected_inventory="SHA256SUMS .env backup-metadata.txt database.sql docker-compose.override.yml docker-compose.yml etebase-server.ini server-data.tar.gz server-image.json"
+  else
+    expected_inventory="SHA256SUMS .env backup-metadata.txt database.sql docker-compose.yml etebase-server.ini server-data.tar.gz"
+  fi
+  expected_inventory="$(printf '%s\n' $expected_inventory | LC_ALL=C sort | tr '\n' ' ' | sed 's/ *$//')"
+  check "$inventory" "$expected_inventory" "$label: exact backup inventory"
+
+  check "$(metadata_value "$dest" schema_version)" "1" "$label: metadata schema version"
+  check "$(metadata_value "$dest" compose_project)" "$expected_project" "$label: metadata records the real project"
+  check "$(metadata_value "$dest" migration_rows)" "2" "$label: metadata records the real migration count"
+  check "$(metadata_value "$dest" secret_file_scope)" "archived" "$label: the configured secret_file was archived"
+
+  # The recorded volume is the one the live container mounts, and is not a
+  # guessed name.
+  server_cid="$(run_compose "$dir" "$project" ps --all --quiet server)"
+  real_volume="$(docker inspect --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}' "$server_cid")"
+  check "$(metadata_value "$dest" server_volume)" "$real_volume" "$label: metadata names the live physical volume"
+  for decoy in "${DECOYS[@]}"; do
+    if [ "$(metadata_value "$dest" server_volume)" = "$decoy" ]; then
+      fail "$label: the helper resolved to the guessed decoy volume $decoy"
+    fi
+  done
+
+  # Real content, not an empty successful tar.
+  members="$(tar -tzf "$dest/server-data.tar.gz")"
+  printf '%s\n' "$members" | grep -Fxq "./secret.txt" &&
+    pass "$label: the secret file is inside the archive" ||
+    fail "$label: the secret file is missing from the archive"
+  grep -q "fixture-sentinel-row" "$dest/database.sql" &&
+    pass "$label: the database dump carries the sentinel row" ||
+    fail "$label: the database dump lost the sentinel row"
+  grep -q "fixture-password-not-a-secret" "$dest/.env" &&
+    pass "$label: the .env file was captured" ||
+    fail "$label: the .env file was not captured"
+
+  # Checksums cover every other file, exactly once.
+  check "$(grep -c . "$dest/SHA256SUMS")" \
+    "$(find "$dest" -maxdepth 1 -type f ! -name SHA256SUMS -printf '.' | wc -c)" \
+    "$label: the manifest covers every artefact but itself"
+  ( cd "$dest" && sha256sum --quiet --check SHA256SUMS ) &&
+    pass "$label: checksums verify" || fail "$label: checksums do not verify"
+  run_helper "$dir" "$project" verify "$dest" >/dev/null &&
+    pass "$label: verify accepts the fresh backup" ||
+    fail "$label: verify rejected a fresh backup"
+
+  POSITIVE_DEST="$dest"
+  POSITIVE_DIR="$dir"
+  POSITIVE_PROJECT="$project"
+}
+
+run_consistency_cases() {
+  note "manifest consistency and verification boundary"
+  dir="$POSITIVE_DIR"; project="$POSITIVE_PROJECT"
+  work="$WORK/consistency"
+  rm -rf -- "$work"
+  cp -a "$POSITIVE_DEST" "$work"
+
+  printf 'corrupt\n' >> "$work/database.sql"
+  if run_helper "$dir" "$project" verify "$work" >/dev/null 2>&1; then
+    fail "verify accepted database corruption with an unchanged manifest"
+  else
+    pass "verify rejects database corruption with an unchanged manifest"
+  fi
+
+  # SHA256SUMS is adjacent metadata, not an authenticated statement. A
+  # same-length artifact edit accompanied by a valid recomputed manifest is
+  # internally consistent and must not be represented as authenticity proof.
+  rm -rf -- "$work"; cp -a "$POSITIVE_DEST" "$work"
+  original_size="$(wc -c < "$work/database.sql" | tr -d '[:space:]')"
+  first_byte="$(dd if="$work/database.sql" bs=1 count=1 status=none)"
+  case "$first_byte" in
+    X) replacement=Y ;;
+    *) replacement=X ;;
+  esac
+  printf '%s' "$replacement" | dd of="$work/database.sql" bs=1 count=1 conv=notrunc status=none
+  check "$(wc -c < "$work/database.sql" | tr -d '[:space:]')" "$original_size" \
+    "the manifest-boundary edit preserves artifact length"
+  ( cd "$work" && find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%P\n' |
+    LC_ALL=C sort | xargs -r sha256sum -- > SHA256SUMS )
+  if run_helper "$dir" "$project" verify "$work" >/dev/null 2>&1; then
+    pass "verify accepts a same-length edit with a recomputed valid unauthenticated manifest"
+  else
+    fail "verify rejected an internally consistent backup after its unauthenticated manifest was recomputed"
+  fi
+
+  rm -rf -- "$work"; cp -a "$POSITIVE_DEST" "$work"
+  grep -v ' database.sql$' "$work/SHA256SUMS" > "$work/SHA256SUMS.new"
+  mv "$work/SHA256SUMS.new" "$work/SHA256SUMS"
+  if run_helper "$dir" "$project" verify "$work" >/dev/null 2>&1; then
+    fail "verify accepted a manifest with a deleted record"
+  else
+    pass "verify rejects a manifest with a deleted record"
+  fi
+
+  # Metadata rewritten *and* re-checksummed: only the closed metadata grammar
+  # can catch this one.
+  rm -rf -- "$work"; cp -a "$POSITIVE_DEST" "$work"
+  printf 'unexpected_key=1\n' >> "$work/backup-metadata.txt"
+  ( cd "$work" && find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%P\n' |
+    LC_ALL=C sort | xargs -r sha256sum -- > SHA256SUMS )
+  if run_helper "$dir" "$project" verify "$work" >/dev/null 2>&1; then
+    fail "verify accepted metadata with an unexpected key"
+  else
+    pass "verify rejects metadata with an unexpected key"
+  fi
+
+  rm -rf -- "$work"; cp -a "$POSITIVE_DEST" "$work"
+  sed -i 's/^migration_rows=.*/migration_rows=zero/' "$work/backup-metadata.txt"
+  ( cd "$work" && find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%P\n' |
+    LC_ALL=C sort | xargs -r sha256sum -- > SHA256SUMS )
+  if run_helper "$dir" "$project" verify "$work" >/dev/null 2>&1; then
+    fail "verify accepted a malformed metadata value"
+  else
+    pass "verify rejects a malformed metadata value"
+  fi
+
+  # Interpose only in this fixture. verify invokes tar after its first checksum
+  # pass, giving us a deterministic boundary at which to mutate or replace an
+  # already-validated file without sleeps or any production test hook.
+  real_tar="$(command -v tar)"
+  mkdir -p "$WORK/sabotage-bin"
+  cat > "$WORK/sabotage-bin/tar" <<'SABOTAGE'
+#!/usr/bin/env bash
+set -euo pipefail
+"$REAL_TAR" "$@"
+case "$SABOTAGE_MODE" in
+  mutate) printf 'changed-during-verification\n' >> "$SABOTAGE_TARGET" ;;
+  replace)
+    cp -p -- "$SABOTAGE_TARGET" "$SABOTAGE_TARGET.replacement"
+    mv -- "$SABOTAGE_TARGET.replacement" "$SABOTAGE_TARGET"
+    ;;
+esac
+SABOTAGE
+  chmod +x "$WORK/sabotage-bin/tar"
+
+  for mode in mutate replace; do
+    rm -rf -- "$work"; cp -a "$POSITIVE_DEST" "$work"
+    if PATH="$WORK/sabotage-bin:$PATH" REAL_TAR="$real_tar" \
+      SABOTAGE_MODE="$mode" SABOTAGE_TARGET="$work/database.sql" \
+      run_helper "$dir" "$project" verify "$work" >/dev/null 2>&1; then
+      fail "verify accepted a file $mode between validation phases"
+    else
+      pass "verify rejects a file $mode between validation phases"
+    fi
+  done
+}
+
+run_publication_signal_case() {
+  note "signal immediately after atomic publication"
+  dir="$POSITIVE_DIR"; project="$POSITIVE_PROJECT"
+  dest="$dir/backup-signalled"
+  real_mv="$(command -v mv)"
+  mkdir -p "$WORK/publication-bin"
+  cat > "$WORK/publication-bin/mv" <<'SABOTAGE'
+#!/usr/bin/env bash
+set -euo pipefail
+"$REAL_MV" "$@"
+kill -TERM "$PPID"
+SABOTAGE
+  chmod +x "$WORK/publication-bin/mv"
+
+  if output="$(PATH="$WORK/publication-bin:$PATH" REAL_MV="$real_mv" \
+    run_helper "$dir" "$project" backup "$dest" 2>&1)"; then
+    pass "TERM after rename does not turn a published backup into failure"
+  else
+    fail "TERM after rename made publication fail: $output"
+    return 0
+  fi
+  printf '%s\n' "$output" | grep -Fq "Backup complete: $dest" &&
+    pass "the published backup is truthfully acknowledged" ||
+    fail "the published backup was not acknowledged"
+  if printf '%s\n' "$output" | grep -Fq "nothing was kept"; then
+    fail "the published backup was falsely reported as discarded"
+  else
+    pass "no false nothing-kept claim follows publication"
+  fi
+  [ -s "$dest/database.sql" ] && [ -s "$dest/server-data.tar.gz" ] &&
+    pass "the signalled publication remains complete and non-empty" ||
+    fail "the signalled publication is missing or empty"
+}
+
+# ── Negative identities ───────────────────────────────────────────────
+
+run_negative_case() {
+  variant="$1"
+  note "negative: $variant identity"
+  dir="$WORK/neg-$variant"
+  project="ssneg${variant}${SUFFIX//-/}"
+  write_install_dir "$dir" "$variant"
+  start_stack "$dir" "$project"
+
+  dest="$dir/backup-out"
+  if run_helper "$dir" "$project" backup "$dest" >/dev/null 2>&1; then
+    fail "$variant identity produced a backup"
+  else
+    pass "$variant identity was refused"
+  fi
+  if [ -e "$dest" ] || [ -e "$dest.partial" ]; then
+    fail "$variant identity left a backup directory behind"
+  else
+    pass "$variant identity left nothing behind"
+  fi
+}
+
+# ── Run ───────────────────────────────────────────────────────────────
+
+docker image inspect "$IMAGE" >/dev/null 2>&1 || docker pull "$IMAGE" >/dev/null
+setup_decoys
+
+run_positive_case "default project name" "silentsuite-server" "" no
+run_publication_signal_case
+run_consistency_cases
+run_positive_case "custom project name" "custom-dir" "operator-chosen-${SUFFIX//-/}" yes
+
+for variant in bind shared redirected options; do
+  run_negative_case "$variant"
+done
+
+assert_decoys_untouched
+
+note "summary"
+if [ "$FAILURES" -ne 0 ]; then
+  echo "$FAILURES behavioural check(s) failed" >&2
+  exit 1
+fi
+echo "all behavioural checks passed"

--- a/tests/test_self_host_backup_helper.py
+++ b/tests/test_self_host_backup_helper.py
@@ -1,0 +1,852 @@
+"""Static contracts for the self-host backup helper and the docs around it.
+
+The bug these guard against is specific and was shipped: documentation printed
+`docker run -v self-host_server_data:/data ... tar czf ...`. Docker creates a
+missing named volume silently, so on any install whose Compose project name is
+not `self-host` that command archives a brand-new empty volume and reports
+success. The fix is not a better guess — manual installs and
+`COMPOSE_PROJECT_NAME` vary — it is refusing to name physical volumes in
+documentation at all and reading them out of the live containers instead.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from selfhost_release_contract import BUNDLE_SOURCE_FILES  # noqa: E402
+
+BACKUP = ROOT / "self-host" / "backup.sh"
+INSTALLER = ROOT / "self-host" / "install.sh"
+COMPOSE = ROOT / "self-host" / "docker-compose.yml"
+CI_SERVER = ROOT / ".github" / "workflows" / "ci-server.yml"
+
+DOCS = (
+    ROOT / "self-host" / "SELF-HOSTING.md",
+    *sorted((ROOT / "docs" / "self-hosting").glob("*.md")),
+    *sorted((ROOT / "apps" / "docs" / "self-hosting").glob("*.md")),
+)
+
+def code_only(source: str) -> str:
+    """The helper's source with whole-line comments removed.
+
+    The comments explain the failure mode by naming the shipped bad recipe and
+    the mutable images it must not use; the assertions below are about what the
+    script executes.
+    """
+
+    return "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+FENCE = re.compile(r"^```(bash|sh|shell|console)\n(.*?)^```", re.MULTILINE | re.DOTALL)
+
+# A Compose-generated physical name is "<project>_<logical>". The logical names
+# are ours and fixed, so any token ending in one of them, with a prefix, is a
+# guess about the operator's project — including the exact strings that shipped.
+GENERATED_NAME = re.compile(
+    r"\b[A-Za-z0-9][A-Za-z0-9._-]*_(server_data|pgdata|silentsuite)\b"
+)
+
+
+def executable_lines(path: Path) -> list[tuple[int, str]]:
+    """Every line inside a shell code fence, with its 1-based file line number."""
+
+    text = path.read_text(encoding="utf-8")
+    lines: list[tuple[int, str]] = []
+    for match in FENCE.finditer(text):
+        first = text.count("\n", 0, match.start(2)) + 1
+        for offset, line in enumerate(match.group(2).splitlines()):
+            lines.append((first + offset, line))
+    return lines
+
+
+@pytest.mark.parametrize("doc", DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+def test_documentation_never_names_a_compose_generated_volume(doc):
+    for number, line in executable_lines(doc):
+        hit = GENERATED_NAME.search(line)
+        assert hit is None, (
+            f"{doc.relative_to(ROOT)}:{number} names the Compose-generated identity "
+            f"{hit.group(0)!r}. Docker creates a missing named volume silently, so a "
+            "guessed name can archive or destroy the wrong thing; resolve it from the "
+            "live container with ./backup.sh inspect instead."
+        )
+
+
+@pytest.mark.parametrize("doc", DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+def test_documentation_does_not_script_destructive_data_loss(doc):
+    forbidden = (
+        "docker volume rm",
+        "docker volume prune",
+        "docker compose down -v",
+        "docker-compose down -v",
+        "docker system prune",
+    )
+    for number, line in executable_lines(doc):
+        for command in forbidden:
+            assert command not in line, (
+                f"{doc.relative_to(ROOT)}:{number} scripts {command!r}; automated data-volume "
+                "deletion is not supported by this release"
+            )
+
+
+def test_uninstall_docs_do_not_guess_a_recursive_deletion_target():
+    canonical = ROOT / "docs" / "self-hosting" / "uninstalling.md"
+    mirror = ROOT / "apps" / "docs" / "self-hosting" / "uninstalling.md"
+    canonical_bytes = canonical.read_bytes()
+    assert mirror.read_bytes() == canonical_bytes, "the uninstall docs mirrors must be byte-identical"
+
+    text = canonical_bytes.decode("utf-8")
+    assert "pwd -P" in text, "operators must inspect and record the canonical install path"
+    assert "remove that exact path yourself" in text
+    for number, line in executable_lines(canonical):
+        assert not re.search(r"\brm\s+-[^\n]*r[^\n]*f\b", line), (
+            f"{canonical.relative_to(ROOT)}:{number} scripts recursive forced deletion; "
+            "an installation may use any directory name"
+        )
+    assert "rm -rf silentsuite-server" not in text
+
+
+@pytest.mark.parametrize("doc", DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+def test_documentation_does_not_run_a_mutable_helper_image(doc):
+    for number, line in executable_lines(doc):
+        if "docker run" not in line and "docker pull" not in line:
+            continue
+        assert not re.search(r"\balpine\b", line), (
+            f"{doc.relative_to(ROOT)}:{number} runs a mutable helper image; the backup "
+            "helper reuses the admitted server container's own immutable image ID"
+        )
+        assert ":latest" not in line, f"{doc.relative_to(ROOT)}:{number} pins a mutable tag"
+
+
+def test_the_canonical_docs_point_operators_at_the_helper():
+    for doc in (
+        ROOT / "self-host" / "SELF-HOSTING.md",
+        ROOT / "docs" / "self-hosting" / "backup-and-restore.md",
+        ROOT / "apps" / "docs" / "self-hosting" / "backup-and-restore.md",
+    ):
+        text = doc.read_text(encoding="utf-8")
+        assert "./backup.sh inspect" in text, doc
+        assert "./backup.sh backup" in text, doc
+
+
+def test_the_canonical_docs_are_honest_about_recovery():
+    for doc in (
+        ROOT / "self-host" / "SELF-HOSTING.md",
+        ROOT / "docs" / "self-hosting" / "backup-and-restore.md",
+        ROOT / "apps" / "docs" / "self-hosting" / "backup-and-restore.md",
+    ):
+        text = doc.read_text(encoding="utf-8")
+        assert "Automated restore is not supported yet" in text, doc
+        assert "docker compose down" in text, f"{doc}: the supported stop path must be documented"
+        assert "does **not** reverse Django migrations" in text, doc
+        assert "expert assistance" in text, doc
+
+
+MAINTENANCE_DOCS = tuple(
+    doc for doc in DOCS
+    if doc.name in {
+        "backup-and-restore.md",
+        "troubleshooting.md",
+        "uninstalling.md",
+        "updating.md",
+    }
+)
+
+
+@pytest.mark.parametrize("doc", MAINTENANCE_DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+def test_maintenance_docs_do_not_rerun_the_installer_as_an_upgrade_or_reset(doc):
+    for number, line in executable_lines(doc):
+        if "install.sh" not in line:
+            continue
+        # Staging a release into a new directory is the one safe installer call:
+        # it verifies and writes nothing into an existing installation.
+        assert "--stage-only" in line, (
+            f"{doc.relative_to(ROOT)}:{number} runs install.sh in a maintenance recipe; "
+            "re-running the installer is neither an upgrade nor a reset path"
+        )
+
+
+@pytest.mark.parametrize("doc", DOCS, ids=lambda p: str(p.relative_to(ROOT)))
+def test_no_doc_offers_a_reset_everything_recipe(doc):
+    text = doc.read_text(encoding="utf-8")
+    assert "reset everything" not in text.lower(), doc
+
+
+# ── The helper itself ─────────────────────────────────────────────────
+
+
+def test_the_helper_offers_no_destructive_command():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    for forbidden in (
+        "docker volume rm",
+        "docker volume prune",
+        "docker system prune",
+        "docker rm ",
+        "docker compose down",
+        "docker compose up",
+        "docker pull",
+        "docker image rm",
+        "psql -f",
+        "pg_restore",
+    ):
+        assert forbidden not in source, f"backup.sh must never run {forbidden!r}"
+    # The only recursive removal is the helper's own partial directory.
+    assert source.count("rm -rf") == 1
+    assert 'rm -rf -- "$PARTIAL_DIR"' in source
+
+
+def test_the_helper_resolves_identity_instead_of_guessing_it():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    hit = GENERATED_NAME.search(source)
+    assert hit is None, (
+        f"backup.sh builds or hard-codes the physical identity {hit.group(0) if hit else ''!r}"
+    )
+    # Compose resolves the project (directory, COMPOSE_PROJECT_NAME or name:),
+    # which is what keeps custom projects and overrides working.
+    assert "compose ps --all --quiet" in source, (
+        "a stopped duplicate container is an ambiguous identity and must be seen"
+    )
+    assert '[ "$count" -eq 1 ]' in source
+    assert '[ "$state" = "true" ]' in source
+    assert "com.docker.compose.project" in source
+    assert "com.docker.compose.service" in source
+    assert "com.docker.compose.volume" in source
+
+
+def test_the_helper_admits_only_a_plain_local_named_volume():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    for required in (
+        '[ "$driver" = "local" ]',
+        '[ "$scope" = "local" ]',
+        '[ "$options" -eq 0 ]',
+        '[ "$mtype" = "volume" ]',
+        '[ "$found" -eq 1 ]',
+        '[ "$SERVER_VOLUME" != "$POSTGRES_VOLUME" ]',
+        '[ "$PROJECT" = "$pg_project" ]',
+    ):
+        assert required in source, f"backup.sh must enforce {required}"
+
+
+def test_the_helper_uses_an_immutable_local_image_identity():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    assert "docker image inspect" in source
+    assert "-czf - -C" in source, (
+        "the archive is streamed to a host-owned file, not written through a bind mount"
+    )
+    assert "require_image_id" in source
+    assert '[ "${#hex}" -eq 64 ]' in source and "*[!0-9a-f]*" in source, (
+        "an image ID must be exactly sha256: plus 64 lowercase hex"
+    )
+    assert "--network none" in source
+    assert "--read-only" in source
+    assert "--cap-drop ALL" in source
+    assert "no-new-privileges" in source
+    assert "--mount" in source and "readonly,volume-nocopy" in source, (
+        "the admitted volume must be mounted read-only without Docker auto-creating a missing source"
+    )
+    for mutable in ("alpine", ":latest", "docker pull"):
+        assert mutable not in source, f"backup.sh must not depend on {mutable!r}"
+
+
+def test_the_helper_proves_the_backup_is_not_empty():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    assert "django_migrations" in source
+    assert '"$rows" -gt 0' in source
+    assert '"$ARCHIVE_FILES" -gt 0' in source
+
+
+def shell_statements(source: str) -> list[str]:
+    """The helper's source grouped into logical statements.
+
+    A statement continues while the accumulated text ends in a pipe or boolean
+    continuation, or has an unclosed command substitution. That is exactly how
+    the masked shape hid: the `|| true` sat on the line after the `tar` call.
+    """
+
+    statements: list[str] = []
+    current = ""
+    for line in source.splitlines():
+        current = line if not current else f"{current}\n{line}"
+        if current.rstrip().endswith(("|", "\\", "&&", "||")):
+            continue
+        if current.count("$(") > current.count(")"):
+            continue
+        statements.append(current)
+        current = ""
+    if current:
+        statements.append(current)
+    return statements
+
+
+def test_no_archive_listing_can_have_its_failure_excused():
+    """A tar listing whose status is discarded lets a corrupt archive pass.
+
+    `x="$(tar -tvzf ... | grep -c '^-' || true)"` was the shipped shape: the
+    `|| true` is there for grep's "no matches" exit 1, but it swallows a failing
+    tar too, so a truncated archive that lists the expected members before it
+    fails verifies clean once its checksums have been recomputed.
+    """
+
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    listings = [line for line in shell_statements(source) if "tar -t" in line]
+    assert listings, "the helper must still list the archive to count its regular files"
+    for statement in listings:
+        assert "|| true" not in statement, (
+            f"an archive listing excuses its own failure:\n{statement}"
+        )
+        assert "die " in statement, f"an archive listing does not fail closed:\n{statement}"
+
+
+def test_verify_counts_regular_files_only_after_tar_exited_successfully():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    assert 'archive_listing="$(tar -tvzf "$dir/$ARCHIVE_NAME")" ||' in source, (
+        "verify must capture the listing in its own statement so tar's status is checked"
+    )
+    assert "it is truncated or corrupt" in source
+    # Counting runs over the captured listing, so `|| true` can only excuse
+    # grep's zero-match status; a valid archive holding no regular file still
+    # reaches the count comparison and is rejected there.
+    counted = (
+        'actual_archive_files="$(printf \'%s\\n\' "$archive_listing" '
+        "| grep -c '^-' || true)\""
+    )
+    assert counted in source
+    assert '[ "$actual_archive_files" = "$META_ARCHIVE_FILES" ]' in source
+
+
+def test_success_output_claims_the_secret_key_only_when_it_was_archived():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    summary = source.split('echo "Backup complete: $DEST_DIR"', 1)[1].split("esac", 1)[0]
+    assert 'case "$SECRET_FILE_SCOPE" in' in summary, (
+        "the secret-key claim must depend on the resolved scope, not be unconditional"
+    )
+    preamble, arms = summary.split('case "$SECRET_FILE_SCOPE" in', 1)
+    assert "secret key" not in preamble, "the unconditional secret-key claim must be gone"
+    archived, external = arms.split("archived)", 1)[1].split(";;", 1)
+    assert "contains your .env and your server secret key" in archived
+    assert "your server secret key is NOT in this backup" in external, (
+        "an external secret_file is never read or archived; saying otherwise is false"
+    )
+    assert "must be backed up separately" in external
+    assert "$SERVER_TARGET" in external
+
+
+def test_the_helper_writes_atomically_into_a_private_partial_directory():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    assert "umask 077" in source
+    assert 'chmod 700 -- "$DEST_DIR" "$PARTIAL_DIR"' in source
+    # -T is what makes the final step a replacement of the empty directory this
+    # run claimed, rather than a move *into* whatever now sits at that name.
+    assert 'mv -T -- "$PARTIAL_DIR" "$DEST_DIR"' in source
+    assert "trap cleanup EXIT" in source
+    assert "trap 'cleanup INT' INT" in source
+    assert "trap 'cleanup TERM' TERM" in source
+    assert 'die "destination' in source
+    assert "assert_trusted_parent" in source
+    assert '! -perm /022' in source, "a group- or world-writable parent must be refused"
+    assert 'cd -P --' in source, "the parent must be canonicalised, not trusted lexically"
+    assert '[ "$status" -ne 0 ] || status=1' in source, (
+        "an interrupted or failed run must never exit 0"
+    )
+
+
+def test_publication_and_success_acknowledgement_are_signal_safe_and_ordered():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    finalise = source.split("finalise_destination() {", 1)[1].split("\n}", 1)[0]
+
+    ignore = finalise.index("trap '' INT TERM")
+    publish = finalise.index('mv -T -- "$PARTIAL_DIR" "$DEST_DIR"')
+    state = finalise.index('PARTIAL_DIR=""')
+    retire_exit = finalise.index("trap - EXIT")
+    success = finalise.index('echo "Backup complete: $DEST_DIR"')
+    restore = finalise.index("trap - INT TERM")
+    assert ignore < publish < state < retire_exit < success < restore
+    assert "if ! mv -T" in finalise, "EXIT cleanup must remain armed when mv fails"
+    failed_mv = finalise.split("if ! mv -T", 1)[1].split("fi", 1)[0]
+    assert "trap 'cleanup INT' INT" in failed_mv
+    assert "trap 'cleanup TERM' TERM" in failed_mv
+    assert "nothing was kept" in failed_mv
+
+
+def test_the_helper_keeps_the_expected_services_and_logical_volumes():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    compose = COMPOSE.read_text(encoding="utf-8")
+    for token in ("server", "postgres"):
+        assert f"\n  {token}:\n" in compose, f"Compose service {token} was renamed"
+    for token in ("server_data", "pgdata"):
+        assert f"\n  {token}:\n" in compose, f"logical volume {token} was renamed"
+    assert "SERVER_SERVICE=server" in source
+    assert "POSTGRES_SERVICE=postgres" in source
+    assert "SERVER_VOLUME_LABEL=server_data" in source
+    assert "POSTGRES_VOLUME_LABEL=pgdata" in source
+    assert "SERVER_TARGET=/data" in source
+    assert "POSTGRES_TARGET=/var/lib/postgresql/data" in source
+
+
+def test_the_helper_preserves_override_compatibility():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    assert "docker-compose.override.yml" in source, (
+        "an operator override is part of the stack definition and belongs in the backup"
+    )
+    assert "compose -f" not in source and "compose(-f" not in source, (
+        "pinning a single Compose file would ignore docker-compose.override.yml"
+    )
+    assert "--project-name" not in source and "compose -p" not in source, (
+        "the helper must let Compose resolve the operator's own project identity"
+    )
+
+
+def test_the_helper_copies_configuration_without_following_symlinks():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    assert "iflag=nofollow" in source
+    assert '[ ! -L "$PARTIAL_DIR/$name" ]' in source
+
+
+def function_body(source: str, name: str) -> list[str]:
+    """The executable lines of one shell function, comments already stripped."""
+
+    assert f"{name}() {{" in source, f"{name} is missing from the helper"
+    body = source.split(f"{name}() {{\n", 1)[1].split("\n}", 1)[0]
+    return body.splitlines()
+
+
+def test_the_configuration_copy_uses_a_bounded_no_follow_source_open():
+    """The source tests are advisory; only the copy itself can fail closed.
+
+    `[ ! -L ]` then `cp` is a time-of-check/time-of-use gap: a source replaced
+    with a symlink between the two is followed by a dereferencing copy, and an
+    arbitrary host file lands in the backup under a configuration file's name.
+    """
+
+    lines = function_body(code_only(BACKUP.read_text(encoding="utf-8")), "copy_config_file")
+
+    def index_of(fragment):
+        for number, line in enumerate(lines):
+            if fragment in line:
+                return number
+        raise AssertionError(f"copy_config_file must contain {fragment!r}")
+
+    assert not any(re.search(r'\bcp\s+', line) for line in lines), (
+        "cp -P still races between classifying and opening a replaced source"
+    )
+    copied = index_of("dd if=")
+    primitive = "\n".join(lines[copied:copied + 3])
+    for flag in ("nofollow", "nonblock", "count_bytes"):
+        assert flag in primitive, f"the fd-opening copy must use {flag}"
+    assert 'count="$source_size"' in primitive, "a raced device read must be bounded"
+    before = index_of('source_before="$(stat ')
+    after = index_of('source_after="$(stat ')
+    unchanged = index_of('[ "$source_before" = "$source_after" ]')
+
+    # The copy is only accepted once the thing that landed is itself a regular
+    # file, and that verdict must precede both the chmod and the inventory line
+    # the metadata is built from.
+    not_a_link = index_of('[ ! -L "$PARTIAL_DIR/$name" ]')
+    regular = index_of('[ -f "$PARTIAL_DIR/$name" ]')
+    for number in (not_a_link, regular):
+        assert "die" in "\n".join(lines[number:number + 2]), (
+            "a failed destination check must die so the exit trap removes the partial"
+        )
+    accepted = min(index_of("chmod 600"), index_of("CONFIG_FILES="))
+    assert before < copied < after < unchanged < not_a_link < accepted
+    assert copied < regular < accepted, (
+        "the destination must be validated after the copy and before the copy is "
+        "chmod'ed or recorded as a config file"
+    )
+
+
+def test_verify_revalidates_pinned_identities_and_content_before_success():
+    lines = function_body(code_only(BACKUP.read_text(encoding="utf-8")), "cmd_verify")
+
+    def indices(fragment):
+        return [number for number, line in enumerate(lines) if fragment in line]
+
+    checksums = indices("sha256sum --quiet --check")
+    snapshots = indices('backup_identity_snapshot "$dir"')
+    success = indices('echo "Backup verified:')
+    assert len(checksums) == 2 and len(snapshots) == 2 and len(success) == 1
+    assert snapshots[0] < checksums[0] < checksums[1] < snapshots[1] < success[0]
+    assert any("manifest_digest=" in line for line in lines)
+    assert any('final_snapshot" = "$verified_snapshot' in line for line in lines)
+
+
+def test_the_helper_never_prints_database_credentials():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    # The credentials are expanded inside the container by its own shell, never
+    # interpolated by this script and never written to metadata.
+    assert '$POSTGRES_USER' in source and '${POSTGRES_USER' not in source
+    metadata = source.split("cat > \"$PARTIAL_DIR/$METADATA_NAME\"", 1)[1].split("META\n", 2)[1]
+    for leak in ("POSTGRES_USER", "POSTGRES_PASSWORD", "POSTGRES_DB", "DATABASE_PASSWORD"):
+        assert leak not in metadata, f"backup metadata must not carry {leak}"
+
+
+def test_the_helper_writes_a_closed_metadata_key_set_and_a_full_manifest():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    metadata = source.split("cat > \"$PARTIAL_DIR/$METADATA_NAME\"", 1)[1].split("META\n", 2)[1]
+    keys = [line.split("=", 1)[0] for line in metadata.splitlines() if line.strip()]
+    assert keys == [
+        "schema_version",
+        "created_utc",
+        "compose_project",
+        "server_volume",
+        "postgres_volume",
+        "server_image_id",
+        "database_dump",
+        "database_dump_bytes",
+        "migration_rows",
+        "server_data_archive",
+        "server_data_archive_bytes",
+        "server_data_files",
+        "secret_file_scope",
+        "config_files",
+    ]
+    assert len(keys) == len(set(keys)), "metadata keys must be unique"
+    assert '! -name "$CHECKSUM_NAME"' in source, "the manifest covers every file but itself"
+    assert "sha256sum --quiet --check" in source, "verify must re-check the manifest"
+    assert "assert_checksum_grammar" in source and "assert_metadata_grammar" in source, (
+        "verify must enforce the checksum and metadata grammars, not just recompute digests"
+    )
+    assert "does not end with a newline" in source
+    assert "not in canonical filename order" in source
+    assert "contains a non-regular or nested entry" in source
+    assert "exact inventory declared by" in source
+    assert "^[0-9a-f]{64}  [A-Za-z0-9._][A-Za-z0-9._-]*$" in source, (
+        "a manifest name starting with '-' would be read as an option"
+    )
+    assert 'die "$METADATA_NAME is missing keys' in source
+    assert "has more lines than the backup metadata grammar defines" in source
+    assert '[ "$listed" = "$present" ]' in source, (
+        "verify must reject added, removed or renamed files, not only edited bytes"
+    )
+
+
+def test_the_helper_requires_the_configured_secret_file_when_it_lives_in_the_volume():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    assert "secret_file" in source
+    assert "[global]" in source, "only the effective [global] declaration counts"
+    assert "$ARCHIVE_REGULAR_FILES" in source, (
+        "membership must be proven against regular files, not any tar member name"
+    )
+    assert '"$global_sections" -eq 1' in source
+    assert "does not declare secret_file" in source
+    assert '"$declarations" -le 1' in source, "duplicate secret_file declarations must be rejected"
+    assert "the configured secret_file is not archived as a regular file" in source
+    assert "SECRET_FILE_SCOPE=external" in source, (
+        "a secret_file outside /data is operator-managed and must not be read from the host"
+    )
+
+
+def test_backup_and_verify_read_the_config_with_one_shared_grammar():
+    """Two parsers is how a false claim gets blessed.
+
+    A verifier with its own, looser idea of what `secret_file` means can accept
+    a directory the backup path would never have written. There is one parser
+    for the effective `[global]` declaration and one classifier for the scope it
+    resolves to, and both commands go through them.
+    """
+
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    parser = "\n".join(function_body(source, "read_secret_file_declaration"))
+    classifier = "\n".join(function_body(source, "classify_secret_file"))
+    elsewhere = source.replace(parser, "").replace(classifier, "")
+    for grammar in (r"\[global\]", "secret_file[[:space:]]*=", '"$SERVER_TARGET"/*'):
+        assert grammar not in elsewhere, (
+            f"{grammar!r} is read outside the shared secret_file grammar; a second "
+            "parser is a second set of rules for the same file"
+        )
+    for caller in ("assert_secret_file_archived", "cmd_verify"):
+        body = "\n".join(function_body(source, caller))
+        assert "read_secret_file_declaration " in body, f"{caller} must use the shared parser"
+        assert "classify_secret_file " in body, f"{caller} must use the shared classifier"
+
+
+def test_verification_refuses_a_scope_no_backup_can_produce():
+    """`none` is not a scope a successful backup generates.
+
+    Metadata and the manifest are both recomputable by whoever holds the
+    directory, so a value the verifier tolerates but generation never writes is
+    a free hiding place: it conceals that the server secret key is not here and
+    has to be recovered from somewhere else.
+    """
+
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    grammar = "\n".join(function_body(source, "assert_metadata_grammar"))
+    arm = grammar.split("      secret_file_scope)\n", 1)[1].split("\n      config_files)", 1)[0]
+    assert "archived | external" in arm
+    assert re.search(r"\bnone\b", arm) is None, (
+        "verification must not accept secret_file_scope=none"
+    )
+    assert 'META_SECRET_FILE_SCOPE="$value"' in arm, (
+        "the recorded scope must be captured so it can be cross-checked"
+    )
+    assert "SECRET_FILE_SCOPE=none" not in source, (
+        "a backup run must not be able to record a placeholder scope either"
+    )
+    resolved = "\n".join(function_body(source, "write_metadata"))
+    assert "the secret_file scope was not resolved" in resolved, (
+        "generation must refuse to write an unresolved scope"
+    )
+
+
+def test_verify_derives_the_scope_from_the_backed_up_config_and_the_archive():
+    """The recorded scope is a claim; the included config is the evidence.
+
+    An attacker who edits `secret_file_scope` to `external` and recomputes the
+    checksums makes an archived key's absence look intentional; the reverse
+    edit promises a key the archive does not hold. Both are caught only by
+    re-deriving the scope from the etebase-server.ini that was backed up, and
+    proving the archived case against the archive that was just verified.
+    """
+
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    lines = function_body(source, "cmd_verify")
+    body = "\n".join(lines)
+
+    def index_of(fragment):
+        for number, line in enumerate(lines):
+            if fragment in line:
+                return number
+        raise AssertionError(f"cmd_verify must contain {fragment!r}")
+
+    checked = index_of("sha256sum --quiet --check")
+    read = index_of('read_secret_file_declaration "$dir/etebase-server.ini"')
+    classified = index_of("classify_secret_file ")
+    member = index_of("assert_archived_member ")
+    compared = index_of('[ "$META_SECRET_FILE_SCOPE" = "$SECRET_FILE_SCOPE" ]')
+    assert checked < read < classified < member < compared, (
+        "verify must read the config only after its checksum is proven, and must "
+        "prove archive membership before it accepts the recorded scope"
+    )
+    assert '[ "$SECRET_FILE_SCOPE" = archived ]' in body, (
+        "membership is only provable for a secret_file that lives in the volume"
+    )
+    assert '"$archive_listing" | archive_regular_members' in body, (
+        "membership must be proven against the listing tar's own exit status vouched "
+        "for, and against regular members only"
+    )
+    assert "the archive does not hold as a regular file" in body
+    assert "but etebase-server.ini resolves to" in body, (
+        "a scope that disagrees with the config must be named in the refusal"
+    )
+
+
+def test_a_malformed_secret_file_path_is_refused_before_it_is_given_a_scope():
+    """One path grammar, applied before the archived/external split.
+
+    Classifying `/srv//key` or `/data/../etc/key` as `external` and returning
+    early would hand a malformed claim a scope, and a scope is what the verifier
+    cross-checks against: an unresolvable path must be refused for both scopes,
+    not excused by pointing outside the volume.
+    """
+
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    lines = function_body(source, "classify_secret_file")
+
+    def index_of(fragment):
+        for number, line in enumerate(lines):
+            if fragment in line:
+                return number
+        raise AssertionError(f"classify_secret_file must contain {fragment!r}")
+
+    control = index_of("[[:cntrl:]]")
+    absolute = index_of("is not an absolute path")
+    ambiguous = index_of("*//*")
+    external = index_of("SECRET_FILE_SCOPE=external")
+    archived = index_of("SECRET_FILE_SCOPE=archived")
+    assert control < absolute < ambiguous < external < archived, (
+        "control characters, non-absolute paths and ambiguous paths must all be "
+        "refused before either scope is assigned"
+    )
+    ambiguity_case = lines[ambiguous]
+    for shape in ("*//*", "*/./*", "*../*", "*' '*"):
+        assert shape in ambiguity_case, f"the shared path grammar must still refuse {shape}"
+    assert "path is ambiguous" in lines[ambiguous + 1]
+
+
+def test_server_volume_root_is_refused_before_the_external_scope():
+    """The volume root is neither an archived file nor an external key.
+
+    Backup generation and verification share this classifier, so both must stop
+    on the exact target before the external return can misdescribe it.
+    """
+
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    lines = function_body(source, "classify_secret_file")
+    body = "\n".join(lines)
+    exact = next(i for i, line in enumerate(lines) if '"$SERVER_TARGET")' in line)
+    external = next(i for i, line in enumerate(lines) if "SECRET_FILE_SCOPE=external" in line)
+    archived = next(i for i, line in enumerate(lines) if "SECRET_FILE_SCOPE=archived" in line)
+    assert exact < external < archived
+    assert "names $SERVER_TARGET itself, not a file in it" in lines[exact + 1]
+    assert '${value#"$SERVER_TARGET"/}' in body, "archived paths must remain relative to the volume"
+    for caller in ("assert_secret_file_archived", "cmd_verify"):
+        assert "classify_secret_file " in "\n".join(function_body(source, caller)), (
+            f"{caller} must inherit the exact-root rejection"
+        )
+
+
+def test_an_external_secret_file_is_classified_and_never_read():
+    """A path outside /data is operator-managed, in backup and in verify alike.
+
+    Opening it would say nothing about the backup directory — the file may exist
+    on this host and still be absent from the backup, or the reverse — and would
+    pull an operator's key into a code path that has no business holding it.
+    """
+
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    classifier = "\n".join(function_body(source, "classify_secret_file"))
+    assert "SECRET_FILE_SCOPE=external" in classifier
+    for probe in ('"$value"]', '-f "$value"', '-e "$value"', 'cat "$value"', 'cat -- "$value"'):
+        assert probe not in classifier, f"the declared path must not be opened ({probe})"
+    for line in (line.strip() for line in source.splitlines()):
+        if "SECRET_FILE_VALUE" not in line:
+            continue
+        assert line.startswith(("SECRET_FILE_VALUE=", "classify_secret_file ")), (
+            f"the declared secret_file path is only ever classified, never used: {line}"
+        )
+
+
+def test_verify_is_read_only_and_does_not_require_docker():
+    source = code_only(BACKUP.read_text(encoding="utf-8"))
+    entrypoint = source.split('action="$1"', 1)[1]
+    verify_arm = entrypoint.split("verify)", 1)[1].split(";;", 1)[0]
+    assert "docker" not in verify_arm
+
+
+# ── Release wiring ────────────────────────────────────────────────────
+
+
+def test_the_helper_ships_in_the_release_bundle():
+    assert "backup.sh" in BUNDLE_SOURCE_FILES
+    assert BUNDLE_SOURCE_FILES == tuple(sorted(BUNDLE_SOURCE_FILES, key=str))
+
+
+def test_the_installer_admits_installs_and_marks_the_helper_executable():
+    source = INSTALLER.read_text(encoding="utf-8")
+    expected = source.split("EXPECTED_MEMBERS=", 1)[1].split("LC_ALL=C sort)", 1)[0]
+    assert "backup.sh" in expected, "the closed bundle inventory must include backup.sh"
+    copy_loop = source.split("for file in docker-compose.yml", 1)[1].split("\n", 1)[0]
+    assert "backup.sh" in copy_loop, "the installer must copy backup.sh into the install directory"
+    chmod_line = next(line for line in source.splitlines() if line.startswith("chmod +x "))
+    assert "backup.sh" in chmod_line, "backup.sh must be installed executable"
+
+
+def test_the_helper_is_a_tracked_executable_shell_script():
+    assert BACKUP.exists()
+    assert BACKUP.read_text(encoding="utf-8").startswith("#!/usr/bin/env bash")
+    assert BACKUP.stat().st_mode & 0o111, "backup.sh must be executable in the repository"
+
+
+def test_ci_covers_the_helper():
+    workflow = CI_SERVER.read_text(encoding="utf-8")
+    assert workflow.count("- 'self-host/**'") == 2, (
+        "push and pull_request path filters must both cover self-host/, including backup.sh"
+    )
+    syntax_loop = workflow.split("Check release and self-host shell syntax", 1)[1].split(
+        "bash -n", 1
+    )[0]
+    assert "self-host/backup.sh" in syntax_loop, "backup.sh must be syntax-checked in CI"
+
+
+# ── The behavioural fixture ───────────────────────────────────────────
+
+HARNESS = ROOT / "tests" / "fixtures" / "self-host-backup" / "harness.sh"
+
+
+def ci_job(name: str) -> str:
+    workflow = CI_SERVER.read_text(encoding="utf-8")
+    body = workflow.split(f"\n  {name}:\n", 1)[1]
+    return body.split("\n  ", 1)[0] if re.match(r"^[a-z]", body) else re.split(r"\n  [a-z-]+:\n", body)[0]
+
+
+def test_the_behavioural_fixture_is_wired_into_ci():
+    workflow = CI_SERVER.read_text(encoding="utf-8")
+    assert workflow.count("- 'tests/fixtures/self-host-backup/**'") == 2, (
+        "push and pull_request path filters must both cover the behavioural fixture"
+    )
+    syntax_loop = workflow.split("Check release and self-host shell syntax", 1)[1].split(
+        "bash -n", 1
+    )[0]
+    assert "tests/fixtures/self-host-backup/harness.sh" in syntax_loop
+    assert "self-host-backup-behaviour:" in workflow
+    assert "tests/fixtures/self-host-backup/harness.sh" in workflow.split(
+        "self-host-backup-behaviour:", 1
+    )[1]
+
+
+def test_the_behavioural_job_is_github_hosted_and_credential_free():
+    job = ci_job("self-host-backup-behaviour")
+    assert "runs-on: ubuntu-latest" in job, "the fixture must run on a GitHub-hosted AMD64 runner"
+    assert "self-hosted" not in job
+    assert "permissions:\n      contents: read" in job
+    for forbidden in ("secrets.", "environment:", "packages:", "docker/login-action", "push: true"):
+        assert forbidden not in job, f"the behavioural job must not use {forbidden!r}"
+    assert "persist-credentials: false" in job
+
+
+def test_the_native_image_jobs_are_unchanged_by_the_fixture():
+    workflow = CI_SERVER.read_text(encoding="utf-8")
+    image_job = workflow.split("\n  self-host-image:\n", 1)[1]
+    assert "ubuntu-24.04-arm" in image_job
+    assert "runner: ubuntu-24.04\n" in image_job
+    assert "push: false" in image_job
+
+
+def test_the_fixture_covers_both_project_names_and_the_negative_identities():
+    harness = HARNESS.read_text(encoding="utf-8")
+    assert "default project name" in harness and "custom project name" in harness
+    assert "COMPOSE_PROJECT_NAME" in harness
+    assert "django_migrations" in harness, "the database sentinel must be real migration rows"
+    assert "sentinel_rows" in harness
+    assert "media-sentinel.bin" in harness, "the server volume must be non-empty"
+    assert "docker-compose.override.yml" in harness, "the custom-project run must exercise override compatibility"
+    for variant in ("bind", "shared", "redirected", "options"):
+        assert f'"{variant}"' in harness or f" {variant})" in harness, variant
+    assert "left a backup directory behind" in harness, (
+        "a refused identity must fail before any backup directory exists"
+    )
+    assert "verify accepted database corruption with an unchanged manifest" in harness
+    assert "same-length edit with a recomputed valid unauthenticated manifest" in harness
+    assert "verify accepted metadata with an unexpected key" in harness
+    assert "SABOTAGE_MODE" in harness
+    assert "between validation phases" in harness
+
+
+def test_the_fixture_uses_the_old_guessed_names_only_as_untouched_decoys():
+    harness = HARNESS.read_text(encoding="utf-8")
+    assert 'DECOYS=("self-host_server_data" "self-host_pgdata")' in harness, (
+        "the fixture must plant exactly the names the shipped documentation guessed"
+    )
+    assert "assert_decoys_untouched" in harness
+    assert "the helper resolved to the guessed decoy volume" in harness
+
+
+def test_the_fixture_cleans_up_only_after_itself():
+    harness = HARNESS.read_text(encoding="utf-8")
+    assert "trap cleanup EXIT" in harness
+    assert 'SUFFIX="$$-$(date +%s)"' in harness, "fixture identities must be run-scoped"
+    assert "refusing to run: a volume named" in harness, (
+        "the fixture must refuse to run if a decoy name already exists on the host"
+    )
+    assert "mktemp -d" in harness
+    # The only image it runs is the digest this repository already pins.
+    assert harness.count("IMAGE=") == 1
+    assert "postgres@sha256:" in harness
+    assert ":latest" not in harness
+
+
+@pytest.mark.parametrize("name", ["backup-and-restore.md", "uninstalling.md"])
+def test_the_two_documentation_trees_stay_aligned(name):
+    """These two pages are sibling copies; a fix applied to one is a fix to both."""
+
+    published = (ROOT / "docs" / "self-hosting" / name).read_text(encoding="utf-8")
+    site = (ROOT / "apps" / "docs" / "self-hosting" / name).read_text(encoding="utf-8")
+    assert published == site, f"docs/self-hosting/{name} and its apps/docs sibling have drifted"

--- a/tests/test_self_host_installer.py
+++ b/tests/test_self_host_installer.py
@@ -62,6 +62,7 @@ DRAFT_FALSE = '  "draft": false,\n'
 BUNDLE_FILES = (
     ".env.example",
     "SELF-HOSTING.md",
+    "backup.sh",
     "close-signups.sh",
     "docker-compose.yml",
     "install.sh",
@@ -430,6 +431,7 @@ def test_a_valid_release_installs_and_pins_the_immutable_index_digest(workspace)
         "update.sh",
         "verify.sh",
         "close-signups.sh",
+        "backup.sh",
         "success.html",
         MANIFEST_NAME,
     ):


### PR DESCRIPTION
## Summary

- replace guessed Compose-generated volume identities in self-host operator guidance with live container and mount discovery
- add a bounded `backup.sh` helper for read-only identity inspection, verified PostgreSQL/server-data backup, and read-only backup verification
- fail closed on ambiguous, redirected, shared, bind-mounted, custom-driver, or option-bearing storage
- ship the helper in the deterministic self-host bundle and installer
- add static contracts and a credential-free GitHub-hosted Docker fixture for default and custom Compose project names
- replace destructive recovery/reset guidance with explicit manual-recovery boundaries

## Verification

Local permitted checks passed:

- shell syntax for affected release and fixture scripts
- Python compilation for affected contract files
- workflow YAML parsing
- deterministic bundle/inventory and documentation contracts
- source and execution-level sabotage proof for the prior tar-status masking bug
- focused backup-verifier static checks
- `git diff --check`
- exact-head code/security review
- exact-head release/supply-chain/CI review

Docker behavior and Python test execution remain delegated to GitHub Actions by repository policy.

## Risk and boundaries

- no restore, reset, volume deletion, unattended upgrade, deployment, or publication behavior is added
- `.github/workflows/deploy-server.yml` is unchanged
- release tags, draft assets, GHCR versions, `latest`, and hosted production are unchanged
- image rollback does not reverse Django migrations; full rollback may require restoring a pre-migration database dump

Addresses the release-blocking self-host safety work tracked in #682. The issue should remain open until the corrected release is completed and verified.