### PR TITLE
docs: clarify license boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,14 @@ The marketing site and hosted billing/accounts API live separately and have no c
 
 ## License
 
-[AGPL-3.0-only](./LICENSE) · [`android/LICENSE`](./android/LICENSE) (GPL-3.0) · [Third-party logo notices](./apps/docs/app-logo-notices.md)
+SilentSuite is a multi-license repository:
+
+- **Server, web client, self-host, and documentation** ([`server/`](./server/), [`apps/web/`](./apps/web/), [`self-host/`](./self-host/), and the docs tree): [AGPL-3.0-only](./LICENSE).
+- **Bridge** ([`bridge/`](./bridge/)): see [`bridge/LICENSE`](./bridge/LICENSE) (GNU AGPL v3 or later).
+- **Android sync adapter** ([`android/`](./android/)): [GPL-3.0-only](./android/LICENSE), reflecting its Android/EteSync/DAVx5/bitfire lineage.
+- A subtree may include a `LICENSE` statement of its own; see that file for the applicable terms for the subtree.
+
+[Third-party logo notices](./apps/docs/app-logo-notices.md)
 
 <div align="center">
 

--- a/android/README.md
+++ b/android/README.md
@@ -11,7 +11,7 @@ Secure, end-to-end encrypted, and privacy respecting sync for your contacts, cal
 
 Please see the [SilentSuite website](https://silentsuite.io) for more information.
 
-SilentSuite is licensed under the [GPLv3 License](LICENSE).
+The Android sync adapter is licensed under [GPL-3.0-only](LICENSE), reflecting its Android/EteSync/DAVx5/bitfire lineage. The rest of the SilentSuite repository (server, web, self-host, and documentation) is licensed separately under AGPL-3.0-only; the Bridge has its own bridge/LICENSE terms (GNU AGPL v3 or later). F-Droid reviewers and downstream packagers should identify the Android package as GPL-3.0-only per this license file.
 
 Based on [EteSync for Android](https://github.com/etesync/android) by Ricki Hirner / bitfire web engineering and Tom Hacohen. See [NOTICE](NOTICE) for full attribution.
 

--- a/apps/docs/contributing/index.md
+++ b/apps/docs/contributing/index.md
@@ -40,4 +40,4 @@ Be respectful, constructive, and inclusive. We're building privacy tools for eve
 
 ## License
 
-By contributing to SilentSuite, you agree that your contributions will be licensed under the AGPL-3.0 license.
+By contributing to SilentSuite, you agree that your contributions will be licensed under the license that applies to the component you are modifying: AGPL-3.0-only for the server, web, self-host, and documentation components; GPL-3.0-only for the Android sync adapter; and the terms in bridge/LICENSE (GNU AGPL v3 or later) for the Bridge. Check the LICENSE file in the subtree you are contributing to.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -38,4 +38,4 @@ Be respectful, constructive, and inclusive. We're building privacy tools for eve
 
 ## License
 
-By contributing to SilentSuite, you agree that your contributions will be licensed under the AGPL-3.0 license.
+By contributing to SilentSuite, you agree that your contributions will be licensed under the license that applies to the component you are modifying: AGPL-3.0-only for the server, web, self-host, and documentation components; GPL-3.0-only for the Android sync adapter; and the terms in bridge/LICENSE (GNU AGPL v3 or later) for the Bridge. Check the LICENSE file in the subtree you are contributing to.


### PR DESCRIPTION
## Summary

- document the repository's license boundaries
- explain the Android GPL-3.0-only lineage and F-Droid/downstream package identifier
- distinguish the Bridge's subtree licence from components covered by the root AGPL-3.0-only licence
- correct blanket contribution-license wording in both contributing guides

## Issue

Addresses #161.

This issue is referenced for review and will not be closed automatically by this PR.

## Validation

- `pnpm --filter @silentsuite/docs test:android-distribution` (11 tests passed)
- `pnpm run build:docs`
- license-link target assertions
- `git diff --check`
- unchanged root, Android, and Bridge license/provenance files
- required independent review gate approved the exact candidate tree

## Scope and risk

Documentation only. No license files, notices, source headers, package data, application code, workflows, dependencies, or lockfiles changed. Residual risk is limited to interpretation of the clarified license wording; the text is grounded in the repository's root, Android, and Bridge license files and Android provenance notice.
