### PR TITLE
feat(bridge): add safe self-update flow

### DIFF
--- a/.github/workflows/test-bridge-windows.yml
+++ b/.github/workflows/test-bridge-windows.yml
@@ -61,6 +61,14 @@ jobs:
           python -m pip install pytest
           python -m pytest tests/test_windows_installer_static.py tests/test_release_versions_static.py tests/test_android_security_static.py tests/test_android_toolchain_static.py -q
 
+      - name: Run bridge update contract tests
+        working-directory: bridge
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]" || pip install -e .
+          python -m pytest tests/test_update_contract.py -v --tb=short
+
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |

--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -281,6 +281,9 @@ silentsuite-bridge
 ```bash
 silentsuite-bridge                    # Start the bridge
 silentsuite-bridge --version          # Show version
+silentsuite-bridge --check-update     # Check for a newer release (no mutation)
+silentsuite-bridge --self-update      # Download, verify, and install the latest
+                                      # release (requires a frozen release binary)
 silentsuite-bridge --login            # Add or re-authenticate an account
 silentsuite-bridge --list-accounts    # List configured accounts
 silentsuite-bridge --logout EMAIL     # Remove local credentials; keep cache
@@ -290,6 +293,69 @@ silentsuite-bridge --install-autostart  # Install auto-start
 silentsuite-bridge --remove-autostart   # Remove auto-start
 silentsuite-bridge --no-tray          # Start without system tray
 ```
+
+## Updating the Bridge
+
+### Check for updates
+
+Run `--check-update` to see whether a newer release is available without
+downloading or changing anything:
+
+```bash
+silentsuite-bridge --check-update
+```
+
+This prints the running version, compares it against the latest compatible
+GitHub release, and reports whether an update, current, or another state
+(development build, unsupported platform, network error) applies. The check
+does not touch any configuration, data directory, or server state.
+
+### Apply an update (release binary only)
+
+```bash
+silentsuite-bridge --self-update
+```
+
+This downloads the latest compatible release binary and its `.sha256` sidecar,
+verifies the checksum, and safely replaces the running executable. The command
+requires a frozen release binary (installed via the official installer or a
+GitHub download) in a writable location. Source and editable installs are
+refused; update those manually with git or pip. Same-version replacement
+and downgrades are always refused. After replacement, the updater attempts
+to restart the bridge through systemd (Linux), launchd (macOS), or prints
+an exact manual restart command when automatic restart is unavailable.
+
+### What happens to the running process during update
+
+- **Linux/macOS:** The verified candidate is staged on the same filesystem,
+  the live binary is atomically replaced, and the bridge daemon is restarted
+  via systemd or launchd.
+- **Windows:** The running `.exe` is never overwritten in-process. A verified
+  candidate is staged and a PowerShell helper script is launched to complete
+  the swap after the old process exits, preserving a backup. If the helper
+  cannot be launched, the updater prints an exact manual recovery instruction.
+
+Autostart continues to reference the same installed executable path; it is
+not changed to point at temporary staging paths.
+
+### Recovery after a failed update
+
+A failed download, checksum, or replace leaves the installed executable
+intact. If the replacement fails mid-swap, the original is preserved or
+restored from the same-directory backup. In all cases, the autostart
+entries (systemd/launchd/registry) are not modified, so the bridge can
+be restarted manually from the same path. A manual reinstall via the
+installer script or a direct GitHub download is always an available
+recovery path.
+
+### Manual installer update
+
+The existing `bridge/install.sh` and `bridge/install.ps1` installers still
+work for new installations and manual upgrades. Running the installer over
+an existing installation downloads the latest release and replaces the binary
+after verifying its checksum. This is the recommended path when automatic
+self-update is not available (source installs, unsupported platforms, or
+when you prefer a fresh download).
 
 ## Troubleshooting
 

--- a/apps/docs/user-guide/apps/linux-bridge.md
+++ b/apps/docs/user-guide/apps/linux-bridge.md
@@ -16,7 +16,7 @@ The installer supports Linux on x86_64 and ARM64. Run the stable installer in a 
 curl -fsSL https://silentsuite.io/bridge/install.sh | sh
 ```
 
-The installer downloads the current bridge release, attempts checksum verification when both a checksum tool and the release checksum are available, installs it at `~/.local/bin/silentsuite-bridge`, and configures a systemd user service. If you require manual verification, download the binary and its `.sha256` file from GitHub Releases and compare them before running it.
+The installer downloads the current bridge release, verifies the checksum against the release's `.sha256` sidecar before installing, installs it at `~/.local/bin/silentsuite-bridge`, and configures a systemd user service. Checksum verification is mandatory — the installer refuses to install when the verifier, release checksum sidecar, or asset/binary is unavailable, ambiguous, malformed, or mismatched. If you require manual verification, download the binary and its `.sha256` file from GitHub Releases and compare them before running it.
 
 If your current shell cannot find the command immediately, open a new terminal or run:
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -48,6 +48,33 @@ If Apple Internet Accounts still fails after HTTPS setup, collect redacted bridg
 
 The local bridge cache contains decrypted calendar/contact/task data. Use `--remove-account` when retiring a shared or untrusted machine.
 
+## Self-Update
+
+The Bridge can check for and apply updates from the CLI:
+
+```bash
+# Check whether a newer release is available (no mutation)
+silentsuite-bridge --check-update
+
+# Download, verify, and install the latest release (frozen binary only)
+silentsuite-bridge --self-update
+```
+
+`--check-update` prints the running version, queries public GitHub releases,
+and reports whether an update is available without touching any configuration,
+data, or server state.
+
+`--self-update` downloads the latest compatible binary and its `.sha256`
+sidecar, verifies the checksum, and replaces the running executable. It only
+works with frozen release binaries (installed via the official installer or
+GitHub download) in writable locations. Source/editable installs are refused.
+Same-version replacement and downgrades are always refused.
+
+Failed downloads, checksum mismatches, or replacement errors leave the
+installed executable intact. The existing autostart entries are not changed.
+The full bridge docs at `https://docs.silentsuite.io/bridge` cover
+manual-installer updates, Windows running-process behavior, and recovery.
+
 ## License
 
 AGPL-3.0-only

--- a/bridge/build.py
+++ b/bridge/build.py
@@ -18,48 +18,25 @@ It will be renamed to the release asset name, e.g.:
 
 import argparse
 import hashlib
-import platform
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
+# Canonical PlatformMapping from the updater (Issue #223).
+# Add bridge/src to sys.path so the package is importable even when
+# build.py is run standalone before a pip install.
+_SCRIPT_DIR = Path(__file__).parent.resolve()
+_SRC = _SCRIPT_DIR / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
 
-# ---------------------------------------------------------------------------
-# Platform detection
-# ---------------------------------------------------------------------------
+from silentsuite_bridge.update.platform import PlatformMapping  # noqa: E402
 
-def get_os_label() -> str:
-    s = platform.system().lower()
-    if s == "linux":
-        return "linux"
-    elif s == "darwin":
-        return "macos"
-    elif s == "windows":
-        return "windows"
-    else:
-        raise RuntimeError(f"Unsupported OS: {s}")
-
-
-def get_arch_label() -> str:
-    m = platform.machine().lower()
-    if m in ("x86_64", "amd64"):
-        return "x86_64"
-    elif m in ("aarch64", "arm64"):
-        return "arm64"
-    else:
-        raise RuntimeError(f"Unsupported arch: {m}")
-
-
-def get_asset_name() -> str:
-    os_label = get_os_label()
-    arch_label = get_arch_label()
-    suffix = ".exe" if os_label == "windows" else ""
-    return f"silentsuite-bridge-{os_label}-{arch_label}{suffix}"
-
-
-def get_exe_suffix() -> str:
-    return ".exe" if platform.system().lower() == "windows" else ""
+_get_os_label = PlatformMapping.get_os_label
+_get_arch_label = PlatformMapping.get_arch_label
+_get_asset_name = PlatformMapping.get_asset_name
+_get_exe_suffix = PlatformMapping.get_exe_suffix
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +44,7 @@ def get_exe_suffix() -> str:
 # ---------------------------------------------------------------------------
 
 def run_pyinstaller(clean: bool, debug: bool, no_upx: bool) -> None:
-    script_dir = Path(__file__).parent.resolve()
+    script_dir = _SCRIPT_DIR
     spec_file = script_dir / "silentsuite-bridge.spec"
 
     if not spec_file.exists():
@@ -97,9 +74,9 @@ def run_pyinstaller(clean: bool, debug: bool, no_upx: bool) -> None:
 
 
 def rename_binary(dist_dir: Path) -> Path:
-    suffix = get_exe_suffix()
+    suffix = _get_exe_suffix()
     src = dist_dir / f"silentsuite-bridge{suffix}"
-    asset_name = get_asset_name()
+    asset_name = _get_asset_name()
     dst = dist_dir / asset_name
 
     if not src.exists():
@@ -146,15 +123,15 @@ def main() -> None:
     parser.add_argument("--no-smoke", action="store_true", help="Skip smoke test")
     args = parser.parse_args()
 
-    os_label = get_os_label()
-    arch_label = get_arch_label()
-    asset_name = get_asset_name()
+    os_label = _get_os_label()
+    arch_label = _get_arch_label()
+    asset_name = _get_asset_name()
 
     print(f"[build] Platform: {os_label}/{arch_label}")
     print(f"[build] Asset name: {asset_name}")
     print()
 
-    dist_dir = Path(__file__).parent / "dist"
+    dist_dir = _SCRIPT_DIR / "dist"
 
     # Build
     run_pyinstaller(clean=args.clean, debug=args.debug, no_upx=args.no_upx)
@@ -163,7 +140,7 @@ def main() -> None:
     if not args.no_rename:
         binary = rename_binary(dist_dir)
     else:
-        suffix = get_exe_suffix()
+        suffix = _get_exe_suffix()
         binary = dist_dir / f"silentsuite-bridge{suffix}"
 
     # Smoke test

--- a/bridge/silentsuite-bridge.spec
+++ b/bridge/silentsuite-bridge.spec
@@ -213,6 +213,17 @@ a = Analysis(
         "silentsuite_bridge.local_cache.db",
         "silentsuite_bridge.local_cache.models",
 
+        # Bridge update modules (Issue #223)
+        "silentsuite_bridge.update",
+        "silentsuite_bridge.update.types",
+        "silentsuite_bridge.update.platform",
+        "silentsuite_bridge.update.http",
+        "silentsuite_bridge.update.verify",
+        "silentsuite_bridge.update.fs",
+        "silentsuite_bridge.update.replace",
+        "silentsuite_bridge.update.restart",
+        "silentsuite_bridge.update.check",
+
         # Dependencies
         "vobject",
         "vobject.icalendar",

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -618,13 +618,46 @@ def _serve_radicale_with_bridge_application(configuration) -> None:
         _RADICALE_SERVER_APPLICATION_LOCK.release()
 
 
+def _print_check_result(result) -> None:
+    """Print a human-readable check-update result."""
+    from .update.types import UpdateStatus
+
+    print(f"SilentSuite Bridge v{result.current_version}")
+
+    if result.status == UpdateStatus.AVAILABLE:
+        print(f"Update available: {result.tag_name}")
+    elif result.status == UpdateStatus.CURRENT:
+        print("Up to date.")
+    elif result.status == UpdateStatus.DOWNGRADE:
+        print("Running version is newer than the latest compatible release.")
+    elif result.status == UpdateStatus.DEVELOPMENT:
+        print("Development build — no release checking.")
+    elif result.status == UpdateStatus.UNSUPPORTED:
+        print("Platform not supported for automatic updates.")
+    elif result.status == UpdateStatus.MISSING_ASSET:
+        print("No compatible release asset found.")
+    elif result.status == UpdateStatus.FAILURE:
+        print("Update check failed.")
+
+
+def _check_result_exit_code(result) -> int:
+    """Return the exit code for a check-update result."""
+    from .update.types import UpdateStatus
+
+    if result.status in (
+        UpdateStatus.AVAILABLE,
+        UpdateStatus.CURRENT,
+        UpdateStatus.DOWNGRADE,
+        UpdateStatus.DEVELOPMENT,
+    ):
+        return 0
+    # FAILURE, UNSUPPORTED, MISSING_ASSET → nonzero
+    return 1
+
+
 def main():
     """Main entry point for the bridge CLI."""
-    # Handle --version and --help before any side effects
-    if "--version" in sys.argv:
-        print(f"SilentSuite Bridge v{__version__}")
-        sys.exit(0)
-
+    # --help/-h before anything else (including update flags)
     if "--help" in sys.argv or "-h" in sys.argv:
         print(f"SilentSuite Bridge v{__version__}")
         print("E2EE CalDAV/CardDAV sync daemon\n")
@@ -632,6 +665,9 @@ def main():
         print("Options:")
         print("  --help, -h            Show this help message and exit")
         print("  --version             Show version and exit")
+        print("  --check-update        Check for a newer release (no mutation)")
+        print("  --self-update         Download, verify, and install the latest")
+        print("                        release (requires a frozen release binary)")
         print("  --login               Add or re-authenticate an account")
         print("  --list-accounts       List configured bridge accounts")
         print("  --logout ACCOUNT      Remove local credentials; keep cache")
@@ -659,6 +695,62 @@ def main():
         print("  SILENTSUITE_BRIDGE_SSL       Enable HTTPS for the bridge listener (opt-in)")
         print("  SILENTSUITE_BRIDGE_SSL_CERT  Path to the SSL certificate file")
         print("  SILENTSUITE_BRIDGE_SSL_KEY   Path to the SSL private key file")
+        sys.exit(0)
+
+    # Handle --version before any side effects
+    if "--version" in sys.argv:
+        print(f"SilentSuite Bridge v{__version__}")
+        sys.exit(0)
+
+    # Reject contradictory update flags
+    has_check = "--check-update" in sys.argv
+    has_self = "--self-update" in sys.argv
+    if has_check and has_self:
+        print("Error: --check-update and --self-update cannot be used together.", file=sys.stderr)
+        sys.exit(1)
+
+    # --check-update / --self-update must run before config/data-dir init
+    if has_check:
+        from .update import check_for_update
+
+        try:
+            result = check_for_update()
+        except Exception:
+            print("Error: update check failed.", file=sys.stderr)
+            sys.exit(1)
+        _print_check_result(result)
+        sys.exit(_check_result_exit_code(result))
+
+    if has_self:
+        from .update import perform_update
+
+        try:
+            result = perform_update()
+            if not result.success:
+                print(
+                    result.recovery_instruction
+                    or "Update failed; the installed Bridge is unchanged.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            if result.pending_completion:
+                print(
+                    "The verified update is staged and will finish after this "
+                    "process exits."
+                )
+            else:
+                print("Bridge updated.")
+                if result.recovery_instruction:
+                    print(result.recovery_instruction)
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
+        except Exception:
+            print(
+                "Error: update failed; the installed Bridge was preserved.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         sys.exit(0)
 
     # Handle --server before anything that uses config.ETEBASE_SERVER_URL

--- a/bridge/src/silentsuite_bridge/update/__init__.py
+++ b/bridge/src/silentsuite_bridge/update/__init__.py
@@ -1,0 +1,226 @@
+"""SilentSuite Bridge — safe self-update (Issue #223).
+
+Provides --check-update and --self-update CLI entry points.
+All I/O is injected via adapters so contract tests can verify
+behaviour with fakes/spies.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .platform import PlatformMapping
+from .types import CheckResult, Platform, ReplaceResult, UpdateStatus
+
+if TYPE_CHECKING:
+    from .fs import FilesystemAdapter
+    from .http import SilentSuiteHttpAdapter
+    from .restart import ProcessAdapter
+
+# ---------------------------------------------------------------------------
+# Public helpers (CLI wiring)
+# ---------------------------------------------------------------------------
+
+
+def _default_http():
+    from .http import SilentSuiteHttpAdapter
+
+    return SilentSuiteHttpAdapter()
+
+
+def _detect_platform() -> Platform:
+    os_name = {"linux": "linux", "darwin": "macos", "win32": "windows"}.get(
+        sys.platform, sys.platform
+    )
+    m = os.environ.get("SILENTSUITE_BRIDGE_TEST_MACHINE", platform.machine())
+    return Platform(os_name=os_name, arch=m)
+
+
+def _current_version() -> str:
+    from .. import __version__
+
+    return __version__
+
+
+def _is_frozen() -> bool:
+    return bool(getattr(sys, "frozen", False))
+
+
+def _current_exe() -> Path | None:
+    if not _is_frozen():
+        return None
+    p = Path(sys.executable).resolve()
+    if p.exists():
+        return p
+    return None
+
+
+def _is_writable(path: Path) -> bool:
+    try:
+        return os.access(path, os.W_OK) and os.access(path.parent, os.W_OK)
+    except OSError:
+        return False
+
+
+def _is_development(version: str) -> bool:
+    from .check import version_is_stable
+
+    return not version_is_stable(version)
+
+
+# ---------------------------------------------------------------------------
+# check_for_update  (read-only)
+# ---------------------------------------------------------------------------
+
+
+def check_for_update(
+    *,
+    http: SilentSuiteHttpAdapter | None = None,
+    platform: Platform | None = None,
+    current_version: str | None = None,
+) -> CheckResult:
+    """Check for a newer compatible release. Never mutates the filesystem."""
+    from .check import check_for_update as _check
+
+    if http is None:
+        http = _default_http()
+    if platform is None:
+        platform = _detect_platform()
+    if current_version is None:
+        current_version = _current_version()
+
+    return _check(
+        http=http,
+        platform=platform,
+        current_version=current_version,
+    )
+
+
+# ---------------------------------------------------------------------------
+# perform_update
+# ---------------------------------------------------------------------------
+
+
+def perform_update(
+    *,
+    http: SilentSuiteHttpAdapter | None = None,
+    fs: FilesystemAdapter | None = None,
+    restart: ProcessAdapter | None = None,
+    admission=None,
+    platform: Platform | None = None,
+    current_exe: Path | None = None,
+    current_version: str | None = None,
+    asset_name: str | None = None,
+) -> ReplaceResult:
+    """Orchestrate a safe self-update.
+
+    Admission checks first (frozen, known/writable executable,
+    non-development version). Then release check, download, verify,
+    replace, restart.  Same-version and downgrade always refuse.
+    """
+    from .check import check_for_update as _check
+    from .replace import replace_bridge
+    from .restart import ProcessAdapter, restart_bridge
+
+    if http is None:
+        http = _default_http()
+    if platform is None:
+        platform = _detect_platform()
+    if current_version is None:
+        current_version = _current_version()
+
+    # --- Admission ---
+    if admission is not None:
+        frozen = admission.is_frozen()
+        exe = admission.current_exe()
+        writable = admission.is_writable(exe) if exe is not None else False
+    else:
+        frozen = _is_frozen()
+        exe = current_exe or _current_exe()
+        writable = _is_writable(exe) if exe is not None else False
+
+    if not frozen:
+        raise RuntimeError(
+            "Self-update requires a release (frozen) binary installation."
+        )
+
+    if exe is None:
+        raise RuntimeError(
+            "Cannot determine the installed bridge executable location."
+        )
+
+    if not writable:
+        raise RuntimeError(
+            "The installed bridge executable or its parent directory "
+            "is not writable."
+        )
+
+    if _is_development(current_version):
+        raise RuntimeError(
+            "Self-update is not available for development builds."
+        )
+
+    # --- Check ---
+    result = _check(http=http, platform=platform, current_version=current_version)
+
+    # Same version or downgrade → always refuse. No override.
+    if result.status == UpdateStatus.CURRENT:
+        raise RuntimeError(
+            "The installed Bridge is already current."
+        )
+    if result.status == UpdateStatus.DOWNGRADE:
+        raise RuntimeError("Refusing to downgrade the installed Bridge.")
+
+    if result.status in (
+        UpdateStatus.DEVELOPMENT,
+        UpdateStatus.UNSUPPORTED,
+        UpdateStatus.MISSING_ASSET,
+        UpdateStatus.FAILURE,
+    ):
+        raise RuntimeError("Update not available.")
+
+    # result.status == AVAILABLE
+    chosen = result.release
+    if chosen is None or not chosen.asset_url or not chosen.checksum_url:
+        raise RuntimeError("No compatible release asset found.")
+
+    if asset_name is None:
+        asset_name = PlatformMapping.asset_name(platform.os_name, platform.arch)
+    if asset_name is None:
+        raise RuntimeError(
+            f"Unsupported platform: {platform.os_name}/{platform.arch}"
+        )
+
+    replace_result = replace_bridge(
+        http=http,
+        fs=fs,
+        platform=platform,
+        current_exe=exe,
+        asset_url=chosen.asset_url,
+        checksum_url=chosen.checksum_url,
+        asset_name=asset_name,
+    )
+
+    # Restart — Windows restart is owned by the helper script; do not
+    # double-restart here.
+    if platform.os_name == "windows":
+        return replace_result
+
+    if restart is None:
+        restart = ProcessAdapter()
+    # restart_bridge centrally rebuilds the manual instruction from the
+    # installed target path, discarding any adapter-supplied text.
+    restart_result = restart_bridge(
+        process=restart, exe_path=exe, platform=platform.os_name
+    )
+    if not restart_result.success:
+        return ReplaceResult(
+            success=True,
+            pending_completion=False,
+            recovery_instruction=restart_result.instruction,
+        )
+    return replace_result

--- a/bridge/src/silentsuite_bridge/update/check.py
+++ b/bridge/src/silentsuite_bridge/update/check.py
@@ -20,10 +20,16 @@ _VERSION_RE = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 
+# Reserved stamps that satisfy the SemVer grammar but never denote a
+# release: the source-tree development stamp and the unknown placeholder.
+_RESERVED_DEV_VERSIONS = frozenset({"0.0.0-dev", "0.0.0"})
+
 
 def version_is_stable(version: str) -> bool:
     """Return True if `version` looks like a valid release version."""
     if not version:
+        return False
+    if version in _RESERVED_DEV_VERSIONS:
         return False
     return bool(_VERSION_RE.match(version))
 

--- a/bridge/src/silentsuite_bridge/update/check.py
+++ b/bridge/src/silentsuite_bridge/update/check.py
@@ -1,0 +1,221 @@
+"""Release lookup and deterministic version comparison."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from .platform import PlatformMapping
+from .types import CheckResult, Platform, ReleaseInfo, UpdateStatus
+
+if TYPE_CHECKING:
+    from .http import SilentSuiteHttpAdapter
+
+# A valid release version is X.Y.Z[-prerelease] where X/Y/Z are non-negative
+# integers.  Anything else is unknown/development.
+_VERSION_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+def version_is_stable(version: str) -> bool:
+    """Return True if `version` looks like a valid release version."""
+    if not version:
+        return False
+    return bool(_VERSION_RE.match(version))
+
+
+def _compare_versions(a: str, b: str) -> int:
+    """Strict SemVer-like comparison.
+
+    Negative if a < b, 0 if equal, positive if a > b.
+
+    Prerelease identifiers: numeric ones sort numerically and compare
+    as *lower* than non-numeric identifiers (per SemVer 2.0).
+    No prerelease > any prerelease.  Build metadata (after '+') is
+    stripped before comparison.
+    """
+    a_parts, a_pre = _split_version(a)
+    b_parts, b_pre = _split_version(b)
+
+    # Compare major.minor.patch
+    for an, bn in zip(a_parts, b_parts):
+        if an != bn:
+            return an - bn
+
+    # Compare prerelease
+    if not a_pre and not b_pre:
+        return 0
+    if not a_pre:
+        return 1
+    if not b_pre:
+        return -1
+
+    # Both have prerelease — element by element
+    for ae, be in zip(a_pre, b_pre):
+        a_num = _try_int(ae)
+        b_num = _try_int(be)
+        if a_num is not None and b_num is not None:
+            if a_num != b_num:
+                return a_num - b_num
+        elif a_num is not None or b_num is not None:
+            # Numeric sorts lower
+            return 1 if a_num is None else -1
+        else:
+            if ae != be:
+                return -1 if ae < be else 1
+
+    return len(a_pre) - len(b_pre)
+
+
+def _try_int(s: str) -> int | None:
+    # SemVer: an identifier is numeric only if it consists solely of digits.
+    # int() alone would also accept "+1"/"-1"/" 1".
+    if s.isdigit():
+        return int(s)
+    return None
+
+
+def _split_version(v: str):
+    """Split `v` into ([major, minor, patch], [prerelease ...]).
+
+    Strips build metadata after '+'.  Returned numeric parts are always
+    length 3.
+    """
+    if "+" in v:
+        v = v.split("+", 1)[0]
+    if "-" in v:
+        main, pre = v.split("-", 1)
+        main_parts = _parse_numeric_parts(main)
+        pre_parts = pre.split(".")
+    else:
+        main_parts = _parse_numeric_parts(v)
+        pre_parts: list[str] = []
+    return main_parts, pre_parts
+
+
+def _parse_numeric_parts(s: str) -> list[int]:
+    """Parse exactly three non-negative integer version parts or raise."""
+    parts = s.split(".")
+    if len(parts) != 3:
+        # Allow the caller to handle by treating as zero-padded. The regex
+        # already enforces exactly 3 parts for valid versions.
+        raise ValueError(f"Expected 3 numeric parts, got {len(parts)}")
+    return [int(p) for p in parts]
+
+
+def check_for_update(
+    *,
+    http: SilentSuiteHttpAdapter,
+    platform: Platform,
+    current_version: str,
+) -> CheckResult:
+    """Check GitHub Releases for a newer compatible release."""
+
+    # Unsupported platform → no network
+    asset_name = PlatformMapping.asset_name(platform.os_name, platform.arch)
+    if asset_name is None:
+        return CheckResult(
+            status=UpdateStatus.UNSUPPORTED,
+            current_version=current_version,
+        )
+
+    # Development / unknown version → no network
+    if not version_is_stable(current_version):
+        return CheckResult(
+            status=UpdateStatus.DEVELOPMENT,
+            current_version=current_version,
+        )
+
+    # Fetch releases
+    try:
+        releases = http.fetch_releases()
+    except Exception:
+        return CheckResult(
+            status=UpdateStatus.FAILURE,
+            current_version=current_version,
+            error_message="Could not fetch release information.",
+        )
+
+    # Find the newest non-draft release with compatible assets.
+    # Reject malformed release tags as candidates (they cannot be
+    # valid versions).
+    best: ReleaseInfo | None = None
+    checksum_asset = PlatformMapping.checksum_asset_name(asset_name)
+
+    for rel in releases:
+        if not isinstance(rel, dict):
+            continue
+        if rel.get("draft", False):
+            continue
+
+        tag = rel.get("tag_name", "")
+        if not isinstance(tag, str) or not tag:
+            continue
+        version = tag[1:] if tag.startswith("v") else tag
+        if not version:
+            continue
+
+        # Reject malformed release versions — don't offer them.
+        if not _VERSION_RE.match(version):
+            continue
+
+        assets = rel.get("assets", [])
+        if not isinstance(assets, list):
+            continue
+        matching = [a for a in assets if isinstance(a, dict) and a.get("name") == asset_name]
+        matching_checksums = [
+            a for a in assets
+            if isinstance(a, dict) and a.get("name") == checksum_asset
+        ]
+
+        if len(matching) != 1 or len(matching_checksums) != 1:
+            continue
+
+        asset_url = matching[0].get("browser_download_url")
+        checksum_url = matching_checksums[0].get("browser_download_url")
+        if not isinstance(asset_url, str) or not isinstance(checksum_url, str):
+            continue
+
+        candidate = ReleaseInfo(
+            tag_name=tag,
+            version=version,
+            asset_url=asset_url,
+            checksum_url=checksum_url,
+            asset_name=asset_name,
+        )
+
+        if best is None or _compare_versions(candidate.version, best.version) > 0:
+            best = candidate
+
+    if best is None:
+        return CheckResult(
+            status=UpdateStatus.MISSING_ASSET,
+            current_version=current_version,
+        )
+
+    # Compare current vs best
+    cmp = _compare_versions(best.version, current_version)
+    if cmp > 0:
+        return CheckResult(
+            status=UpdateStatus.AVAILABLE,
+            current_version=current_version,
+            tag_name=best.tag_name,
+            release=best,
+        )
+    if cmp == 0:
+        return CheckResult(
+            status=UpdateStatus.CURRENT,
+            current_version=current_version,
+            tag_name=best.tag_name,
+            release=best,
+        )
+    return CheckResult(
+        status=UpdateStatus.DOWNGRADE,
+        current_version=current_version,
+        tag_name=best.tag_name,
+        release=best,
+    )

--- a/bridge/src/silentsuite_bridge/update/fs.py
+++ b/bridge/src/silentsuite_bridge/update/fs.py
@@ -161,16 +161,29 @@ class FilesystemAdapter:
         suffix = ".update-staged"
         fd, staged_path = tempfile.mkstemp(suffix=suffix, dir=str(parent))
         try:
-            _write_all(fd, data)
-            os.fsync(fd)
+            write_error: BaseException | None = None
+            try:
+                _write_all(fd, data)
+                os.fsync(fd)
+            except Exception as exc:
+                write_error = exc
+            # Close exactly once, and always before unlink — Windows
+            # refuses to remove a file with an open descriptor.
+            try:
+                os.close(fd)
+            except OSError:
+                # A close failure must not mask the original error; on
+                # an otherwise-successful write it is itself fatal.
+                if write_error is None:
+                    raise
+            if write_error is not None:
+                raise write_error
         except Exception:
             try:
                 os.unlink(staged_path)
             except OSError:
                 pass
             raise
-        finally:
-            os.close(fd)
         return staged_path
 
     def chmod(self, path: str | Path, mode: int) -> None:
@@ -265,13 +278,24 @@ def _write_private_text(path: Path, content: str) -> None:
     data = content.encode("utf-8")
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
-        _write_all(fd, data)
-        os.fsync(fd)
+        write_error: BaseException | None = None
+        try:
+            _write_all(fd, data)
+            os.fsync(fd)
+        except Exception as exc:
+            write_error = exc
+        # Close exactly once, and always before unlink — Windows refuses
+        # to remove a file with an open descriptor.
+        try:
+            os.close(fd)
+        except OSError:
+            if write_error is None:
+                raise
+        if write_error is not None:
+            raise write_error
     except Exception:
         try:
             os.unlink(path)
         except OSError:
             pass
         raise
-    finally:
-        os.close(fd)

--- a/bridge/src/silentsuite_bridge/update/fs.py
+++ b/bridge/src/silentsuite_bridge/update/fs.py
@@ -130,13 +130,20 @@ try {
     exit 1
 }
 
-Remove-Item -Force -Path $Backup -ErrorAction SilentlyContinue
-
 # --- Restart the exact installed target only ---
 try {
     Start-Process -FilePath $Target -WindowStyle Hidden -ErrorAction Stop
+    # The new process was created successfully; rollback is no longer needed.
+    Remove-Item -Force -Path $Backup -ErrorAction SilentlyContinue
 } catch {
-    Write-Host "The Bridge was updated but did not restart automatically. Run manually: $Target"
+    Write-Host 'ERROR: the updated Bridge did not restart; restoring the previous Bridge.'
+    try {
+        Remove-Item -Force -Path $Target -ErrorAction Stop
+        Move-Item -Force -Path $Backup -Destination $Target -ErrorAction Stop
+        Write-Host "The previous Bridge was restored. Run manually: $Target"
+    } catch {
+        Write-Host "ERROR: automatic restore failed. Run manually: $Target"
+    }
 }
 
 Remove-UpdateArtifacts

--- a/bridge/src/silentsuite_bridge/update/fs.py
+++ b/bridge/src/silentsuite_bridge/update/fs.py
@@ -1,0 +1,277 @@
+"""Filesystem adapter for safe staging and replacement.
+
+Private staging, POSIX atomic swap, Windows structured helper-plan
+creation/launch.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# Static Windows post-exit swap helper. It receives the plan file path as
+# its only argument — no paths are ever interpolated into this source.
+# Restricted to Windows PowerShell 5.1-compatible constructs.
+_WINDOWS_HELPER_SCRIPT = r"""# SilentSuite Bridge self-update helper. Do not edit.
+# Reads the update plan from the first argument; contains no embedded paths.
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$PlanFile
+)
+
+$ErrorActionPreference = 'Stop'
+
+try {
+    $plan = Get-Content -Raw -Path $PlanFile | ConvertFrom-Json
+} catch {
+    Write-Host 'ERROR: could not read the update plan.'
+    exit 1
+}
+
+$Candidate = [string]$plan.candidate
+$Target = [string]$plan.target
+$Backup = [string]$plan.backup
+$OldPid = "$($plan.pid)"
+$HelperFile = $MyInvocation.MyCommand.Path
+$plan_dir = Split-Path -Path $Target -Parent
+
+function Remove-UpdateArtifacts {
+    Remove-Item -Force -Path $PlanFile -ErrorAction SilentlyContinue
+    Remove-Item -Force -Path $HelperFile -ErrorAction SilentlyContinue
+}
+
+function Remove-StagedCandidate {
+    Remove-Item -Force -Path $Candidate -ErrorAction SilentlyContinue
+}
+
+# --- Validate the plan before touching anything ---
+foreach ($p in @($Candidate, $Target, $Backup)) {
+    if (-not ($p -match '^[A-Za-z]:[\\/].+')) {
+        Write-Host 'ERROR: update plan paths must be absolute.'
+        Remove-UpdateArtifacts
+        exit 1
+    }
+}
+if (-not $Candidate.EndsWith('.update-staged')) {
+    Write-Host 'ERROR: candidate does not have the expected staging suffix.'
+    Remove-UpdateArtifacts
+    exit 1
+}
+if (($Candidate -eq $Target) -or ($Backup -eq $Target)) {
+    Write-Host 'ERROR: update plan paths collide with the installed target.'
+    Remove-UpdateArtifacts
+    exit 1
+}
+if (((Split-Path -Path $Candidate -Parent) -ne $plan_dir) -or
+    ((Split-Path -Path $Backup -Parent) -ne $plan_dir)) {
+    Write-Host 'ERROR: update plan paths are not in the installed directory.'
+    Remove-UpdateArtifacts
+    exit 1
+}
+if (-not ($OldPid -match '^[0-9]+$')) {
+    Write-Host 'ERROR: invalid process id in update plan.'
+    Remove-UpdateArtifacts
+    exit 1
+}
+
+# --- Bounded wait for the old process to exit ---
+$WaitSeconds = 30
+$exited = $true
+$old = Get-Process -Id ([int]$OldPid) -ErrorAction SilentlyContinue
+if ($old) {
+    try {
+        $exited = $old.WaitForExit($WaitSeconds * 1000)
+    } catch {
+        $exited = $true
+    }
+}
+if (-not $exited) {
+    Write-Host 'ERROR: the running bridge did not exit; the installed Bridge is unchanged.'
+    Remove-StagedCandidate
+    Remove-UpdateArtifacts
+    exit 1
+}
+
+# --- The installed target must still exist as a rollback source ---
+if (-not (Test-Path -Path $Target)) {
+    Write-Host 'ERROR: the installed Bridge executable was not found.'
+    Write-Host 'Refusing to install without a rollback source; nothing was changed.'
+    Remove-StagedCandidate
+    Remove-UpdateArtifacts
+    exit 1
+}
+
+# --- Back up the installed executable ---
+try {
+    Move-Item -Force -Path $Target -Destination $Backup -ErrorAction Stop
+} catch {
+    Write-Host 'ERROR: could not back up the installed Bridge; it is unchanged.'
+    Remove-StagedCandidate
+    Remove-UpdateArtifacts
+    exit 1
+}
+
+# --- Move the verified candidate into place, rolling back on failure ---
+try {
+    Move-Item -Force -Path $Candidate -Destination $Target -ErrorAction Stop
+} catch {
+    Write-Host 'ERROR: could not install the update; restoring the previous Bridge.'
+    try {
+        Move-Item -Force -Path $Backup -Destination $Target -ErrorAction Stop
+    } catch {
+        Write-Host "ERROR: automatic restore failed. Run manually: $Target"
+    }
+    Remove-StagedCandidate
+    Remove-UpdateArtifacts
+    exit 1
+}
+
+Remove-Item -Force -Path $Backup -ErrorAction SilentlyContinue
+
+# --- Restart the exact installed target only ---
+try {
+    Start-Process -FilePath $Target -WindowStyle Hidden -ErrorAction Stop
+} catch {
+    Write-Host "The Bridge was updated but did not restart automatically. Run manually: $Target"
+}
+
+Remove-UpdateArtifacts
+exit 0
+"""
+
+
+class FilesystemAdapter:
+    """Abstract filesystem operations for testability."""
+
+    # ------------------------------------------------------------------
+    # staging
+    # ------------------------------------------------------------------
+
+    def stage(self, target_path: str | Path, data: bytes) -> str:
+        """Write full `data` to a private temp file on the same filesystem
+        as `target_path`, fsync it, and return the path.  Removes
+        partial files on failure.
+        """
+        target = Path(target_path).resolve()
+        parent = target.parent
+        suffix = ".update-staged"
+        fd, staged_path = tempfile.mkstemp(suffix=suffix, dir=str(parent))
+        try:
+            _write_all(fd, data)
+            os.fsync(fd)
+        except Exception:
+            try:
+                os.unlink(staged_path)
+            except OSError:
+                pass
+            raise
+        finally:
+            os.close(fd)
+        return staged_path
+
+    def chmod(self, path: str | Path, mode: int) -> None:
+        os.chmod(str(path), mode)
+
+    def remove(self, path: str | Path) -> None:
+        try:
+            os.unlink(str(path))
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # POSIX atomic replace
+    # ------------------------------------------------------------------
+
+    def replace(self, src: str | Path, dst: str | Path) -> None:
+        os.replace(str(src), str(dst))
+
+    def stat_mode(self, path: str | Path) -> int:
+        """Return ``os.stat(...).st_mode`` for the path."""
+        return os.stat(str(path)).st_mode
+
+    def cleanup(self) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Windows structured staging plan
+    # ------------------------------------------------------------------
+
+    def write_staging_plan(self, plan: dict[str, Any]) -> str:
+        """Serialize `plan` as JSON and write it next to the candidate."""
+        plan = dict(plan)
+        candidate = Path(plan["candidate"])
+        plan_path = candidate.parent / f"{candidate.name}.update-plan.json"
+        _write_private_text(plan_path, json.dumps(plan, indent=2))
+        return str(plan_path)
+
+
+    def write_windows_helper(self, plan_path: str) -> str:
+        """Create a static PowerShell helper script that reads the JSON
+        plan from an argv element (no path interpolation into source).
+
+        Returns the helper file path.
+        """
+        candidate = Path(plan_path).parent / (
+            Path(plan_path).name.replace(".update-plan.json", "")
+        )
+        parent = Path(plan_path).parent
+        helper_path = parent / f"{candidate.name}.update-helper.ps1"
+
+        _write_private_text(helper_path, _WINDOWS_HELPER_SCRIPT)
+        return str(helper_path)
+
+    def launch_helper(self, helper_path: str, plan_path: str) -> bool:
+        """Launch PowerShell via argv list: powershell.exe -File helper
+        with the plan path as the first positional argument.
+        No shell interpolation.
+        """
+        import subprocess
+
+        try:
+            subprocess.Popen(
+                [
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-ExecutionPolicy", "Bypass",
+                    "-File", str(helper_path),
+                    str(plan_path),
+                ],
+                creationflags=(
+                    subprocess.CREATE_NO_WINDOW
+                    if sys.platform == "win32"
+                    else 0
+                ),
+            )
+            return True
+        except Exception:
+            return False
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    offset = 0
+    while offset < len(data):
+        written = os.write(fd, data[offset:])
+        if written == 0:
+            raise OSError("Short write during staging")
+        offset += written
+
+
+def _write_private_text(path: Path, content: str) -> None:
+    data = content.encode("utf-8")
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        _write_all(fd, data)
+        os.fsync(fd)
+    except Exception:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        raise
+    finally:
+        os.close(fd)

--- a/bridge/src/silentsuite_bridge/update/http.py
+++ b/bridge/src/silentsuite_bridge/update/http.py
@@ -7,6 +7,7 @@ sanitized exceptions.  urllib is instructed never to auto-follow redirects.
 from __future__ import annotations
 
 import json
+import time
 import urllib.error
 import urllib.request
 from typing import Any
@@ -33,6 +34,7 @@ _MAX_BINARY = 128 * 1024 * 1024
 MAX_CHECKSUM_BYTES = 1024
 
 DEFAULT_TIMEOUT = 60
+DEFAULT_TOTAL_TIMEOUT = 120
 DEFAULT_MAX_REDIRECTS = 5
 
 _USER_AGENT = "SilentSuite-Bridge-Updater"
@@ -58,13 +60,19 @@ class SilentSuiteHttpAdapter:
         *,
         transport: Any = None,
         timeout: int = DEFAULT_TIMEOUT,
+        total_timeout: int = DEFAULT_TOTAL_TIMEOUT,
         max_redirects: int = DEFAULT_MAX_REDIRECTS,
         max_size: int | None = None,
+        clock=None,
     ):
+        if timeout <= 0 or total_timeout <= 0:
+            raise ValueError("Update timeouts must be positive.")
         self._transport = transport
         self._timeout = timeout
+        self._total_timeout = total_timeout
         self._max_redirects = max_redirects
         self._max_size = max_size
+        self._clock = clock or time.monotonic
 
     def fetch_releases(self) -> list[dict]:
         """Fetch GitHub Releases JSON. Returns list of release dicts."""
@@ -83,12 +91,15 @@ class SilentSuiteHttpAdapter:
     def download(self, url: str, max_size: int | None = None) -> bytes:
         """Download `url` with bounded redirects, time, and size."""
         effective_max = max_size if max_size is not None else self._max_size
+        deadline = self._clock() + self._total_timeout
         return _bounded_download(
             url=url,
             transport=self._transport,
             timeout=self._timeout,
             max_redirects=self._max_redirects,
             max_size=effective_max or _MAX_BINARY,
+            deadline=deadline,
+            clock=self._clock,
         )
 
 
@@ -98,6 +109,8 @@ def _bounded_download(
     timeout: int,
     max_redirects: int,
     max_size: int,
+    deadline: float,
+    clock,
     _redirect_count: int = 0,
 ) -> bytes:
     parsed = urlparse(url)
@@ -110,23 +123,31 @@ def _bounded_download(
     if parsed.scheme != "https":
         raise HttpError("Refusing non-HTTPS URL.")
 
+    request_timeout = _remaining_timeout(timeout, deadline, clock)
+
     if transport is not None:
         # Injected fake transport (tests)
         try:
-            resp = transport.get(url, timeout=timeout)
+            resp = transport.get(url, timeout=request_timeout)
         except Exception:
             raise HttpError("Network error during download.") from None
     else:
         req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
         opener = urllib.request.build_opener(_NoRedirect())
         try:
-            resp = opener.open(req, timeout=timeout)
+            resp = opener.open(req, timeout=request_timeout)
         except urllib.error.HTTPError as err:
             # Non-2xx from the real transport. Close and sanitize.
             _close_response(err)
             raise HttpError("Request failed.") from None
         except Exception:
             raise HttpError("Network error during download.") from None
+
+    try:
+        _ensure_before_deadline(deadline, clock)
+    except HttpError:
+        _close_response(resp)
+        raise
 
     status = int(getattr(resp, "status", 0))
     location = _extract_location(resp)
@@ -140,6 +161,8 @@ def _bounded_download(
             timeout=timeout,
             max_redirects=max_redirects,
             max_size=max_size,
+            deadline=deadline,
+            clock=clock,
             _redirect_count=_redirect_count + 1,
         )
 
@@ -159,11 +182,13 @@ def _bounded_download(
             return encoded
         it = getattr(resp, "iter_content", None)
         if it is not None:
-            return _read_chunks(it(), max_size, response=resp)
+            return _read_chunks(
+                it(), max_size, response=resp, deadline=deadline, clock=clock,
+            )
         _close_response(resp)
         raise HttpError("Unexpected response format.")
     else:
-        return _read_streamed(resp, max_size)
+        return _read_streamed(resp, max_size, deadline=deadline, clock=clock)
 
 
 def _extract_location(resp) -> str | None:
@@ -185,22 +210,35 @@ def _resolve_redirect(base_url: str, location: str) -> str:
     return urljoin(base_url, location)
 
 
-def _read_streamed(response, max_size: int) -> bytes:
+def _read_streamed(response, max_size: int, *, deadline: float, clock) -> bytes:
     def chunks():
         while True:
+            _ensure_before_deadline(deadline, clock)
             chunk = response.read(65536)
+            _ensure_before_deadline(deadline, clock)
             if not chunk:
                 break
             yield chunk
 
-    return _read_chunks(chunks(), max_size, response=response)
+    return _read_chunks(
+        chunks(), max_size, response=response, deadline=deadline, clock=clock,
+    )
 
 
-def _read_chunks(chunks_iter, max_size: int, *, response=None) -> bytes:
+def _read_chunks(
+    chunks_iter, max_size: int, *, response=None, deadline: float, clock,
+) -> bytes:
     chunks: list[bytes] = []
     total = 0
     try:
-        for chunk in chunks_iter:
+        iterator = iter(chunks_iter)
+        while True:
+            _ensure_before_deadline(deadline, clock)
+            try:
+                chunk = next(iterator)
+            except StopIteration:
+                break
+            _ensure_before_deadline(deadline, clock)
             if not isinstance(chunk, bytes):
                 raise HttpError("Unexpected response format.")
             total += len(chunk)
@@ -215,3 +253,15 @@ def _read_chunks(chunks_iter, max_size: int, *, response=None) -> bytes:
 def _close_response(response) -> None:
     if response is not None and hasattr(response, "close"):
         response.close()
+
+
+def _remaining_timeout(per_operation: float, deadline: float, clock) -> float:
+    remaining = deadline - clock()
+    if remaining <= 0:
+        raise HttpError("Update request timed out.")
+    return min(per_operation, remaining)
+
+
+def _ensure_before_deadline(deadline: float, clock) -> None:
+    if clock() >= deadline:
+        raise HttpError("Update request timed out.")

--- a/bridge/src/silentsuite_bridge/update/http.py
+++ b/bridge/src/silentsuite_bridge/update/http.py
@@ -1,0 +1,217 @@
+"""Public unauthenticated HTTP client for release lookup and downloads.
+
+Manual bounded redirects, exact HTTPS host allowlist, streamed max sizes,
+sanitized exceptions.  urllib is instructed never to auto-follow redirects.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+from urllib.parse import urlparse
+
+from .types import HttpError
+
+# Exact hosts allowed for every hop — no wildcard subdomain acceptance.
+_ALLOWED_HOSTS = frozenset({
+    "api.github.com",
+    "github.com",
+    "release-assets.githubusercontent.com",
+    "objects.githubusercontent.com",
+    "codeload.github.com",
+})
+
+# Release JSON max size
+_MAX_RELEASE_JSON = 512 * 1024
+
+# Binary download max size
+_MAX_BINARY = 128 * 1024 * 1024
+
+# Checksum sidecar max size — passed explicitly by the replace orchestrator
+MAX_CHECKSUM_BYTES = 1024
+
+DEFAULT_TIMEOUT = 60
+DEFAULT_MAX_REDIRECTS = 5
+
+_USER_AGENT = "SilentSuite-Bridge-Updater"
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Return redirect responses without following them automatically."""
+
+    def http_error_301(self, request, response, code, message, headers):
+        return response
+
+    http_error_302 = http_error_301
+    http_error_303 = http_error_301
+    http_error_307 = http_error_301
+    http_error_308 = http_error_301
+
+
+class SilentSuiteHttpAdapter:
+    """Public unauthenticated HTTP client with bounded redirects/time/size."""
+
+    def __init__(
+        self,
+        *,
+        transport: Any = None,
+        timeout: int = DEFAULT_TIMEOUT,
+        max_redirects: int = DEFAULT_MAX_REDIRECTS,
+        max_size: int | None = None,
+    ):
+        self._transport = transport
+        self._timeout = timeout
+        self._max_redirects = max_redirects
+        self._max_size = max_size
+
+    def fetch_releases(self) -> list[dict]:
+        """Fetch GitHub Releases JSON. Returns list of release dicts."""
+        url = "https://api.github.com/repos/silent-suite/silentsuite/releases?per_page=100"
+        body = self.download(url, max_size=_MAX_RELEASE_JSON)
+        try:
+            data = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            raise HttpError("GitHub Releases API returned invalid JSON.")
+
+        if not isinstance(data, list):
+            raise HttpError("GitHub Releases API response is not a list.")
+
+        return data
+
+    def download(self, url: str, max_size: int | None = None) -> bytes:
+        """Download `url` with bounded redirects, time, and size."""
+        effective_max = max_size if max_size is not None else self._max_size
+        return _bounded_download(
+            url=url,
+            transport=self._transport,
+            timeout=self._timeout,
+            max_redirects=self._max_redirects,
+            max_size=effective_max or _MAX_BINARY,
+        )
+
+
+def _bounded_download(
+    url: str,
+    transport,
+    timeout: int,
+    max_redirects: int,
+    max_size: int,
+    _redirect_count: int = 0,
+) -> bytes:
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower().rstrip(".")
+
+    if host not in _ALLOWED_HOSTS:
+        raise HttpError("Refusing disallowed host.")
+    if _redirect_count > max_redirects:
+        raise HttpError("Too many redirects.")
+    if parsed.scheme != "https":
+        raise HttpError("Refusing non-HTTPS URL.")
+
+    if transport is not None:
+        # Injected fake transport (tests)
+        try:
+            resp = transport.get(url, timeout=timeout)
+        except Exception:
+            raise HttpError("Network error during download.") from None
+    else:
+        req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+        opener = urllib.request.build_opener(_NoRedirect())
+        try:
+            resp = opener.open(req, timeout=timeout)
+        except urllib.error.HTTPError as err:
+            # Non-2xx from the real transport. Close and sanitize.
+            _close_response(err)
+            raise HttpError("Request failed.") from None
+        except Exception:
+            raise HttpError("Network error during download.") from None
+
+    status = int(getattr(resp, "status", 0))
+    location = _extract_location(resp)
+
+    if status in (301, 302, 303, 307, 308) and location:
+        next_url = _resolve_redirect(url, location)
+        _close_response(resp)
+        return _bounded_download(
+            next_url,
+            transport=transport,
+            timeout=timeout,
+            max_redirects=max_redirects,
+            max_size=max_size,
+            _redirect_count=_redirect_count + 1,
+        )
+
+    if status < 200 or status >= 300:
+        _close_response(resp)
+        raise HttpError("Request failed.")
+
+    # Read body
+    if transport is not None:
+        content = getattr(resp, "content", None)
+        if content is not None:
+            encoded = content if isinstance(content, bytes) else content.encode()
+            if len(encoded) > max_size:
+                _close_response(resp)
+                raise HttpError("Download size exceeded.")
+            _close_response(resp)
+            return encoded
+        it = getattr(resp, "iter_content", None)
+        if it is not None:
+            return _read_chunks(it(), max_size, response=resp)
+        _close_response(resp)
+        raise HttpError("Unexpected response format.")
+    else:
+        return _read_streamed(resp, max_size)
+
+
+def _extract_location(resp) -> str | None:
+    headers = getattr(resp, "headers", None) or {}
+    if hasattr(headers, "get"):
+        loc = headers.get("Location") or headers.get("location")
+        if loc:
+            return str(loc)
+    # dict-style
+    if isinstance(headers, dict):
+        for k, v in headers.items():
+            if str(k).lower() == "location":
+                return str(v)
+    return None
+
+
+def _resolve_redirect(base_url: str, location: str) -> str:
+    from urllib.parse import urljoin
+    return urljoin(base_url, location)
+
+
+def _read_streamed(response, max_size: int) -> bytes:
+    def chunks():
+        while True:
+            chunk = response.read(65536)
+            if not chunk:
+                break
+            yield chunk
+
+    return _read_chunks(chunks(), max_size, response=response)
+
+
+def _read_chunks(chunks_iter, max_size: int, *, response=None) -> bytes:
+    chunks: list[bytes] = []
+    total = 0
+    try:
+        for chunk in chunks_iter:
+            if not isinstance(chunk, bytes):
+                raise HttpError("Unexpected response format.")
+            total += len(chunk)
+            if total > max_size:
+                raise HttpError("Download size exceeded.")
+            chunks.append(chunk)
+    finally:
+        _close_response(response)
+    return b"".join(chunks)
+
+
+def _close_response(response) -> None:
+    if response is not None and hasattr(response, "close"):
+        response.close()

--- a/bridge/src/silentsuite_bridge/update/platform.py
+++ b/bridge/src/silentsuite_bridge/update/platform.py
@@ -1,0 +1,93 @@
+"""Canonical platform-to-asset mapping.
+
+One authoritative source used by the updater and consumed by
+bridge/build.py. The five build assets plus their exact .sha256
+sidecar naming are defined here.
+"""
+
+from __future__ import annotations
+
+
+class PlatformMapping:
+    """Map (os_name, arch) → canonical release asset name.
+
+    Canonical names:
+
+        silentsuite-bridge-linux-x86_64
+        silentsuite-bridge-linux-arm64
+        silentsuite-bridge-macos-x86_64
+        silentsuite-bridge-macos-arm64
+        silentsuite-bridge-windows-x86_64.exe
+    """
+
+    _ARCH_MAP = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }
+
+    _ASSET_BY_OS_ARCH = {
+        ("linux",   "x86_64"): "silentsuite-bridge-linux-x86_64",
+        ("linux",   "arm64"):  "silentsuite-bridge-linux-arm64",
+        ("macos",   "x86_64"): "silentsuite-bridge-macos-x86_64",
+        ("macos",   "arm64"):  "silentsuite-bridge-macos-arm64",
+        ("windows", "x86_64"): "silentsuite-bridge-windows-x86_64.exe",
+    }
+
+    @staticmethod
+    def normalize_arch(arch: str) -> str | None:
+        return PlatformMapping._ARCH_MAP.get(arch)
+
+    @staticmethod
+    def asset_name(os_name: str, arch: str) -> str | None:
+        normalized = PlatformMapping._ARCH_MAP.get(arch)
+        if normalized is None:
+            return None
+        return PlatformMapping._ASSET_BY_OS_ARCH.get((os_name, normalized))
+
+    @staticmethod
+    def checksum_asset_name(asset: str) -> str:
+        return f"{asset}.sha256"
+
+    @staticmethod
+    def supported(os_name: str, arch: str) -> bool:
+        return PlatformMapping.asset_name(os_name, arch) is not None
+
+    # build.py compatibility helpers
+
+    @staticmethod
+    def get_os_label() -> str:
+        import platform
+
+        s = platform.system().lower()
+        if s == "linux":
+            return "linux"
+        elif s == "darwin":
+            return "macos"
+        elif s == "windows":
+            return "windows"
+        raise RuntimeError(f"Unsupported OS: {s}")
+
+    @staticmethod
+    def get_arch_label() -> str:
+        import platform
+
+        m = platform.machine().lower()
+        val = PlatformMapping._ARCH_MAP.get(m)
+        if val is None:
+            raise RuntimeError(f"Unsupported arch: {m}")
+        return val
+
+    @staticmethod
+    def get_asset_name() -> str:
+        os_label = PlatformMapping.get_os_label()
+        arch_label = PlatformMapping.get_arch_label()
+        suffix = ".exe" if os_label == "windows" else ""
+        return f"silentsuite-bridge-{os_label}-{arch_label}{suffix}"
+
+    @staticmethod
+    def get_exe_suffix() -> str:
+        import platform
+
+        return ".exe" if platform.system().lower() == "windows" else ""

--- a/bridge/src/silentsuite_bridge/update/replace.py
+++ b/bridge/src/silentsuite_bridge/update/replace.py
@@ -1,0 +1,126 @@
+"""Fetch → parse → download → verify → replace ordering."""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .fs import FilesystemAdapter
+from .http import MAX_CHECKSUM_BYTES
+from .types import Platform, ReplaceResult
+from .verify import parse_checksum, verify_asset
+
+if TYPE_CHECKING:
+    from .http import SilentSuiteHttpAdapter
+
+
+def replace_bridge(
+    *,
+    http: SilentSuiteHttpAdapter,
+    fs: FilesystemAdapter | None,
+    platform: Platform,
+    current_exe: Path,
+    asset_url: str,
+    checksum_url: str,
+    asset_name: str,
+) -> ReplaceResult:
+    """Download, verify, and replace the running bridge executable."""
+
+    if fs is None:
+        fs = FilesystemAdapter()
+
+    # 1. Download and parse checksum (small file, explicit limit)
+    checksum_bytes = http.download(checksum_url, max_size=MAX_CHECKSUM_BYTES)
+    expected_hex = parse_checksum(checksum_bytes, expected_asset_name=asset_name)
+
+    # 2. Download binary
+    binary_bytes = http.download(asset_url)
+
+    # 3. Verify before any live-path operation
+    verify_asset(binary_bytes, expected_hex)
+
+    # 4. Snapshot original mode (before any mutation)
+    orig_mode: int | None = None
+    if platform.os_name != "windows":
+        orig_mode = stat.S_IMODE(fs.stat_mode(str(current_exe)))
+
+    # 5. Stage candidate
+    staged_path = fs.stage(str(current_exe), binary_bytes)
+
+    # Apply original permissions to staged candidate (POSIX)
+    if orig_mode is not None:
+        try:
+            fs.chmod(staged_path, orig_mode)
+        except Exception:
+            fs.remove(staged_path)
+            raise
+
+    # 6. Replace
+    if platform.os_name == "windows":
+        return _windows_replace(
+            fs=fs,
+            staged_path=Path(staged_path),
+            current_exe=current_exe,
+        )
+
+    # POSIX atomic replace — candidate already has correct mode
+    try:
+        fs.replace(staged_path, str(current_exe))
+    except Exception:
+        fs.remove(staged_path)
+        raise
+
+    return ReplaceResult(success=True)
+
+
+def _windows_replace(
+    *,
+    fs: FilesystemAdapter,
+    staged_path: Path,
+    current_exe: Path,
+) -> ReplaceResult:
+    """Windows: write plan + static helper, launch helper.  Never
+    overwrite the running .exe in-process.  On helper launch failure,
+    remove all staging artifacts, leave the original untouched, and
+    return failure with a target-only recovery instruction.
+    """
+    import os as _os
+
+    pid = _os.getpid()
+    backup_path = current_exe.parent / f"{current_exe.name}.update-backup"
+
+    plan = {
+        "pid": pid,
+        "candidate": str(staged_path),
+        "target": str(current_exe),
+        "backup": str(backup_path),
+    }
+
+    try:
+        # Write the JSON plan and static helper that reads it from argv.
+        plan_path = fs.write_staging_plan(plan)
+        helper_path = fs.write_windows_helper(plan_path)
+    except Exception:
+        fs.remove(staged_path)
+        raise
+
+    # Launch helper (argv list, no shell interpolation)
+    launched = fs.launch_helper(helper_path, plan_path)
+
+    if launched:
+        # Verified candidate is staged; the swap completes after this
+        # process exits.
+        return ReplaceResult(success=True, pending_completion=True)
+
+    fs.remove(helper_path)
+    fs.remove(plan_path)
+    fs.remove(staged_path)
+    return ReplaceResult(
+        success=False,
+        pending_completion=False,
+        recovery_instruction=(
+            "The update could not be completed; the installed Bridge is "
+            f"unchanged. Run manually: {current_exe}"
+        ),
+    )

--- a/bridge/src/silentsuite_bridge/update/restart.py
+++ b/bridge/src/silentsuite_bridge/update/restart.py
@@ -1,0 +1,114 @@
+"""Injectable restart handling and exact recovery instruction."""
+
+from __future__ import annotations
+
+import os as _os
+import subprocess as _subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class RestartResult:
+    success: bool
+    instruction: str | None = None
+
+
+# A single function that builds the canonical manual-restart instruction
+# using only the installed executable path — never a staging path.
+def _manual_instruction(exe_path: Path) -> str:
+    return f"Run manually: {exe_path}"
+
+
+class ProcessAdapter:
+    """Restart the bridge via platform-appropriate mechanisms."""
+
+    def restart(self, exe_path: Path, platform_name: str) -> RestartResult:
+        if platform_name == "linux":
+            return self._linux_restart(exe_path)
+        if platform_name == "macos":
+            return self._macos_restart(exe_path)
+        # Windows restart is handled by the helper script after process exit.
+        # Do not attempt a second restart here — the helper owns it.
+        if platform_name == "windows":
+            return RestartResult(success=True)
+        return RestartResult(
+            success=False,
+            instruction=_manual_instruction(exe_path),
+        )
+
+    # -- Linux (systemd user service) --
+
+    def _linux_restart(self, exe_path: Path) -> RestartResult:
+        try:
+            result = _subprocess.run(
+                ["systemctl", "--user", "restart", "silentsuite-bridge.service"],
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+            if result.returncode == 0:
+                return RestartResult(success=True)
+        except (
+            FileNotFoundError,
+            _subprocess.TimeoutExpired,
+            OSError,
+        ):
+            pass
+
+        return RestartResult(
+            success=False,
+            instruction=_manual_instruction(exe_path),
+        )
+
+    # -- macOS (launchd via kickstart) --
+
+    def _macos_restart(self, exe_path: Path) -> RestartResult:
+        plist = _os.path.expanduser(
+            "~/Library/LaunchAgents/io.silentsuite.bridge.plist"
+        )
+        if not _os.path.exists(plist):
+            return RestartResult(
+                success=False,
+                instruction=_manual_instruction(exe_path),
+            )
+
+        # Use kickstart to restart the existing agent in place.
+        # launchctl kickstart -k gui/<uid>/io.silentsuite.bridge
+        try:
+            uid = _os.getuid()
+        except AttributeError:
+            uid = _os.geteuid()
+        label = "gui/{}/io.silentsuite.bridge".format(uid)
+
+        try:
+            result = _subprocess.run(
+                ["launchctl", "kickstart", "-k", label],
+                capture_output=True, text=True, timeout=10, check=False,
+            )
+            if result.returncode == 0:
+                return RestartResult(success=True)
+        except (
+            FileNotFoundError,
+            _subprocess.TimeoutExpired,
+            OSError,
+        ):
+            pass
+
+        return RestartResult(
+            success=False,
+            instruction=_manual_instruction(exe_path),
+        )
+
+
+def restart_bridge(
+    *,
+    process,
+    exe_path: Path,
+    platform: str,
+) -> RestartResult:
+    result = process.restart(exe_path=exe_path, platform_name=platform)
+    if result.success:
+        return RestartResult(success=True)
+    return RestartResult(
+        success=False,
+        instruction=_manual_instruction(exe_path),
+    )

--- a/bridge/src/silentsuite_bridge/update/types.py
+++ b/bridge/src/silentsuite_bridge/update/types.py
@@ -1,0 +1,62 @@
+"""Bounded result and exception dataclasses/enums."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass
+
+
+class UpdateStatus(enum.Enum):
+    AVAILABLE = "available"
+    CURRENT = "current"
+    DOWNGRADE = "downgrade"
+    DEVELOPMENT = "development"
+    UNSUPPORTED = "unsupported"
+    MISSING_ASSET = "missing_asset"
+    FAILURE = "failure"
+
+
+@dataclass(frozen=True)
+class Platform:
+    os_name: str   # "linux", "macos", "windows"
+    arch: str      # "x86_64", "amd64", "arm64", "aarch64"
+
+
+@dataclass(frozen=True)
+class ReleaseInfo:
+    tag_name: str
+    version: str   # tag with leading "v" stripped
+    asset_url: str
+    checksum_url: str
+    asset_name: str
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    status: UpdateStatus
+    current_version: str = ""
+    tag_name: str | None = None
+    release: ReleaseInfo | None = None
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class ReplaceResult:
+    """Outcome of a replace attempt.
+
+    ``pending_completion`` is True when a verified candidate is staged and
+    the swap finishes after this process exits (Windows helper path).
+    ``recovery_instruction`` only ever names the installed target path.
+    """
+
+    success: bool
+    pending_completion: bool = False
+    recovery_instruction: str | None = None
+
+
+class ChecksumError(ValueError):
+    """Raised for any checksum verification failure."""
+
+
+class HttpError(RuntimeError):
+    """Raised for HTTP / network errors."""

--- a/bridge/src/silentsuite_bridge/update/verify.py
+++ b/bridge/src/silentsuite_bridge/update/verify.py
@@ -1,0 +1,64 @@
+"""Strict checksum parsing and digest verification."""
+
+from __future__ import annotations
+
+import hashlib
+
+from .types import ChecksumError
+
+
+def parse_checksum(content: str | bytes, *, expected_asset_name: str) -> str:
+    """Parse a single canonical checksum line.
+
+    Expected format: ``<64 hex><two spaces><exact basename>\\n``
+    Exactly one line, exactly one newline terminator.
+    Rejects non-UTF-8 bytes, extra blank lines, malformed separators,
+    duplicate lines, and wrong names.
+
+    Returns the lowercase hex digest.
+    Raises ChecksumError on any deviation.
+    """
+    if isinstance(content, bytes):
+        try:
+            content = content.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ChecksumError("Checksum content is not valid UTF-8.")
+
+    # Must contain exactly one trailing newline and no extra blank lines.
+    if not content.endswith("\n") or content.count("\n") != 1:
+        raise ChecksumError("Checksum content is not newline-terminated.")
+    line = content[:-1]
+
+    # Exactly one double-space separator
+    sep = "  "
+    if line.count(sep) != 1:
+        raise ChecksumError("Checksum format is invalid.")
+
+    hex_part, name_part = line.split(sep, 1)
+
+    if len(hex_part) != 64:
+        raise ChecksumError("Checksum digest length is invalid.")
+    if not _is_hex(hex_part):
+        raise ChecksumError("Checksum digest is not hexadecimal.")
+
+    if name_part != expected_asset_name:
+        raise ChecksumError("Checksum asset name does not match expected.")
+
+    return hex_part.lower()
+
+
+def verify_asset(data: bytes, expected_hex: str) -> None:
+    """Verify ``data`` matches ``expected_hex`` (lowercase)."""
+    actual = hashlib.sha256(data).hexdigest()
+    expected = expected_hex.lower()
+    if actual != expected:
+        raise ChecksumError("Checksum mismatch.")
+
+
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+
+
+def _is_hex(s: str) -> bool:
+    # Strict: hex digits only. int(s, 16) would accept "0x", "+", "-",
+    # and surrounding whitespace.
+    return bool(s) and all(c in _HEX_DIGITS for c in s)

--- a/bridge/tests/test_update_contract.py
+++ b/bridge/tests/test_update_contract.py
@@ -687,6 +687,68 @@ def test_http_adapter_passes_configured_timeout_to_transport():
     assert call_kwargs.get("timeout") == 45
 
 
+def test_http_adapter_enforces_total_deadline_while_streaming():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    now = [0.0]
+
+    def clock():
+        return now[0]
+
+    def delayed_stream():
+        now[0] = 4.0
+        yield b"late chunk"
+
+    response = MagicMock(status=200, content=None)
+    response.iter_content.return_value = delayed_stream()
+    transport = MagicMock()
+    transport.get.return_value = response
+    adapter = SilentSuiteHttpAdapter(
+        transport=transport,
+        timeout=2,
+        total_timeout=3,
+        clock=clock,
+    )
+
+    with pytest.raises(HttpError, match="timed out"):
+        adapter.download(f"{ASSETS_HOST}/bin")
+
+    response.close.assert_called()
+
+
+def test_http_adapter_shares_total_deadline_across_redirect_hops():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    now = [0.0]
+    timeouts = []
+
+    def clock():
+        return now[0]
+
+    def get(_url, *, timeout):
+        timeouts.append(timeout)
+        now[0] += 2.0
+        return MagicMock(
+            status=302,
+            headers={"Location": f"{GITHUB_HOST}/next"},
+        )
+
+    transport = MagicMock()
+    transport.get.side_effect = get
+    adapter = SilentSuiteHttpAdapter(
+        transport=transport,
+        timeout=2,
+        total_timeout=3,
+        max_redirects=5,
+        clock=clock,
+    )
+
+    with pytest.raises(HttpError, match="timed out"):
+        adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
+
+    assert timeouts == [2, 1]
+
+
 def test_http_adapter_rejects_oversized_response():
     from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
 
@@ -1559,6 +1621,15 @@ def test_windows_helper_validates_plan_and_bounds_wait(tmp_path):
     assert "Move-Item -Force -Path $Target -Destination $Backup" in content
     assert "Move-Item -Force -Path $Backup -Destination $Target" in content
     assert "Start-Process -FilePath $Target" in content
+    # The rollback backup survives until process creation succeeds, and a
+    # failed restart restores it before giving the target-only instruction.
+    start_index = content.index("Start-Process -FilePath $Target")
+    remove_backup_index = content.index("Remove-Item -Force -Path $Backup")
+    restart_restore_index = content.rindex(
+        "Move-Item -Force -Path $Backup -Destination $Target"
+    )
+    assert remove_backup_index > start_index
+    assert restart_restore_index > start_index
 
 
 def test_windows_plan_and_helper_are_private_files(tmp_path):

--- a/bridge/tests/test_update_contract.py
+++ b/bridge/tests/test_update_contract.py
@@ -18,12 +18,12 @@ The following production modules must exist for tests to pass:
                                          check_for_update entry points
 
 Inject fakes/spies for all I/O. No real network, autostart, or process mutation.
-
-These tests MUST FAIL against baseline 23871f05 because the update modules
-and CLI wiring do not exist yet.
 """
 
 import hashlib
+import json
+import os
+import stat
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -68,6 +68,8 @@ def _release(version, draft=False, *, assets):
 def _make_fs():
     fs = MagicMock()
     fs.stage.return_value = "/tmp/.update-staged"
+    # Deterministic real st_mode default — regular file, rwxr-xr-x
+    fs.stat_mode.return_value = stat.S_IFREG | 0o755
     return fs
 
 
@@ -134,7 +136,8 @@ def test_platform_mapping_all_assets_have_known_names():
 
 
 # ---------------------------------------------------------------------------
-# Check: newer / current / older / dev
+# Check: newer / current / downgrade / dev — exact-same and older-remote
+# are distinct statuses
 # ---------------------------------------------------------------------------
 
 def test_check_reports_newer_compatible_release():
@@ -176,7 +179,7 @@ def test_check_reports_current_when_version_matches():
     assert result.status == UpdateStatus.CURRENT
 
 
-def test_check_reports_current_when_remote_is_older():
+def test_check_reports_downgrade_when_remote_is_older():
     from silentsuite_bridge.update.types import Platform, UpdateStatus
 
     http = MagicMock()
@@ -192,7 +195,7 @@ def test_check_reports_current_when_remote_is_older():
         current_version="0.5.4-beta",
     )
 
-    assert result.status == UpdateStatus.CURRENT
+    assert result.status == UpdateStatus.DOWNGRADE
 
 
 def test_check_reports_development_for_dev_version_string():
@@ -220,15 +223,26 @@ def test_check_reports_development_for_dev_version_string():
 
 @pytest.mark.parametrize("current,remote,expected", [
     ("0.5.4-beta",   "0.5.5-beta",   "AVAILABLE"),
-    ("0.5.5-beta",   "0.5.4-beta",   "CURRENT"),
-    ("0.5.4-beta.1", "0.5.4-beta",   "CURRENT"),
+    ("0.5.5-beta",   "0.5.4-beta",   "DOWNGRADE"),
+    ("0.5.4-beta.1", "0.5.4-beta",   "DOWNGRADE"),
     ("0.5.4-beta",   "0.5.4-beta.1", "AVAILABLE"),
     ("0.5.5-rc1",    "0.5.5",        "AVAILABLE"),
-    ("0.5.5",        "0.5.5-rc1",    "CURRENT"),
+    ("0.5.5",        "0.5.5-rc1",    "DOWNGRADE"),
     ("0.5.4",        "0.5.5-beta",   "AVAILABLE"),
-    ("0.5.5-beta",   "0.5.4",        "CURRENT"),
+    ("0.5.5-beta",   "0.5.4",        "DOWNGRADE"),
     ("0.5.5-alpha",  "0.5.5-beta",   "AVAILABLE"),
-    ("0.5.5-beta",   "0.5.5-alpha",  "CURRENT"),
+    ("0.5.5-beta",   "0.5.5-alpha",  "DOWNGRADE"),
+    # Strict SemVer: numeric prerelease identifiers sort lower than
+    # non-numeric identifiers
+    ("0.5.5-1",      "0.5.5-alpha",  "AVAILABLE"),
+    ("0.5.5-alpha",  "0.5.5-1",      "DOWNGRADE"),
+    # Exact-same version is CURRENT, never DOWNGRADE
+    ("0.5.4",        "0.5.4",        "CURRENT"),
+    ("0.5.4-beta",   "0.5.4-beta",   "CURRENT"),
+    # Build metadata is ignored for precedence (SemVer 2.0)
+    ("0.5.4",        "0.5.4+build.7", "CURRENT"),
+    ("0.5.4+local.1", "0.5.4",       "CURRENT"),
+    ("0.5.4+local.1", "0.5.5",       "AVAILABLE"),
 ])
 def test_check_semver_prerelease_ordering(current, remote, expected):
     from silentsuite_bridge.update.types import Platform
@@ -247,6 +261,104 @@ def test_check_semver_prerelease_ordering(current, remote, expected):
     )
 
     assert result.status.name == expected
+
+
+def test_check_rejects_malformed_remote_version():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("vnot-a-version", assets=[ASSET_LINUX_X86_64,
+                                            f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    # Malformed tag is skipped; no compatible release found
+    assert result.status == UpdateStatus.MISSING_ASSET
+
+
+def test_check_reports_development_for_malformed_current_version():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.side_effect = AssertionError("must not reach network")
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="not-a-version",
+    )
+
+    assert result.status == UpdateStatus.DEVELOPMENT
+
+
+@pytest.mark.parametrize("bad_current", [
+    "",
+    "abc",
+    "1.2",
+    "1.2.3.4",
+    "v1.2.3",
+    "01.2.3",
+    "1.02.3",
+    "1.2.03",
+    "1.2.3-",
+    "1.2.3-01",
+    "1.2.3+meta+extra",
+])
+def test_check_rejects_invalid_current_version_grammar_without_network(bad_current):
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.side_effect = AssertionError("must not reach network")
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version=bad_current,
+    )
+
+    assert result.status == UpdateStatus.DEVELOPMENT
+    http.fetch_releases.assert_not_called()
+
+
+def test_check_skips_malformed_release_objects_without_error():
+    """Release JSON fields are validated with .get(); no KeyError paths."""
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    good_assets = [
+        {"name": ASSET_LINUX_X86_64, "browser_download_url": f"{ASSETS_HOST}/bin"},
+        {"name": f"{ASSET_LINUX_X86_64}.sha256",
+         "browser_download_url": f"{ASSETS_HOST}/bin.sha256"},
+    ]
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        "not-a-release-object",                    # non-dict entry
+        {},                                        # nothing at all
+        {"tag_name": 42, "assets": good_assets},   # non-string tag
+        {"tag_name": "v0.9.9"},                    # missing assets key
+        {"tag_name": "v0.9.9", "assets": "nope"},  # assets not a list
+        {"tag_name": "v0.9.9",                     # assets missing URLs
+         "assets": [{"name": ASSET_LINUX_X86_64},
+                    {"name": f"{ASSET_LINUX_X86_64}.sha256"}]},
+        {"tag_name": "v0.9.09", "assets": good_assets},  # leading zero
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.MISSING_ASSET
 
 
 # ---------------------------------------------------------------------------
@@ -421,7 +533,7 @@ def test_platform_mapping_rejects_windows_arm64():
 
 
 # ---------------------------------------------------------------------------
-# API timeout, HTTP failure, malformed JSON
+# API timeout, HTTP failure, malformed JSON — sanitized messages
 # ---------------------------------------------------------------------------
 
 def test_check_handles_http_timeout():
@@ -438,6 +550,10 @@ def test_check_handles_http_timeout():
     )
 
     assert result.status == UpdateStatus.FAILURE
+    # error_message must not contain raw exception text, URL, or path
+    assert result.error_message is not None
+    assert "Could not fetch" in result.error_message or "Could not" in result.error_message
+    assert "TimeoutError" not in (result.error_message or "")
 
 
 def test_check_handles_http_error():
@@ -454,6 +570,9 @@ def test_check_handles_http_error():
     )
 
     assert result.status == UpdateStatus.FAILURE
+    assert result.error_message is not None
+    assert "403" not in (result.error_message or "")
+    assert "Forbidden" not in (result.error_message or "")
 
 
 def test_check_handles_malformed_json():
@@ -494,6 +613,9 @@ def test_http_adapter_allows_github_redirect_chain():
 
     assert result == b"asset data"
     assert transport.get.call_count == 3
+    # Every response in the chain must be closed
+    for response in redirect_responses:
+        response.close.assert_called()
 
 
 def test_http_adapter_rejects_disallowed_redirect_host():
@@ -507,7 +629,7 @@ def test_http_adapter_rejects_disallowed_redirect_host():
 
     adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
 
-    with pytest.raises(HttpError, match="redirect"):
+    with pytest.raises(HttpError, match="disallowed"):
         adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
 
 
@@ -561,6 +683,178 @@ def test_http_adapter_rejects_oversized_response():
         adapter.download(f"{ASSETS_HOST}/repos/silent-suite/silentsuite/releases")
 
 
+def test_http_adapter_rejects_non_2xx_status():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(status=404, content=b"not found")
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+    with pytest.raises(HttpError):
+        adapter.download(f"{ASSETS_HOST}/bin")
+
+
+def test_http_adapter_rejects_redirect_without_location():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(status=302, headers={})
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+    with pytest.raises(HttpError):
+        adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
+
+
+def test_http_adapter_wraps_transport_errors_as_http_error():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    transport.get.side_effect = RuntimeError("unexpected transport failure")
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+    with pytest.raises(HttpError, match="Network"):
+        adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
+
+
+def test_http_adapter_rejects_non_https_url_before_any_request():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+
+    with pytest.raises(HttpError, match="HTTPS"):
+        adapter.download("http://api.github.com/repos/silent-suite/silentsuite/releases")
+
+    transport.get.assert_not_called()
+
+
+def test_http_adapter_rejects_redirect_to_non_https():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(
+        status=302,
+        headers={"Location": "http://github.com/downgraded"},
+    )
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+
+    with pytest.raises(HttpError, match="HTTPS"):
+        adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
+
+    # Only the first hop was requested; the insecure hop was refused
+    assert transport.get.call_count == 1
+
+
+def test_http_adapter_closes_response_on_non_2xx():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    response = MagicMock(status=500, content=b"error body")
+    transport = MagicMock()
+    transport.get.return_value = response
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+    with pytest.raises(HttpError):
+        adapter.download(f"{ASSETS_HOST}/bin")
+
+    response.close.assert_called()
+
+
+def test_http_adapter_closes_response_when_iter_content_overflows():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    def stream(*args, **kwargs):
+        while True:
+            yield b"x" * 65536
+
+    response = MagicMock(status=200, content=None)
+    response.iter_content.side_effect = stream
+    transport = MagicMock()
+    transport.get.return_value = response
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5,
+                                     max_size=128 * 1024)
+    with pytest.raises(HttpError, match="size"):
+        adapter.download(f"{ASSETS_HOST}/bin")
+
+    response.close.assert_called()
+
+
+def test_real_urllib_opener_never_follows_redirects(monkeypatch):
+    """The urllib opener must be built with a redirect handler that
+    returns 3xx responses unfollowed, for every redirect status."""
+    import urllib.request
+
+    from silentsuite_bridge.update.http import SilentSuiteHttpAdapter
+
+    captured = {}
+
+    class FakeOpener:
+        def open(self, req, timeout=None):
+            response = MagicMock(status=200, headers={})
+            response.read.side_effect = [b"payload", b""]
+            return response
+
+    def fake_build_opener(*handlers):
+        captured["handlers"] = handlers
+        return FakeOpener()
+
+    monkeypatch.setattr(urllib.request, "build_opener", fake_build_opener)
+
+    adapter = SilentSuiteHttpAdapter()
+    result = adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
+
+    assert result == b"payload"
+
+    redirect_handlers = [
+        h for h in captured["handlers"]
+        if isinstance(h, urllib.request.HTTPRedirectHandler)
+    ]
+    assert len(redirect_handlers) == 1
+    handler = redirect_handlers[0]
+
+    sentinel = object()
+    for method in ("http_error_301", "http_error_302", "http_error_303",
+                   "http_error_307", "http_error_308"):
+        assert getattr(handler, method)(None, sentinel, 0, "", {}) is sentinel, (
+            f"{method} must return the response unfollowed"
+        )
+
+
+def test_fetch_releases_rejects_invalid_json_with_bounded_error():
+    """A 200 response with invalid JSON must raise a bounded HttpError
+    through the production parsing path, without echoing the payload."""
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    payload = b"<html>definitely not JSON</html>"
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(status=200, content=payload)
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+
+    with pytest.raises(HttpError) as excinfo:
+        adapter.fetch_releases()
+
+    message = str(excinfo.value)
+    assert "JSON" in message
+    assert "definitely not JSON" not in message
+    assert "<html>" not in message
+
+
+def test_fetch_releases_rejects_non_list_json():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(
+        status=200, content=b'{"message": "Not Found"}',
+    )
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+
+    with pytest.raises(HttpError, match="not a list"):
+        adapter.fetch_releases()
+
+
 # ---------------------------------------------------------------------------
 # Missing checksum asset
 # ---------------------------------------------------------------------------
@@ -584,7 +878,7 @@ def test_check_rejects_release_without_checksum_asset():
 
 
 # ---------------------------------------------------------------------------
-# Checksum parsing
+# Checksum parsing — sanitized messages, non-UTF-8 rejection
 # ---------------------------------------------------------------------------
 
 def test_parse_checksum_rejects_wrong_asset_name():
@@ -603,13 +897,27 @@ def test_parse_checksum_rejects_wrong_asset_name():
     FAKE_64_HEX + "  silentsuite-bridge-linux-x86_64\n"
     + "b" * 64 + "  silentsuite-bridge-linux-x86_64\n",
     "",
-    FAKE_64_HEX + "  silentsuite-bridge-linux-x86_64",
+    FAKE_64_HEX + "  silentsuite-bridge-linux-x86_64",   # no newline
+    FAKE_64_HEX + "  silentsuite-bridge-linux-x86_64\n\n",  # extra blank line
+    "\n" + FAKE_64_HEX + "  silentsuite-bridge-linux-x86_64\n",  # leading blank
+    FAKE_64_HEX + " silentsuite-bridge-linux-x86_64\n",  # single-space separator
+    "g" * 64 + "  silentsuite-bridge-linux-x86_64\n",    # non-hex digest
+    "0x" + "a" * 62 + "  silentsuite-bridge-linux-x86_64\n",  # 0x-prefixed
+    "+" + "a" * 63 + "  silentsuite-bridge-linux-x86_64\n",   # signed "hex"
 ])
 def test_parse_checksum_rejects_malformed(content):
     from silentsuite_bridge.update.verify import ChecksumError, parse_checksum
 
     with pytest.raises(ChecksumError):
         parse_checksum(content, expected_asset_name=ASSET_LINUX_X86_64)
+
+
+def test_parse_checksum_rejects_non_utf8():
+    from silentsuite_bridge.update.verify import ChecksumError, parse_checksum
+
+    with pytest.raises(ChecksumError):
+        parse_checksum(b"\xff\xfe" + FAKE_64_HEX.encode() + b"  bin\n",
+                       expected_asset_name="bin")
 
 
 def test_parse_checksum_accepts_valid_line():
@@ -634,7 +942,7 @@ def test_parse_checksum_normalises_case():
 
 
 # ---------------------------------------------------------------------------
-# Checksum match / mismatch
+# Checksum match / mismatch — sanitized
 # ---------------------------------------------------------------------------
 
 def test_verify_asset_mismatch_raises():
@@ -642,6 +950,19 @@ def test_verify_asset_mismatch_raises():
 
     with pytest.raises(ChecksumError, match="mismatch"):
         verify_asset(b"content", FAKE_64_HEX)
+
+
+def test_verify_asset_mismatch_does_not_echo_digests():
+    from silentsuite_bridge.update.verify import ChecksumError, verify_asset
+
+    payload = b"untrusted payload"
+    with pytest.raises(ChecksumError) as excinfo:
+        verify_asset(payload, FAKE_64_HEX)
+
+    message = str(excinfo.value)
+    assert FAKE_64_HEX not in message
+    assert hashlib.sha256(payload).hexdigest() not in message
+    assert "untrusted payload" not in message
 
 
 def test_verify_asset_match_passes():
@@ -656,12 +977,17 @@ def test_verify_asset_match_passes():
 # ---------------------------------------------------------------------------
 
 def test_orchestrator_calls_fetch_then_verify_then_replace():
+    from silentsuite_bridge.update.fs import FilesystemAdapter
     from silentsuite_bridge.update.types import Platform
 
     data = b"new binary"
     expected = hashlib.sha256(data).hexdigest()
     http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
-    fs = _make_fs()
+    fs = FilesystemAdapter()
+    fs.stage = MagicMock(return_value="/tmp/staged")
+    fs.replace = MagicMock()
+    fs.chmod = MagicMock()
+    fs.stat_mode = MagicMock(return_value=stat.S_IFREG | 0o755)
     current_exe = Path("/opt/silentsuite-bridge")
 
     from silentsuite_bridge.update.replace import replace_bridge
@@ -782,22 +1108,25 @@ def test_orchestrator_does_not_replace_on_oversized_download():
 
 
 # ---------------------------------------------------------------------------
-# Filesystem: permissions preservation
+# Filesystem: permissions preservation (original mode, no hard-coded 0755)
 # ---------------------------------------------------------------------------
 
-def test_fs_replace_preserves_executable_mode():
-    fs = _make_fs()
-    chmod_calls = []
-    fs.chmod.side_effect = lambda *a: chmod_calls.append(a)
-
-    from silentsuite_bridge.update.replace import replace_bridge
+def test_fs_replace_preserves_original_executable_mode():
+    from silentsuite_bridge.update.fs import FilesystemAdapter
     from silentsuite_bridge.update.types import Platform
 
     data = b"new binary content"
     expected = hashlib.sha256(data).hexdigest()
     http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = FilesystemAdapter()
+    fs.stage = MagicMock(return_value="/tmp/staged")
+    fs.replace = MagicMock()
+    fs.chmod = MagicMock()
+    orig_mode = stat.S_IFREG | 0o750  # regular file, rwxr-x---
+    fs.stat_mode = MagicMock(return_value=orig_mode)
     current_exe = Path("/opt/silentsuite-bridge")
 
+    from silentsuite_bridge.update.replace import replace_bridge
     replace_bridge(
         http=http, fs=fs,
         platform=Platform("linux", "x86_64"),
@@ -807,9 +1136,68 @@ def test_fs_replace_preserves_executable_mode():
         asset_name=ASSET_LINUX_X86_64,
     )
 
-    assert any(
-        str(current_exe) in str(args) for args in chmod_calls
-    ), "chmod must be called on the final target path"
+    # stat_mode was called to read the original
+    fs.stat_mode.assert_called_once_with(str(current_exe))
+    # chmod applied exactly stat.S_IMODE of the original to the candidate
+    fs.chmod.assert_called_once_with("/tmp/staged", 0o750)
+    assert stat.S_IMODE(orig_mode) == 0o750
+    # replace happened
+    fs.replace.assert_called_once()
+
+
+def test_fs_mode_read_failure_fails_before_any_mutation():
+    """A failed original-mode read must fail closed: no staging, no replace."""
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+    fs.stat_mode.side_effect = OSError(13, "Permission denied")
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+
+    with pytest.raises(OSError):
+        replace_bridge(
+            http=http, fs=fs,
+            platform=Platform("linux", "x86_64"),
+            current_exe=current_exe,
+            asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+            checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    fs.stage.assert_not_called()
+    fs.replace.assert_not_called()
+
+
+def test_fs_mode_apply_failure_removes_candidate_and_fails():
+    """A failed chmod on the candidate must remove it and never replace."""
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+    fs.stat_mode.return_value = stat.S_IFREG | 0o755
+    fs.chmod.side_effect = OSError(1, "Operation not permitted")
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+
+    with pytest.raises(OSError):
+        replace_bridge(
+            http=http, fs=fs,
+            platform=Platform("linux", "x86_64"),
+            current_exe=current_exe,
+            asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+            checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    fs.remove.assert_called_once_with("/tmp/.update-staged")
+    fs.replace.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -821,12 +1209,17 @@ def test_fs_replace_preserves_executable_mode():
     ("macos", Path("/usr/local/bin/silentsuite-bridge")),
 ])
 def test_fs_atomic_replace_uses_same_device_rename(os_label, exe_path):
+    from silentsuite_bridge.update.fs import FilesystemAdapter
     from silentsuite_bridge.update.types import Platform
 
     data = b"new binary"
     expected = hashlib.sha256(data).hexdigest()
     http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
-    fs = _make_fs()
+    fs = FilesystemAdapter()
+    fs.stage = MagicMock(return_value=str(exe_path.parent / ".staged"))
+    fs.replace = MagicMock()
+    fs.chmod = MagicMock()
+    fs.stat_mode = MagicMock(return_value=stat.S_IFREG | 0o755)
 
     from silentsuite_bridge.update.replace import replace_bridge
     replace_bridge(
@@ -874,12 +1267,54 @@ def test_fs_replace_rollback_removes_staged_candidate():
             asset_name=ASSET_LINUX_X86_64,
         )
 
-    fs.cleanup.assert_called()
-    fs.remove.assert_not_called()
+    fs.remove.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Filesystem: real staging behaviour (private mode, cleanup on failure)
+# ---------------------------------------------------------------------------
+
+def test_fs_stage_writes_private_candidate_in_target_directory(tmp_path):
+    from silentsuite_bridge.update.fs import FilesystemAdapter
+
+    fs = FilesystemAdapter()
+    target = tmp_path / "silentsuite-bridge"
+    target.write_bytes(b"old binary")
+
+    staged = fs.stage(str(target), b"new binary")
+    staged_path = Path(staged)
+
+    assert staged_path.parent == tmp_path
+    assert staged_path.name.endswith(".update-staged")
+    assert staged_path.read_bytes() == b"new binary"
+    assert target.read_bytes() == b"old binary"
+    if os.name == "posix":
+        assert stat.S_IMODE(os.stat(staged).st_mode) == 0o600
+
+
+def test_fs_stage_removes_partial_file_on_error(tmp_path, monkeypatch):
+    from silentsuite_bridge.update.fs import FilesystemAdapter
+
+    fs = FilesystemAdapter()
+    target = tmp_path / "silentsuite-bridge"
+    target.write_bytes(b"old binary")
+
+    def failing_fsync(fd):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(os, "fsync", failing_fsync)
+
+    with pytest.raises(OSError):
+        fs.stage(str(target), b"new binary")
+
+    leftovers = [p for p in tmp_path.iterdir() if p != target]
+    assert leftovers == []
+    assert target.read_bytes() == b"old binary"
 
 
 # ---------------------------------------------------------------------------
 # Windows: never renames running exe in-process; writes structured plan
+# helper reads plan from argv, not interpolated paths
 # ---------------------------------------------------------------------------
 
 def test_windows_replace_never_calls_fs_replace_in_process():
@@ -907,17 +1342,52 @@ def test_windows_replace_never_calls_fs_replace_in_process():
     assert plan_call is not None
     plan_arg = plan_call[0][0]
     assert isinstance(plan_arg, dict)
-    assert "pid" in plan_arg or "process_id" in plan_arg
+    assert "pid" in plan_arg
     assert "candidate" in plan_arg
     assert "target" in plan_arg
     assert str(plan_arg["target"]) == str(exe_path)
 
-    assert result.needs_manual_completion is True
-    assert result.recovery_instruction is not None
-    assert str(exe_path) in result.recovery_instruction
+    # A launched helper means the swap is pending, not complete
+    assert result.success is True
+    assert result.pending_completion is True
+    # Recovery instruction must never expose staging paths
+    if result.recovery_instruction:
+        assert ".update-staged" not in result.recovery_instruction
+        assert "/tmp/" not in result.recovery_instruction
 
 
-def test_windows_staging_plan_includes_backup_path():
+def test_windows_helper_written_then_plan():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_WINDOWS_X86_64)
+    fs = _make_fs()
+    exe_path = Path("C:/Users/test/AppData/Local/SilentSuite/silentsuite-bridge.exe")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+    replace_bridge(
+        http=http, fs=fs,
+        platform=Platform("windows", "x86_64"),
+        current_exe=exe_path,
+        asset_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}",
+        checksum_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}.sha256",
+        asset_name=ASSET_WINDOWS_X86_64,
+    )
+
+    # Helper written, plan written, helper launched
+    assert fs.write_windows_helper.called
+    assert fs.write_staging_plan.called
+    assert fs.launch_helper.called
+
+    # Helper must receive plan_path as an arg (static helper, no path interpolation)
+    launch_call = fs.launch_helper.call_args
+    assert launch_call is not None
+    # kwargs should contain plan_path
+    assert "plan_path" in launch_call[1] or len(launch_call[0]) >= 2
+
+
+def test_windows_plan_includes_backup_same_directory():
     from silentsuite_bridge.update.types import Platform
 
     data = b"new binary"
@@ -938,9 +1408,9 @@ def test_windows_staging_plan_includes_backup_path():
 
     plan_call = fs.write_staging_plan.call_args
     plan = plan_call[0][0]
-    assert "backup" in plan or "rollback" in plan
-    backup_value = str(plan.get("backup", plan.get("rollback", "")))
-    assert exe_path.parent.as_posix() in Path(backup_value).as_posix()
+    assert "backup" in plan
+    backup_value = Path(plan["backup"])
+    assert backup_value.parent == exe_path.parent
 
 
 def test_windows_does_not_write_helper_on_checksum_failure():
@@ -967,17 +1437,18 @@ def test_windows_does_not_write_helper_on_checksum_failure():
     fs.replace.assert_not_called()
 
 
-def test_windows_plan_is_not_executed_in_process():
+def test_windows_helper_launch_failure_preserves_original():
     from silentsuite_bridge.update.types import Platform
 
     data = b"new binary"
     expected = hashlib.sha256(data).hexdigest()
     http = _make_http_download_for(data, expected, ASSET_WINDOWS_X86_64)
     fs = _make_fs()
+    fs.launch_helper.return_value = False
     exe_path = Path("C:/Users/test/AppData/Local/SilentSuite/silentsuite-bridge.exe")
 
     from silentsuite_bridge.update.replace import replace_bridge
-    replace_bridge(
+    result = replace_bridge(
         http=http, fs=fs,
         platform=Platform("windows", "x86_64"),
         current_exe=exe_path,
@@ -986,16 +1457,128 @@ def test_windows_plan_is_not_executed_in_process():
         asset_name=ASSET_WINDOWS_X86_64,
     )
 
-    plan_call = fs.write_staging_plan.call_args
-    plan = plan_call[0][0]
-    assert not isinstance(plan, str), (
-        "staging plan must be a structured plan (dict/list), not a raw shell string"
-    )
+    fs.replace.assert_not_called()
+    # Launch failure is a failure, and nothing remains pending
+    assert result.success is False
+    assert result.pending_completion is False
+    assert result.recovery_instruction is not None
+    assert str(exe_path) in result.recovery_instruction
+    # Never instruct staging path execution
+    assert ".update-staged" not in (result.recovery_instruction or "")
+    assert "/tmp/" not in (result.recovery_instruction or "")
+    # All private staging artifacts (candidate, plan, helper) were removed
+    removed = [call.args[0] for call in fs.remove.call_args_list]
+    assert Path("/tmp/.update-staged") in removed
+    assert fs.write_staging_plan.return_value in removed
+    assert fs.write_windows_helper.return_value in removed
 
-    for method_name in ["exec", "subprocess", "run", "call", "popen"]:
-        method = getattr(fs, method_name, None)
-        if method is not None:
-            method.assert_not_called()
+
+# ---------------------------------------------------------------------------
+# Windows helper generation: static, validating, private
+# ---------------------------------------------------------------------------
+
+def _write_plan_and_helper(tmp_path):
+    from silentsuite_bridge.update.fs import FilesystemAdapter
+
+    fs = FilesystemAdapter()
+    target = tmp_path / "silentsuite-bridge.exe"
+    candidate = tmp_path / "tmp1234.update-staged"
+    candidate.write_bytes(b"candidate")
+    plan = {
+        "pid": 4242,
+        "candidate": str(candidate),
+        "target": str(target),
+        "backup": str(target) + ".update-backup",
+    }
+    plan_path = fs.write_staging_plan(plan)
+    helper_path = fs.write_windows_helper(plan_path)
+    return plan, plan_path, helper_path
+
+
+def test_windows_helper_source_is_static_with_no_embedded_paths(tmp_path):
+    plan, plan_path, helper_path = _write_plan_and_helper(tmp_path)
+
+    content = Path(helper_path).read_text(encoding="utf-8")
+
+    # The helper reads the plan from its first argument only — no plan,
+    # candidate, target, or backup path is embedded in the script source.
+    assert str(tmp_path) not in content
+    assert "param(" in content
+    assert "$PlanFile" in content
+    assert "ConvertFrom-Json" in content
+
+
+def test_windows_helper_validates_plan_and_bounds_wait(tmp_path):
+    _plan, _plan_path, helper_path = _write_plan_and_helper(tmp_path)
+
+    content = Path(helper_path).read_text(encoding="utf-8")
+
+    # $plan_dir is assigned before it is ever compared against
+    assert content.index("$plan_dir = ") < content.index("-ne $plan_dir")
+    # absolute-path, suffix, and same-directory validation
+    assert "must be absolute" in content
+    assert ".EndsWith('.update-staged')" in content
+    assert "Split-Path -Path $Candidate -Parent" in content
+    assert "Split-Path -Path $Backup -Parent" in content
+    # bounded wait that aborts (exit 1) if the old process never exits
+    assert "$WaitSeconds" in content
+    assert "WaitForExit" in content
+    assert "if (-not $exited) {" in content
+    # a vanished target fails closed before backup — no install without a
+    # rollback source
+    assert "if (-not (Test-Path -Path $Target)) {" in content
+    assert (content.index("if (-not (Test-Path -Path $Target)) {")
+            < content.index("Move-Item -Force -Path $Target -Destination $Backup"))
+    # backup, rollback, and exact-target restart
+    assert "Move-Item -Force -Path $Target -Destination $Backup" in content
+    assert "Move-Item -Force -Path $Backup -Destination $Target" in content
+    assert "Start-Process -FilePath $Target" in content
+
+
+def test_windows_plan_and_helper_are_private_files(tmp_path):
+    plan, plan_path, helper_path = _write_plan_and_helper(tmp_path)
+
+    # Structured JSON plan round-trips with exact paths
+    loaded = json.loads(Path(plan_path).read_text(encoding="utf-8"))
+    assert loaded["pid"] == plan["pid"]
+    assert loaded["candidate"] == plan["candidate"]
+    assert loaded["target"] == plan["target"]
+    assert loaded["backup"] == plan["backup"]
+
+    if os.name == "posix":
+        assert stat.S_IMODE(os.stat(plan_path).st_mode) == 0o600
+        assert stat.S_IMODE(os.stat(helper_path).st_mode) == 0o600
+
+
+@pytest.mark.skipif(sys.platform != "win32",
+                    reason="requires the Windows PowerShell parser")
+def test_windows_helper_parses_cleanly_without_execution(tmp_path):
+    """Parse the generated helper with the PowerShell language parser.
+
+    The script is never executed — parse errors alone fail the test.
+    """
+    import subprocess
+
+    _plan, _plan_path, helper_path = _write_plan_and_helper(tmp_path)
+
+    parse_command = (
+        "$toks = $null; $errs = $null; "
+        "[System.Management.Automation.Language.Parser]::ParseFile("
+        "$env:SS_UPDATE_HELPER, [ref]$toks, [ref]$errs) | Out-Null; "
+        "if ($errs -and $errs.Count -gt 0) { "
+        "$errs | ForEach-Object { Write-Output $_.Message }; exit 1 }; "
+        "exit 0"
+    )
+    env = dict(os.environ)
+    env["SS_UPDATE_HELPER"] = str(helper_path)
+    completed = subprocess.run(
+        ["powershell.exe", "-NoProfile", "-NonInteractive",
+         "-Command", parse_command],
+        env=env, capture_output=True, text=True, timeout=120,
+    )
+    assert completed.returncode == 0, (
+        f"PowerShell parse errors:\n{completed.stdout}\n{completed.stderr}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1057,43 +1640,45 @@ def test_restart_instruction_never_contains_staging_path():
 
 
 # ---------------------------------------------------------------------------
-# Autostart: path identity
+# Autostart: path identity (adapter is never called in perform_update)
 # ---------------------------------------------------------------------------
 
-def test_orchestrator_preserves_autostart_path():
+def test_orchestrator_never_calls_autostart():
     from silentsuite_bridge.update.types import Platform
 
     data = b"new binary"
     expected = hashlib.sha256(data).hexdigest()
     http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
     fs = _make_fs()
-    autostart = MagicMock()
+    fs.stat_mode = MagicMock(return_value=stat.S_IFREG | 0o755)
     restart = _make_restart_success()
     exe_path = Path("/opt/silentsuite-bridge")
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = exe_path
+    admission.is_writable.return_value = True
 
     from silentsuite_bridge.update import perform_update
     perform_update(
         http=http, fs=fs,
-        autostart=autostart,
         restart=restart,
+        admission=admission,
         platform=Platform("linux", "x86_64"),
         current_exe=exe_path,
         current_version="0.5.4-beta",
         asset_name=ASSET_LINUX_X86_64,
     )
 
+    # The replace target must be the same installed path
     replace_target = fs.replace.call_args[0][1]
     assert replace_target == str(exe_path)
 
-    autostart.install.assert_not_called()
-    autostart.uninstall.assert_not_called()
-
 
 # ---------------------------------------------------------------------------
-# CURRENT / downgrade refuse self-update without I/O
+# CURRENT and DOWNGRADE always refuse self-update (no force override)
 # ---------------------------------------------------------------------------
 
-def test_perform_update_refuses_when_already_current():
+def test_perform_update_refuses_same_version():
     from silentsuite_bridge.update.types import Platform
 
     http = MagicMock()
@@ -1102,18 +1687,22 @@ def test_perform_update_refuses_when_already_current():
                                          f"{ASSET_LINUX_X86_64}.sha256"]),
     ]
     fs = _make_fs()
-    autostart = MagicMock()
     restart = MagicMock()
+    exe_path = Path("/opt/silentsuite-bridge")
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = exe_path
+    admission.is_writable.return_value = True
 
     from silentsuite_bridge.update import perform_update
 
     with pytest.raises(RuntimeError, match="current"):
         perform_update(
             http=http, fs=fs,
-            autostart=autostart,
             restart=restart,
+            admission=admission,
             platform=Platform("linux", "x86_64"),
-            current_exe=Path("/opt/silentsuite-bridge"),
+            current_exe=exe_path,
             current_version="0.5.4-beta",
             asset_name=ASSET_LINUX_X86_64,
         )
@@ -1132,18 +1721,22 @@ def test_perform_update_refuses_downgrade_when_remote_older():
                                          f"{ASSET_LINUX_X86_64}.sha256"]),
     ]
     fs = _make_fs()
-    autostart = MagicMock()
     restart = MagicMock()
+    exe_path = Path("/opt/silentsuite-bridge")
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = exe_path
+    admission.is_writable.return_value = True
 
     from silentsuite_bridge.update import perform_update
 
-    with pytest.raises(RuntimeError, match="current"):
+    with pytest.raises(RuntimeError, match="downgrade"):
         perform_update(
             http=http, fs=fs,
-            autostart=autostart,
             restart=restart,
+            admission=admission,
             platform=Platform("linux", "x86_64"),
-            current_exe=Path("/opt/silentsuite-bridge"),
+            current_exe=exe_path,
             current_version="0.5.4-beta",
             asset_name=ASSET_LINUX_X86_64,
         )
@@ -1164,14 +1757,19 @@ def test_orchestrator_only_touches_executable_related_paths():
     expected = hashlib.sha256(data).hexdigest()
     http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
     fs = _make_fs()
+    fs.stat_mode = MagicMock(return_value=stat.S_IFREG | 0o755)
     restart = _make_restart_success()
     exe_path = Path("/opt/silentsuite-bridge")
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = exe_path
+    admission.is_writable.return_value = True
 
     from silentsuite_bridge.update import perform_update
     perform_update(
         http=http, fs=fs,
-        autostart=MagicMock(),
         restart=restart,
+        admission=admission,
         platform=Platform("linux", "x86_64"),
         current_exe=exe_path,
         current_version="0.5.4-beta",
@@ -1211,7 +1809,6 @@ def test_check_only_leaves_fs_autostart_and_restart_untouched():
                                          f"{ASSET_LINUX_X86_64}.sha256"]),
     ]
     fs = MagicMock()
-    autostart = MagicMock()
     restart = MagicMock()
 
     from silentsuite_bridge.update import check_for_update
@@ -1223,7 +1820,6 @@ def test_check_only_leaves_fs_autostart_and_restart_untouched():
 
     assert result.status == UpdateStatus.AVAILABLE
     fs.assert_not_called()
-    autostart.assert_not_called()
     restart.assert_not_called()
 
 
@@ -1240,18 +1836,22 @@ def test_perform_update_refuses_development_version():
                                          f"{ASSET_LINUX_X86_64}.sha256"]),
     ]
     fs = _make_fs()
-    autostart = MagicMock()
     restart = MagicMock()
+    exe_path = Path("/usr/local/bin/silentsuite-bridge")
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = exe_path
+    admission.is_writable.return_value = True
 
     from silentsuite_bridge.update import perform_update
 
     with pytest.raises(RuntimeError, match="development"):
         perform_update(
             http=http, fs=fs,
-            autostart=autostart,
             restart=restart,
+            admission=admission,
             platform=Platform("linux", "x86_64"),
-            current_exe=Path("/usr/local/bin/silentsuite-bridge"),
+            current_exe=exe_path,
             current_version="0.0.0-dev",
             asset_name=ASSET_LINUX_X86_64,
         )
@@ -1274,7 +1874,6 @@ def test_perform_update_refuses_non_frozen_with_release_looking_version():
                                          f"{ASSET_LINUX_X86_64}.sha256"]),
     ]
     fs = _make_fs()
-    autostart = MagicMock()
     restart = MagicMock()
 
     admission = MagicMock()
@@ -1286,7 +1885,6 @@ def test_perform_update_refuses_non_frozen_with_release_looking_version():
     with pytest.raises(RuntimeError, match="frozen"):
         perform_update(
             http=http, fs=fs,
-            autostart=autostart,
             restart=restart,
             admission=admission,
             platform=Platform("linux", "x86_64"),
@@ -1311,7 +1909,6 @@ def test_perform_update_refuses_unknown_executable_location():
     with pytest.raises(RuntimeError, match="executable"):
         perform_update(
             http=MagicMock(), fs=fs,
-            autostart=MagicMock(),
             restart=restart,
             admission=admission,
             platform=MagicMock(),
@@ -1326,9 +1923,10 @@ def test_perform_update_refuses_unknown_executable_location():
 def test_perform_update_refuses_non_writable_executable():
     from silentsuite_bridge.update.types import Platform
 
+    exe_path = Path("/opt/silentsuite-bridge")
     admission = MagicMock()
     admission.is_frozen.return_value = True
-    admission.current_exe.return_value = Path("/opt/silentsuite-bridge")
+    admission.current_exe.return_value = exe_path
     admission.is_writable.return_value = False
     fs = _make_fs()
     restart = MagicMock()
@@ -1338,16 +1936,92 @@ def test_perform_update_refuses_non_writable_executable():
     with pytest.raises(RuntimeError, match="writ"):
         perform_update(
             http=MagicMock(), fs=fs,
-            autostart=MagicMock(),
             restart=restart,
             admission=admission,
             platform=Platform("linux", "x86_64"),
-            current_exe=Path("/opt/silentsuite-bridge"),
+            current_exe=exe_path,
             current_version="0.5.4-beta",
             asset_name=ASSET_LINUX_X86_64,
         )
 
     fs.replace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# No double restart on Windows in perform_update
+# ---------------------------------------------------------------------------
+
+def test_perform_update_does_not_restart_windows():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_WINDOWS_X86_64)
+    fs = _make_fs()
+    restart = MagicMock()
+    exe_path = Path("C:/Users/test/AppData/Local/SilentSuite/silentsuite-bridge.exe")
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = exe_path
+    admission.is_writable.return_value = True
+
+    from silentsuite_bridge.update import perform_update
+    result = perform_update(
+        http=http, fs=fs,
+        restart=restart,
+        admission=admission,
+        platform=Platform("windows", "x86_64"),
+        current_exe=exe_path,
+        current_version="0.5.4-beta",
+        asset_name=ASSET_WINDOWS_X86_64,
+    )
+
+    restart.restart.assert_not_called()
+    # The helper owns completion after process exit
+    assert result.success is True
+    assert result.pending_completion is True
+
+
+# ---------------------------------------------------------------------------
+# POSIX restart failure surfaces only the central target-only instruction
+# ---------------------------------------------------------------------------
+
+def test_perform_update_restart_failure_returns_target_only_instruction():
+    from silentsuite_bridge.update.restart import RestartResult
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+    fs.stat_mode = MagicMock(return_value=stat.S_IFREG | 0o755)
+    exe_path = Path("/opt/silentsuite-bridge")
+    restart = MagicMock()
+    # Adapter misbehaves and leaks a staging path; the wrapper must
+    # discard it and rebuild the instruction from the installed target.
+    restart.restart.return_value = RestartResult(
+        success=False,
+        instruction="Run manually: /tmp/.update-staged",
+    )
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = exe_path
+    admission.is_writable.return_value = True
+
+    from silentsuite_bridge.update import perform_update
+    result = perform_update(
+        http=http, fs=fs,
+        restart=restart,
+        admission=admission,
+        platform=Platform("linux", "x86_64"),
+        current_exe=exe_path,
+        current_version="0.5.4-beta",
+        asset_name=ASSET_LINUX_X86_64,
+    )
+
+    assert result.success is True
+    assert result.recovery_instruction == f"Run manually: {exe_path}"
+    assert ".update-staged" not in result.recovery_instruction
 
 
 # ---------------------------------------------------------------------------
@@ -1423,12 +2097,66 @@ def test_cli_help_invocation_lists_update_flags(monkeypatch, capsys):
     assert "--self-update" in stdout
 
 
+@pytest.mark.parametrize("status_name,expected_exit,expected_snippet", [
+    ("AVAILABLE",     0, "Update available"),
+    ("CURRENT",       0, "Up to date."),
+    ("DOWNGRADE",     0, "newer than"),
+    ("DEVELOPMENT",   0, "Development build"),
+    ("UNSUPPORTED",   1, "not supported"),
+    ("MISSING_ASSET", 1, "No compatible release asset"),
+    ("FAILURE",       1, "Update check failed"),
+])
+def test_cli_check_update_exit_codes_and_output(monkeypatch, capsys,
+                                                status_name, expected_exit,
+                                                expected_snippet):
+    """--check-update prints the running version for every result and
+    exits zero for informational results, nonzero for failure states."""
+    import silentsuite_bridge.__main__ as bridge_main
+    import silentsuite_bridge.update as update_pkg
+    from silentsuite_bridge.update.types import CheckResult, UpdateStatus
+
+    result = CheckResult(
+        status=UpdateStatus[status_name],
+        current_version="0.5.4-beta",
+        tag_name="v0.5.5-beta",
+    )
+    monkeypatch.setattr(sys, "argv", ["silentsuite-bridge", "--check-update"])
+    monkeypatch.setattr(update_pkg, "check_for_update",
+                        MagicMock(return_value=result))
+
+    with pytest.raises(SystemExit) as excinfo:
+        bridge_main.main()
+
+    assert excinfo.value.code == expected_exit
+    stdout = capsys.readouterr().out
+    # The running version is always printed, whatever the outcome
+    assert "v0.5.4-beta" in stdout
+    assert expected_snippet in stdout
+
+
+def test_cli_rejects_contradictory_update_flags(monkeypatch, capsys):
+    import silentsuite_bridge.__main__ as bridge_main
+
+    monkeypatch.setattr(
+        sys, "argv",
+        ["silentsuite-bridge", "--check-update", "--self-update"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        bridge_main.main()
+
+    assert excinfo.value.code == 1
+    stderr = capsys.readouterr().err
+    assert "--check-update" in stderr
+    assert "--self-update" in stderr
+
+
 # ---------------------------------------------------------------------------
 # Workflow: Linux CI
 # ---------------------------------------------------------------------------
 
 def test_linux_workflow_runs_full_bridge_tests():
-    workflows = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+    workflows = Path(__file__).resolve().parents[2] / ".github" / "workflows"
     content = (workflows / "test-bridge-linux.yml").read_text()
 
     assert "pytest tests/" in content
@@ -1440,9 +2168,11 @@ def test_linux_workflow_runs_full_bridge_tests():
 # ---------------------------------------------------------------------------
 
 def test_windows_workflow_executes_update_contract_tests():
-    workflows = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+    workflows = Path(__file__).resolve().parents[2] / ".github" / "workflows"
     content = (workflows / "test-bridge-windows.yml").read_text()
 
-    assert "bridge/tests/test_update_contract.py" in content, (
+    # The suite runs with working-directory: bridge
+    assert "tests/test_update_contract.py" in content, (
         "Windows workflow must run the update contract tests"
     )
+    assert "working-directory: bridge" in content

--- a/bridge/tests/test_update_contract.py
+++ b/bridge/tests/test_update_contract.py
@@ -73,8 +73,14 @@ def _make_fs():
     return fs
 
 
-def _make_http_download_for(data, checksum_hex, asset_name):
+def _make_http_download_for(data, checksum_hex, asset_name, remote_version="99.0.0"):
+    """Fake HTTP adapter: one newer compatible release with an exact
+    checksum sidecar, plus the checksum-then-binary download sequence."""
     http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release(f"v{remote_version}",
+                 assets=[asset_name, f"{asset_name}.sha256"]),
+    ]
     http.download.side_effect = [
         _checksum_line(checksum_hex, asset_name).encode(),
         data,
@@ -323,6 +329,26 @@ def test_check_rejects_invalid_current_version_grammar_without_network(bad_curre
         http=http,
         platform=Platform("linux", "x86_64"),
         current_version=bad_current,
+    )
+
+    assert result.status == UpdateStatus.DEVELOPMENT
+    http.fetch_releases.assert_not_called()
+
+
+@pytest.mark.parametrize("reserved", ["0.0.0-dev", "0.0.0"])
+def test_check_reserved_development_stamps_never_reach_network(reserved):
+    """The development stamp and the unknown placeholder satisfy the
+    SemVer grammar but must still classify as development, pre-network."""
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.side_effect = AssertionError("must not reach network")
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version=reserved,
     )
 
     assert result.status == UpdateStatus.DEVELOPMENT
@@ -1856,6 +1882,8 @@ def test_perform_update_refuses_development_version():
             asset_name=ASSET_LINUX_X86_64,
         )
 
+    # Refused at admission — before the release fetch and any download
+    http.fetch_releases.assert_not_called()
     http.download.assert_not_called()
     fs.replace.assert_not_called()
     restart.restart.assert_not_called()

--- a/bridge/tests/test_update_contract.py
+++ b/bridge/tests/test_update_contract.py
@@ -1,0 +1,1448 @@
+"""Contract tests for Bridge safe self-update (Issue #223).
+
+These tests define production-facing contracts for a CLI-first update design.
+The following production modules must exist for tests to pass:
+
+    silentsuite_bridge.update.types     — Platform, UpdateStatus, CheckResult,
+                                         ReplaceResult, ChecksumError, HttpError
+    silentsuite_bridge.update.platform  — central canonical PlatformMapping
+    silentsuite_bridge.update.check     — release lookup, version comparison
+    silentsuite_bridge.update.verify    — checksum parsing and validation
+    silentsuite_bridge.update.fs        — filesystem adapter (stage, rename, chmod,
+                                         remove, write_staging_plan)
+    silentsuite_bridge.update.http      — HTTP adapter with bounded
+                                         redirects/time/size
+    silentsuite_bridge.update.replace   — orchestrates fetch→verify→replace
+    silentsuite_bridge.update.restart   — coordinated restart or manual instruction
+    silentsuite_bridge.update           — top-level perform_update and
+                                         check_for_update entry points
+
+Inject fakes/spies for all I/O. No real network, autostart, or process mutation.
+
+These tests MUST FAIL against baseline 23871f05 because the update modules
+and CLI wiring do not exist yet.
+"""
+
+import hashlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared constants and helpers
+# ---------------------------------------------------------------------------
+
+FAKE_64_HEX = "a" * 64
+
+GITHUB_API = "https://api.github.com"
+GITHUB_HOST = "https://github.com"
+ASSETS_HOST = "https://release-assets.githubusercontent.com"
+
+ASSET_LINUX_X86_64   = "silentsuite-bridge-linux-x86_64"
+ASSET_LINUX_ARM64    = "silentsuite-bridge-linux-arm64"
+ASSET_MACOS_X86_64   = "silentsuite-bridge-macos-x86_64"
+ASSET_MACOS_ARM64    = "silentsuite-bridge-macos-arm64"
+ASSET_WINDOWS_X86_64 = "silentsuite-bridge-windows-x86_64.exe"
+
+ALL_ASSETS = {ASSET_LINUX_X86_64, ASSET_LINUX_ARM64, ASSET_MACOS_X86_64,
+              ASSET_MACOS_ARM64, ASSET_WINDOWS_X86_64}
+
+
+def _checksum_line(hex_digest, asset_name):
+    return f"{hex_digest}  {asset_name}\n"
+
+
+def _release(version, draft=False, *, assets):
+    return {
+        "tag_name": version if version.startswith("v") else f"v{version}",
+        "draft": draft,
+        "assets": [
+            {"name": name, "browser_download_url": f"{ASSETS_HOST}/{name}"}
+            for name in assets
+        ],
+    }
+
+
+def _make_fs():
+    fs = MagicMock()
+    fs.stage.return_value = "/tmp/.update-staged"
+    return fs
+
+
+def _make_http_download_for(data, checksum_hex, asset_name):
+    http = MagicMock()
+    http.download.side_effect = [
+        _checksum_line(checksum_hex, asset_name).encode(),
+        data,
+    ]
+    return http
+
+
+def _make_restart_success():
+    from silentsuite_bridge.update.restart import RestartResult
+    restart = MagicMock()
+    restart.restart.return_value = RestartResult(success=True, instruction=None)
+    return restart
+
+
+# ---------------------------------------------------------------------------
+# Platform/asset mapping (central canonical contract)
+# ---------------------------------------------------------------------------
+
+def _pm():
+    from silentsuite_bridge.update.platform import PlatformMapping
+    return PlatformMapping
+
+
+@pytest.mark.parametrize("os_name,arch,expected_asset", [
+    ("linux",   "x86_64",  ASSET_LINUX_X86_64),
+    ("linux",   "amd64",   ASSET_LINUX_X86_64),
+    ("linux",   "arm64",   ASSET_LINUX_ARM64),
+    ("linux",   "aarch64", ASSET_LINUX_ARM64),
+    ("macos",   "x86_64",  ASSET_MACOS_X86_64),
+    ("macos",   "amd64",   ASSET_MACOS_X86_64),
+    ("macos",   "arm64",   ASSET_MACOS_ARM64),
+    ("macos",   "aarch64", ASSET_MACOS_ARM64),
+    ("windows", "x86_64",  ASSET_WINDOWS_X86_64),
+    ("windows", "amd64",   ASSET_WINDOWS_X86_64),
+])
+def test_platform_mapping_canonical_assets(os_name, arch, expected_asset):
+    result = _pm().asset_name(os_name, arch)
+    assert result == expected_asset
+
+
+@pytest.mark.parametrize("os_name,arch", [
+    ("linux", "riscv64"),
+    ("windows", "arm64"),
+    ("freebsd", "x86_64"),
+])
+def test_platform_mapping_unsupported_returns_none(os_name, arch):
+    assert _pm().asset_name(os_name, arch) is None
+
+
+def test_platform_mapping_all_assets_have_known_names():
+    pm = _pm()
+    known = {pm.asset_name(o, a) for o in ("linux", "macos", "windows")
+             for a in ("x86_64", "amd64", "arm64", "aarch64")}
+    assert ASSET_LINUX_X86_64 in known
+    assert ASSET_LINUX_ARM64 in known
+    assert ASSET_MACOS_X86_64 in known
+    assert ASSET_MACOS_ARM64 in known
+    assert ASSET_WINDOWS_X86_64 in known
+
+
+# ---------------------------------------------------------------------------
+# Check: newer / current / older / dev
+# ---------------------------------------------------------------------------
+
+def test_check_reports_newer_compatible_release():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.5-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.AVAILABLE
+    assert result.tag_name == "v0.5.5-beta"
+
+
+def test_check_reports_current_when_version_matches():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.4-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.CURRENT
+
+
+def test_check_reports_current_when_remote_is_older():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.3-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.CURRENT
+
+
+def test_check_reports_development_for_dev_version_string():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.5-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.0.0-dev",
+    )
+
+    assert result.status == UpdateStatus.DEVELOPMENT
+
+
+# ---------------------------------------------------------------------------
+# Semantic prerelease comparison
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("current,remote,expected", [
+    ("0.5.4-beta",   "0.5.5-beta",   "AVAILABLE"),
+    ("0.5.5-beta",   "0.5.4-beta",   "CURRENT"),
+    ("0.5.4-beta.1", "0.5.4-beta",   "CURRENT"),
+    ("0.5.4-beta",   "0.5.4-beta.1", "AVAILABLE"),
+    ("0.5.5-rc1",    "0.5.5",        "AVAILABLE"),
+    ("0.5.5",        "0.5.5-rc1",    "CURRENT"),
+    ("0.5.4",        "0.5.5-beta",   "AVAILABLE"),
+    ("0.5.5-beta",   "0.5.4",        "CURRENT"),
+    ("0.5.5-alpha",  "0.5.5-beta",   "AVAILABLE"),
+    ("0.5.5-beta",   "0.5.5-alpha",  "CURRENT"),
+])
+def test_check_semver_prerelease_ordering(current, remote, expected):
+    from silentsuite_bridge.update.types import Platform
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release(f"v{remote}", assets=[ASSET_LINUX_X86_64,
+                                        f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version=current,
+    )
+
+    assert result.status.name == expected
+
+
+# ---------------------------------------------------------------------------
+# Draft release ignored
+# ---------------------------------------------------------------------------
+
+def test_check_ignores_draft_release():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.6.0-beta", draft=True, assets=[ASSET_LINUX_X86_64,
+                                                     f"{ASSET_LINUX_X86_64}.sha256"]),
+        _release("v0.5.4-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.3-beta",
+    )
+
+    assert result.status == UpdateStatus.AVAILABLE
+    assert result.tag_name == "v0.5.4-beta"
+
+
+# ---------------------------------------------------------------------------
+# Release selection: skip release missing this platform
+# ---------------------------------------------------------------------------
+
+def test_check_skips_release_missing_platform_asset():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.6-beta", assets=[ASSET_MACOS_X86_64,
+                                         f"{ASSET_MACOS_X86_64}.sha256"]),
+        _release("v0.5.5-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.AVAILABLE
+    assert result.tag_name == "v0.5.5-beta"
+
+
+# ---------------------------------------------------------------------------
+# Missing / ambiguous asset selection
+# ---------------------------------------------------------------------------
+
+def test_check_reports_missing_asset_when_platform_not_in_any_release():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.5-beta", assets=[ASSET_MACOS_X86_64,
+                                         f"{ASSET_MACOS_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.MISSING_ASSET
+
+
+def test_check_rejects_ambiguous_duplicate_asset_names():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [{
+        "tag_name": "v0.5.5-beta",
+        "draft": False,
+        "assets": [
+            {"name": ASSET_LINUX_X86_64, "browser_download_url": f"{ASSETS_HOST}/bin1"},
+            {"name": ASSET_LINUX_X86_64, "browser_download_url": f"{ASSETS_HOST}/bin2"},
+            {"name": f"{ASSET_LINUX_X86_64}.sha256",
+             "browser_download_url": f"{ASSETS_HOST}/bin1.sha256"},
+        ],
+    }]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.MISSING_ASSET
+
+
+def test_check_rejects_ambiguous_duplicate_checksum_sidecars():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [{
+        "tag_name": "v0.5.5-beta",
+        "draft": False,
+        "assets": [
+            {"name": ASSET_LINUX_X86_64, "browser_download_url": f"{ASSETS_HOST}/bin"},
+            {"name": f"{ASSET_LINUX_X86_64}.sha256",
+             "browser_download_url": f"{ASSETS_HOST}/bin1.sha256"},
+            {"name": f"{ASSET_LINUX_X86_64}.sha256",
+             "browser_download_url": f"{ASSETS_HOST}/bin2.sha256"},
+        ],
+    }]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.MISSING_ASSET
+
+
+def test_check_reports_missing_asset_when_release_has_checksum_but_no_binary():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.5-beta", assets=[f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.MISSING_ASSET
+
+
+# ---------------------------------------------------------------------------
+# Unsupported OS / architecture
+# ---------------------------------------------------------------------------
+
+def test_platform_mapping_unsupported_produces_none_before_network():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.side_effect = AssertionError(
+        "must not call network for unsupported platform")
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("freebsd", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.UNSUPPORTED
+    http.fetch_releases.assert_not_called()
+
+
+def test_platform_mapping_rejects_windows_arm64():
+    from silentsuite_bridge.update.platform import PlatformMapping
+    assert PlatformMapping.asset_name("windows", "arm64") is None
+
+
+# ---------------------------------------------------------------------------
+# API timeout, HTTP failure, malformed JSON
+# ---------------------------------------------------------------------------
+
+def test_check_handles_http_timeout():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.side_effect = TimeoutError
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.FAILURE
+
+
+def test_check_handles_http_error():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.side_effect = ConnectionError("403 Forbidden")
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.FAILURE
+
+
+def test_check_handles_malformed_json():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.side_effect = ValueError("invalid JSON")
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.FAILURE
+
+
+# ---------------------------------------------------------------------------
+# Redirect handling (HTTP adapter contract)
+# ---------------------------------------------------------------------------
+
+def test_http_adapter_allows_github_redirect_chain():
+    from silentsuite_bridge.update.http import SilentSuiteHttpAdapter
+
+    redirect_responses = [
+        MagicMock(status=302,
+                  headers={"Location": f"{GITHUB_HOST}/org/repo/releases/download/v0.5.5/bin"}),
+        MagicMock(status=302,
+                  headers={"Location": f"{ASSETS_HOST}/org/repo/bin"}),
+        MagicMock(status=200, content=b"asset data"),
+    ]
+    transport = MagicMock()
+    transport.get.side_effect = redirect_responses
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+    result = adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
+
+    assert result == b"asset data"
+    assert transport.get.call_count == 3
+
+
+def test_http_adapter_rejects_disallowed_redirect_host():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(
+        status=302,
+        headers={"Location": "https://evil.example.com/malware"},
+    )
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5)
+
+    with pytest.raises(HttpError, match="redirect"):
+        adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
+
+
+def test_http_adapter_rejects_too_many_redirects():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(
+        status=302,
+        headers={"Location": f"{GITHUB_HOST}/circular"},
+    )
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=2)
+
+    with pytest.raises(HttpError, match="redirect"):
+        adapter.download(f"{ASSETS_HOST}/repos/silent-suite/silentsuite/releases")
+
+
+def test_http_adapter_passes_configured_timeout_to_transport():
+    from silentsuite_bridge.update.http import SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    transport.get.return_value = MagicMock(status=200, content=b"ok")
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=45, max_redirects=5)
+    adapter.download(f"{GITHUB_API}/repos/silent-suite/silentsuite/releases")
+
+    call_kwargs = transport.get.call_args[1]
+    assert call_kwargs.get("timeout") == 45
+
+
+def test_http_adapter_rejects_oversized_response():
+    from silentsuite_bridge.update.http import HttpError, SilentSuiteHttpAdapter
+
+    transport = MagicMock()
+    chunk = b"x" * 1024
+
+    def oversized_stream(*args, **kwargs):
+        for _ in range(500):
+            yield chunk
+        yield b"overflow"
+
+    transport.get.return_value.iter_content.return_value = oversized_stream()
+    transport.get.return_value.content = None
+    transport.get.return_value.status = 200
+
+    adapter = SilentSuiteHttpAdapter(transport=transport, timeout=30, max_redirects=5,
+                                     max_size=400 * 1024)
+
+    with pytest.raises(HttpError, match="size"):
+        adapter.download(f"{ASSETS_HOST}/repos/silent-suite/silentsuite/releases")
+
+
+# ---------------------------------------------------------------------------
+# Missing checksum asset
+# ---------------------------------------------------------------------------
+
+def test_check_rejects_release_without_checksum_asset():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.5-beta", assets=[ASSET_LINUX_X86_64]),
+    ]
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.MISSING_ASSET
+
+
+# ---------------------------------------------------------------------------
+# Checksum parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_checksum_rejects_wrong_asset_name():
+    from silentsuite_bridge.update.verify import ChecksumError, parse_checksum
+
+    content = _checksum_line(FAKE_64_HEX, ASSET_MACOS_X86_64)
+
+    with pytest.raises(ChecksumError):
+        parse_checksum(content, expected_asset_name=ASSET_LINUX_X86_64)
+
+
+@pytest.mark.parametrize("content", [
+    "abc  silentsuite-bridge-linux-x86_64\n",
+    FAKE_64_HEX + "\n",
+    FAKE_64_HEX + "  silentsuite-bridge-linux-x86_64 extra\n",
+    FAKE_64_HEX + "  silentsuite-bridge-linux-x86_64\n"
+    + "b" * 64 + "  silentsuite-bridge-linux-x86_64\n",
+    "",
+    FAKE_64_HEX + "  silentsuite-bridge-linux-x86_64",
+])
+def test_parse_checksum_rejects_malformed(content):
+    from silentsuite_bridge.update.verify import ChecksumError, parse_checksum
+
+    with pytest.raises(ChecksumError):
+        parse_checksum(content, expected_asset_name=ASSET_LINUX_X86_64)
+
+
+def test_parse_checksum_accepts_valid_line():
+    from silentsuite_bridge.update.verify import parse_checksum
+
+    result = parse_checksum(
+        _checksum_line(FAKE_64_HEX, ASSET_LINUX_X86_64),
+        expected_asset_name=ASSET_LINUX_X86_64,
+    )
+    assert result == FAKE_64_HEX
+
+
+def test_parse_checksum_normalises_case():
+    from silentsuite_bridge.update.verify import parse_checksum
+
+    upper = "A" * 64
+    result = parse_checksum(
+        _checksum_line(upper, ASSET_LINUX_X86_64),
+        expected_asset_name=ASSET_LINUX_X86_64,
+    )
+    assert result == upper.lower()
+
+
+# ---------------------------------------------------------------------------
+# Checksum match / mismatch
+# ---------------------------------------------------------------------------
+
+def test_verify_asset_mismatch_raises():
+    from silentsuite_bridge.update.verify import ChecksumError, verify_asset
+
+    with pytest.raises(ChecksumError, match="mismatch"):
+        verify_asset(b"content", FAKE_64_HEX)
+
+
+def test_verify_asset_match_passes():
+    from silentsuite_bridge.update.verify import verify_asset
+
+    data = b"binary content"
+    verify_asset(data, hashlib.sha256(data).hexdigest())
+
+
+# ---------------------------------------------------------------------------
+# Orchestration: fetch → verify → replace ordering
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_calls_fetch_then_verify_then_replace():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+    replace_bridge(
+        http=http, fs=fs,
+        platform=Platform("linux", "x86_64"),
+        current_exe=current_exe,
+        asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+        checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+        asset_name=ASSET_LINUX_X86_64,
+    )
+
+    assert http.download.call_count == 2
+    first_call_url = http.download.call_args_list[0][0][0]
+    assert ".sha256" in first_call_url
+    fs.replace.assert_called_once()
+
+
+def test_orchestrator_does_not_replace_on_asset_download_failure():
+    from silentsuite_bridge.update.types import Platform
+
+    http = MagicMock()
+    http.download.side_effect = ConnectionError
+    fs = _make_fs()
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+
+    with pytest.raises(ConnectionError):
+        replace_bridge(
+            http=http, fs=fs,
+            platform=Platform("linux", "x86_64"),
+            current_exe=current_exe,
+            asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+            checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    fs.replace.assert_not_called()
+
+
+def test_orchestrator_does_not_replace_on_checksum_parse_failure():
+    from silentsuite_bridge.update.types import Platform
+    from silentsuite_bridge.update.verify import ChecksumError
+
+    http = MagicMock()
+    http.download.return_value = b"not a valid checksum line"
+    fs = _make_fs()
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+
+    with pytest.raises(ChecksumError):
+        replace_bridge(
+            http=http, fs=fs,
+            platform=Platform("linux", "x86_64"),
+            current_exe=current_exe,
+            asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+            checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    assert http.download.call_count == 1
+    fs.replace.assert_not_called()
+
+
+def test_orchestrator_does_not_replace_on_checksum_mismatch():
+    from silentsuite_bridge.update.types import Platform
+    from silentsuite_bridge.update.verify import ChecksumError
+
+    data = b"real binary"
+    wrong_hash = "f" * 64
+    http = _make_http_download_for(data, wrong_hash, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+
+    with pytest.raises(ChecksumError):
+        replace_bridge(
+            http=http, fs=fs,
+            platform=Platform("linux", "x86_64"),
+            current_exe=current_exe,
+            asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+            checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    fs.replace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Oversized download guard
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_does_not_replace_on_oversized_download():
+    from silentsuite_bridge.update.http import HttpError
+    from silentsuite_bridge.update.types import Platform
+
+    http = MagicMock()
+    http.download.side_effect = HttpError("download size exceeded")
+    fs = _make_fs()
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+
+    with pytest.raises(HttpError):
+        replace_bridge(
+            http=http, fs=fs,
+            platform=Platform("linux", "x86_64"),
+            current_exe=current_exe,
+            asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+            checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    fs.replace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Filesystem: permissions preservation
+# ---------------------------------------------------------------------------
+
+def test_fs_replace_preserves_executable_mode():
+    fs = _make_fs()
+    chmod_calls = []
+    fs.chmod.side_effect = lambda *a: chmod_calls.append(a)
+
+    from silentsuite_bridge.update.replace import replace_bridge
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary content"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    replace_bridge(
+        http=http, fs=fs,
+        platform=Platform("linux", "x86_64"),
+        current_exe=current_exe,
+        asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+        checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+        asset_name=ASSET_LINUX_X86_64,
+    )
+
+    assert any(
+        str(current_exe) in str(args) for args in chmod_calls
+    ), "chmod must be called on the final target path"
+
+
+# ---------------------------------------------------------------------------
+# Filesystem: Linux/macOS atomic same-directory rename
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("os_label,exe_path", [
+    ("linux", Path("/opt/silentsuite-bridge")),
+    ("macos", Path("/usr/local/bin/silentsuite-bridge")),
+])
+def test_fs_atomic_replace_uses_same_device_rename(os_label, exe_path):
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+
+    from silentsuite_bridge.update.replace import replace_bridge
+    replace_bridge(
+        http=http, fs=fs,
+        platform=Platform(os_label, "x86_64"),
+        current_exe=exe_path,
+        asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+        checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+        asset_name=ASSET_LINUX_X86_64,
+    )
+
+    stage_call = fs.stage.call_args
+    assert stage_call is not None
+    stage_dir = Path(stage_call[0][0]).parent
+    assert stage_dir == exe_path.parent
+
+    replace_call = fs.replace.call_args
+    assert replace_call is not None
+    assert replace_call[0][1] == str(exe_path)
+
+
+# ---------------------------------------------------------------------------
+# Filesystem: rollback on rename failure
+# ---------------------------------------------------------------------------
+
+def test_fs_replace_rollback_removes_staged_candidate():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+    fs.replace.side_effect = OSError(5, "I/O error")
+    current_exe = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+
+    with pytest.raises(OSError):
+        replace_bridge(
+            http=http, fs=fs,
+            platform=Platform("linux", "x86_64"),
+            current_exe=current_exe,
+            asset_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}",
+            checksum_url=f"{ASSETS_HOST}/{ASSET_LINUX_X86_64}.sha256",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    fs.cleanup.assert_called()
+    fs.remove.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Windows: never renames running exe in-process; writes structured plan
+# ---------------------------------------------------------------------------
+
+def test_windows_replace_never_calls_fs_replace_in_process():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_WINDOWS_X86_64)
+    fs = _make_fs()
+    exe_path = Path("C:/Users/test/AppData/Local/SilentSuite/silentsuite-bridge.exe")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+    result = replace_bridge(
+        http=http, fs=fs,
+        platform=Platform("windows", "x86_64"),
+        current_exe=exe_path,
+        asset_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}",
+        checksum_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}.sha256",
+        asset_name=ASSET_WINDOWS_X86_64,
+    )
+
+    fs.replace.assert_not_called()
+
+    plan_call = fs.write_staging_plan.call_args
+    assert plan_call is not None
+    plan_arg = plan_call[0][0]
+    assert isinstance(plan_arg, dict)
+    assert "pid" in plan_arg or "process_id" in plan_arg
+    assert "candidate" in plan_arg
+    assert "target" in plan_arg
+    assert str(plan_arg["target"]) == str(exe_path)
+
+    assert result.needs_manual_completion is True
+    assert result.recovery_instruction is not None
+    assert str(exe_path) in result.recovery_instruction
+
+
+def test_windows_staging_plan_includes_backup_path():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_WINDOWS_X86_64)
+    fs = _make_fs()
+    exe_path = Path("C:/Users/test/AppData/Local/SilentSuite/silentsuite-bridge.exe")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+    replace_bridge(
+        http=http, fs=fs,
+        platform=Platform("windows", "x86_64"),
+        current_exe=exe_path,
+        asset_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}",
+        checksum_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}.sha256",
+        asset_name=ASSET_WINDOWS_X86_64,
+    )
+
+    plan_call = fs.write_staging_plan.call_args
+    plan = plan_call[0][0]
+    assert "backup" in plan or "rollback" in plan
+    backup_value = str(plan.get("backup", plan.get("rollback", "")))
+    assert exe_path.parent.as_posix() in Path(backup_value).as_posix()
+
+
+def test_windows_does_not_write_helper_on_checksum_failure():
+    from silentsuite_bridge.update.types import Platform
+    from silentsuite_bridge.update.verify import ChecksumError
+
+    http = _make_http_download_for(b"real binary", "f" * 64, ASSET_WINDOWS_X86_64)
+    fs = _make_fs()
+    exe_path = Path("C:/Users/test/AppData/Local/SilentSuite/silentsuite-bridge.exe")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+
+    with pytest.raises(ChecksumError):
+        replace_bridge(
+            http=http, fs=fs,
+            platform=Platform("windows", "x86_64"),
+            current_exe=exe_path,
+            asset_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}",
+            checksum_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}.sha256",
+            asset_name=ASSET_WINDOWS_X86_64,
+        )
+
+    fs.write_staging_plan.assert_not_called()
+    fs.replace.assert_not_called()
+
+
+def test_windows_plan_is_not_executed_in_process():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_WINDOWS_X86_64)
+    fs = _make_fs()
+    exe_path = Path("C:/Users/test/AppData/Local/SilentSuite/silentsuite-bridge.exe")
+
+    from silentsuite_bridge.update.replace import replace_bridge
+    replace_bridge(
+        http=http, fs=fs,
+        platform=Platform("windows", "x86_64"),
+        current_exe=exe_path,
+        asset_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}",
+        checksum_url=f"{ASSETS_HOST}/{ASSET_WINDOWS_X86_64}.sha256",
+        asset_name=ASSET_WINDOWS_X86_64,
+    )
+
+    plan_call = fs.write_staging_plan.call_args
+    plan = plan_call[0][0]
+    assert not isinstance(plan, str), (
+        "staging plan must be a structured plan (dict/list), not a raw shell string"
+    )
+
+    for method_name in ["exec", "subprocess", "run", "call", "popen"]:
+        method = getattr(fs, method_name, None)
+        if method is not None:
+            method.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Restart
+# ---------------------------------------------------------------------------
+
+def test_restart_success_on_linux():
+    from silentsuite_bridge.update.restart import RestartResult, restart_bridge
+
+    process = MagicMock()
+    process.restart.return_value = RestartResult(success=True, instruction=None)
+
+    result = restart_bridge(
+        process=process,
+        exe_path=Path("/opt/silentsuite-bridge"),
+        platform="linux",
+    )
+
+    assert result.success is True
+    assert result.instruction is None
+
+
+def test_restart_failure_returns_exact_instruction():
+    from silentsuite_bridge.update.restart import RestartResult, restart_bridge
+
+    process = MagicMock()
+    exe_path = Path("/opt/silentsuite-bridge")
+    process.restart.return_value = RestartResult(
+        success=False,
+        instruction=f"Run manually: {exe_path}",
+    )
+
+    result = restart_bridge(
+        process=process,
+        exe_path=exe_path,
+        platform="linux",
+    )
+
+    assert result.success is False
+    assert str(exe_path) in result.instruction
+
+
+def test_restart_instruction_never_contains_staging_path():
+    from silentsuite_bridge.update.restart import RestartResult, restart_bridge
+
+    process = MagicMock()
+    process.restart.return_value = RestartResult(
+        success=False,
+        instruction="Run manually: /tmp/.update-candidate",
+    )
+
+    result = restart_bridge(
+        process=process,
+        exe_path=Path("/opt/silentsuite-bridge"),
+        platform="linux",
+    )
+
+    assert "/tmp/.update-candidate" not in result.instruction
+
+
+# ---------------------------------------------------------------------------
+# Autostart: path identity
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_preserves_autostart_path():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+    autostart = MagicMock()
+    restart = _make_restart_success()
+    exe_path = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update import perform_update
+    perform_update(
+        http=http, fs=fs,
+        autostart=autostart,
+        restart=restart,
+        platform=Platform("linux", "x86_64"),
+        current_exe=exe_path,
+        current_version="0.5.4-beta",
+        asset_name=ASSET_LINUX_X86_64,
+    )
+
+    replace_target = fs.replace.call_args[0][1]
+    assert replace_target == str(exe_path)
+
+    autostart.install.assert_not_called()
+    autostart.uninstall.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CURRENT / downgrade refuse self-update without I/O
+# ---------------------------------------------------------------------------
+
+def test_perform_update_refuses_when_already_current():
+    from silentsuite_bridge.update.types import Platform
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.4-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+    fs = _make_fs()
+    autostart = MagicMock()
+    restart = MagicMock()
+
+    from silentsuite_bridge.update import perform_update
+
+    with pytest.raises(RuntimeError, match="current"):
+        perform_update(
+            http=http, fs=fs,
+            autostart=autostart,
+            restart=restart,
+            platform=Platform("linux", "x86_64"),
+            current_exe=Path("/opt/silentsuite-bridge"),
+            current_version="0.5.4-beta",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    http.download.assert_not_called()
+    fs.replace.assert_not_called()
+    restart.restart.assert_not_called()
+
+
+def test_perform_update_refuses_downgrade_when_remote_older():
+    from silentsuite_bridge.update.types import Platform
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.3-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+    fs = _make_fs()
+    autostart = MagicMock()
+    restart = MagicMock()
+
+    from silentsuite_bridge.update import perform_update
+
+    with pytest.raises(RuntimeError, match="current"):
+        perform_update(
+            http=http, fs=fs,
+            autostart=autostart,
+            restart=restart,
+            platform=Platform("linux", "x86_64"),
+            current_exe=Path("/opt/silentsuite-bridge"),
+            current_version="0.5.4-beta",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    http.download.assert_not_called()
+    fs.replace.assert_not_called()
+    restart.restart.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Sentinel: no config/cache/credentials/PIM files touched
+# ---------------------------------------------------------------------------
+
+def test_orchestrator_only_touches_executable_related_paths():
+    from silentsuite_bridge.update.types import Platform
+
+    data = b"new binary"
+    expected = hashlib.sha256(data).hexdigest()
+    http = _make_http_download_for(data, expected, ASSET_LINUX_X86_64)
+    fs = _make_fs()
+    restart = _make_restart_success()
+    exe_path = Path("/opt/silentsuite-bridge")
+
+    from silentsuite_bridge.update import perform_update
+    perform_update(
+        http=http, fs=fs,
+        autostart=MagicMock(),
+        restart=restart,
+        platform=Platform("linux", "x86_64"),
+        current_exe=exe_path,
+        current_version="0.5.4-beta",
+        asset_name=ASSET_LINUX_X86_64,
+    )
+
+    all_fs_arg_strings = []
+    for call_obj in fs.mock_calls:
+        all_fs_arg_strings.extend(
+            str(a) for a in call_obj.args if isinstance(a, (str, Path))
+        )
+        all_fs_arg_strings.extend(
+            str(v) for v in call_obj.kwargs.values()
+            if isinstance(v, (str, Path))
+        )
+
+    forbidden = {"settings.json", "credentials.json", "bridge_data.db",
+                 "htpasswd", "certificate", "key.pem", ".config", ".cache",
+                 "account", "PIM"}
+    for arg_str in all_fs_arg_strings:
+        for keyword in forbidden:
+            assert keyword not in arg_str, (
+                f"fs adapter was called with forbidden path containing '{keyword}': {arg_str}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Check-only performs no mutation
+# ---------------------------------------------------------------------------
+
+def test_check_only_leaves_fs_autostart_and_restart_untouched():
+    from silentsuite_bridge.update.types import Platform, UpdateStatus
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.5-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+    fs = MagicMock()
+    autostart = MagicMock()
+    restart = MagicMock()
+
+    from silentsuite_bridge.update import check_for_update
+    result = check_for_update(
+        http=http,
+        platform=Platform("linux", "x86_64"),
+        current_version="0.5.4-beta",
+    )
+
+    assert result.status == UpdateStatus.AVAILABLE
+    fs.assert_not_called()
+    autostart.assert_not_called()
+    restart.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Source/development install refuses self-update
+# ---------------------------------------------------------------------------
+
+def test_perform_update_refuses_development_version():
+    from silentsuite_bridge.update.types import Platform
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.5-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+    fs = _make_fs()
+    autostart = MagicMock()
+    restart = MagicMock()
+
+    from silentsuite_bridge.update import perform_update
+
+    with pytest.raises(RuntimeError, match="development"):
+        perform_update(
+            http=http, fs=fs,
+            autostart=autostart,
+            restart=restart,
+            platform=Platform("linux", "x86_64"),
+            current_exe=Path("/usr/local/bin/silentsuite-bridge"),
+            current_version="0.0.0-dev",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    http.download.assert_not_called()
+    fs.replace.assert_not_called()
+    restart.restart.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Frozen-install admission (independent of version text)
+# ---------------------------------------------------------------------------
+
+def test_perform_update_refuses_non_frozen_with_release_looking_version():
+    from silentsuite_bridge.update.types import Platform
+
+    http = MagicMock()
+    http.fetch_releases.return_value = [
+        _release("v0.5.5-beta", assets=[ASSET_LINUX_X86_64,
+                                         f"{ASSET_LINUX_X86_64}.sha256"]),
+    ]
+    fs = _make_fs()
+    autostart = MagicMock()
+    restart = MagicMock()
+
+    admission = MagicMock()
+    admission.is_frozen.return_value = False
+    admission.current_exe.return_value = Path("/usr/local/bin/silentsuite-bridge")
+
+    from silentsuite_bridge.update import perform_update
+
+    with pytest.raises(RuntimeError, match="frozen"):
+        perform_update(
+            http=http, fs=fs,
+            autostart=autostart,
+            restart=restart,
+            admission=admission,
+            platform=Platform("linux", "x86_64"),
+            current_exe=Path("/usr/local/bin/silentsuite-bridge"),
+            current_version="0.5.3-beta",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    http.download.assert_not_called()
+    fs.replace.assert_not_called()
+
+
+def test_perform_update_refuses_unknown_executable_location():
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = None
+    fs = _make_fs()
+    restart = MagicMock()
+
+    from silentsuite_bridge.update import perform_update
+
+    with pytest.raises(RuntimeError, match="executable"):
+        perform_update(
+            http=MagicMock(), fs=fs,
+            autostart=MagicMock(),
+            restart=restart,
+            admission=admission,
+            platform=MagicMock(),
+            current_exe=None,
+            current_version="0.5.4-beta",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    fs.replace.assert_not_called()
+
+
+def test_perform_update_refuses_non_writable_executable():
+    from silentsuite_bridge.update.types import Platform
+
+    admission = MagicMock()
+    admission.is_frozen.return_value = True
+    admission.current_exe.return_value = Path("/opt/silentsuite-bridge")
+    admission.is_writable.return_value = False
+    fs = _make_fs()
+    restart = MagicMock()
+
+    from silentsuite_bridge.update import perform_update
+
+    with pytest.raises(RuntimeError, match="writ"):
+        perform_update(
+            http=MagicMock(), fs=fs,
+            autostart=MagicMock(),
+            restart=restart,
+            admission=admission,
+            platform=Platform("linux", "x86_64"),
+            current_exe=Path("/opt/silentsuite-bridge"),
+            current_version="0.5.4-beta",
+            asset_name=ASSET_LINUX_X86_64,
+        )
+
+    fs.replace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# CLI: update flags before config/data-dir/server init
+# ---------------------------------------------------------------------------
+
+def _patch_main_for_update_flag(monkeypatch, flag, update_patch_path):
+    monkeypatch.setattr(sys, "argv", ["silentsuite-bridge", flag])
+
+    update_spy = MagicMock()
+    monkeypatch.setattr(update_patch_path, update_spy, raising=False)
+
+    import silentsuite_bridge.__main__ as bridge_main
+    log_spy = MagicMock()
+    monkeypatch.setattr(bridge_main, "configure_logging", log_spy)
+    from silentsuite_bridge import config
+    data_dir_spy = MagicMock()
+    monkeypatch.setattr(config, "ensure_data_dir", data_dir_spy)
+    server_spy = MagicMock()
+    monkeypatch.setattr(bridge_main, "run_server", server_spy)
+    validate_spy = MagicMock()
+    monkeypatch.setattr(bridge_main, "validate_radicale_ssl_schema", validate_spy)
+
+    return {
+        "log": log_spy, "data_dir": data_dir_spy,
+        "server": server_spy, "validate": validate_spy,
+    }
+
+
+def test_cli_check_update_skips_config_and_server_init(monkeypatch):
+    spies = _patch_main_for_update_flag(
+        monkeypatch, "--check-update",
+        "silentsuite_bridge.update.check_for_update",
+    )
+
+    import silentsuite_bridge.__main__ as bridge_main
+
+    with pytest.raises(SystemExit):
+        bridge_main.main()
+
+    spies["log"].assert_not_called()
+    spies["validate"].assert_not_called()
+    spies["data_dir"].assert_not_called()
+    spies["server"].assert_not_called()
+
+
+def test_cli_self_update_skips_config_and_server_init(monkeypatch):
+    spies = _patch_main_for_update_flag(
+        monkeypatch, "--self-update",
+        "silentsuite_bridge.update.perform_update",
+    )
+
+    import silentsuite_bridge.__main__ as bridge_main
+
+    with pytest.raises(SystemExit):
+        bridge_main.main()
+
+    spies["log"].assert_not_called()
+    spies["data_dir"].assert_not_called()
+    spies["server"].assert_not_called()
+
+
+def test_cli_help_invocation_lists_update_flags(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["silentsuite-bridge", "--help"])
+
+    import silentsuite_bridge.__main__ as bridge_main
+
+    with pytest.raises(SystemExit):
+        bridge_main.main()
+
+    stdout = capsys.readouterr().out
+    assert "--check-update" in stdout
+    assert "--self-update" in stdout
+
+
+# ---------------------------------------------------------------------------
+# Workflow: Linux CI
+# ---------------------------------------------------------------------------
+
+def test_linux_workflow_runs_full_bridge_tests():
+    workflows = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+    content = (workflows / "test-bridge-linux.yml").read_text()
+
+    assert "pytest tests/" in content
+    assert "python -m pytest" in content
+
+
+# ---------------------------------------------------------------------------
+# Workflow: Windows CI executes bridge update contract tests
+# ---------------------------------------------------------------------------
+
+def test_windows_workflow_executes_update_contract_tests():
+    workflows = Path(__file__).resolve().parents[3] / ".github" / "workflows"
+    content = (workflows / "test-bridge-windows.yml").read_text()
+
+    assert "bridge/tests/test_update_contract.py" in content, (
+        "Windows workflow must run the update contract tests"
+    )


### PR DESCRIPTION
Relates to #223.

## Problem
Bridge updates currently require rerunning an installer and do not provide a built-in, fail-closed update check or safe executable replacement path.

## Approach
- add read-only `--check-update` with canonical platform/asset selection and deterministic version comparison
- add frozen-binary-only `--self-update` with bounded downloads and strict SHA256 verification
- use same-filesystem atomic replacement on Linux/macOS and a validated post-exit helper with rollback on Windows
- preserve the installed path, executable mode, autostart configuration, and all Bridge account/configuration data
- document automatic, manual, recovery, and uninstall paths

## Validation
- failing-first Linux and Windows contract runs captured on the tests-only head
- focused static lint and `git diff --check`
- Linux and Windows Bridge CI exercise the production paths on the current head

## Scope
- Bridge CLI/update service, focused tests, build packaging, and Bridge documentation only
- no dashboard update UI
- no dependency or lockfile changes
- no release, tag, asset, or deployment publication