### PR TITLE
fix(web): reset payment acknowledgement before input

### DIFF
--- a/apps/web/app/components/payment-choice-panel.tsx
+++ b/apps/web/app/components/payment-choice-panel.tsx
@@ -316,7 +316,9 @@ export default function PaymentChoicePanel({
         ? `${currentFlow.flowKind}:${currentFlow.createdAt}`
         : 'none'
 
-  useEffect(() => {
+  // Reset before the browser can accept input for the new authority. A passive
+  // effect can run after an immediate acknowledgement click and erase it.
+  useLayoutEffect(() => {
     setBitcoinCancelAcknowledged(false)
     setBitcoinAcknowledgementProven(false)
   }, [activeFlowKey])


### PR DESCRIPTION
## Summary

- reset the Bitcoin cancellation acknowledgement before the browser can accept input for a newly loaded payment authority
- remove the passive-effect race that made the provider-switching test intermittently lose a deliberate acknowledgement

## Verification

- reproduced the focused failure on iteration 10 before the fix
- focused regression: 50 consecutive passes after the fix
- payment-provider-switching suite: 48 passed
- complete web suite: 990 passed
- web type-check and lint completed (pre-existing warnings only)

Release blocker discovered by post-merge `main` CI while preparing v0.5.4-beta.