### PR TITLE
fix(web): restore signup and billing fetch calls in browsers

### DIFF
--- a/apps/web/app/lib/__tests__/injected-fetch-receiver.test.ts
+++ b/apps/web/app/lib/__tests__/injected-fetch-receiver.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  activateAnnualCheckout,
+  activateAuthenticatedAnnualCheckout,
+  cancelAnonymousPaymentSessionRecovery,
+  consumeSignupEmailOwnership,
+  fetchAnonymousAnnualOffer,
+  fetchAuthenticatedAnnualOffer,
+  getAnonymousPaymentSessionRecovery,
+  reconcileAnonymousPaymentSessionRecovery,
+  requestSignupEmailOwnership,
+  startAuthenticatedAnnualPayment,
+  startSignupAnnualPayment,
+  type BillingV2Fetch,
+} from '../billing-v2'
+import { cancelPaymentFlow } from '../payment-flow-cancellation'
+
+const billingApiUrl = 'https://billing.example.test'
+const requestId = 'e91a6d70-0d4e-4352-9bdc-426d1f76d771'
+const requestKey = '5fd4d86d-34de-4b82-9a66-9598ddf6e02f'
+const token = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG'
+const email = 'customer@example.test'
+const offer = { contractVersion: 2, requestId, offer: { planId: 'early_annual', customerClass: 'early', billingInterval: 'annual', annualAmountMinor: 3600, monthlyEquivalentMinor: 300, currency: 'EUR', providers: ['stripe', 'btcpay'], offerRevision: 1, offerToken: 'signed-offer', expiresAt: '2026-08-10T12:10:00Z' } }
+const disclosure = { kind: 'prepaid', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: null, monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null, cancelBy: null, cancelByInclusive: false, autoRenew: false, prepaid: true, refundWindowDays: 30, bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null }
+const activation = { contractVersion: 2, checkoutIntentToken: token, expiresAt: '2026-08-10T12:05:00Z', disclosure }
+const recovery = { contractVersion: 2, state: 'open', flow: { provider: 'btcpay', status: 'provider_pending' } }
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status })
+}
+
+/**
+ * The browser's `fetch` is a `Window` method: calling it with any receiver
+ * other than the global object raises "Illegal invocation" (Chromium) or
+ * "'fetch' called on an object that does not implement interface Window"
+ * (Firefox). A plain mock accepts any receiver, so it cannot show whether a
+ * helper invokes an injected fetcher as a bare call or as a method of its own
+ * parameter object. This stand-in enforces the platform rule instead.
+ */
+function windowBoundFetcher(response: () => Response): BillingV2Fetch {
+  return function fetchLike(this: unknown) {
+    if (this !== undefined && this !== globalThis) {
+      throw new TypeError("Failed to execute 'fetch' on 'Window': Illegal invocation")
+    }
+    return Promise.resolve(response())
+  }
+}
+
+const recoveryParams = (fetcher: BillingV2Fetch) => ({ fetcher, billingApiUrl, paymentSessionToken: token, recoverySecret: token, requestKey, email })
+
+const cases: ReadonlyArray<readonly [string, () => Response, (fetcher: BillingV2Fetch) => Promise<unknown>]> = [
+  ['fetchAnonymousAnnualOffer', () => json(offer), fetcher => fetchAnonymousAnnualOffer({ fetcher, billingApiUrl, email, requestId })],
+  ['activateAnnualCheckout', () => json(activation), fetcher => activateAnnualCheckout({ fetcher, billingApiUrl, offer, email, emailOwnershipToken: token, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })],
+  ['requestSignupEmailOwnership', () => new Response('{}', { status: 202 }), fetcher => requestSignupEmailOwnership({ fetcher, billingApiUrl, email, requestId })],
+  ['consumeSignupEmailOwnership', () => json({ contractVersion: 2, emailOwnershipToken: token, expiresAt: '2026-08-10T12:05:00Z' }), fetcher => consumeSignupEmailOwnership({ fetcher, billingApiUrl, email, token })],
+  ['fetchAuthenticatedAnnualOffer', () => json(offer), fetcher => fetchAuthenticatedAnnualOffer({ fetcher, billingApiUrl })],
+  ['activateAuthenticatedAnnualCheckout', () => json(activation), fetcher => activateAuthenticatedAnnualCheckout({ fetcher, billingApiUrl, offer, trialPath: 'immediate', provider: 'stripe', behavior: 'immediate_card' })],
+  ['startSignupAnnualPayment', () => json({ contractVersion: 2, kind: 'stripe', clientSecret: 'pi_secret', paymentSessionToken: token }), fetcher => startSignupAnnualPayment({ fetcher, billingApiUrl, checkoutIntentToken: token, email, requestKey, recoverySecret: token, wantsProductUpdates: true, rememberDevice: false, returnUrl: 'https://app.example.test/signup/success' })],
+  ['startAuthenticatedAnnualPayment', () => json({ contractVersion: 2, kind: 'stripe', authorityId: requestKey, clientSecret: 'pi_secret' }), fetcher => startAuthenticatedAnnualPayment({ fetcher, billingApiUrl, checkoutIntentToken: token, expectedAuthorityId: requestKey, returnUrl: 'https://app.example.test/settings/subscription' })],
+  ['getAnonymousPaymentSessionRecovery', () => json(recovery), fetcher => getAnonymousPaymentSessionRecovery(recoveryParams(fetcher))],
+  ['cancelAnonymousPaymentSessionRecovery', () => json(recovery), fetcher => cancelAnonymousPaymentSessionRecovery(recoveryParams(fetcher))],
+  ['reconcileAnonymousPaymentSessionRecovery', () => json(recovery), fetcher => reconcileAnonymousPaymentSessionRecovery(recoveryParams(fetcher))],
+]
+
+describe('injected fetchers are invoked with a browser-legal receiver', () => {
+  it.each(cases)('%s does not pass its parameter object as the fetch receiver', async (_name, response, call) => {
+    const settled = await call(windowBoundFetcher(response)).then(() => 'called with a legal receiver', (error: unknown) => String(error))
+    expect(settled).toBe('called with a legal receiver')
+  })
+
+  it('cancelPaymentFlow does not pass its parameter object as the fetch receiver', async () => {
+    const result = await cancelPaymentFlow({
+      fetcher: windowBoundFetcher(() => json({ cancelled: true, flowKind: 'stripe_annual' })),
+      billingApiUrl,
+      provider: 'stripe',
+      confirmNoBitcoinSent: false,
+    })
+    expect(result).toEqual({ cancelled: true, flowKind: 'stripe_annual' })
+  })
+})

--- a/apps/web/app/lib/billing-v2.ts
+++ b/apps/web/app/lib/billing-v2.ts
@@ -3,7 +3,14 @@
  * promotions, terms and provider authority are intentionally never inferred
  * by the client: an invalid or incomplete server reply is a visible failure.
  */
-export type BillingV2Fetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+/**
+ * The injected fetcher is normally the browser's `fetch`, which rejects any
+ * receiver that is not the window ("Illegal invocation"). It must therefore be
+ * called as a plain function, never as a method of a params object. `this: void`
+ * states that contract and keeps receiver-dependent implementations out.
+ */
+export type BillingV2Fetch = (this: void, input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 export type AnnualProvider = 'stripe' | 'btcpay'
 export type AnnualPlanId = 'early_annual' | 'standard_annual'
@@ -187,21 +194,24 @@ export async function fetchAnonymousAnnualOffer(params: {
   email: string
   requestId: string
 }): Promise<AnnualOfferResponse> {
-  const body = await jsonOrThrow(await params.fetcher(api(params.billingApiUrl, '/auth/offers/v2'), jsonInit('POST', { contractVersion: 2, email: params.email, requestId: params.requestId })))
+  const { fetcher } = params
+  const body = await jsonOrThrow(await fetcher(api(params.billingApiUrl, '/auth/offers/v2'), jsonInit('POST', { contractVersion: 2, email: params.email, requestId: params.requestId })))
   assertAnnualOfferResponse(body)
   if (body.requestId !== params.requestId) throw new Error('Billing returned an offer for another request')
   return body
 }
 
 export async function activateAnnualCheckout(params: { fetcher: BillingV2Fetch; billingApiUrl: string; offer: AnnualOfferResponse; email: string; emailOwnershipToken: string; trialPath: AnnualTrialPath; provider: 'none' | AnnualProvider; behavior: AnnualBehavior }): Promise<AnnualCheckoutActivation> {
+  const { fetcher } = params
   assertAnnualOfferResponse(params.offer)
-  const body = await jsonOrThrow(await params.fetcher(api(params.billingApiUrl, '/auth/offers/v2/activate'), jsonInit('POST', { contractVersion: 2, offerToken: params.offer.offer.offerToken, requestId: params.offer.requestId, email: params.email, emailOwnershipToken: params.emailOwnershipToken, trialPath: params.trialPath, provider: params.provider, behavior: params.behavior })))
+  const body = await jsonOrThrow(await fetcher(api(params.billingApiUrl, '/auth/offers/v2/activate'), jsonInit('POST', { contractVersion: 2, offerToken: params.offer.offer.offerToken, requestId: params.offer.requestId, email: params.email, emailOwnershipToken: params.emailOwnershipToken, trialPath: params.trialPath, provider: params.provider, behavior: params.behavior })))
   assertActivation(body)
   return body
 }
 
 export async function requestSignupEmailOwnership(params: { fetcher: BillingV2Fetch; billingApiUrl: string; email: string; requestId: string }) {
-  const response = await params.fetcher(api(params.billingApiUrl, '/auth/signup-email-verifications/v2'), jsonInit('POST', { contractVersion: 2, email: params.email, requestId: params.requestId }))
+  const { fetcher } = params
+  const response = await fetcher(api(params.billingApiUrl, '/auth/signup-email-verifications/v2'), jsonInit('POST', { contractVersion: 2, email: params.email, requestId: params.requestId }))
   if (response.status !== 202) {
     await jsonOrThrow(response)
     throw new Error('Billing did not acknowledge email proof delivery')
@@ -209,20 +219,23 @@ export async function requestSignupEmailOwnership(params: { fetcher: BillingV2Fe
 }
 
 export async function consumeSignupEmailOwnership(params: { fetcher: BillingV2Fetch; billingApiUrl: string; email: string; token: string }): Promise<EmailOwnership> {
-  const body = await jsonOrThrow(await params.fetcher(api(params.billingApiUrl, '/auth/signup-email-verifications/v2/consume'), jsonInit('POST', { contractVersion: 2, email: params.email, token: params.token })))
+  const { fetcher } = params
+  const body = await jsonOrThrow(await fetcher(api(params.billingApiUrl, '/auth/signup-email-verifications/v2/consume'), jsonInit('POST', { contractVersion: 2, email: params.email, token: params.token })))
   if (!isObject(body) || !hasExactKeys(body, ['contractVersion', 'emailOwnershipToken', 'expiresAt']) || body.contractVersion !== 2 || !isRecoveryToken(body.emailOwnershipToken) || !isUtcTimestamp(body.expiresAt)) throw new Error('Billing did not return valid email proof')
   return body as unknown as EmailOwnership
 }
 
 export async function fetchAuthenticatedAnnualOffer(params: { fetcher: BillingV2Fetch; billingApiUrl: string }): Promise<AnnualOfferResponse> {
-  const body = await jsonOrThrow(await params.fetcher(api(params.billingApiUrl, '/subscription/offers/v2'), jsonInit('GET')))
+  const { fetcher } = params
+  const body = await jsonOrThrow(await fetcher(api(params.billingApiUrl, '/subscription/offers/v2'), jsonInit('GET')))
   assertAnnualOfferResponse(body)
   return body
 }
 
 export async function activateAuthenticatedAnnualCheckout(params: { fetcher: BillingV2Fetch; billingApiUrl: string; offer: AnnualOfferResponse; trialPath: AnnualTrialPath; provider: 'none' | AnnualProvider; behavior: AnnualBehavior }): Promise<AnnualCheckoutActivation> {
+  const { fetcher } = params
   assertAnnualOfferResponse(params.offer)
-  const body = await jsonOrThrow(await params.fetcher(api(params.billingApiUrl, '/subscription/offers/v2/activate'), jsonInit('POST', { contractVersion: 2, offerToken: params.offer.offer.offerToken, requestId: params.offer.requestId, trialPath: params.trialPath, provider: params.provider, behavior: params.behavior })))
+  const body = await jsonOrThrow(await fetcher(api(params.billingApiUrl, '/subscription/offers/v2/activate'), jsonInit('POST', { contractVersion: 2, offerToken: params.offer.offer.offerToken, requestId: params.offer.requestId, trialPath: params.trialPath, provider: params.provider, behavior: params.behavior })))
   assertActivation(body)
   return body
 }
@@ -241,8 +254,9 @@ function assertAuthenticatedPayment(value: unknown): asserts value is Authentica
 }
 
 export async function startSignupAnnualPayment(params: { fetcher: BillingV2Fetch; billingApiUrl: string; checkoutIntentToken: string; email: string; requestKey: string; recoverySecret: string; wantsProductUpdates: boolean; rememberDevice: boolean; returnUrl: string }): Promise<SignupAnnualPayment> {
+  const { fetcher } = params
   const returnUrl = requireAbsoluteHttpUrl(params.returnUrl)
-  const body = await jsonOrThrow(await params.fetcher(api(params.billingApiUrl, '/auth/signup/payment-session/v2'), jsonInit('POST', { contractVersion: 2, checkoutIntentToken: params.checkoutIntentToken, email: params.email, requestKey: params.requestKey, recoverySecret: params.recoverySecret, wantsProductUpdates: params.wantsProductUpdates, rememberDevice: params.rememberDevice, returnUrl })))
+  const body = await jsonOrThrow(await fetcher(api(params.billingApiUrl, '/auth/signup/payment-session/v2'), jsonInit('POST', { contractVersion: 2, checkoutIntentToken: params.checkoutIntentToken, email: params.email, requestKey: params.requestKey, recoverySecret: params.recoverySecret, wantsProductUpdates: params.wantsProductUpdates, rememberDevice: params.rememberDevice, returnUrl })))
   assertSignupPayment(body)
   if (body.paymentSessionToken !== params.recoverySecret) throw new Error('Billing returned payment recovery for another signup')
   if (body.kind === 'btcpay' && body.cryptoInvoiceLookupToken !== params.recoverySecret) throw new Error('Billing returned Bitcoin recovery for another signup')
@@ -250,9 +264,10 @@ export async function startSignupAnnualPayment(params: { fetcher: BillingV2Fetch
 }
 
 export async function startAuthenticatedAnnualPayment(params: { fetcher: BillingV2Fetch; billingApiUrl: string; checkoutIntentToken: string; expectedAuthorityId: string; returnUrl: string }): Promise<AuthenticatedAnnualPayment> {
+  const { fetcher } = params
   if (!isUuid(params.expectedAuthorityId)) throw new Error('The expected annual authority is invalid')
   const returnUrl = requireAbsoluteHttpUrl(params.returnUrl)
-  const body = await jsonOrThrow(await params.fetcher(api(params.billingApiUrl, '/subscription/payment-flows/v2'), jsonInit('POST', { contractVersion: 2, checkoutIntentToken: params.checkoutIntentToken, returnUrl })))
+  const body = await jsonOrThrow(await fetcher(api(params.billingApiUrl, '/subscription/payment-flows/v2'), jsonInit('POST', { contractVersion: 2, checkoutIntentToken: params.checkoutIntentToken, returnUrl })))
   assertAuthenticatedPayment(body)
   if (body.authorityId !== params.expectedAuthorityId) throw new Error('Billing returned payment details for another annual authority')
   return body
@@ -287,6 +302,7 @@ async function anonymousPaymentSessionRecovery(
   path: '/current' | '/cancel' | '/reconcile',
   params: AnonymousPaymentSessionRecoveryRequest,
 ): Promise<AnonymousPaymentSessionRecovery> {
+  const { fetcher } = params
   if (!isRecoveryToken(params.paymentSessionToken)
     || !isRecoveryToken(params.recoverySecret)
     || params.paymentSessionToken !== params.recoverySecret
@@ -297,7 +313,7 @@ async function anonymousPaymentSessionRecovery(
     || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(params.email)) {
     throw new Error('The annual payment recovery context is invalid')
   }
-  const response = await params.fetcher(
+  const response = await fetcher(
     api(params.billingApiUrl, `/auth/signup/payment-session/v2${path}`),
     {
       method: 'POST',

--- a/apps/web/app/lib/payment-flow-cancellation.ts
+++ b/apps/web/app/lib/payment-flow-cancellation.ts
@@ -93,10 +93,12 @@ export async function cancelPaymentFlow(params: {
     return failed('bitcoin-acknowledgement-required')
   }
 
+  const { fetcher } = params
+
   let response: Response
   let body: unknown
   try {
-    response = await params.fetcher(`${params.billingApiUrl.replace(/\/$/, '')}/subscription/payment-flows/cancel`, {
+    response = await fetcher(`${params.billingApiUrl.replace(/\/$/, '')}/subscription/payment-flows/cancel`, {
       method: 'POST',
       credentials: 'include',
       headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
## Summary

Fix hosted signup failing on Continue with Firefox's `'fetch' called on an object that does not implement interface Window` and Chromium's `Illegal invocation` error.

The billing client received native `fetch` through a parameter object and called it as `params.fetcher(...)`. That supplies the parameter object as `this`, which the browser rejects before sending the request. Extract the callable before invoking it across the annual billing helpers and the sibling payment cancellation helper.

- Preserve endpoint paths, request bodies, credentials, headers, response validation, and cancellation safeguards.
- Add receiver-sensitive regression coverage for all 12 affected exported entry points; ordinary mocked fetch functions did not enforce this browser constraint.
- Leave analytics CORS and WASM CSP warnings out of this hotfix; the latter remains tracked separately in #44.

## Verification

- New regression suite: 12 failures on the original code, passing after the fix.
- Focused billing/receiver/cancellation suites: 48 tests passed.
- Web TypeScript check and focused ESLint passed.
- Native Firefox 151 and Chromium 149 execution of the actual helper modules: original signup/recovery fail before any request; patched signup/recovery/cancellation complete the expected intercepted POSTs. All network responses were synthetic Playwright fixtures; no real account, email, payment, or cancellation was performed.
- Full web suite: 71 files, 1002 tests passed.
- Independent review: GREEN for `5305b3142a4709c624e980ed784e590a54858957` → `b26df935e1b36e0513d3fd17e4b5aa1d8e072057`, with no blockers.
- Repository CI, web build, and PR preview-image build passed on that exact head. The shared web-preview deployment jobs were intentionally skipped on the PR event.

## Risk and release boundary

Tier 1, shared frontend transport invocation only. No backend, pricing, authentication policy, analytics or CSP changes. This PR does not deploy production. Full deployed signup/email/payment end-to-end testing remains separate from the isolated native-browser transport proof.
