### PR TITLE
fix(web): recover signup email verification continuation

### DIFF
--- a/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SignupPage from '../page'
+import VerificationCallbackPage from '../verify-email/page'
+import { StrictMode } from 'react'
 
 vi.hoisted(() => {
   process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED = 'true'
@@ -43,12 +45,126 @@ vi.mock('next/link', () => ({ default: ({ children }: { children: React.ReactNod
 describe('email-link seven-day no-card continuation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.stubGlobal('scrollTo', vi.fn())
     sessionStorage.clear()
     localStorage.clear()
     window.history.replaceState({}, '', '/signup')
   })
 
-  it('survives a full navigation without persisting a password and completes the verified lineage', async () => {
+  it('retries an offer failure without consuming the email link again', async () => {
+    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
+      [requestId]: { email: 'retry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false,
+        returnTo: null, expiresAt: Date.now() + 60_000 },
+    }))
+    let consumptions = 0
+    let offers = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/consume')) {
+        consumptions += 1
+        if (consumptions > 1) return new Response('{}', { status: 400 })
+        return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken: ownershipToken,
+          expiresAt: new Date(Date.now() + 60_000).toISOString().replace(/\.\d{3}Z$/, 'Z') }))
+      }
+      if (String(input).endsWith('/auth/offers/v2')) {
+        offers += 1
+        return offers === 1 ? new Response('{}', { status: 503 }) : new Response(JSON.stringify(offer))
+      }
+      throw new Error('Unexpected request')
+    }))
+    window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
+    render(<StrictMode><SignupPage /></StrictMode>)
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry loading trial options' }))
+    expect(await screen.findByRole('heading', { name: 'Re-enter your account details' })).toBeInTheDocument()
+    expect(consumptions).toBe(1)
+    expect(offers).toBe(2)
+    expect(window.location.search).not.toContain('link-token')
+    expect(JSON.stringify(localStorage)).not.toContain(ownershipToken)
+    expect(JSON.stringify(sessionStorage)).not.toContain(ownershipToken)
+  })
+
+  it.each(['expired', 'lost-response'])('requests a fresh lineage after %s without consuming the old link again', async (failure) => {
+    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
+      [requestId]: { email: 'retry@example.test', requestId, wantsProductUpdates: true, rememberDevice: false,
+        returnTo: 'silentsuite://signup-complete', expiresAt: Date.now() + 60_000 },
+    }))
+    let consumptions = 0
+    const requests: { email: string; requestId: string }[] = []
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/consume')) {
+        consumptions += 1
+        if (failure === 'lost-response') throw new TypeError('Network failed after commit')
+        return new Response('{}', { status: 400 })
+      }
+      if (String(input).endsWith('/auth/signup-email-verifications/v2')) {
+        requests.push(JSON.parse(String(init?.body)))
+        return new Response(JSON.stringify({ accepted: true }), { status: 202 })
+      }
+      throw new Error('Unexpected request')
+    }))
+    window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
+    render(<StrictMode><SignupPage /></StrictMode>)
+    fireEvent.click(await screen.findByRole('button', { name: 'Request a new verification email' }))
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Check your email'))
+    expect(consumptions).toBe(1)
+    expect(requests).toHaveLength(1)
+    expect(requests[0].email).toBe('retry@example.test')
+    expect(requests[0].requestId).not.toBe(requestId)
+    const stored = JSON.parse(localStorage.getItem('silentsuite-signup-email-proof') ?? '{}')
+    expect(stored).not.toHaveProperty(requestId)
+    expect(stored[requests[0].requestId]).toMatchObject({ wantsProductUpdates: true, rememberDevice: false, returnTo: 'silentsuite://signup-complete' })
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    expect(window.location.search).not.toContain('link-token')
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+  })
+
+  it('does not publish a continuation after the page unmounts', async () => {
+    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
+      [requestId]: { email: 'retry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false,
+        returnTo: null, expiresAt: Date.now() + 60_000 },
+    }))
+    let resolveOffer!: (value: Response) => void
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/consume')) return new Response(JSON.stringify({
+        contractVersion: 2, emailOwnershipToken: ownershipToken, expiresAt: '2099-01-01T00:00:00Z',
+      }))
+      return new Promise<Response>((resolve) => { resolveOffer = resolve })
+    }))
+    window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
+    const view = render(<SignupPage />)
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
+    view.unmount()
+    await act(async () => { resolveOffer(new Response(JSON.stringify(offer))) })
+    expect(authState.prepareSignupDraft).not.toHaveBeenCalled()
+    expect(localStorage.getItem('silentsuite-signup-email-proof')).toContain(requestId)
+  })
+
+  it('preserves the new non-secret lineage when a resend acknowledgement is lost', async () => {
+    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
+      [requestId]: { email: 'retry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false,
+        returnTo: null, expiresAt: Date.now() + 60_000 },
+    }))
+    let nextId = ''
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/consume')) return new Response('{}', { status: 400 })
+      nextId = JSON.parse(String(init?.body)).requestId
+      // The emailed link may arrive even though this response never does.
+      expect(localStorage.getItem('silentsuite-signup-email-proof')).toContain(nextId)
+      throw new TypeError('Acknowledgement lost')
+    }))
+    window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
+    render(<SignupPage />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Request a new verification email' }))
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('Check your inbox'))
+    expect(nextId).not.toBe(requestId)
+    expect(localStorage.getItem('silentsuite-signup-email-proof')).toContain(nextId)
+    expect(screen.getByRole('button', { name: 'Request a new verification email' })).toBeEnabled()
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+  })
+
+  it.each(['/signup', '/signup/verify-email'])('completes the verified lineage through %s without persisting a password', async (callbackPath) => {
     localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
       [requestId]: { email: 'customer@example.test', requestId, wantsProductUpdates: true, rememberDevice: false,
         returnTo: 'silentsuite://signup-complete', expiresAt: Date.now() + 60_000 },
@@ -68,8 +184,9 @@ describe('email-link seven-day no-card continuation', () => {
 
     const firstMount = render(<SignupPage />)
     firstMount.unmount()
-    window.history.replaceState({}, '', `/signup?email_verification_token=link-token&request_id=${requestId}`)
-    render(<SignupPage />)
+    window.history.replaceState({}, '', `${callbackPath}?token=link-token&request_id=${requestId}`)
+    const Page = callbackPath === '/signup' ? SignupPage : VerificationCallbackPage
+    render(<Page />)
 
     expect(await screen.findByRole('heading', { name: 'Re-enter your account details' })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })

--- a/apps/web/app/(auth)/signup/__tests__/verification-callback-route.test.ts
+++ b/apps/web/app/(auth)/signup/__tests__/verification-callback-route.test.ts
@@ -1,0 +1,12 @@
+// @vitest-environment node
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('issued signup email callback route', () => {
+  it('registers the historical email URL against the annual signup consumer', () => {
+    const page = resolve(process.cwd(), 'app/(auth)/signup/verify-email/page.tsx')
+    expect(existsSync(page), 'already-issued email callback must be a registered Next route').toBe(true)
+    expect(readFileSync(page, 'utf8')).toContain("export { default } from '../page'")
+  })
+})

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -25,6 +25,7 @@ import dynamic from 'next/dynamic'
 import { StepCreateVault } from './components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from './components/step-create-paid-account'
 import { QRCodeSVG } from 'qrcode.react'
+import { createEmailLinkContinuation } from '@/app/lib/signup-email-continuation'
 import { trackCheckoutInitiated, trackPlanSelected } from './commercial-funnel-analytics'
 import {
   activateAnnualCheckout,
@@ -101,6 +102,16 @@ function clearEmailProofContext(requestId?: string | null) {
   } catch {
     // A storage failure must not break the funnel it was only annotating.
   }
+}
+
+function saveEmailProofContext(context: EmailProofContext) {
+  const existing = (() => {
+    try {
+      const parsed: unknown = JSON.parse(localStorage.getItem(EMAIL_PROOF_CONTEXT_KEY) ?? '{}')
+      return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) ? parsed : {}
+    } catch { return {} }
+  })()
+  localStorage.setItem(EMAIL_PROOF_CONTEXT_KEY, JSON.stringify({ ...existing, [context.requestId]: context }))
 }
 
 /** Drops the single-use verification token from the address bar and history. */
@@ -1387,33 +1398,57 @@ export default function SignupPage() {
   const [recoveredSignupEmail, setRecoveredSignupEmail] = useState<string | null>(null)
   const [awaitingEmailProof, setAwaitingEmailProof] = useState(false)
   const [emailProofUnavailable, setEmailProofUnavailable] = useState(false)
+  const [emailProofError, setEmailProofError] = useState<string | null>(null)
+  const [emailProofBusy, setEmailProofBusy] = useState(false)
+  const [requestingEmailProof, setRequestingEmailProof] = useState(false)
+  const resendBusyRef = useRef(false)
+  const mountedRef = useRef(false)
+  const [emailProofAttempt, setEmailProofAttempt] = useState(0)
+  const emailContinuationRef = useRef<{
+    context: EmailProofContext
+    continuation: ReturnType<typeof createEmailLinkContinuation>
+  } | null>(null)
   const formDataRef = useRef<SignupFormData | null>(null)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => { mountedRef.current = false }
+  }, [])
 
   useEffect(() => {
     setReturnTo(normalizeSignupReturnTo(new URLSearchParams(window.location.search).get('return_to')))
   }, [])
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search)
-    const token = params.get('email_verification_token') ?? params.get('token')
-    if (!token) return
-    const requestId = params.get('request_id')
-    const context = readEmailProofContext(requestId)
-    if (!context) {
-      // Without the draft there is no email to verify the token against, so the
-      // link cannot be spent here. Say so and leave the signup form usable
-      // rather than silently discarding the only path into plan selection.
-      clearEmailProofContext(requestId)
+    if (!emailContinuationRef.current) {
+      const params = new URLSearchParams(window.location.search)
+      const token = params.get('email_verification_token') ?? params.get('token')
+      if (!token) return
+      const requestId = params.get('request_id')
+      const context = readEmailProofContext(requestId)
+      // Capture once, then remove the bearer URL before any fallible request.
+      // Strict Mode replay joins the captured continuation, not a second consume.
       stripEmailVerificationTokenFromUrl()
-      setEmailProofUnavailable(true)
-      setAwaitingEmailProof(false)
-      return
+      if (!context) {
+        clearEmailProofContext(requestId)
+        setEmailProofUnavailable(true)
+        setAwaitingEmailProof(false)
+        return
+      }
+      emailContinuationRef.current = {
+        context,
+        continuation: createEmailLinkContinuation(
+          () => consumeSignupEmailOwnership({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email: context.email, token }),
+          () => fetchAnonymousAnnualOffer({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email: context.email, requestId: context.requestId }),
+        ),
+      }
     }
-
+    const { context, continuation } = emailContinuationRef.current
     let cancelled = false
+    setEmailProofBusy(true)
+    setEmailProofError(null)
     void (async () => {
-      const ownership = await consumeSignupEmailOwnership({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email: context.email, token })
-      const offer = await fetchAnonymousAnnualOffer({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email: context.email, requestId: context.requestId })
+      const { ownership, offer } = await continuation.load()
       if (cancelled) return
       prepareSignupDraft(context.email, context.wantsProductUpdates, context.rememberDevice)
       setEmailOwnershipToken(ownership.emailOwnershipToken)
@@ -1438,13 +1473,54 @@ export default function SignupPage() {
       // browser-profile storage. Other concurrently requested lineages remain.
       clearEmailProofContext(context.requestId)
       stripEmailVerificationTokenFromUrl()
-    })().catch((err: unknown) => {
-      if (!cancelled) setProvisionError(err instanceof Error ? err.message : 'Email verification could not be completed. Request a new link.')
+    })().catch(() => {
+      if (!cancelled) setEmailProofError(continuation.hasProof()
+        ? 'Your email was verified, but trial options could not be loaded. Retry, or request a new link if verification has expired.'
+        : 'This verification link could not be completed. It may have expired, already been used, or the connection was interrupted. Request a new link to continue safely.')
+    }).finally(() => {
+      if (!cancelled) setEmailProofBusy(false)
     })
     return () => { cancelled = true }
-  }, [prepareSignupDraft])
+  }, [prepareSignupDraft, emailProofAttempt])
+
+  const requestNewVerificationEmail = useCallback(async () => {
+    const previous = emailContinuationRef.current?.context
+    if (!previous || resendBusyRef.current) return
+    resendBusyRef.current = true
+    setRequestingEmailProof(true)
+    setEmailProofBusy(true)
+    const context = { ...previous, requestId: crypto.randomUUID(), expiresAt: Date.now() + 15 * 60_000 }
+    try {
+      // Persist the non-secret lineage before sending: a lost acknowledgement
+      // must not make a successfully delivered replacement link unusable.
+      saveEmailProofContext(context)
+      await requestSignupEmailOwnership({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email: context.email, requestId: context.requestId })
+      if (!mountedRef.current) return
+      clearEmailProofContext(previous.requestId)
+      emailContinuationRef.current = null
+      setEmailOwnershipToken(null)
+      setAnnualOffer(null)
+      setAnnualOfferRequestId(null)
+      setRecoveredSignupEmail(null)
+      setEmailProofError(null)
+      setEmailProofUnavailable(false)
+      setAwaitingEmailProof(true)
+    } catch {
+      if (mountedRef.current) setEmailProofError('A new verification email could not be confirmed. Check your inbox, or try requesting another link shortly.')
+    } finally {
+      resendBusyRef.current = false
+      if (mountedRef.current) {
+        setRequestingEmailProof(false)
+        setEmailProofBusy(false)
+      }
+    }
+  }, [])
 
   const handleAccountComplete = useCallback(async (data: SignupFormData) => {
+    emailContinuationRef.current = null
+    setEmailProofError(null)
+    setEmailOwnershipToken(null)
+    setAnnualOffer(null)
     formDataRef.current = data
     const normalizedUrl = serverUrl.trim() ? normalizeServerUrl(serverUrl) : undefined
     if (normalizedUrl) {
@@ -1486,11 +1562,10 @@ export default function SignupPage() {
       returnTo,
       expiresAt: Date.now() + 15 * 60_000,
     }
-    await requestSignupEmailOwnership({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email: identifier, requestId })
     // This full-navigation continuation intentionally contains no password, and
     // is browser-profile scoped so the emailed link works from a new tab.
-    const existing = (() => { try { return JSON.parse(localStorage.getItem(EMAIL_PROOF_CONTEXT_KEY) ?? '{}') as Record<string, EmailProofContext> } catch { return {} } })()
-    localStorage.setItem(EMAIL_PROOF_CONTEXT_KEY, JSON.stringify({ ...existing, [requestId]: context }))
+    saveEmailProofContext(context)
+    await requestSignupEmailOwnership({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email: identifier, requestId })
     setEmailProofUnavailable(false)
     setAwaitingEmailProof(true)
   }, [createEtebaseAccount, prepareSignupDraft, rememberDevice, returnTo, serverUrl, wantsProductUpdates])
@@ -1789,6 +1864,22 @@ export default function SignupPage() {
       <div className="mx-auto w-full max-w-md min-w-0 md:mx-0 md:flex-1">
         {step === 'account' && (
           <>
+            {emailProofBusy && <p role="status" className="mb-4 text-sm text-[rgb(var(--muted))]">{requestingEmailProof ? 'Requesting a new verification email...' : 'Verifying your email and loading trial options...'}</p>}
+            {emailProofError && (
+              <div role="alert" className="mb-4 rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">
+                <p>{emailProofError}</p>
+                {emailContinuationRef.current?.continuation.hasProof() && (
+                  <Button className="mt-3" disabled={emailProofBusy} onClick={() => setEmailProofAttempt((attempt) => attempt + 1)}>
+                    Retry loading trial options
+                  </Button>
+                )}
+                {emailContinuationRef.current && (
+                  <Button className="mt-3" variant="outline" disabled={emailProofBusy} onClick={requestNewVerificationEmail}>
+                    Request a new verification email
+                  </Button>
+                )}
+              </div>
+            )}
             {emailProofUnavailable && (
               <div role="alert" className="mb-4 rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">
                 <p className="font-medium">This verification link could not be matched to a signup in this browser.</p>
@@ -1797,7 +1888,7 @@ export default function SignupPage() {
                 </p>
               </div>
             )}
-            <StepCreateAccount
+            {!emailProofBusy && <StepCreateAccount
               onNext={handleAccountComplete}
               serverUrl={serverUrl}
               setServerUrl={setServerUrl}
@@ -1806,7 +1897,7 @@ export default function SignupPage() {
               onWantsProductUpdatesChange={setWantsProductUpdates}
               rememberDevice={rememberDevice}
               onRememberDeviceChange={setRememberDevice}
-            />
+            />}
             {awaitingEmailProof && <p role="status" className="mt-4 text-center text-sm text-[rgb(var(--muted))]">Check your email and open the verification link in this browser. Your password is not saved while you open the link.</p>}
           </>
         )}

--- a/apps/web/app/(auth)/signup/verify-email/page.tsx
+++ b/apps/web/app/(auth)/signup/verify-email/page.tsx
@@ -1,0 +1,3 @@
+// Compatibility for verification emails already issued by hosted Billing.
+// Reuse the annual consumer without redirecting bearer tokens through another URL.
+export { default } from '../page'

--- a/apps/web/app/lib/__tests__/signup-email-continuation.test.ts
+++ b/apps/web/app/lib/__tests__/signup-email-continuation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createEmailLinkContinuation } from '../signup-email-continuation'
+import type { AnnualOfferResponse, EmailOwnership } from '../billing-v2'
+
+const proof: EmailOwnership = {
+  contractVersion: 2, emailOwnershipToken: 'synthetic-proof', expiresAt: '2099-01-01T00:00:00Z',
+}
+const offer: AnnualOfferResponse = {
+  contractVersion: 2, requestId: 'e91a6d70-0d4e-4352-9bdc-426d1f76d771',
+  offer: { planId: 'early_annual', customerClass: 'early', billingInterval: 'annual', annualAmountMinor: 3600,
+    monthlyEquivalentMinor: 300, currency: 'EUR', providers: ['stripe', 'btcpay'], offerRevision: 1,
+    offerToken: 'synthetic-offer', expiresAt: '2099-01-01T00:00:00Z' },
+}
+
+describe('mounted email continuation', () => {
+  it('joins overlapping calls before consumption resolves', async () => {
+    let deliver!: (value: EmailOwnership) => void
+    const consume = vi.fn(() => new Promise<EmailOwnership>((resolve) => { deliver = resolve }))
+    const load = vi.fn(async () => offer)
+    const continuation = createEmailLinkContinuation(consume, load)
+    const first = continuation.load()
+    const second = continuation.load()
+    expect(second).toBe(first)
+    expect(consume).toHaveBeenCalledTimes(1)
+    expect(load).not.toHaveBeenCalled()
+    deliver(proof)
+    expect(await first).toEqual({ ownership: proof, offer })
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it('never automatically replays an ambiguous consumption failure', async () => {
+    const consume = vi.fn(async () => { throw new TypeError('Response lost') })
+    const load = vi.fn(async () => offer)
+    const continuation = createEmailLinkContinuation(consume, load)
+    await expect(continuation.load()).rejects.toThrow('Response lost')
+    await expect(continuation.load()).rejects.toThrow('Response lost')
+    expect(consume).toHaveBeenCalledTimes(1)
+    expect(load).not.toHaveBeenCalled()
+    expect(continuation.hasProof()).toBe(false)
+  })
+
+  it('does not load another offer after the retained proof expires', async () => {
+    const consume = vi.fn(async () => ({ ...proof, expiresAt: '2000-01-01T00:00:00Z' }))
+    const load = vi.fn(async () => { throw new TypeError('Offer unavailable') })
+    const continuation = createEmailLinkContinuation(consume, load)
+    await expect(continuation.load()).rejects.toThrow('Offer unavailable')
+    await expect(continuation.load()).rejects.toThrow('Request a new link')
+    expect(consume).toHaveBeenCalledTimes(1)
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/app/lib/signup-email-continuation.ts
+++ b/apps/web/app/lib/signup-email-continuation.ts
@@ -1,0 +1,29 @@
+import type { AnnualOfferResponse, EmailOwnership } from '@/app/lib/billing-v2'
+
+/** One mounted email-link lineage. Bearer proof stays in memory, never storage. */
+export function createEmailLinkContinuation(
+  consume: () => Promise<EmailOwnership>,
+  loadOffer: () => Promise<AnnualOfferResponse>,
+) {
+  let proof: EmailOwnership | null = null
+  let consumption: Promise<EmailOwnership> | null = null
+  let pending: Promise<{ ownership: EmailOwnership; offer: AnnualOfferResponse }> | null = null
+
+  return {
+    hasProof: () => proof !== null,
+    load() {
+      // Strict Mode effect replay and rapid retries must join the same request.
+      if (pending) return pending
+      const retrying = proof !== null
+      pending = (async () => {
+        consumption ??= consume()
+        proof = await consumption
+        if (retrying && Date.parse(proof.expiresAt) <= Date.now()) {
+          throw new Error('Email verification expired. Request a new link.')
+        }
+        return { ownership: proof, offer: await loadOffer() }
+      })().finally(() => { pending = null })
+      return pending
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Accept already-issued `/signup/verify-email` links using the annual signup consumer.
- Keep email ownership in memory while retrying offer loading, without consuming single-use links twice.
- Add fresh-link recovery for expired/interrupted verification and regression coverage for Strict Mode, unmounts, and missing browser context.

## Verification
- Full web suite: 1,020 passed; type-check and changed-file ESLint passed.
- Production build passed; standalone trace warning reproduced on unchanged base.
- Actual generated callback paths matched built route manifest.
- Independent review gate GREEN on the exact source; no Medium+ findings.

## Boundaries and follow-ups
- Not deployed; real-email through completed signup acceptance remains pending.
- Missing browser context still requires restarting verification; no seamless cross-device claim.
- Low-severity follow-ups: expired retained proof still displays Retry beside fresh-link recovery; compatibility route misses the layout terms footer; resend rejection copy is generic; post-plan expiry restart remains unchanged.
- No account, payment, entitlement, or production configuration changes.
