### PR TITLE
test(annual): prove finalized artifact transport without deployment

### DIFF
--- a/.github/workflows/annual-artifact-transport-proof.yml
+++ b/.github/workflows/annual-artifact-transport-proof.yml
@@ -25,13 +25,15 @@ jobs:
     permissions:
       actions: read
       contents: read
-    env:
-      PROOF_DIRECTORY: ${{ runner.temp }}/annual-artifact-transport-proof
     steps:
       - name: Checkout without persisted credentials
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      # The runner context is not available in job-level env, so the proof directory is
+      # derived inside a step from RUNNER_TEMP and exported (nonsecret) through GITHUB_ENV.
+      - name: Initialize the proof directory under runner temp
+        run: echo "PROOF_DIRECTORY=$RUNNER_TEMP/annual-artifact-transport-proof" >> "$GITHUB_ENV"
       - name: Set up Node 22
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/annual-artifact-transport-proof.yml
+++ b/.github/workflows/annual-artifact-transport-proof.yml
@@ -1,0 +1,67 @@
+name: Annual Artifact Transport Proof (non-production)
+
+# Proof-only. Evidences that an artifact signed BEFORE upload with an ephemeral key, uploaded
+# through the pinned official actions/upload-artifact, can be consumed independently by its
+# exact finalized artifact ID through the GitHub API with archive digest, run, attempt, head
+# SHA, repository, and producer-workflow bindings. It changes no production path, uses no
+# secret, environment, or reusable deployment workflow, and is evidence of transport only,
+# never permission to deploy. Runs on this feature PR without a default-branch merge.
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/annual-artifact-transport-proof.yml'
+      - 'scripts/annual-artifact-transport-proof.mjs'
+      - 'scripts/annual-artifact-transport-proof.test.mjs'
+
+permissions: {}
+
+jobs:
+  proof:
+    name: Upload through the official action and consume by exact finalized artifact ID
+    # Same-repository pull requests only; a fork head has no business exercising this path.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    env:
+      PROOF_DIRECTORY: ${{ runner.temp }}/annual-artifact-transport-proof
+    steps:
+      - name: Checkout without persisted credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node 22
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+      - name: Run the proof unit tests against mocked API fixtures first
+        run: node --test scripts/annual-artifact-transport-proof.test.mjs
+      - name: Produce the synthetic signed payload with an ephemeral key kept only in runner temp
+        env:
+          PROOF_SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/annual-artifact-transport-proof.mjs produce
+      - name: Upload through the pinned official artifact action
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: annual-artifact-transport-proof-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/annual-artifact-transport-proof/stage/annual-artifact-transport-proof.json
+          if-no-files-found: error
+          include-hidden-files: false
+          retention-days: 1
+      - name: Remove the staged payload so consumption can only come from the artifact service
+        run: rm -rf "$PROOF_DIRECTORY/stage"
+      - name: Consume independently by exact finalized artifact ID through the GitHub API
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROOF_ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          PROOF_UPLOAD_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+        run: node scripts/annual-artifact-transport-proof.mjs consume
+      - name: Reject every substitution and replay negative against the real finalized artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROOF_ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          PROOF_UPLOAD_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+        run: node scripts/annual-artifact-transport-proof.mjs negatives

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore:
       - main
+      # Exact branch only: the annual artifact transport proof touches .github/workflows/**
+      # and must not deploy an incidental docs preview. No other branch is excluded.
+      - chore/annual-artifact-proof-20260905
     paths:
       - 'apps/docs/**'
       - 'apps/web/**'

--- a/scripts/annual-artifact-transport-proof.mjs
+++ b/scripts/annual-artifact-transport-proof.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+// Nonproduction transport proof for the annual Stage B artifact simplification.
+//
+// It evidences one thing: a payload signed BEFORE upload with a key that never leaves
+// the job, uploaded through the pinned official actions/upload-artifact, can be consumed
+// independently by its exact finalized artifact ID through the GitHub API with archive
+// digest, run, attempt, head SHA, repository, and producer workflow bindings. The signed
+// body never names its own storage artifact ID. Nothing here touches a production path,
+// verifier, key, secret, environment, or deployment.
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { crc32, inflateRawSync } from 'node:zlib'
+import { buildStoredZipArchive } from './publish-annual-public-served-attestation.mjs'
+
+export const PROOF_ENTRY_NAME = 'annual-artifact-transport-proof.json'
+export const PROOF_PREDICATE_TYPE = 'https://silentsuite.io/attestations/annual-artifact-transport-proof/v1'
+export const PROOF_WORKFLOW_PATH = '.github/workflows/annual-artifact-transport-proof.yml'
+export const PROOF_PAYLOAD_KEYS = ['schemaVersion', 'predicateType', 'repository', 'sourceSha', 'run', 'workflowPath', 'artifactName', 'predecessorDigest', 'servedIdentities', 'clientServedAt', 'verifiedAt', 'signature']
+const MAX_ENTRY_BYTES = 64 * 1024
+const sha = /^[0-9a-f]{40}$/
+const hex64 = /^[0-9a-f]{64}$/
+const repositoryPattern = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/
+const entryNamePattern = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
+const timestamp = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$/
+
+const assert = (value, message) => { if (!value) throw new Error(message) }
+const positive = (value) => Number.isInteger(value) && value > 0
+const positiveEnv = (value) => typeof value === 'string' && /^[1-9][0-9]*$/.test(value) ? Number(value) : undefined
+const exactKeys = (value, keys) => Boolean(value) && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === keys.length && keys.every((key) => Object.hasOwn(value, key))
+const validTimestamp = (value) => typeof value === 'string' && timestamp.test(value) && !Number.isNaN(Date.parse(value)) && new Date(value).toISOString().replace(/\.000Z$/, 'Z') === value
+const utcSeconds = () => new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
+
+export const bytesDigest = (bytes) => `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+// The official action's `artifact-digest` output and the GitHub API `digest` member may
+// differ only by the `sha256:` prefix; both canonicalize to the prefixed lowercase form.
+export function canonicalDigest(value) { if (typeof value !== 'string') return undefined; const raw = value.startsWith('sha256:') ? value.slice(7) : value; return hex64.test(raw) ? `sha256:${raw}` : undefined }
+export function proofArtifactName({ runId, runAttempt } = {}) { assert(positive(runId) && positive(runAttempt), 'Proof run identity is invalid'); return `annual-artifact-transport-proof-${runId}-${runAttempt}` }
+const signPayload = (key, unsigned) => createHmac('sha256', key).update(bytesDigest(Buffer.from(JSON.stringify(unsigned)))).digest('hex')
+function verifyServedIdentities(value, sourceSha) { assert(exactKeys(value, ['web', 'docs']), 'Served identities are malformed'); for (const surface of ['web', 'docs']) { assert(exactKeys(value[surface], ['publicSha']) && value[surface].publicSha === sourceSha, `Served identity for ${surface} is not the source SHA`) } }
+function verifyBindings({ repository, sourceSha, run, workflowPath, predecessorDigest, servedIdentities }) {
+  assert(typeof repository === 'string' && repositoryPattern.test(repository), 'Proof repository is invalid')
+  assert(typeof sourceSha === 'string' && sha.test(sourceSha), 'Proof source SHA is invalid')
+  assert(exactKeys(run, ['runId', 'runAttempt']) && positive(run.runId) && positive(run.runAttempt), 'Proof run identity is invalid')
+  assert(typeof workflowPath === 'string' && /^\.github\/workflows\/[A-Za-z0-9._-]+\.ya?ml$/.test(workflowPath), 'Proof workflow path is invalid')
+  assert(canonicalDigest(predecessorDigest) === predecessorDigest, 'Proof predecessor digest is invalid')
+  verifyServedIdentities(servedIdentities, sourceSha)
+}
+
+export function buildProofPayload({ key, repository, sourceSha, run, workflowPath, predecessorDigest, servedIdentities, clientServedAt, verifiedAt }) {
+  assert(typeof key === 'string' && hex64.test(key), 'Proof key must be 32 random bytes in lowercase hex')
+  verifyBindings({ repository, sourceSha, run, workflowPath, predecessorDigest, servedIdentities })
+  assert(validTimestamp(clientServedAt) && validTimestamp(verifiedAt) && Date.parse(verifiedAt) >= Date.parse(clientServedAt), 'Proof timestamps are invalid')
+  // Deliberately no storage artifact ID: the consumer binds the finalized ID through the
+  // GitHub API, so signing can happen before any artifact exists.
+  const unsigned = { schemaVersion: 1, predicateType: PROOF_PREDICATE_TYPE, repository, sourceSha, run: { runId: run.runId, runAttempt: run.runAttempt }, workflowPath, artifactName: proofArtifactName(run), predecessorDigest, servedIdentities, clientServedAt, verifiedAt }
+  const payload = { ...unsigned, signature: signPayload(key, unsigned) }
+  return { payload, bytes: Buffer.from(`${JSON.stringify(payload)}\n`) }
+}
+
+// Bounded extraction of the one expected entry. Reads only the end record, the single
+// central-directory entry, and the local header it points at; rejects anything else
+// (multiple entries, other names, path separators, encryption, unknown methods,
+// oversize, inconsistent offsets, size or CRC mismatch). Supports stored (method 0, the
+// in-process production builder) and deflate (method 8, the official action's archiver,
+// which uses data descriptors so sizes come from the central directory).
+export function readSingleEntryArchive(bytes, expectedName, { maxBytes = MAX_ENTRY_BYTES } = {}) {
+  assert(typeof expectedName === 'string' && entryNamePattern.test(expectedName) && !expectedName.includes('..'), 'Expected archive entry name is invalid')
+  assert(Buffer.isBuffer(bytes) && bytes.length >= 22 + 46 + 30, 'Archive is truncated')
+  let end = -1
+  for (let offset = bytes.length - 22; offset >= Math.max(0, bytes.length - 22 - 0xffff); offset -= 1) { if (bytes.readUInt32LE(offset) === 0x06054b50) { end = offset; break } }
+  assert(end >= 0, 'Archive end record is missing')
+  assert(bytes.readUInt16LE(end + 20) === bytes.length - end - 22, 'Archive end record comment length is inconsistent')
+  assert(bytes.readUInt16LE(end + 8) === 1 && bytes.readUInt16LE(end + 10) === 1, 'Archive must contain exactly one entry')
+  const centralSize = bytes.readUInt32LE(end + 12); const centralOffset = bytes.readUInt32LE(end + 16)
+  assert(centralOffset + centralSize === end && centralSize >= 46, 'Archive central directory is inconsistent')
+  assert(bytes.readUInt32LE(centralOffset) === 0x02014b50, 'Archive central directory header is invalid')
+  const flags = bytes.readUInt16LE(centralOffset + 8); const method = bytes.readUInt16LE(centralOffset + 10); const checksum = bytes.readUInt32LE(centralOffset + 16)
+  const compressedSize = bytes.readUInt32LE(centralOffset + 20); const uncompressedSize = bytes.readUInt32LE(centralOffset + 24)
+  const nameLength = bytes.readUInt16LE(centralOffset + 28); const extraLength = bytes.readUInt16LE(centralOffset + 30); const commentLength = bytes.readUInt16LE(centralOffset + 32); const localOffset = bytes.readUInt32LE(centralOffset + 42)
+  assert(46 + nameLength + extraLength + commentLength === centralSize, 'Archive central directory size is inconsistent')
+  assert((flags & 0x1) === 0, 'Archive entry is encrypted')
+  assert(method === 0 || method === 8, 'Archive entry compression method is unsupported')
+  assert(bytes.subarray(centralOffset + 46, centralOffset + 46 + nameLength).toString('utf8') === expectedName, 'Archive entry name is not the exact expected file')
+  assert(compressedSize <= maxBytes && uncompressedSize <= maxBytes && uncompressedSize > 0, 'Archive entry exceeds the bounded size')
+  assert(localOffset + 30 <= centralOffset && bytes.readUInt32LE(localOffset) === 0x04034b50, 'Archive local header is invalid')
+  const localNameLength = bytes.readUInt16LE(localOffset + 26); const localExtraLength = bytes.readUInt16LE(localOffset + 28)
+  assert(bytes.subarray(localOffset + 30, localOffset + 30 + localNameLength).toString('utf8') === expectedName, 'Archive local entry name differs from the central directory')
+  const dataStart = localOffset + 30 + localNameLength + localExtraLength
+  assert(dataStart + compressedSize <= centralOffset, 'Archive entry data overruns the central directory')
+  const compressed = bytes.subarray(dataStart, dataStart + compressedSize)
+  let content
+  try { content = method === 0 ? Buffer.from(compressed) : inflateRawSync(compressed, { maxOutputLength: maxBytes }) } catch { throw new Error('Archive entry could not be inflated within the bounded size') }
+  assert(content.length === uncompressedSize, 'Archive entry size does not match its header')
+  assert((crc32(content) >>> 0) === checksum, 'Archive entry checksum does not match')
+  return content
+}
+
+export function verifyProofArchive(archiveBytes, { key, repository, sourceSha, run, workflowPath, predecessorDigest, servedIdentities, payloadDigest }) {
+  assert(typeof key === 'string' && hex64.test(key), 'Proof key is invalid')
+  verifyBindings({ repository, sourceSha, run, workflowPath, predecessorDigest, servedIdentities })
+  const content = readSingleEntryArchive(archiveBytes, PROOF_ENTRY_NAME)
+  if (payloadDigest !== undefined) assert(bytesDigest(content) === payloadDigest, 'Extracted payload bytes differ from the produced payload digest')
+  let payload
+  try { payload = JSON.parse(content.toString('utf8')) } catch { throw new Error('Proof payload is not JSON') }
+  assert(exactKeys(payload, PROOF_PAYLOAD_KEYS), 'Proof payload is malformed')
+  const { signature, ...unsigned } = payload
+  assert(typeof signature === 'string' && hex64.test(signature), 'Proof signature is malformed')
+  assert(timingSafeEqual(Buffer.from(signature, 'hex'), Buffer.from(signPayload(key, unsigned), 'hex')), 'Proof signature does not verify')
+  assert(payload.schemaVersion === 1 && payload.predicateType === PROOF_PREDICATE_TYPE, 'Proof predicate is not the transport proof')
+  assert(payload.repository === repository, 'Proof repository binding differs')
+  assert(payload.sourceSha === sourceSha, 'Proof source SHA binding differs')
+  assert(exactKeys(payload.run, ['runId', 'runAttempt']) && payload.run.runId === run.runId && payload.run.runAttempt === run.runAttempt, 'Proof run binding differs')
+  assert(payload.workflowPath === workflowPath, 'Proof workflow path binding differs')
+  assert(payload.artifactName === proofArtifactName(run), 'Proof artifact name binding differs')
+  assert(payload.predecessorDigest === predecessorDigest, 'Proof predecessor digest binding differs')
+  assert(JSON.stringify(payload.servedIdentities) === JSON.stringify(servedIdentities), 'Proof served identities differ')
+  assert(validTimestamp(payload.clientServedAt) && validTimestamp(payload.verifiedAt) && Date.parse(payload.verifiedAt) >= Date.parse(payload.clientServedAt), 'Proof timestamps are invalid')
+  return payload
+}
+
+// Independent consumption: every fact comes from the GitHub API, never from the producer's
+// working tree. The archive download follows exactly one redirect and sends no credential
+// to the storage host. Error messages carry routes, statuses, and IDs only; never a token.
+export async function verifyPublishedArtifact({ fetchImpl = fetch, apiBase = 'https://api.github.com', token, repository, artifactId, uploadDigest, expectedEvent = 'pull_request', key, sourceSha, run, workflowPath, predecessorDigest, servedIdentities, payloadDigest }) {
+  assert(typeof token === 'string' && token.length > 0, 'GitHub API token is missing')
+  assert(positive(artifactId), 'Finalized artifact ID is invalid')
+  const digest = canonicalDigest(uploadDigest); assert(digest, 'Upload digest output is malformed')
+  verifyBindings({ repository, sourceSha, run, workflowPath, predecessorDigest, servedIdentities })
+  const headers = { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28' }
+  const api = async (route, init = {}) => { const response = await fetchImpl(new URL(`/repos/${repository}/${route}`, apiBase), { headers, redirect: 'manual', ...init }); return response }
+  const json = async (route) => { const response = await api(route); assert(response.status === 200, `GitHub API ${route} failed (HTTP ${response.status})`); return response.json() }
+  const name = proofArtifactName(run)
+  const artifact = await json(`actions/artifacts/${artifactId}`)
+  assert(artifact.id === artifactId, 'Artifact identity differs from the finalized ID')
+  assert(artifact.name === name, 'Artifact name is not the exact run-scoped proof name')
+  assert(artifact.expired === false, 'Artifact is expired')
+  assert(canonicalDigest(artifact.digest) === digest, 'GitHub API artifact digest differs from the upload output digest')
+  assert(artifact.workflow_run?.id === run.runId, 'Artifact does not belong to the exact run')
+  assert(artifact.workflow_run?.head_sha === sourceSha, 'Artifact run head differs from the source SHA')
+  const workflowRun = await json(`actions/runs/${run.runId}`)
+  assert(workflowRun.id === run.runId && workflowRun.run_attempt === run.runAttempt, 'Run attempt differs from the expected attempt')
+  assert(workflowRun.head_sha === sourceSha, 'Run head differs from the source SHA')
+  assert(workflowRun.repository?.full_name === repository && workflowRun.head_repository?.full_name === repository, 'Run repository is not the exact same repository')
+  assert(workflowRun.event === expectedEvent, 'Run event is not the expected trigger')
+  assert(positive(workflowRun.workflow_id), 'Run workflow identity is invalid')
+  const workflow = await json(`actions/workflows/${workflowRun.workflow_id}`)
+  assert(workflow.id === workflowRun.workflow_id && workflow.path === workflowPath, 'Producer workflow path differs')
+  let download = await api(`actions/artifacts/${artifactId}/zip`)
+  if ([301, 302, 303, 307, 308].includes(download.status)) { const location = download.headers.get('location'); assert(typeof location === 'string' && /^https:\/\//.test(location), 'Artifact download redirect is invalid'); download = await fetchImpl(location, { redirect: 'manual' }) }
+  assert(download.status === 200, `Artifact archive download failed (HTTP ${download.status})`)
+  const archive = Buffer.from(await download.arrayBuffer())
+  assert(bytesDigest(archive) === digest, 'Downloaded archive SHA-256 differs from the upload output and API digest')
+  const payload = verifyProofArchive(archive, { key, repository, sourceSha, run, workflowPath, predecessorDigest, servedIdentities, payloadDigest })
+  return { artifactId, digest, archive, payload }
+}
+
+// CLI: produce | consume | negatives. The ephemeral key lives only in PROOF_DIRECTORY/key
+// (mode 0600) inside the runner's temp directory and is never printed or exported.
+function proofDirectory(env) { const directory = env.PROOF_DIRECTORY; assert(typeof directory === 'string' && path.isAbsolute(directory), 'PROOF_DIRECTORY must be an absolute path'); return directory }
+export async function produceProof({ env = process.env, random = randomBytes, now = utcSeconds } = {}) {
+  const directory = proofDirectory(env)
+  const run = { runId: positiveEnv(env.GITHUB_RUN_ID), runAttempt: positiveEnv(env.GITHUB_RUN_ATTEMPT) }
+  const key = random(32).toString('hex'); const sourceSha = env.PROOF_SOURCE_SHA; const clientServedAt = now(); const verifiedAt = now()
+  const expected = { repository: env.GITHUB_REPOSITORY, sourceSha, run, workflowPath: env.PROOF_WORKFLOW_PATH ?? PROOF_WORKFLOW_PATH, artifactName: undefined, predecessorDigest: bytesDigest(random(32)), servedIdentities: { web: { publicSha: sourceSha }, docs: { publicSha: sourceSha } } }
+  const { bytes } = buildProofPayload({ key, ...expected, clientServedAt, verifiedAt })
+  expected.artifactName = proofArtifactName(run); expected.payloadDigest = bytesDigest(bytes)
+  const stage = path.join(directory, 'stage')
+  await mkdir(stage, { recursive: true, mode: 0o700 })
+  await writeFile(path.join(stage, PROOF_ENTRY_NAME), bytes, { mode: 0o600 })
+  await writeFile(path.join(directory, 'key'), key, { mode: 0o600 })
+  await writeFile(path.join(directory, 'expected.json'), `${JSON.stringify(expected)}\n`, { mode: 0o600 })
+  return { artifactName: expected.artifactName, payloadDigest: expected.payloadDigest, stagedPath: path.join(stage, PROOF_ENTRY_NAME) }
+}
+async function consumerInputs(env) {
+  const directory = proofDirectory(env)
+  assert(!existsSync(path.join(directory, 'stage')), 'Staged payload must be removed before independent consumption')
+  const expected = JSON.parse(await readFile(path.join(directory, 'expected.json'), 'utf8'))
+  const key = (await readFile(path.join(directory, 'key'), 'utf8')).trim()
+  return { token: env.GH_TOKEN, artifactId: positiveEnv(env.PROOF_ARTIFACT_ID), uploadDigest: env.PROOF_UPLOAD_DIGEST, expectedEvent: env.PROOF_EVENT ?? 'pull_request', key, repository: expected.repository, sourceSha: expected.sourceSha, run: expected.run, workflowPath: expected.workflowPath, predecessorDigest: expected.predecessorDigest, servedIdentities: expected.servedIdentities, payloadDigest: expected.payloadDigest }
+}
+export async function consumeProof({ env = process.env, fetchImpl = fetch } = {}) {
+  const inputs = await consumerInputs(env)
+  const result = await verifyPublishedArtifact({ fetchImpl, ...inputs })
+  return { artifactId: result.artifactId, digest: result.digest, artifactName: result.payload.artifactName, payloadDigest: bytesDigest(Buffer.from(`${JSON.stringify(result.payload)}\n`)) }
+}
+export function tamperedArchive(archive, mutate) {
+  const content = readSingleEntryArchive(archive, PROOF_ENTRY_NAME); const payload = JSON.parse(content.toString('utf8')); mutate(payload)
+  return buildStoredZipArchive(PROOF_ENTRY_NAME, `${JSON.stringify(payload)}\n`)
+}
+export async function runNegatives({ env = process.env, fetchImpl = fetch } = {}) {
+  const inputs = await consumerInputs(env)
+  const positiveResult = await verifyPublishedArtifact({ fetchImpl, ...inputs })
+  const flipDigest = (digest) => `${digest.slice(0, -1)}${digest.endsWith('0') ? '1' : '0'}`
+  const otherSha = inputs.sourceSha.endsWith('0') ? `${inputs.sourceSha.slice(0, -1)}1` : `${inputs.sourceSha.slice(0, -1)}0`
+  const remote = (name, patch) => [name, () => verifyPublishedArtifact({ fetchImpl, ...inputs, ...patch })]
+  const cases = [
+    remote('wrong artifact ID', { artifactId: inputs.artifactId + 1 }),
+    remote('wrong upload digest', { uploadDigest: flipDigest(inputs.uploadDigest) }),
+    remote('wrong run ID', { run: { ...inputs.run, runId: inputs.run.runId + 1 } }),
+    remote('wrong run attempt', { run: { ...inputs.run, runAttempt: inputs.run.runAttempt + 1 } }),
+    remote('wrong source SHA', { sourceSha: otherSha, servedIdentities: { web: { publicSha: otherSha }, docs: { publicSha: otherSha } } }),
+    remote('wrong producer workflow path', { workflowPath: '.github/workflows/annual-only-public-cutover.yml' }),
+    remote('wrong repository', { repository: `${inputs.repository}-substitute` }),
+    remote('wrong predecessor digest', { predecessorDigest: flipDigest(inputs.predecessorDigest) }),
+    remote('wrong signing key', { key: flipDigest(inputs.key) }),
+    // The produced-bytes digest is deliberately not supplied here so that the signature,
+    // not the byte digest, is what rejects a payload altered after signing.
+    ['altered signed payload', () => verifyProofArchive(tamperedArchive(positiveResult.archive, (payload) => { payload.predecessorDigest = flipDigest(payload.predecessorDigest) }), { ...inputs, predecessorDigest: flipDigest(inputs.predecessorDigest), payloadDigest: undefined })],
+  ]
+  const results = []
+  for (const [name, attempt] of cases) { try { await attempt(); results.push({ name, rejected: false, message: 'accepted' }) } catch (error) { results.push({ name, rejected: true, message: error instanceof Error ? error.message : 'unknown error' }) } }
+  return results
+}
+export async function runProofCli(command = process.argv[2], io = { env: process.env, fetchImpl: fetch, stdout: process.stdout, stderr: process.stderr }) {
+  try {
+    if (command === 'produce') { const result = await produceProof({ env: io.env }); io.stdout.write(`Proof payload staged for ${result.artifactName} (payload ${result.payloadDigest})\n`); return 0 }
+    if (command === 'consume') { const result = await consumeProof({ env: io.env, fetchImpl: io.fetchImpl }); io.stdout.write(`Proof consumed independently: artifact ${result.artifactId} ${result.digest} entry ${PROOF_ENTRY_NAME} payload ${result.payloadDigest}\n`); return 0 }
+    if (command === 'negatives') {
+      const results = await runNegatives({ env: io.env, fetchImpl: io.fetchImpl }); let accepted = 0
+      for (const result of results) { io.stdout.write(`${result.rejected ? 'rejected' : 'ACCEPTED'} ${result.name}: ${result.message}\n`); if (!result.rejected) accepted += 1 }
+      assert(results.length === 10 && accepted === 0, `${accepted} substitution or replay negative(s) were accepted`); return 0
+    }
+    throw new Error('Usage: annual-artifact-transport-proof.mjs produce|consume|negatives')
+  } catch (error) { io.stderr.write(`Annual artifact transport proof failed: ${error instanceof Error ? error.message : 'unknown error'}\n`); return 1 }
+}
+if (process.argv[1] === fileURLToPath(import.meta.url)) process.exitCode = await runProofCli()

--- a/scripts/annual-artifact-transport-proof.mjs
+++ b/scripts/annual-artifact-transport-proof.mjs
@@ -190,28 +190,40 @@ export function tamperedArchive(archive, mutate) {
   const content = readSingleEntryArchive(archive, PROOF_ENTRY_NAME); const payload = JSON.parse(content.toString('utf8')); mutate(payload)
   return buildStoredZipArchive(PROOF_ENTRY_NAME, `${JSON.stringify(payload)}\n`)
 }
-export async function runNegatives({ env = process.env, fetchImpl = fetch } = {}) {
+// Each negative must fail for its intended binding. Any other error (HTTP 500, rate limit,
+// network, parsing, fixture construction) is reported as `unexpected`, never as a rejection,
+// so an outage after the positive retrieval cannot masquerade as ten security rejections.
+// Only the wrong-ID and wrong-repository cases may reject on an explicit HTTP 404 (or, if the
+// service returns a different artifact, on the exact ID mismatch).
+const artifactNotFound = /^GitHub API actions\/artifacts\/[0-9]+ failed \(HTTP 404\)$|^Artifact identity differs from the finalized ID$/
+export async function runNegatives({ env = process.env, fetchImpl = fetch, tamper = tamperedArchive } = {}) {
   const inputs = await consumerInputs(env)
   const positiveResult = await verifyPublishedArtifact({ fetchImpl, ...inputs })
   const flipDigest = (digest) => `${digest.slice(0, -1)}${digest.endsWith('0') ? '1' : '0'}`
   const otherSha = inputs.sourceSha.endsWith('0') ? `${inputs.sourceSha.slice(0, -1)}1` : `${inputs.sourceSha.slice(0, -1)}0`
-  const remote = (name, patch) => [name, () => verifyPublishedArtifact({ fetchImpl, ...inputs, ...patch })]
+  const remote = (name, patch, expected) => [name, () => verifyPublishedArtifact({ fetchImpl, ...inputs, ...patch }), expected]
   const cases = [
-    remote('wrong artifact ID', { artifactId: inputs.artifactId + 1 }),
-    remote('wrong upload digest', { uploadDigest: flipDigest(inputs.uploadDigest) }),
-    remote('wrong run ID', { run: { ...inputs.run, runId: inputs.run.runId + 1 } }),
-    remote('wrong run attempt', { run: { ...inputs.run, runAttempt: inputs.run.runAttempt + 1 } }),
-    remote('wrong source SHA', { sourceSha: otherSha, servedIdentities: { web: { publicSha: otherSha }, docs: { publicSha: otherSha } } }),
-    remote('wrong producer workflow path', { workflowPath: '.github/workflows/annual-only-public-cutover.yml' }),
-    remote('wrong repository', { repository: `${inputs.repository}-substitute` }),
-    remote('wrong predecessor digest', { predecessorDigest: flipDigest(inputs.predecessorDigest) }),
-    remote('wrong signing key', { key: flipDigest(inputs.key) }),
+    remote('wrong artifact ID', { artifactId: inputs.artifactId + 1 }, artifactNotFound),
+    remote('wrong upload digest', { uploadDigest: flipDigest(inputs.uploadDigest) }, /^GitHub API artifact digest differs from the upload output digest$/),
+    remote('wrong run ID', { run: { ...inputs.run, runId: inputs.run.runId + 1 } }, /^Artifact name is not the exact run-scoped proof name$/),
+    remote('wrong run attempt', { run: { ...inputs.run, runAttempt: inputs.run.runAttempt + 1 } }, /^Artifact name is not the exact run-scoped proof name$/),
+    remote('wrong source SHA', { sourceSha: otherSha, servedIdentities: { web: { publicSha: otherSha }, docs: { publicSha: otherSha } } }, /^Artifact run head differs from the source SHA$/),
+    remote('wrong producer workflow path', { workflowPath: '.github/workflows/annual-only-public-cutover.yml' }, /^Producer workflow path differs$/),
+    remote('wrong repository', { repository: `${inputs.repository}-substitute` }, artifactNotFound),
+    remote('wrong predecessor digest', { predecessorDigest: flipDigest(inputs.predecessorDigest) }, /^Proof predecessor digest binding differs$/),
+    remote('wrong signing key', { key: flipDigest(inputs.key) }, /^Proof signature does not verify$/),
     // The produced-bytes digest is deliberately not supplied here so that the signature,
     // not the byte digest, is what rejects a payload altered after signing.
-    ['altered signed payload', () => verifyProofArchive(tamperedArchive(positiveResult.archive, (payload) => { payload.predecessorDigest = flipDigest(payload.predecessorDigest) }), { ...inputs, predecessorDigest: flipDigest(inputs.predecessorDigest), payloadDigest: undefined })],
+    ['altered signed payload', () => verifyProofArchive(tamper(positiveResult.archive, (payload) => { payload.predecessorDigest = flipDigest(payload.predecessorDigest) }), { ...inputs, predecessorDigest: flipDigest(inputs.predecessorDigest), payloadDigest: undefined }), /^Proof signature does not verify$/],
   ]
   const results = []
-  for (const [name, attempt] of cases) { try { await attempt(); results.push({ name, rejected: false, message: 'accepted' }) } catch (error) { results.push({ name, rejected: true, message: error instanceof Error ? error.message : 'unknown error' }) } }
+  for (const [name, attempt, expected] of cases) {
+    try { await attempt(); results.push({ name, rejected: false, unexpected: false, message: 'accepted' }) } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error'
+      const rejected = expected.test(message)
+      results.push({ name, rejected, unexpected: !rejected, message })
+    }
+  }
   return results
 }
 export async function runProofCli(command = process.argv[2], io = { env: process.env, fetchImpl: fetch, stdout: process.stdout, stderr: process.stderr }) {
@@ -219,9 +231,12 @@ export async function runProofCli(command = process.argv[2], io = { env: process
     if (command === 'produce') { const result = await produceProof({ env: io.env }); io.stdout.write(`Proof payload staged for ${result.artifactName} (payload ${result.payloadDigest})\n`); return 0 }
     if (command === 'consume') { const result = await consumeProof({ env: io.env, fetchImpl: io.fetchImpl }); io.stdout.write(`Proof consumed independently: artifact ${result.artifactId} ${result.digest} entry ${PROOF_ENTRY_NAME} payload ${result.payloadDigest}\n`); return 0 }
     if (command === 'negatives') {
-      const results = await runNegatives({ env: io.env, fetchImpl: io.fetchImpl }); let accepted = 0
-      for (const result of results) { io.stdout.write(`${result.rejected ? 'rejected' : 'ACCEPTED'} ${result.name}: ${result.message}\n`); if (!result.rejected) accepted += 1 }
-      assert(results.length === 10 && accepted === 0, `${accepted} substitution or replay negative(s) were accepted`); return 0
+      const results = await runNegatives({ env: io.env, fetchImpl: io.fetchImpl }); let accepted = 0; let unexpected = 0
+      for (const result of results) {
+        io.stdout.write(`${result.rejected ? 'rejected' : result.unexpected ? 'UNEXPECTED ERROR' : 'ACCEPTED'} ${result.name}: ${result.message}\n`)
+        if (result.unexpected) unexpected += 1; else if (!result.rejected) accepted += 1
+      }
+      assert(results.length === 10 && accepted === 0 && unexpected === 0, `${accepted} substitution or replay negative(s) were accepted and ${unexpected} failed for an unexpected reason`); return 0
     }
     throw new Error('Usage: annual-artifact-transport-proof.mjs produce|consume|negatives')
   } catch (error) { io.stderr.write(`Annual artifact transport proof failed: ${error instanceof Error ? error.message : 'unknown error'}\n`); return 1 }

--- a/scripts/annual-artifact-transport-proof.test.mjs
+++ b/scripts/annual-artifact-transport-proof.test.mjs
@@ -152,6 +152,25 @@ test('every GitHub API provenance, digest, identity, or key substitution is reje
   for (const [name, attempt, pattern] of substitutions) await assert.rejects(() => attempt(fixture()), pattern, name)
 })
 
+test('workflow contract: PROOF_DIRECTORY comes from a step via RUNNER_TEMP, never a job-level runner expression, and the docs preview ignores exactly this proof branch', () => {
+  const proof = readFileSync(resolve(PROOF_WORKFLOW_PATH), 'utf8')
+  const jobBody = proof.slice(proof.indexOf('\njobs:\n'))
+  const beforeSteps = jobBody.slice(0, jobBody.indexOf('\n    steps:\n'))
+  assert.ok(beforeSteps.length > 0, 'job must declare steps')
+  assert.doesNotMatch(beforeSteps, /\$\{\{\s*runner\./, 'runner context is invalid at job level')
+  assert.doesNotMatch(beforeSteps, /^\s{4}env:/m, 'job-level env must not carry PROOF_DIRECTORY')
+  assert.match(proof, /^\s+run: echo "PROOF_DIRECTORY=\$RUNNER_TEMP\/annual-artifact-transport-proof" >> "\$GITHUB_ENV"$/m)
+  assert.ok(proof.indexOf('>> "$GITHUB_ENV"') < proof.indexOf('annual-artifact-transport-proof.mjs produce'), 'directory must be initialized before produce')
+  assert.match(proof, /^\s+path: \$\{\{ runner\.temp \}\}\/annual-artifact-transport-proof\/stage\/annual-artifact-transport-proof\.json$/m, 'upload path must stay exact')
+  const preview = readFileSync(resolve('.github/workflows/preview-docs.yml'), 'utf8')
+  const ignoreBlock = /^\s{4}branches-ignore:\n((?:\s{6}.*\n)+)/m.exec(preview)
+  assert.ok(ignoreBlock, 'push.branches-ignore must exist')
+  const ignored = ignoreBlock[1].split('\n').map((line) => line.trim()).filter((line) => line.startsWith('- ')).map((line) => line.slice(2).trim())
+  assert.deepEqual(ignored, ['main', 'chore/annual-artifact-proof-20260905'], 'only main and the exact proof branch are ignored')
+  assert.ok(ignored.every((branch) => !/[*?\[\]+!]/.test(branch)), 'no glob may widen the exclusion')
+  assert.match(ignoreBlock[1], /annual artifact transport proof/i, 'exclusion must carry its explanatory comment')
+})
+
 function produceInto(root, extra = {}) {
   const env = { PROOF_DIRECTORY: join(root, 'proof'), GITHUB_REPOSITORY: repository, GITHUB_RUN_ID: String(run.runId), GITHUB_RUN_ATTEMPT: String(run.runAttempt), PROOF_SOURCE_SHA: sourceSha, ...extra }
   return env

--- a/scripts/annual-artifact-transport-proof.test.mjs
+++ b/scripts/annual-artifact-transport-proof.test.mjs
@@ -1,0 +1,200 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import test from 'node:test'
+import { crc32, deflateRawSync } from 'node:zlib'
+import { buildStoredZipArchive } from './publish-annual-public-served-attestation.mjs'
+import { PROOF_ENTRY_NAME, PROOF_PAYLOAD_KEYS, PROOF_WORKFLOW_PATH, buildProofPayload, bytesDigest, canonicalDigest, consumeProof, produceProof, proofArtifactName, readSingleEntryArchive, runNegatives, runProofCli, verifyProofArchive, verifyPublishedArtifact } from './annual-artifact-transport-proof.mjs'
+
+const key = 'a1'.repeat(32)
+const sourceSha = 'b'.repeat(40)
+const run = { runId: 33962000001, runAttempt: 1 }
+const repository = 'silent-suite/silentsuite'
+const predecessorDigest = `sha256:${'c'.repeat(64)}`
+const servedIdentities = { web: { publicSha: sourceSha }, docs: { publicSha: sourceSha } }
+const bindings = { key, repository, sourceSha, run, workflowPath: PROOF_WORKFLOW_PATH, predecessorDigest, servedIdentities }
+const times = { clientServedAt: '2026-09-05T12:00:00Z', verifiedAt: '2026-09-05T12:00:01Z' }
+const tokenSentinel = 'API-TOKEN-SENTINEL-3f9c'
+
+// Mimics the official action's archiver output: deflate, general-purpose bit 3 (sizes and
+// CRC only in the data descriptor and central directory), one entry per file.
+function buildDeflatedArchive(entries, { encrypted = false, method = 8, declaredSize } = {}) {
+  const locals = []; const centrals = []; let offset = 0
+  for (const [entryName, content] of entries) {
+    const name = Buffer.from(entryName, 'utf8'); const body = Buffer.from(content); const compressed = method === 8 ? deflateRawSync(body) : body; const checksum = crc32(body) >>> 0
+    const flags = 0x0008 | (encrypted ? 0x0001 : 0)
+    const local = Buffer.alloc(30); local.writeUInt32LE(0x04034b50, 0); local.writeUInt16LE(20, 4); local.writeUInt16LE(flags, 6); local.writeUInt16LE(method, 8); local.writeUInt16LE(name.length, 26)
+    const descriptor = Buffer.alloc(16); descriptor.writeUInt32LE(0x08074b50, 0); descriptor.writeUInt32LE(checksum, 4); descriptor.writeUInt32LE(compressed.length, 8); descriptor.writeUInt32LE(body.length, 12)
+    const central = Buffer.alloc(46); central.writeUInt32LE(0x02014b50, 0); central.writeUInt16LE(20, 4); central.writeUInt16LE(20, 6); central.writeUInt16LE(flags, 8); central.writeUInt16LE(method, 10); central.writeUInt32LE(checksum, 16); central.writeUInt32LE(compressed.length, 20); central.writeUInt32LE(declaredSize ?? body.length, 24); central.writeUInt16LE(name.length, 28); central.writeUInt32LE(offset, 42)
+    locals.push(local, name, compressed, descriptor); centrals.push(central, name); offset += local.length + name.length + compressed.length + descriptor.length
+  }
+  const centralBytes = Buffer.concat(centrals)
+  const end = Buffer.alloc(22); end.writeUInt32LE(0x06054b50, 0); end.writeUInt16LE(entries.length, 8); end.writeUInt16LE(entries.length, 10); end.writeUInt32LE(centralBytes.length, 12); end.writeUInt32LE(offset, 16)
+  return Buffer.concat([...locals, centralBytes, end])
+}
+
+// Stands in for the GitHub API with the exact members the consumer reads. Every response is
+// derived from one mutable fixture so a test can substitute a single fact at a time.
+function fixture({ archive, artifactId = 9001, workflowId = 777, redirect = true } = {}) {
+  const bytes = archive ?? buildDeflatedArchive([[PROOF_ENTRY_NAME, buildProofPayload({ ...bindings, ...times }).bytes]])
+  const state = {
+    archive: bytes, redirect, requests: [],
+    artifact: { id: artifactId, name: proofArtifactName(run), expired: false, digest: bytesDigest(bytes), workflow_run: { id: run.runId, head_sha: sourceSha } },
+    run: { id: run.runId, run_attempt: run.runAttempt, head_sha: sourceSha, event: 'pull_request', workflow_id: workflowId, repository: { full_name: repository }, head_repository: { full_name: repository } },
+    workflow: { id: workflowId, path: PROOF_WORKFLOW_PATH },
+  }
+  const json = (value) => new Response(JSON.stringify(value), { status: 200, headers: { 'content-type': 'application/json' } })
+  state.fetchImpl = async (input, init = {}) => {
+    const url = new URL(String(input)); const authorization = init.headers?.Authorization
+    state.requests.push({ host: url.host, path: url.pathname, authorized: typeof authorization === 'string' && authorization.includes(tokenSentinel) })
+    if (url.host === 'blob.invalid') { assert.equal(authorization, undefined, 'credential must not reach the storage host'); return new Response(state.archive, { status: 200 }) }
+    assert.equal(url.origin, 'https://api.github.com'); assert.ok(typeof authorization === 'string' && authorization.includes(tokenSentinel), 'API calls must carry the token')
+    const prefix = `/repos/${repository}/`
+    if (!url.pathname.startsWith(prefix)) return new Response('{}', { status: 404 })
+    const route = url.pathname.slice(prefix.length)
+    if (route === `actions/artifacts/${state.artifact.id}`) return json(state.artifact)
+    if (route === `actions/artifacts/${state.artifact.id}/zip`) return state.redirect ? new Response(null, { status: 302, headers: { location: 'https://blob.invalid/archive?sig=x' } }) : new Response(state.archive, { status: 200 })
+    if (route === `actions/runs/${state.run.id}`) return json(state.run)
+    if (route === `actions/workflows/${state.workflow.id}`) return json(state.workflow)
+    return new Response('{}', { status: 404 })
+  }
+  state.verify = (patch = {}) => verifyPublishedArtifact({ fetchImpl: state.fetchImpl, token: tokenSentinel, repository, artifactId: state.artifact.id, uploadDigest: state.artifact.digest, ...bindings, ...patch })
+  return state
+}
+
+test('the signed proof payload carries exact bindings and never its own storage artifact ID', () => {
+  const { payload, bytes } = buildProofPayload({ ...bindings, ...times })
+  assert.deepEqual(Object.keys(payload), PROOF_PAYLOAD_KEYS)
+  assert.equal(payload.artifactName, `annual-artifact-transport-proof-${run.runId}-${run.runAttempt}`)
+  assert.doesNotMatch(bytes.toString('utf8'), /artifactId|databaseId|artifact_id/)
+  assert.match(payload.signature, /^[0-9a-f]{64}$/)
+  assert.throws(() => buildProofPayload({ ...bindings, ...times, key: 'short' }), /key/i)
+  assert.throws(() => buildProofPayload({ ...bindings, ...times, servedIdentities: { web: { publicSha: sourceSha }, docs: { publicSha: 'f'.repeat(40) } } }), /docs/)
+  assert.throws(() => buildProofPayload({ ...bindings, clientServedAt: times.verifiedAt, verifiedAt: times.clientServedAt }), /timestamps/i)
+  assert.throws(() => proofArtifactName({ runId: 0, runAttempt: 1 }), /run identity/i)
+})
+test('digests from the official action output and the GitHub API canonicalize to one prefixed form', () => {
+  assert.equal(canonicalDigest('d'.repeat(64)), `sha256:${'d'.repeat(64)}`); assert.equal(canonicalDigest(`sha256:${'d'.repeat(64)}`), `sha256:${'d'.repeat(64)}`)
+  for (const bad of ['D'.repeat(64), 'sha1:' + 'd'.repeat(40), '', undefined, 42]) assert.equal(canonicalDigest(bad), undefined)
+})
+test('bounded extraction accepts exactly one stored or deflated entry with the exact name and rejects every other archive shape', () => {
+  const content = buildProofPayload({ ...bindings, ...times }).bytes
+  assert.deepEqual(readSingleEntryArchive(buildStoredZipArchive(PROOF_ENTRY_NAME, content), PROOF_ENTRY_NAME), content)
+  assert.deepEqual(readSingleEntryArchive(buildDeflatedArchive([[PROOF_ENTRY_NAME, content]]), PROOF_ENTRY_NAME), content)
+  const rejects = [
+    ['two entries', buildDeflatedArchive([[PROOF_ENTRY_NAME, content], ['second.json', '{}']]), /exactly one entry/],
+    ['different name', buildDeflatedArchive([['other.json', content]]), /exact expected file/],
+    ['path traversal name', buildDeflatedArchive([[`../${PROOF_ENTRY_NAME}`, content]]), /exact expected file/],
+    ['nested name', buildDeflatedArchive([[`dir/${PROOF_ENTRY_NAME}`, content]]), /exact expected file/],
+    ['encrypted entry', buildDeflatedArchive([[PROOF_ENTRY_NAME, content]], { encrypted: true }), /encrypted/],
+    ['unsupported method', buildDeflatedArchive([[PROOF_ENTRY_NAME, content]], { method: 12 }), /unsupported/],
+    ['declared size mismatch', buildDeflatedArchive([[PROOF_ENTRY_NAME, content]], { declaredSize: content.length + 1 }), /size does not match/],
+    ['oversize entry', buildDeflatedArchive([[PROOF_ENTRY_NAME, Buffer.alloc(70 * 1024, 0x20)]]), /bounded size/],
+    ['truncated', buildDeflatedArchive([[PROOF_ENTRY_NAME, content]]).subarray(0, 60), /truncated|end record/],
+  ]
+  for (const [name, archive, pattern] of rejects) assert.throws(() => readSingleEntryArchive(archive, PROOF_ENTRY_NAME), pattern, name)
+  const corrupted = Buffer.from(buildStoredZipArchive(PROOF_ENTRY_NAME, content)); corrupted[30 + PROOF_ENTRY_NAME.length + 5] ^= 0xff
+  assert.throws(() => readSingleEntryArchive(corrupted, PROOF_ENTRY_NAME), /checksum/)
+  assert.throws(() => readSingleEntryArchive(buildStoredZipArchive(PROOF_ENTRY_NAME, content), '../escape.json'), /entry name is invalid/)
+})
+test('archive verification binds signature, payload digest, and every identity, and rejects an altered signed payload or wrong key', () => {
+  const built = buildProofPayload({ ...bindings, ...times }); const archive = buildDeflatedArchive([[PROOF_ENTRY_NAME, built.bytes]])
+  assert.equal(verifyProofArchive(archive, { ...bindings, payloadDigest: bytesDigest(built.bytes) }).artifactName, built.payload.artifactName)
+  const altered = { ...built.payload, predecessorDigest: `sha256:${'e'.repeat(64)}` }
+  assert.throws(() => verifyProofArchive(buildDeflatedArchive([[PROOF_ENTRY_NAME, `${JSON.stringify(altered)}\n`]]), { ...bindings, predecessorDigest: altered.predecessorDigest }), /signature does not verify/)
+  assert.throws(() => verifyProofArchive(archive, { ...bindings, key: 'f'.repeat(64) }), /signature does not verify/)
+  assert.throws(() => verifyProofArchive(archive, { ...bindings, payloadDigest: `sha256:${'0'.repeat(64)}` }), /produced payload digest/)
+  assert.throws(() => verifyProofArchive(archive, { ...bindings, run: { runId: run.runId, runAttempt: 2 } }), /run binding/)
+  assert.throws(() => verifyProofArchive(archive, { ...bindings, workflowPath: '.github/workflows/ci.yml' }), /workflow path binding/)
+  const extraKey = { ...built.payload, artifactId: 1 }
+  assert.throws(() => verifyProofArchive(buildDeflatedArchive([[PROOF_ENTRY_NAME, `${JSON.stringify(extraKey)}\n`]]), bindings), /malformed/)
+})
+test('independent consumption reads only the GitHub API, follows one redirect without the credential, and admits the exact finalized artifact', async () => {
+  for (const redirect of [true, false]) {
+    const state = fixture({ redirect })
+    const result = await state.verify()
+    assert.equal(result.artifactId, 9001); assert.equal(result.digest, bytesDigest(state.archive)); assert.equal(result.payload.sourceSha, sourceSha)
+    assert.deepEqual(state.requests.map((request) => request.path.replace(`/repos/${repository}/`, '')), redirect ? ['actions/artifacts/9001', `actions/runs/${run.runId}`, 'actions/workflows/777', 'actions/artifacts/9001/zip', '/archive'] : ['actions/artifacts/9001', `actions/runs/${run.runId}`, 'actions/workflows/777', 'actions/artifacts/9001/zip'])
+    assert.equal(state.requests.filter((request) => request.host === 'blob.invalid' && request.authorized).length, 0)
+  }
+  const bare = fixture(); bare.artifact.digest = bare.artifact.digest.slice(7)
+  assert.equal((await bare.verify({ uploadDigest: bare.artifact.digest })).digest, bytesDigest(bare.archive))
+})
+test('every GitHub API provenance, digest, identity, or key substitution is rejected before the payload can be admitted', async () => {
+  const substitutions = [
+    ['artifact ID', (state) => state.verify({ artifactId: 9002 }), /HTTP 404/],
+    ['upload digest', (state) => state.verify({ uploadDigest: `sha256:${'0'.repeat(64)}` }), /API artifact digest differs/],
+    ['API artifact digest', (state) => { const uploadDigest = state.artifact.digest; state.artifact.digest = `sha256:${'0'.repeat(64)}`; return state.verify({ uploadDigest }) }, /API artifact digest differs/],
+    ['archive bytes', (state) => { state.archive = Buffer.concat([state.archive, Buffer.from('x')]); return state.verify() }, /Downloaded archive SHA-256 differs/],
+    ['artifact name', (state) => { state.artifact.name = 'annual-artifact-transport-proof-1-1'; return state.verify() }, /exact run-scoped proof name/],
+    ['expired artifact', (state) => { state.artifact.expired = true; return state.verify() }, /expired/],
+    ['artifact run', (state) => { state.artifact.workflow_run.id = 5; return state.verify() }, /exact run/],
+    ['artifact head', (state) => { state.artifact.workflow_run.head_sha = 'f'.repeat(40); return state.verify() }, /run head differs/],
+    ['run ID', (state) => state.verify({ run: { runId: run.runId + 1, runAttempt: 1 } }), /run-scoped proof name/],
+    // The expected name is derived from run and attempt, so a substituted attempt is
+    // rejected at the artifact-name binding before the run API is even consulted.
+    ['run attempt', (state) => state.verify({ run: { runId: run.runId, runAttempt: 2 } }), /run-scoped proof name/],
+    ['API run attempt', (state) => { state.run.run_attempt = 2; return state.verify() }, /attempt differs/],
+    ['run head', (state) => { state.run.head_sha = 'f'.repeat(40); return state.verify() }, /Run head differs/],
+    ['run event', (state) => { state.run.event = 'workflow_dispatch'; return state.verify() }, /expected trigger/],
+    ['fork head repository', (state) => { state.run.head_repository.full_name = 'someone/silentsuite'; return state.verify() }, /same repository/],
+    ['producer workflow path', (state) => { state.workflow.path = '.github/workflows/ci.yml'; return state.verify() }, /workflow path differs/],
+    ['expected workflow path', (state) => state.verify({ workflowPath: '.github/workflows/annual-only-public-cutover.yml' }), /workflow path differs/],
+    ['source SHA', (state) => state.verify({ sourceSha: 'f'.repeat(40), servedIdentities: { web: { publicSha: 'f'.repeat(40) }, docs: { publicSha: 'f'.repeat(40) } } }), /head differs/],
+    ['predecessor digest', (state) => state.verify({ predecessorDigest: `sha256:${'0'.repeat(64)}` }), /predecessor digest binding/],
+    ['signing key', (state) => state.verify({ key: 'f'.repeat(64) }), /signature does not verify/],
+    ['insecure redirect', (state) => { state.fetchImpl = ((original) => async (input, init) => { const response = await original(input, init); return response.status === 302 ? new Response(null, { status: 302, headers: { location: 'http://blob.invalid/archive' } }) : response })(state.fetchImpl); return state.verify() }, /redirect is invalid/],
+    ['missing token', (state) => verifyPublishedArtifact({ fetchImpl: state.fetchImpl, token: '', repository, artifactId: 9001, uploadDigest: state.artifact.digest, ...bindings }), /token is missing/],
+  ]
+  for (const [name, attempt, pattern] of substitutions) await assert.rejects(() => attempt(fixture()), pattern, name)
+})
+
+function produceInto(root, extra = {}) {
+  const env = { PROOF_DIRECTORY: join(root, 'proof'), GITHUB_REPOSITORY: repository, GITHUB_RUN_ID: String(run.runId), GITHUB_RUN_ATTEMPT: String(run.runAttempt), PROOF_SOURCE_SHA: sourceSha, ...extra }
+  return env
+}
+test('produce stages one payload, keeps the ephemeral key only in a 0600 file, and prints no key material', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'annual-transport-proof-'))
+  try {
+    const env = produceInto(root)
+    const result = spawnSync(process.execPath, [resolve('scripts/annual-artifact-transport-proof.mjs'), 'produce'], { encoding: 'utf8', env: { ...process.env, ...env } })
+    assert.equal(result.status, 0, result.stderr)
+    const keyValue = readFileSync(join(env.PROOF_DIRECTORY, 'key'), 'utf8')
+    assert.match(keyValue, /^[0-9a-f]{64}$/); assert.equal(statSync(join(env.PROOF_DIRECTORY, 'key')).mode & 0o777, 0o600)
+    assert.doesNotMatch(result.stdout + result.stderr, new RegExp(keyValue)); assert.match(result.stdout, /Proof payload staged for annual-artifact-transport-proof-33962000001-1 \(payload sha256:[0-9a-f]{64}\)/)
+    const expected = JSON.parse(readFileSync(join(env.PROOF_DIRECTORY, 'expected.json'), 'utf8'))
+    assert.deepEqual(Object.keys(expected).sort(), ['artifactName', 'payloadDigest', 'predecessorDigest', 'repository', 'run', 'servedIdentities', 'sourceSha', 'workflowPath']); assert.doesNotMatch(JSON.stringify(expected), new RegExp(keyValue))
+    const staged = readFileSync(join(env.PROOF_DIRECTORY, 'stage', PROOF_ENTRY_NAME))
+    assert.equal(bytesDigest(staged), expected.payloadDigest)
+    verifyProofArchive(buildDeflatedArchive([[PROOF_ENTRY_NAME, staged]]), { key: keyValue, repository, sourceSha, run, workflowPath: PROOF_WORKFLOW_PATH, predecessorDigest: expected.predecessorDigest, servedIdentities: expected.servedIdentities, payloadDigest: expected.payloadDigest })
+    assert.notEqual(spawnSync(process.execPath, [resolve('scripts/annual-artifact-transport-proof.mjs'), 'produce'], { encoding: 'utf8', env: { ...process.env, ...env, PROOF_SOURCE_SHA: 'main' } }).status, 0)
+  } finally { rmSync(root, { recursive: true, force: true }) }
+})
+test('consume refuses while the staged payload still exists, then admits only through the API, and negatives all reject against the same fixture', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'annual-transport-proof-'))
+  try {
+    const env = produceInto(root)
+    const produced = await produceProof({ env })
+    const keyValue = readFileSync(join(env.PROOF_DIRECTORY, 'key'), 'utf8')
+    const staged = readFileSync(produced.stagedPath)
+    const archive = buildDeflatedArchive([[PROOF_ENTRY_NAME, staged]])
+    const state = fixture({ archive })
+    // Fixture identity must match what produce signed: replace its fixed key with the produced key.
+    const consumerEnv = { ...env, GH_TOKEN: tokenSentinel, PROOF_ARTIFACT_ID: '9001', PROOF_UPLOAD_DIGEST: bytesDigest(archive).slice(7) }
+    await assert.rejects(() => consumeProof({ env: consumerEnv, fetchImpl: state.fetchImpl }), /Staged payload must be removed/)
+    rmSync(join(env.PROOF_DIRECTORY, 'stage'), { recursive: true, force: true }); assert.equal(existsSync(produced.stagedPath), false)
+    const consumed = await consumeProof({ env: consumerEnv, fetchImpl: state.fetchImpl })
+    assert.deepEqual(consumed, { artifactId: 9001, digest: bytesDigest(archive), artifactName: produced.artifactName, payloadDigest: produced.payloadDigest })
+    const results = await runNegatives({ env: consumerEnv, fetchImpl: state.fetchImpl })
+    assert.equal(results.length, 10); assert.deepEqual(results.filter((result) => !result.rejected), [])
+    assert.deepEqual(results.map((result) => result.name), ['wrong artifact ID', 'wrong upload digest', 'wrong run ID', 'wrong run attempt', 'wrong source SHA', 'wrong producer workflow path', 'wrong repository', 'wrong predecessor digest', 'wrong signing key', 'altered signed payload'])
+    assert.match(results.at(-1).message, /signature does not verify/)
+    const out = []; const io = { env: consumerEnv, fetchImpl: state.fetchImpl, stdout: { write: (text) => out.push(text) }, stderr: { write: (text) => out.push(text) } }
+    assert.equal(await runProofCli('consume', io), 0); assert.equal(await runProofCli('negatives', io), 0); assert.equal(await runProofCli('bogus', io), 1)
+    const printed = out.join(''); assert.doesNotMatch(printed, new RegExp(keyValue)); assert.doesNotMatch(printed, new RegExp(tokenSentinel)); assert.match(printed, /Proof consumed independently: artifact 9001 sha256:[0-9a-f]{64}/); assert.equal((printed.match(/^rejected /gm) ?? []).length, 10)
+    assert.equal(createHash('sha256').update(staged).digest('hex'), produced.payloadDigest.slice(7))
+  } finally { rmSync(root, { recursive: true, force: true }) }
+})

--- a/scripts/annual-artifact-transport-proof.test.mjs
+++ b/scripts/annual-artifact-transport-proof.test.mjs
@@ -189,12 +189,54 @@ test('consume refuses while the staged payload still exists, then admits only th
     const consumed = await consumeProof({ env: consumerEnv, fetchImpl: state.fetchImpl })
     assert.deepEqual(consumed, { artifactId: 9001, digest: bytesDigest(archive), artifactName: produced.artifactName, payloadDigest: produced.payloadDigest })
     const results = await runNegatives({ env: consumerEnv, fetchImpl: state.fetchImpl })
-    assert.equal(results.length, 10); assert.deepEqual(results.filter((result) => !result.rejected), [])
+    assert.equal(results.length, 10); assert.deepEqual(results.filter((result) => !result.rejected || result.unexpected), [])
     assert.deepEqual(results.map((result) => result.name), ['wrong artifact ID', 'wrong upload digest', 'wrong run ID', 'wrong run attempt', 'wrong source SHA', 'wrong producer workflow path', 'wrong repository', 'wrong predecessor digest', 'wrong signing key', 'altered signed payload'])
-    assert.match(results.at(-1).message, /signature does not verify/)
+    // Every negative must have rejected on its intended binding, not on an incidental error.
+    assert.deepEqual(results.map((result) => result.message), [
+      'GitHub API actions/artifacts/9002 failed (HTTP 404)', 'GitHub API artifact digest differs from the upload output digest',
+      'Artifact name is not the exact run-scoped proof name', 'Artifact name is not the exact run-scoped proof name', 'Artifact run head differs from the source SHA',
+      'Producer workflow path differs', 'GitHub API actions/artifacts/9001 failed (HTTP 404)', 'Proof predecessor digest binding differs',
+      'Proof signature does not verify', 'Proof signature does not verify',
+    ])
     const out = []; const io = { env: consumerEnv, fetchImpl: state.fetchImpl, stdout: { write: (text) => out.push(text) }, stderr: { write: (text) => out.push(text) } }
     assert.equal(await runProofCli('consume', io), 0); assert.equal(await runProofCli('negatives', io), 0); assert.equal(await runProofCli('bogus', io), 1)
     const printed = out.join(''); assert.doesNotMatch(printed, new RegExp(keyValue)); assert.doesNotMatch(printed, new RegExp(tokenSentinel)); assert.match(printed, /Proof consumed independently: artifact 9001 sha256:[0-9a-f]{64}/); assert.equal((printed.match(/^rejected /gm) ?? []).length, 10)
     assert.equal(createHash('sha256').update(staged).digest('hex'), produced.payloadDigest.slice(7))
+  } finally { rmSync(root, { recursive: true, force: true }) }
+})
+test('negatives fail when the positive succeeds but later API requests error, or when the local tamper fixture itself breaks', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'annual-transport-proof-'))
+  try {
+    const env = produceInto(root)
+    const produced = await produceProof({ env })
+    const archive = buildDeflatedArchive([[PROOF_ENTRY_NAME, readFileSync(produced.stagedPath)]])
+    rmSync(join(env.PROOF_DIRECTORY, 'stage'), { recursive: true, force: true })
+    const consumerEnv = { ...env, GH_TOKEN: tokenSentinel, PROOF_ARTIFACT_ID: '9001', PROOF_UPLOAD_DIGEST: bytesDigest(archive) }
+    // The positive retrieval (four API calls plus one storage redirect) succeeds; every request after it is an outage.
+    const outage = (status) => { const state = fixture({ archive }); let calls = 0; const original = state.fetchImpl; state.fetchImpl = async (input, init) => (calls += 1) > 5 ? new Response('{}', { status }) : original(input, init); return state }
+    for (const status of [500, 429]) {
+      const state = outage(status)
+      const results = await runNegatives({ env: consumerEnv, fetchImpl: state.fetchImpl })
+      assert.equal(results.length, 10)
+      const remote = results.slice(0, 9)
+      assert.deepEqual(remote.map((result) => result.rejected), remote.map(() => false), `HTTP ${status} must not count as a rejection`)
+      assert.deepEqual(remote.map((result) => result.unexpected), remote.map(() => true))
+      for (const result of remote) assert.match(result.message, new RegExp(`HTTP ${status}`))
+      assert.equal(results.at(-1).rejected, true, 'the local tamper case does not depend on the API')
+      const out = []; const io = { env: consumerEnv, fetchImpl: outage(status).fetchImpl, stdout: { write: (text) => out.push(text) }, stderr: { write: (text) => out.push(text) } }
+      assert.equal(await runProofCli('negatives', io), 1)
+      const printed = out.join(''); assert.equal((printed.match(/^UNEXPECTED ERROR /gm) ?? []).length, 9); assert.match(printed, /9 failed for an unexpected reason/); assert.doesNotMatch(printed, new RegExp(tokenSentinel))
+    }
+    // A network failure after the positive must likewise never count as a rejection.
+    const network = fixture({ archive }); let calls = 0; const original = network.fetchImpl; network.fetchImpl = async (input, init) => { if ((calls += 1) > 5) throw new TypeError('fetch failed'); return original(input, init) }
+    const networkResults = await runNegatives({ env: consumerEnv, fetchImpl: network.fetchImpl })
+    assert.deepEqual(networkResults.slice(0, 9).map((result) => [result.rejected, result.unexpected, result.message]), Array.from({ length: 9 }, () => [false, true, 'fetch failed']))
+    // A broken local fixture is an unexpected error, not a signature rejection.
+    const healthy = fixture({ archive })
+    const broken = await runNegatives({ env: consumerEnv, fetchImpl: healthy.fetchImpl, tamper: () => { throw new Error('Archive entry checksum does not match') } })
+    assert.deepEqual(broken.slice(0, 9).filter((result) => !result.rejected), [])
+    assert.deepEqual([broken.at(-1).rejected, broken.at(-1).unexpected, broken.at(-1).message], [false, true, 'Archive entry checksum does not match'])
+    const io = { env: consumerEnv, fetchImpl: fixture({ archive }).fetchImpl, stdout: { write: () => {} }, stderr: { write: () => {} } }
+    assert.equal(await runProofCli('negatives', io), 0)
   } finally { rmSync(root, { recursive: true, force: true }) }
 })


### PR DESCRIPTION
## Scope

Non-production, artifact-only proof of signing before official artifact upload, followed by exact finalized-ID retrieval and independent archive digest, signature, and run/workflow provenance checks.

- Adds one narrowly path-triggered same-repository PR workflow and its synthetic Node fixture/tests.
- Uses a job-local ephemeral key and synthetic served/predecessor identities only.
- Leaves the custom production publisher, production workflows, schemas and consumers unchanged.
- No deployment, production signing keys, Billing credentials, migrations or payment mutations.

## Verification

- Nine focused proof tests pass locally (mocked API fixtures; not live-upload evidence), including unexpected outage/fixture failures that must not count as security rejections.
- Existing annual public handshake and billing-copy checks pass.
- The real official-upload proof must succeed before any coordinated producer/consumer correction is considered.

No merge or deployment is authorized by this PR. Stop on the first failed real proof; no production retry is part of this work.
