### PR TITLE
chore: prepare v0.5.6-beta release metadata

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,8 +23,8 @@ android {
         minSdkVersion 21
         targetSdkVersion 36
 
-        versionCode 19
-        versionName "0.5.5-beta"
+        versionCode 20
+        versionName "0.5.6-beta"
 
         buildConfigField "boolean", "customCerts", "true"
     }

--- a/android/fastlane/metadata/android/en-US/changelogs/20.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/20.txt
@@ -1,0 +1,1 @@
+Improves the Android build tooling so the release can be rebuilt and verified on more Java 17 toolchains.

--- a/android/fastlane/metadata/android/en-US/google-play-listing-copy.md
+++ b/android/fastlane/metadata/android/en-US/google-play-listing-copy.md
@@ -1,4 +1,4 @@
-# Store listing paste copy for SilentSuite v0.5.5-beta
+# Store listing paste copy for SilentSuite v0.5.6-beta
 
 Use with the final 6 screenshots exported from Figma on 2026-08-06.
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/docs",
-  "version": "0.5.5-beta",
+  "version": "0.5.6-beta",
   "private": true,
   "scripts": {
     "dev": "vitepress dev",

--- a/apps/web/app/lib/constants.ts
+++ b/apps/web/app/lib/constants.ts
@@ -11,7 +11,7 @@
  * Update this on release so displayed versions don't go stale. Keep in sync
  * with the current release tag.
  */
-export const DISPLAY_VERSION = '0.5.5-beta'
+export const DISPLAY_VERSION = '0.5.6-beta'
 
 // ── Time unit multipliers (ms) ──────────────────────────────────────────
 export const MS_PER_SECOND = 1_000

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/web",
-  "version": "0.5.5-beta",
+  "version": "0.5.6-beta",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",

--- a/bridge/pyproject.toml
+++ b/bridge/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "silentsuite-bridge"
-version = "0.5.5-beta"
+version = "0.5.6-beta"
 description = "SilentSuite Bridge — Local E2EE CalDAV/CardDAV sync daemon"
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/bridge/src/silentsuite_bridge/__init__.py
+++ b/bridge/src/silentsuite_bridge/__init__.py
@@ -13,7 +13,7 @@ from importlib import metadata as _metadata
 # Kept in sync with pyproject.toml [project].version. Used only as a
 # last-resort fallback when neither a build stamp nor package metadata is
 # available (e.g. running straight from source without an editable install).
-_FALLBACK_VERSION = "0.5.5-beta"
+_FALLBACK_VERSION = "0.5.6-beta"
 
 
 def _resolve_version() -> str:

--- a/fastlane/metadata/android/en-US/changelogs/20.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20.txt
@@ -1,0 +1,1 @@
+Improves the Android build tooling so the release can be rebuilt and verified on more Java 17 toolchains.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "silentsuite",
-  "version": "0.5.5-beta",
+  "version": "0.5.6-beta",
   "private": true,
   "engines": {
     "node": ">=22.12.0"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/config",
-  "version": "0.5.5-beta",
+  "version": "0.5.6-beta",
   "private": true,
   "files": [
     "typescript",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/core",
-  "version": "0.5.5-beta",
+  "version": "0.5.6-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silentsuite/ui",
-  "version": "0.5.5-beta",
+  "version": "0.5.6-beta",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/tests/test_release_versions_static.py
+++ b/tests/test_release_versions_static.py
@@ -10,8 +10,8 @@ import json
 import re
 
 ROOT = Path(__file__).resolve().parents[1]
-CURRENT_RELEASE_VERSION = "0.5.5-beta"
-CURRENT_ANDROID_VERSION_CODE = 19
+CURRENT_RELEASE_VERSION = "0.5.6-beta"
+CURRENT_ANDROID_VERSION_CODE = 20
 
 PACKAGE_JSON_PATHS = [
     "package.json",

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,5 +1,5 @@
 repository: https://github.com/silent-suite/silentsuite
-release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.5.5-beta/silentsuite-android-v0.5.5-beta.apk
+release_source: https://github.com/silent-suite/silentsuite/releases/download/v0.5.6-beta/silentsuite-android-v0.5.6-beta.apk
 pubkey: npub1zuusadlzq6vehhaqhqpup0mhnx70q9cnf9hs48t79g6qn4wpg2eqsy8m35
 name: SilentSuite
 summary: End-to-end encrypted sync for calendar, contacts, and tasks
@@ -26,12 +26,12 @@ tags:
   - sync
 license: GPL-3.0-only
 website: https://silentsuite.io
-icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.5-beta/android/fastlane/metadata/android/en-US/images/icon.png
+icon: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.6-beta/android/fastlane/metadata/android/en-US/images/icon.png
 images:
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.5-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-encrypted-sync.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.5-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-cross-platform-sync.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.5-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-calendar-contacts-tasks.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.5-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-collections-sharing.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.5-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/5-import-export.png
-  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.5-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/6-encryption-fingerprint.png
-release_notes: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.5-beta/android/fastlane/metadata/android/en-US/changelogs/19.txt
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.6-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/1-encrypted-sync.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.6-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/2-cross-platform-sync.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.6-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/3-calendar-contacts-tasks.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.6-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/4-collections-sharing.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.6-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/5-import-export.png
+  - https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.6-beta/android/fastlane/metadata/android/en-US/images/phoneScreenshots/6-encryption-fingerprint.png
+release_notes: https://raw.githubusercontent.com/silent-suite/silentsuite/v0.5.6-beta/android/fastlane/metadata/android/en-US/changelogs/20.txt


### PR DESCRIPTION
Align active release versions to 0.5.6-beta and Android versionCode 20. Includes matching Android build-tooling changelogs. No production deployment or app-store submission. Release preparation for the Bridge autostart correction in #716; #658 stays open pending real macOS restart acceptance. Python/Android verification is CI-only.