### PR TITLE
fix(web): accept signed signup and checkout authorities

### DIFF
--- a/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
+++ b/apps/web/app/(app)/settings/subscription/__tests__/page.test.tsx
@@ -1,3 +1,4 @@
+import { checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { act, render, screen, waitFor, fireEvent } from '@testing-library/react'
@@ -84,7 +85,7 @@ const annualOffer = {
 }
 const annualActivation = {
   contractVersion: 2,
-  checkoutIntentToken: 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG',
+  checkoutIntentToken: signedCheckoutIntent,
   expiresAt: '2026-08-10T12:05:00Z',
   disclosure: {
     kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,

--- a/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
@@ -1,3 +1,4 @@
+import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SignupPage from '../page'
@@ -9,7 +10,7 @@ vi.hoisted(() => {
 })
 
 const requestId = 'e91a6d70-0d4e-4352-9bdc-426d1f76d771'
-const ownershipToken = 'A'.repeat(43)
+const ownershipToken = signedEmailProof
 const offer = {
   contractVersion: 2,
   requestId,
@@ -177,7 +178,7 @@ describe('email-link seven-day no-card continuation', () => {
       }
       if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify(offer))
       if (url.endsWith('/auth/offers/v2/activate')) {
-        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: ownershipToken, expiresAt: '2026-08-11T12:05:00Z', disclosure: noCardDisclosure }))
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: noCardDisclosure }))
       }
       return new Response('{}', { status: 404 })
     }))
@@ -199,7 +200,7 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
     fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
 
-    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(ownershipToken))
+    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('customer@example.test', 'ValidPass1', undefined)
     expect(window.location.search).toContain('return_to=silentsuite')
     expect(fetch).toHaveBeenCalledTimes(3)
@@ -220,7 +221,7 @@ describe('email-link seven-day no-card continuation', () => {
       }
       if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify(offer))
       if (url.endsWith('/auth/offers/v2/activate')) {
-        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: ownershipToken, expiresAt: '2026-08-11T12:05:00Z', disclosure: noCardDisclosure }))
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: noCardDisclosure }))
       }
       return new Response('{}', { status: 404 })
     }))
@@ -239,7 +240,7 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
     fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
 
-    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(ownershipToken))
+    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('newtab@example.test', 'ValidPass1', undefined)
     // The consumed continuation must not outlive the funnel it authorized.
     expect(localStorage.getItem('silentsuite-signup-email-proof')).toBeNull()
@@ -328,7 +329,7 @@ describe('email-link seven-day no-card continuation', () => {
       if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify(standardOffer))
       if (url.endsWith('/auth/offers/v2/activate')) {
         return new Response(JSON.stringify({
-          contractVersion: 2, checkoutIntentToken: ownershipToken, expiresAt: '2026-08-11T12:05:00Z',
+          contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z',
           disclosure: { ...standardDisclosure, kind: 'card_trial', firstChargeAmountMinor: 4800, renewalAmountMinor: 4800, trialEndsAt: '2026-09-10T12:00:00Z', firstChargeAt: '2026-09-10T12:00:00Z', cancelBy: '2026-09-10T12:00:00Z', autoRenew: true, refundWindowDays: 30, periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2027-09-10T12:00:00Z', entitlementEndsAt: '2027-09-10T12:00:00Z' },
         }))
       }
@@ -372,7 +373,7 @@ describe('email-link seven-day no-card continuation', () => {
     expect(screen.getAllByText('2027-09-10 12:00 UTC')).toHaveLength(2)
     fireEvent.click(screen.getByRole('button', { name: /confirm annual terms and continue/i }))
     await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(
-      ownershipToken,
+      signedCheckoutIntent,
       'stripe',
       'http://localhost:3000/signup',
     ))
@@ -418,7 +419,7 @@ describe('email-link seven-day no-card continuation', () => {
             detail: 'The selected annual checkout is unavailable.',
           }), { status: 409 })
         }
-        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: ownershipToken, expiresAt: '2026-08-11T12:05:00Z', disclosure: { ...noCardDisclosure, annualAmountMinor: 4800, monthlyEquivalentMinor: 400 } }))
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: { ...noCardDisclosure, annualAmountMinor: 4800, monthlyEquivalentMinor: 400 } }))
       }
       return new Response('{}', { status: 404 })
     }))
@@ -446,7 +447,7 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
     fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
-    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(ownershipToken))
+    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('renew@example.test', 'ValidPass1', undefined)
   })
 

--- a/apps/web/app/(auth)/signup/pending-payment/__tests__/page.test.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/__tests__/page.test.tsx
@@ -1,3 +1,4 @@
+import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -278,7 +279,7 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
 })
 
 describe('PendingPaymentPage Bitcoin restart across the email navigation', () => {
-  const emailOwnershipToken = 'C'.repeat(43)
+  const emailOwnershipToken = signedEmailProof
   const rotatedRequestKey = '7c3f1a52-9a1e-4a1e-8b7c-2f4d6e8a0b12'
   const checkoutUrl = 'https://btcpay.silentsuite.io/i/restarted-invoice'
   const prepaidDisclosure = {
@@ -357,7 +358,7 @@ describe('PendingPaymentPage Bitcoin restart across the email navigation', () =>
       }
       if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify({ ...restartOffer, requestId: persisted.requestId }), { status: 200 })
       if (url.endsWith('/auth/offers/v2/activate')) {
-        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: emailOwnershipToken, expiresAt: '2026-08-11T12:05:00Z', disclosure: prepaidDisclosure }), { status: 200 })
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: prepaidDisclosure }), { status: 200 })
       }
       return new Response('{}', { status: 404 })
     }))
@@ -379,7 +380,7 @@ describe('PendingPaymentPage Bitcoin restart across the email navigation', () =>
     expect(screen.getByText(/does not renew automatically/i)).toBeInTheDocument()
     expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: /agree.*create bitcoin invoice/i }))
-    await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(emailOwnershipToken, 'btcpay', 'https://app.silentsuite.io/signup/pending-payment'))
+    await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(signedCheckoutIntent, 'btcpay', 'https://app.silentsuite.io/signup/pending-payment'))
     expect(screen.queryByText(/return to signup to verify your email/i)).not.toBeInTheDocument()
     expect(window.location.href).toBe(checkoutUrl)
     expect(sessionStorage.getItem('silentsuite-pending-crypto-invoice')).toBe('invoice-restarted')
@@ -419,7 +420,7 @@ describe('PendingPaymentPage Bitcoin restart across the email navigation', () =>
       const url = String(input)
       if (url.endsWith('/auth/signup-email-verifications/v2/consume')) return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken, expiresAt: '2026-08-11T12:05:00Z' }))
       if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify({ ...restartOffer, requestId }))
-      if (url.endsWith('/auth/offers/v2/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: emailOwnershipToken, expiresAt: '2026-08-11T12:05:00Z', disclosure: prepaidDisclosure }))
+      if (url.endsWith('/auth/offers/v2/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: prepaidDisclosure }))
       return new Response('{}', { status: 404 })
     }))
 

--- a/apps/web/app/components/__tests__/payment-choice-panel.test.tsx
+++ b/apps/web/app/components/__tests__/payment-choice-panel.test.tsx
@@ -1,3 +1,4 @@
+import { checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -74,7 +75,7 @@ describe('PaymentChoicePanel cancellation safety', () => {
       if (url.endsWith('/subscription/offers/v2')) return response(annualOffer)
       if (url.endsWith('/subscription/offers/v2/activate')) return response({
         contractVersion: 2,
-        checkoutIntentToken: 'A'.repeat(43),
+        checkoutIntentToken: signedCheckoutIntent,
         expiresAt: '2026-08-10T12:05:00Z',
         disclosure: {
           kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,
@@ -114,7 +115,7 @@ describe('PaymentChoicePanel cancellation safety', () => {
         return response({ ...annualOffer, requestId: offerReads === 1 ? annualOffer.requestId : '22222222-2222-4222-8222-222222222222' })
       }
       if (url.endsWith('/subscription/offers/v2/activate')) return response({
-        contractVersion: 2, checkoutIntentToken: 'A'.repeat(43), expiresAt: '2026-08-10T12:05:00Z',
+        contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-10T12:05:00Z',
         disclosure: {
           kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,
           monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null, cancelBy: null,

--- a/apps/web/app/components/__tests__/payment-flow-lifecycle.test.tsx
+++ b/apps/web/app/components/__tests__/payment-flow-lifecycle.test.tsx
@@ -1,3 +1,4 @@
+import { checkoutIntentToken } from '@/src/__tests__/fixtures/annual-authority'
 import React from 'react'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -85,7 +86,7 @@ const annualOffer = {
 
 const activation = {
   contractVersion: 2,
-  checkoutIntentToken: 'A'.repeat(43),
+  checkoutIntentToken,
   expiresAt: '2026-08-10T12:05:00Z',
   disclosure: {
     kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,

--- a/apps/web/app/components/__tests__/payment-provider-switching.test.tsx
+++ b/apps/web/app/components/__tests__/payment-provider-switching.test.tsx
@@ -1,3 +1,4 @@
+import { checkoutIntentToken } from '@/src/__tests__/fixtures/annual-authority'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
@@ -60,7 +61,7 @@ const stripeOnlyOffer = {
 
 const activation = {
   contractVersion: 2,
-  checkoutIntentToken: 'A'.repeat(43),
+  checkoutIntentToken,
   expiresAt: '2026-08-10T12:05:00Z',
   disclosure: {
     kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,

--- a/apps/web/app/lib/__tests__/billing-v2-signed-authority.test.ts
+++ b/apps/web/app/lib/__tests__/billing-v2-signed-authority.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import { checkoutIntentToken, emailOwnershipToken, signedAuthorityFixture } from '@/src/__tests__/fixtures/annual-authority'
+import { activateAnnualCheckout, activateAuthenticatedAnnualCheckout, consumeSignupEmailOwnership, getAnonymousPaymentSessionRecovery, startSignupAnnualPayment, type AnnualOfferResponse } from '../billing-v2'
+
+const requestId = 'e91a6d70-0d4e-4352-9bdc-426d1f76d771'
+const base = { billingApiUrl: 'https://billing.example.test', email: 'customer@example.test' }
+const offer: AnnualOfferResponse = { contractVersion: 2, requestId, offer: { planId: 'early_annual', customerClass: 'early', billingInterval: 'annual', annualAmountMinor: 3600, monthlyEquivalentMinor: 300, currency: 'EUR', providers: ['stripe', 'btcpay'], offerRevision: 1, offerToken: 'server-offer', expiresAt: '2026-08-11T12:10:00Z' } }
+const disclosure = { kind: 'prepaid', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: null, monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null, cancelBy: null, cancelByInclusive: false, autoRenew: false, prepaid: true, refundWindowDays: 30, bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null }
+const choice = { offer, trialPath: 'immediate' as const, provider: 'btcpay' as const, behavior: 'prepaid_bitcoin' as const }
+const json = (body: unknown) => async () => new Response(JSON.stringify(body))
+const proofResponse = (token: unknown) => ({ contractVersion: 2, emailOwnershipToken: token, expiresAt: '2026-08-11T12:15:00Z' })
+const activationResponse = (token: unknown) => ({ contractVersion: 2, checkoutIntentToken: token, expiresAt: '2026-08-11T12:05:00Z', disclosure })
+
+describe('signed authority versus opaque payment recovery wire profiles', () => {
+  it('accepts ephemeral ES256 email proof and both checkout activation paths', async () => {
+    await expect(consumeSignupEmailOwnership({ ...base, token: 'link-secret', fetcher: json(proofResponse(emailOwnershipToken)) })).resolves.toEqual(proofResponse(emailOwnershipToken))
+    await expect(activateAnnualCheckout({ ...base, ...choice, emailOwnershipToken, fetcher: json(activationResponse(checkoutIntentToken)) })).resolves.toEqual(activationResponse(checkoutIntentToken))
+    await expect(activateAuthenticatedAnnualCheckout({ ...base, ...choice, fetcher: json(activationResponse(checkoutIntentToken)) })).resolves.toEqual(activationResponse(checkoutIntentToken))
+  })
+
+  it.each(['email-ownership', 'checkout-intent'] as const)('rejects wrong profiles and malformed %s signed shape', async (profile) => {
+    const valid = profile === 'email-ownership' ? emailOwnershipToken : checkoutIntentToken
+    const [header, payload, signature] = valid.split('.')
+    const wrong = profile === 'email-ownership' ? checkoutIntentToken : emailOwnershipToken
+    const invalid: unknown[] = [null, 123, '', 'A'.repeat(43), wrong, 'arbitrary-string',
+      signedAuthorityFixture(profile, { alg: 'none' }), signedAuthorityFixture(profile, { typ: 'ss-offer+jwt' }),
+      signedAuthorityFixture(profile, { kid: '' }), signedAuthorityFixture(profile, { crit: ['unexpected'] }),
+      signedAuthorityFixture(profile, {}, { purpose: 'offer' }), signedAuthorityFixture(profile, {}, { aud: 'other' }),
+      signedAuthorityFixture(profile, {}, { iss: 'other' }), signedAuthorityFixture(profile, {}, { contractVersion: 1 }),
+      `${header}.${payload}`, `${header}..${signature}`, `${header}.${payload}.${signature}.extra`,
+      `${header}=.${payload}.${signature}`, `${header}.${payload}.AA`, `${header}.e30.${signature}`,
+      `${header}.${Buffer.from('not json').toString('base64url')}.${signature}`,
+      `${header}.${Buffer.from('[]').toString('base64url')}.${signature}`,
+      `${header}.${Buffer.from([0xff]).toString('base64url')}.${signature}`,
+      signedAuthorityFixture(profile, { kid: 'x'.repeat(1024) }), signedAuthorityFixture(profile, {}, { oversized: 'x'.repeat(8192) }),
+    ]
+    for (const token of invalid) {
+      if (profile === 'email-ownership') {
+        await expect(consumeSignupEmailOwnership({ ...base, token: 'link-secret', fetcher: json(proofResponse(token)) })).rejects.toThrow('valid email proof')
+      } else {
+        await expect(activateAnnualCheckout({ ...base, ...choice, emailOwnershipToken, fetcher: json(activationResponse(token)) })).rejects.toThrow('checkout authority')
+        await expect(activateAuthenticatedAnnualCheckout({ ...base, ...choice, fetcher: json(activationResponse(token)) })).rejects.toThrow('checkout authority')
+      }
+    }
+  })
+
+  it('retains closed response and timestamp validation', async () => {
+    for (const extra of [{ extra: true }, { contractVersion: 1 }, { expiresAt: 'not-a-date' }]) {
+      await expect(consumeSignupEmailOwnership({ ...base, token: 'link-secret', fetcher: json({ ...proofResponse(emailOwnershipToken), ...extra }) })).rejects.toThrow('valid email proof')
+      await expect(activateAuthenticatedAnnualCheckout({ ...base, ...choice, fetcher: json({ ...activationResponse(checkoutIntentToken), ...extra }) })).rejects.toThrow('checkout authority')
+    }
+  })
+
+  it.each(['stripe', 'btcpay'] as const)('keeps %s payment recovery opaque and bounded', async (kind) => {
+    for (const token of ['A'.repeat(43), 'A'.repeat(128), emailOwnershipToken, checkoutIntentToken, 'A'.repeat(42), 'A'.repeat(129), ' '.repeat(43)]) {
+      const valid = /^[A-Za-z0-9_-]{43,128}$/.test(token)
+      const payment = kind === 'stripe'
+        ? { contractVersion: 2, kind, clientSecret: 'pi_secret', paymentSessionToken: token }
+        : { contractVersion: 2, kind, cryptoCheckoutUrl: 'https://pay.example.test/invoice', cryptoInvoiceId: 'invoice', cryptoInvoiceLookupToken: token, paymentSessionToken: token }
+      const result = startSignupAnnualPayment({ ...base, checkoutIntentToken, requestKey: requestId, recoverySecret: token, wantsProductUpdates: false, rememberDevice: false, returnUrl: 'https://app.example.test/signup', fetcher: json(payment) })
+      if (valid) await expect(result).resolves.toEqual(payment)
+      else await expect(result).rejects.toThrow('valid payment session')
+      const fetcher = vi.fn(json({ contractVersion: 2, state: 'closed', flow: null }))
+      const recovery = getAnonymousPaymentSessionRecovery({ ...base, requestKey: requestId, paymentSessionToken: token, recoverySecret: token, fetcher })
+      if (valid) await expect(recovery).resolves.toMatchObject({ state: 'closed' })
+      else { await expect(recovery).rejects.toThrow('recovery context'); expect(fetcher).not.toHaveBeenCalled() }
+    }
+  })
+
+  it('rejects a signed Bitcoin lookup token even when payment recovery is opaque', async () => {
+    const recoverySecret = 'A'.repeat(43)
+    await expect(startSignupAnnualPayment({ ...base, checkoutIntentToken, requestKey: requestId, recoverySecret,
+      wantsProductUpdates: false, rememberDevice: false, returnUrl: 'https://app.example.test/signup',
+      fetcher: json({ contractVersion: 2, kind: 'btcpay', cryptoCheckoutUrl: 'https://pay.example.test/invoice',
+        cryptoInvoiceId: 'invoice', cryptoInvoiceLookupToken: emailOwnershipToken, paymentSessionToken: recoverySecret }),
+    })).rejects.toThrow('valid payment session')
+  })
+})

--- a/apps/web/app/lib/__tests__/billing-v2.test.ts
+++ b/apps/web/app/lib/__tests__/billing-v2.test.ts
@@ -1,3 +1,4 @@
+import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import { describe, expect, it, vi } from 'vitest'
 import { BillingResponseError, activateAnnualCheckout, activateAuthenticatedAnnualCheckout, buildSameOriginReturnUrl, cancelAnonymousPaymentSessionRecovery, consumeSignupEmailOwnership, fetchAnonymousAnnualOffer, fetchAuthenticatedAnnualOffer, getAnonymousPaymentSessionRecovery, isRenewableAnnualOfferError, reconcileAnonymousPaymentSessionRecovery, requestSignupEmailOwnership, startAuthenticatedAnnualPayment, startSignupAnnualPayment, type BillingV2Fetch } from '../billing-v2'
 
@@ -18,7 +19,7 @@ describe('billing v2 public authority client', () => {
 
   it('rejects relative payment return URLs before fetch', async () => {
     const fetcher = vi.fn<BillingV2Fetch>()
-    await expect(startAuthenticatedAnnualPayment({ fetcher, billingApiUrl: 'https://billing.example.test', checkoutIntentToken: token, expectedAuthorityId: requestId, returnUrl: '/settings/subscription' })).rejects.toThrow('absolute HTTP')
+    await expect(startAuthenticatedAnnualPayment({ fetcher, billingApiUrl: 'https://billing.example.test', checkoutIntentToken: signedCheckoutIntent, expectedAuthorityId: requestId, returnUrl: '/settings/subscription' })).rejects.toThrow('absolute HTTP')
     expect(fetcher).not.toHaveBeenCalled()
   })
 
@@ -26,35 +27,35 @@ describe('billing v2 public authority client', () => {
     const fetcher = vi.fn<BillingV2Fetch>().mockResolvedValue(new Response(JSON.stringify(offer), { status: 200 }))
     const returned = await fetchAnonymousAnnualOffer({ fetcher, billingApiUrl: 'https://billing.example.test', email: 'Customer@example.test', requestId })
     expect(returned).toEqual(offer)
-    fetcher.mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: token, expiresAt: '2026-08-10T12:05:00Z', disclosure: prepaidDisclosure }), { status: 200 }))
-    await activateAnnualCheckout({ fetcher, billingApiUrl: 'https://billing.example.test', offer: returned, email: 'Customer@example.test', emailOwnershipToken: token, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })
-    expect(JSON.parse(String(fetcher.mock.calls[1][1]?.body))).toEqual({ contractVersion: 2, offerToken: 'signed-offer', requestId, email: 'Customer@example.test', emailOwnershipToken: token, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })
+    fetcher.mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-10T12:05:00Z', disclosure: prepaidDisclosure }), { status: 200 }))
+    await activateAnnualCheckout({ fetcher, billingApiUrl: 'https://billing.example.test', offer: returned, email: 'Customer@example.test', emailOwnershipToken: signedEmailProof, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })
+    expect(JSON.parse(String(fetcher.mock.calls[1][1]?.body))).toEqual({ contractVersion: 2, offerToken: 'signed-offer', requestId, email: 'Customer@example.test', emailOwnershipToken: signedEmailProof, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })
   })
 
   it('fails closed for malformed offers, terms and provider identifiers', async () => {
     const fetcher = vi.fn<BillingV2Fetch>().mockResolvedValue(new Response(JSON.stringify({ ...offer, offer: { ...offer.offer, planId: 'early_monthly', annualAmountMinor: 3240, monthlyEquivalentMinor: 270 } }), { status: 200 }))
     await expect(fetchAnonymousAnnualOffer({ fetcher, billingApiUrl: 'https://billing.example.test', email: 'customer@example.test', requestId })).rejects.toThrow('annual offer')
-    fetcher.mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: token, expiresAt: '2026-08-10T12:05:00Z', disclosure: { kind: 'prepaid' } }), { status: 200 }))
-    await expect(activateAnnualCheckout({ fetcher, billingApiUrl: 'https://billing.example.test', offer, email: 'customer@example.test', emailOwnershipToken: token, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })).rejects.toThrow('terms')
+    fetcher.mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-10T12:05:00Z', disclosure: { kind: 'prepaid' } }), { status: 200 }))
+    await expect(activateAnnualCheckout({ fetcher, billingApiUrl: 'https://billing.example.test', offer, email: 'customer@example.test', emailOwnershipToken: signedEmailProof, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })).rejects.toThrow('terms')
   })
 
   it('uses the canonical closed email, signup and authenticated payment paths without a caller-selected provider', async () => {
     const fetcher = vi.fn<BillingV2Fetch>()
       .mockResolvedValueOnce(new Response('{}', { status: 202 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken: token, expiresAt: '2026-08-10T12:05:00Z' })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken: signedEmailProof, expiresAt: '2026-08-10T12:05:00Z' })))
       .mockResolvedValueOnce(new Response(JSON.stringify(offer)))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: token, expiresAt: '2026-08-10T12:05:00Z', disclosure: chargeNowDisclosure })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-10T12:05:00Z', disclosure: chargeNowDisclosure })))
       .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, kind: 'stripe', clientSecret: 'pi_secret', paymentSessionToken: token })))
       .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, kind: 'stripe', authorityId: requestKey, clientSecret: 'pi_secret' })))
     await requestSignupEmailOwnership({ fetcher, billingApiUrl: 'https://billing.example.test', email: 'customer@example.test', requestId })
     await consumeSignupEmailOwnership({ fetcher, billingApiUrl: 'https://billing.example.test', email: 'customer@example.test', token })
     const authenticatedOffer = await fetchAuthenticatedAnnualOffer({ fetcher, billingApiUrl: 'https://billing.example.test' })
     await activateAuthenticatedAnnualCheckout({ fetcher, billingApiUrl: 'https://billing.example.test', offer: authenticatedOffer, trialPath: 'immediate', provider: 'stripe', behavior: 'immediate_card' })
-    await startSignupAnnualPayment({ fetcher, billingApiUrl: 'https://billing.example.test', checkoutIntentToken: token, email: 'customer@example.test', requestKey, recoverySecret: token, wantsProductUpdates: true, rememberDevice: false, returnUrl: 'https://app.example.test/signup/success' })
-    await startAuthenticatedAnnualPayment({ fetcher, billingApiUrl: 'https://billing.example.test', checkoutIntentToken: token, expectedAuthorityId: requestKey, returnUrl: 'https://app.example.test/settings/subscription' })
+    await startSignupAnnualPayment({ fetcher, billingApiUrl: 'https://billing.example.test', checkoutIntentToken: signedCheckoutIntent, email: 'customer@example.test', requestKey, recoverySecret: token, wantsProductUpdates: true, rememberDevice: false, returnUrl: 'https://app.example.test/signup/success' })
+    await startAuthenticatedAnnualPayment({ fetcher, billingApiUrl: 'https://billing.example.test', checkoutIntentToken: signedCheckoutIntent, expectedAuthorityId: requestKey, returnUrl: 'https://app.example.test/settings/subscription' })
     expect(fetcher.mock.calls.map(([url]) => url)).toEqual(['https://billing.example.test/auth/signup-email-verifications/v2', 'https://billing.example.test/auth/signup-email-verifications/v2/consume', 'https://billing.example.test/subscription/offers/v2', 'https://billing.example.test/subscription/offers/v2/activate', 'https://billing.example.test/auth/signup/payment-session/v2', 'https://billing.example.test/subscription/payment-flows/v2'])
-    expect(JSON.parse(String(fetcher.mock.calls[4][1]?.body))).toEqual({ contractVersion: 2, checkoutIntentToken: token, email: 'customer@example.test', requestKey, recoverySecret: token, wantsProductUpdates: true, rememberDevice: false, returnUrl: 'https://app.example.test/signup/success' })
-    expect(JSON.parse(String(fetcher.mock.calls[5][1]?.body))).toEqual({ contractVersion: 2, checkoutIntentToken: token, returnUrl: 'https://app.example.test/settings/subscription' })
+    expect(JSON.parse(String(fetcher.mock.calls[4][1]?.body))).toEqual({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, email: 'customer@example.test', requestKey, recoverySecret: token, wantsProductUpdates: true, rememberDevice: false, returnUrl: 'https://app.example.test/signup/success' })
+    expect(JSON.parse(String(fetcher.mock.calls[5][1]?.body))).toEqual({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, returnUrl: 'https://app.example.test/settings/subscription' })
   })
 
   it.each([
@@ -69,7 +70,7 @@ describe('billing v2 public authority client', () => {
     await expect(startAuthenticatedAnnualPayment({
       fetcher,
       billingApiUrl: 'https://billing.example.test',
-      checkoutIntentToken: token,
+      checkoutIntentToken: signedCheckoutIntent,
       expectedAuthorityId: requestId,
       returnUrl: 'https://app.example.test/settings/subscription',
     })).rejects.toThrow('another annual authority')
@@ -118,7 +119,7 @@ describe('billing v2 public authority client', () => {
     await expect(startSignupAnnualPayment({
       fetcher,
       billingApiUrl: 'https://billing.example.test',
-      checkoutIntentToken: token,
+      checkoutIntentToken: signedCheckoutIntent,
       email: 'customer@example.test',
       requestKey,
       recoverySecret: token,
@@ -140,7 +141,7 @@ describe('billing v2 public authority client', () => {
     await expect(startSignupAnnualPayment({
       fetcher,
       billingApiUrl: 'https://billing.example.test',
-      checkoutIntentToken: token,
+      checkoutIntentToken: signedCheckoutIntent,
       email: 'customer@example.test',
       requestKey,
       recoverySecret: token,

--- a/apps/web/app/lib/__tests__/injected-fetch-receiver.test.ts
+++ b/apps/web/app/lib/__tests__/injected-fetch-receiver.test.ts
@@ -1,3 +1,4 @@
+import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import { describe, expect, it } from 'vitest'
 import {
   activateAnnualCheckout,
@@ -22,7 +23,7 @@ const token = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG'
 const email = 'customer@example.test'
 const offer = { contractVersion: 2, requestId, offer: { planId: 'early_annual', customerClass: 'early', billingInterval: 'annual', annualAmountMinor: 3600, monthlyEquivalentMinor: 300, currency: 'EUR', providers: ['stripe', 'btcpay'], offerRevision: 1, offerToken: 'signed-offer', expiresAt: '2026-08-10T12:10:00Z' } }
 const disclosure = { kind: 'prepaid', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: null, monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null, cancelBy: null, cancelByInclusive: false, autoRenew: false, prepaid: true, refundWindowDays: 30, bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null }
-const activation = { contractVersion: 2, checkoutIntentToken: token, expiresAt: '2026-08-10T12:05:00Z', disclosure }
+const activation = { contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-10T12:05:00Z', disclosure }
 const recovery = { contractVersion: 2, state: 'open', flow: { provider: 'btcpay', status: 'provider_pending' } }
 
 function json(body: unknown, status = 200) {
@@ -50,13 +51,13 @@ const recoveryParams = (fetcher: BillingV2Fetch) => ({ fetcher, billingApiUrl, p
 
 const cases: ReadonlyArray<readonly [string, () => Response, (fetcher: BillingV2Fetch) => Promise<unknown>]> = [
   ['fetchAnonymousAnnualOffer', () => json(offer), fetcher => fetchAnonymousAnnualOffer({ fetcher, billingApiUrl, email, requestId })],
-  ['activateAnnualCheckout', () => json(activation), fetcher => activateAnnualCheckout({ fetcher, billingApiUrl, offer, email, emailOwnershipToken: token, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })],
+  ['activateAnnualCheckout', () => json(activation), fetcher => activateAnnualCheckout({ fetcher, billingApiUrl, offer, email, emailOwnershipToken: signedEmailProof, trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin' })],
   ['requestSignupEmailOwnership', () => new Response('{}', { status: 202 }), fetcher => requestSignupEmailOwnership({ fetcher, billingApiUrl, email, requestId })],
-  ['consumeSignupEmailOwnership', () => json({ contractVersion: 2, emailOwnershipToken: token, expiresAt: '2026-08-10T12:05:00Z' }), fetcher => consumeSignupEmailOwnership({ fetcher, billingApiUrl, email, token })],
+  ['consumeSignupEmailOwnership', () => json({ contractVersion: 2, emailOwnershipToken: signedEmailProof, expiresAt: '2026-08-10T12:05:00Z' }), fetcher => consumeSignupEmailOwnership({ fetcher, billingApiUrl, email, token })],
   ['fetchAuthenticatedAnnualOffer', () => json(offer), fetcher => fetchAuthenticatedAnnualOffer({ fetcher, billingApiUrl })],
   ['activateAuthenticatedAnnualCheckout', () => json(activation), fetcher => activateAuthenticatedAnnualCheckout({ fetcher, billingApiUrl, offer, trialPath: 'immediate', provider: 'stripe', behavior: 'immediate_card' })],
-  ['startSignupAnnualPayment', () => json({ contractVersion: 2, kind: 'stripe', clientSecret: 'pi_secret', paymentSessionToken: token }), fetcher => startSignupAnnualPayment({ fetcher, billingApiUrl, checkoutIntentToken: token, email, requestKey, recoverySecret: token, wantsProductUpdates: true, rememberDevice: false, returnUrl: 'https://app.example.test/signup/success' })],
-  ['startAuthenticatedAnnualPayment', () => json({ contractVersion: 2, kind: 'stripe', authorityId: requestKey, clientSecret: 'pi_secret' }), fetcher => startAuthenticatedAnnualPayment({ fetcher, billingApiUrl, checkoutIntentToken: token, expectedAuthorityId: requestKey, returnUrl: 'https://app.example.test/settings/subscription' })],
+  ['startSignupAnnualPayment', () => json({ contractVersion: 2, kind: 'stripe', clientSecret: 'pi_secret', paymentSessionToken: token }), fetcher => startSignupAnnualPayment({ fetcher, billingApiUrl, checkoutIntentToken: signedCheckoutIntent, email, requestKey, recoverySecret: token, wantsProductUpdates: true, rememberDevice: false, returnUrl: 'https://app.example.test/signup/success' })],
+  ['startAuthenticatedAnnualPayment', () => json({ contractVersion: 2, kind: 'stripe', authorityId: requestKey, clientSecret: 'pi_secret' }), fetcher => startAuthenticatedAnnualPayment({ fetcher, billingApiUrl, checkoutIntentToken: signedCheckoutIntent, expectedAuthorityId: requestKey, returnUrl: 'https://app.example.test/settings/subscription' })],
   ['getAnonymousPaymentSessionRecovery', () => json(recovery), fetcher => getAnonymousPaymentSessionRecovery(recoveryParams(fetcher))],
   ['cancelAnonymousPaymentSessionRecovery', () => json(recovery), fetcher => cancelAnonymousPaymentSessionRecovery(recoveryParams(fetcher))],
   ['reconcileAnonymousPaymentSessionRecovery', () => json(recovery), fetcher => reconcileAnonymousPaymentSessionRecovery(recoveryParams(fetcher))],

--- a/apps/web/app/lib/billing-v2.ts
+++ b/apps/web/app/lib/billing-v2.ts
@@ -123,6 +123,40 @@ function isUtcTimestamp(value: unknown): value is string {
 function isNullableTimestamp(value: unknown): value is string | null { return value === null || isUtcTimestamp(value) }
 function isUuid(value: unknown): value is string { return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value) }
 function isRecoveryToken(value: unknown): value is string { return typeof value === 'string' && /^[A-Za-z0-9_-]{43,128}$/.test(value) }
+
+/**
+ * Transport/profile validation only, NOT signature verification. Billing's
+ * HostedOfferAuthority verifies signatures, time, subject and request binding.
+ * Signed authorities are compact ES256 JWS; payment recovery stays opaque.
+ */
+function isSignedAuthorityToken(value: unknown, profile: 'email-ownership' | 'checkout-intent'): value is string {
+  // Bound decoding work before parsing untrusted JSON. Current closed profiles
+  // fit comfortably below 8 KiB, including the larger checkout schedule.
+  if (typeof value !== 'string' || value.length > 8192) return false
+  const parts = value.split('.')
+  if (parts.length !== 3 || parts[0].length > 1024 || parts[2].length !== 86) return false
+  try {
+    const decoded = parts.map(part => {
+      if (!/^[A-Za-z0-9_-]+$/.test(part)) throw new Error('Invalid JWS encoding')
+      const bytes = atob(part.replace(/-/g, '+').replace(/_/g, '/'))
+      // Reject padding and noncanonical trailing bits, including the signature.
+      if (btoa(bytes).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_') !== part) throw new Error('Invalid JWS encoding')
+      return Uint8Array.from(bytes, character => character.charCodeAt(0))
+    })
+    const decoder = new TextDecoder('utf-8', { fatal: true })
+    const header: unknown = JSON.parse(decoder.decode(decoded[0]))
+    const payload: unknown = JSON.parse(decoder.decode(decoded[1]))
+    const checkout = profile === 'checkout-intent'
+    return isObject(header) && hasExactKeys(header, ['alg', 'typ', 'kid'])
+      && header.alg === 'ES256' && header.typ === `ss-${profile}+jwt`
+      && typeof header.kid === 'string' && header.kid.length > 0
+      && decoded[2].length === 64 && isObject(payload)
+      && payload.iss === 'silentsuite-billing'
+      && payload.aud === (checkout ? 'silentsuite-billing-checkout' : 'silentsuite-billing-signup-email-ownership')
+      && payload.purpose === (checkout ? 'checkout_intent' : 'email_ownership')
+      && payload.contractVersion === 2
+  } catch { return false }
+}
 function isHttpsUrl(value: unknown): value is string { try { return typeof value === 'string' && new URL(value).protocol === 'https:' } catch { return false } }
 function requireAbsoluteHttpUrl(value: string): string {
   let url: URL
@@ -165,7 +199,7 @@ export function assertAnnualDisclosure(value: unknown): asserts value is AnnualD
 }
 
 function assertActivation(value: unknown): asserts value is AnnualCheckoutActivation {
-  if (!isObject(value) || !hasExactKeys(value, ['contractVersion', 'checkoutIntentToken', 'expiresAt', 'disclosure']) || value.contractVersion !== 2 || !isRecoveryToken(value.checkoutIntentToken) || !isUtcTimestamp(value.expiresAt)) throw new Error('Billing did not return a valid annual checkout authority')
+  if (!isObject(value) || !hasExactKeys(value, ['contractVersion', 'checkoutIntentToken', 'expiresAt', 'disclosure']) || value.contractVersion !== 2 || !isSignedAuthorityToken(value.checkoutIntentToken, 'checkout-intent') || !isUtcTimestamp(value.expiresAt)) throw new Error('Billing did not return a valid annual checkout authority')
   assertAnnualDisclosure(value.disclosure)
 }
 
@@ -221,7 +255,7 @@ export async function requestSignupEmailOwnership(params: { fetcher: BillingV2Fe
 export async function consumeSignupEmailOwnership(params: { fetcher: BillingV2Fetch; billingApiUrl: string; email: string; token: string }): Promise<EmailOwnership> {
   const { fetcher } = params
   const body = await jsonOrThrow(await fetcher(api(params.billingApiUrl, '/auth/signup-email-verifications/v2/consume'), jsonInit('POST', { contractVersion: 2, email: params.email, token: params.token })))
-  if (!isObject(body) || !hasExactKeys(body, ['contractVersion', 'emailOwnershipToken', 'expiresAt']) || body.contractVersion !== 2 || !isRecoveryToken(body.emailOwnershipToken) || !isUtcTimestamp(body.expiresAt)) throw new Error('Billing did not return valid email proof')
+  if (!isObject(body) || !hasExactKeys(body, ['contractVersion', 'emailOwnershipToken', 'expiresAt']) || body.contractVersion !== 2 || !isSignedAuthorityToken(body.emailOwnershipToken, 'email-ownership') || !isUtcTimestamp(body.expiresAt)) throw new Error('Billing did not return valid email proof')
   return body as unknown as EmailOwnership
 }
 

--- a/apps/web/src/__tests__/fixtures/annual-authority.ts
+++ b/apps/web/src/__tests__/fixtures/annual-authority.ts
@@ -1,0 +1,30 @@
+import { generateKeyPairSync, sign } from 'node:crypto'
+
+// Test-only, ephemeral ES256 signatures. Matches HostedOfferAuthority's compact
+// JWS profile; no production key or signing code is imported into the browser.
+const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'prime256v1' })
+export function signedAuthorityFixture(profile: 'email-ownership' | 'checkout-intent', headerOverrides: Record<string, unknown> = {}, payloadOverrides: Record<string, unknown> = {}): string {
+  const checkout = profile === 'checkout-intent'
+  const header = { alg: 'ES256', typ: `ss-${profile}+jwt`, kid: 'ephemeral-test', ...headerOverrides }
+  const payload = {
+    ...(checkout ? {
+      parentOfferJti: 'b56f3600-c799-4bb6-bd57-a07a5c717f3a', planId: 'early_annual', customerClass: 'early',
+      billingInterval: 'annual', annualAmountMinor: 3600, monthlyEquivalentMinor: 300, currency: 'EUR',
+      provider: 'btcpay', trialPath: 'immediate', behavior: 'prepaid_bitcoin', offerRevision: 1,
+      kind: 'prepaid', firstChargeAmountMinor: 3600, renewalAmountMinor: null, trialEndsAt: null,
+      firstChargeAt: null, cancelBy: null, cancelByInclusive: false, autoRenew: false, prepaid: true,
+      refundWindowDays: 30, bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year',
+      renewalAt: null, entitlementEndsAt: null,
+    } : {}),
+    purpose: checkout ? 'checkout_intent' : 'email_ownership', contractVersion: 2,
+    subjectKeyVersion: 1, requestId: 'e91a6d70-0d4e-4352-9bdc-426d1f76d771',
+    iss: 'silentsuite-billing', aud: checkout ? 'silentsuite-billing-checkout' : 'silentsuite-billing-signup-email-ownership',
+    sub: 'S'.repeat(43), jti: 'a2c4f872-01b7-4176-8325-522486b20cae',
+    iat: 1786449600, nbf: 1786449600, exp: 1786449600 + (checkout ? 300 : 900),
+    ...payloadOverrides,
+  }
+  const signingInput = [header, payload].map(value => Buffer.from(JSON.stringify(value)).toString('base64url')).join('.')
+  return `${signingInput}.${sign('sha256', Buffer.from(signingInput), { key: privateKey, dsaEncoding: 'ieee-p1363' }).toString('base64url')}`
+}
+export const emailOwnershipToken = signedAuthorityFixture('email-ownership')
+export const checkoutIntentToken = signedAuthorityFixture('checkout-intent')


### PR DESCRIPTION
## Summary
- Accept Billing's signed email-ownership and checkout-intent wire profiles instead of treating them as short opaque recovery secrets.
- Preserve strict payment recovery validation, closed responses, and server-side signature/subject/request verification.
- Exercise real-format signed fixtures across signup continuation and sibling checkout/payment paths.

Follow-up to #721: verification delivery and routing succeeded, but the client rejected the successful verification response before loading trial options.

## Verification
- Independent source review: APPROVE; final reviewed file hashes matched this commit.
- Web: 1,027 tests passed; type-check, lint, and production build passed (existing lint warnings).
- Local ephemeral actual-signer/client reproduction passed for ownership, both activation paths, one-use continuation, and server rejection of forgery/wrong lineage. No live API responses were mocked as production evidence.
- No production deployment or completed live signup claimed. Final delivered-email → no-card trial → workspace → logout/login QA remains after deployment.

## Scope
Only client response validation and tests. No backend authorization, recovery-secret format, billing terms, storage, or payment side effects changed.
