### PR TITLE
fix(signup): preserve recovery and verify completion sessions

### DIFF
--- a/apps/web/app/(auth)/signup/__tests__/annual-confirmation-summary.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/annual-confirmation-summary.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { AnnualDisclosure } from '@/app/lib/billing-v2'
+import { AnnualConfirmationSummary } from '../components/annual-confirmation-summary'
+
+const base: AnnualDisclosure = {
+  kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,
+  monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null,
+  cancelBy: null, cancelByInclusive: false, autoRenew: true, prepaid: false, refundWindowDays: 30,
+  bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null,
+}
+describe('server-disclosed confirmation copy', () => {
+  it('never promises no charge for immediate Stripe payment', () => {
+    render(<AnnualConfirmationSummary disclosure={base} />)
+    expect(screen.getByText(/Pay €36.00 now by card/)).toBeInTheDocument()
+    expect(screen.queryByText(/No charge today/)).not.toBeInTheDocument()
+    expect(screen.queryByText('Not applicable')).not.toBeInTheDocument()
+    expect(screen.getByText(/one year after payment confirmation/)).toBeInTheDocument()
+  })
+  it('describes Bitcoin as prepaid without renewal or fake dates', () => {
+    render(<AnnualConfirmationSummary disclosure={{ ...base, kind: 'prepaid', prepaid: true, autoRenew: false, renewalAmountMinor: null, bonusDays: 14 }} />)
+    expect(screen.getByText(/Pay €36.00 in Bitcoin/)).toHaveTextContent('No automatic renewal')
+    expect(screen.getByText(/plus 14 bonus days/)).toBeInTheDocument()
+    expect(screen.queryByText('Cancel before')).not.toBeInTheDocument()
+    expect(screen.queryByText('Not applicable')).not.toBeInTheDocument()
+  })
+  it('shows card-trial amount, exact charge deadline and no charge today', () => {
+    render(<AnnualConfirmationSummary disclosure={{ ...base, kind: 'card_trial', firstChargeAt: '2099-09-10T12:00:00Z', cancelBy: '2099-09-10T12:00:00Z' }} />)
+    expect(screen.getByText(/No charge today/)).toBeInTheDocument()
+    expect(screen.getAllByText('2099-09-10 12:00 UTC')).toHaveLength(2)
+    expect(screen.getByText('After your trial')).toBeInTheDocument()
+  })
+  it('keeps the no-card review limited to free terms', () => {
+    render(<AnnualConfirmationSummary disclosure={{ ...base, kind: 'no_auto_charge', firstChargeAmountMinor: 0, renewalAmountMinor: null, autoRenew: false, refundWindowDays: null, entitlementEndsAt: '2099-09-10T12:00:00Z' }} />)
+    expect(screen.getByText(/7-day free trial/)).toHaveTextContent('No automatic charge or renewal')
+    expect(screen.getByText('Free until')).toBeInTheDocument()
+    expect(screen.queryByText('Payment')).not.toBeInTheDocument()
+    expect(screen.queryByText('Not applicable')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/app/(auth)/signup/__tests__/completed-redirect-session.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/completed-redirect-session.test.tsx
@@ -1,0 +1,114 @@
+import { StrictMode } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SignupSuccessPage from '../success/page'
+import { useAuthStore } from '@/app/stores/use-auth-store'
+
+const mocks = vi.hoisted(() => ({ session: null as string | null, proof: vi.fn(), login: vi.fn(), signup: vi.fn(), push: vi.fn() }))
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }), useSearchParams: () => new URLSearchParams('setup_intent=setup-test&redirect_status=succeeded') }))
+vi.mock('../commercial-funnel-analytics', () => ({ CheckoutReturnAnalytics: () => null }))
+vi.mock('../components/step-create-vault', () => ({ StepCreateVault: ({ onComplete }: { onComplete: () => void }) => <button onClick={onComplete}>Complete vault</button> }))
+vi.mock('../components/step-create-paid-account', () => ({ StepCreatePaidAccount: () => <div>Create new account step</div> }))
+vi.mock('@/app/lib/secure-storage', () => ({
+  secureGet: vi.fn(async () => mocks.session),
+  secureSet: vi.fn(async (_key: string, value: string) => { mocks.session = value }),
+  secureRemove: vi.fn(), secureClear: vi.fn(), migrateFromLocalStorage: vi.fn(),
+}))
+vi.mock('@/app/lib/etebase-auth', () => ({ etebaseSignUp: mocks.signup, etebaseLogIn: mocks.login, issueBillingLinkProof: mocks.proof }))
+vi.mock('@/app/lib/self-hosted', () => ({ isSelfHosted: false, isCustomServer: (url?: string) => !!url && url !== 'https://server.silentsuite.io' }))
+const email = 'receipt@example.test'
+const id = 'completed-user'
+const profile = { id, email, isAdmin: false, rememberDevice: false, emailVerified: true }
+const key = 'silentsuite-signup-redirect-state'
+const json = (data: unknown, status = 200) => new Response(JSON.stringify(data), { status })
+function saveReceipt(completed = true, serverUrl?: string) {
+  useAuthStore.setState({ pendingSignup: {
+    email, serverUrl, paymentSessionToken: 'historical-payment-capability', billingContractVersion: 1,
+    ...(completed ? { provisionedUser: { id, planId: 'historical-plan', isAdmin: false }, provisionedSubscriptionStatus: 'active', billingSessionUserId: id } : {}),
+  } })
+  useAuthStore.getState().saveSignupStateForRedirect('annual')
+  expect(sessionStorage.getItem(key)).not.toContain('billingSessionUserId')
+  useAuthStore.setState({ pendingSignup: null })
+}
+beforeEach(() => {
+  vi.clearAllMocks()
+  sessionStorage.clear(); localStorage.clear()
+  useAuthStore.setState({ pendingSignup: null, user: null, isAuthenticated: false, isLoading: false, error: null, subscriptionStatus: null })
+  mocks.session = 'restored-encrypted-session'
+  mocks.login.mockReset()
+  let sequence = 0
+  mocks.proof.mockImplementation(async () => `fresh-proof-${++sequence}`)
+  vi.stubGlobal('fetch', vi.fn(async () => json(profile)))
+})
+describe('completed historical redirect session recovery', () => {
+  it('verifies fresh session authority before vault, including StrictMode replay', async () => {
+    saveReceipt()
+    // Parser must also discard a forged historical attestation.
+    const snapshot = JSON.parse(sessionStorage.getItem(key)!)
+    snapshot.pendingSignup.billingSessionUserId = id
+    sessionStorage.setItem(key, JSON.stringify(snapshot))
+    render(<StrictMode><SignupSuccessPage /></StrictMode>)
+    expect(screen.queryByText('Complete vault')).not.toBeInTheDocument()
+    fireEvent.click(await screen.findByText('Complete vault'))
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+    expect(mocks.push).toHaveBeenCalledWith('/')
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual(['/auth/token-exchange', '/auth/session'])
+    expect(mocks.proof).toHaveBeenCalledWith('restored-encrypted-session', undefined)
+    expect(mocks.signup).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem(key)).toBeNull()
+  })
+  it.each(['exchange', 'identity'])('shows %s failure and retries session only with a fresh proof', async (failure) => {
+    saveReceipt()
+    let fail = true
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const session = String(url).endsWith('/auth/session')
+      return fail ? (failure === 'exchange' ? json({}, 503) : json(session ? { ...profile, id: 'wrong-user' } : profile)) : json(profile)
+    })
+    render(<SignupSuccessPage />)
+    expect(await screen.findByRole('alert')).toHaveTextContent(/session/i)
+    expect(screen.queryByText('Complete vault')).not.toBeInTheDocument()
+    expect(useAuthStore.getState().pendingSignup?.provisionedUser?.id).toBe(id)
+    expect(() => useAuthStore.getState().completeSignup()).toThrow(/session/i)
+    fail = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry sign in' }))
+    await screen.findByText('Complete vault')
+    expect(mocks.proof).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(fetch).mock.calls.every(([url]) => /\/auth\/(token-exchange|session)$/.test(String(url)))).toBe(true)
+    useAuthStore.getState().saveSignupStateForRedirect('annual')
+    expect(sessionStorage.getItem(key)).not.toContain('billingSessionUserId')
+    expect(mocks.signup).not.toHaveBeenCalled()
+  })
+  it('recovers missing credentials by existing-account login, with visible wrong-password retry', async () => {
+    saveReceipt()
+    mocks.session = null
+    mocks.login.mockRejectedValueOnce(new Error('Invalid credentials')).mockResolvedValueOnce({ savedSession: 'recovered-session', authToken: 'unused' })
+    render(<SignupSuccessPage />)
+    expect(await screen.findByRole('alert')).toHaveTextContent('Enter your existing account password')
+    expect(fetch).not.toHaveBeenCalled()
+    fireEvent.change(screen.getByLabelText('Existing account password'), { target: { value: 'wrong-password' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Retry sign in' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Check your existing account password')
+    fireEvent.change(screen.getByLabelText('Existing account password'), { target: { value: 'correct-password' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Retry sign in' }))
+    await screen.findByText('Complete vault')
+    expect(mocks.login).toHaveBeenLastCalledWith(email, 'correct-password', undefined)
+    expect(mocks.signup).not.toHaveBeenCalled()
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual(['/auth/token-exchange', '/auth/session'])
+    expect(sessionStorage.getItem(key)).toBeNull()
+  })
+  it('keeps uncompleted 3DS on account creation without session replay', async () => {
+    saveReceipt(false)
+    render(<SignupSuccessPage />)
+    await screen.findByText('Create new account step')
+    expect(fetch).not.toHaveBeenCalled()
+    expect(mocks.proof).not.toHaveBeenCalled()
+  })
+  it('does not require hosted Billing for a completed custom-server account', async () => {
+    saveReceipt(true, 'https://custom.example.test')
+    render(<SignupSuccessPage />)
+    fireEvent.click(await screen.findByText('Complete vault'))
+    await waitFor(() => expect(useAuthStore.getState().isAuthenticated).toBe(true))
+    expect(fetch).not.toHaveBeenCalled()
+    expect(mocks.proof).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
@@ -1,5 +1,5 @@
-import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent, signedAuthorityFixture } from '@/src/__tests__/fixtures/annual-authority'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { BillingResponseError } from '@/app/lib/billing-v2'
 import SignupPage from '../page'
@@ -131,13 +131,13 @@ describe('email-link seven-day no-card continuation', () => {
     } finally { clock.mockRestore() }
   })
 
-  async function openConfirmation(provider: 'none' | 'stripe') {
+  async function openConfirmation(provider: 'none' | 'stripe' | 'btcpay', checkoutToken = signedCheckoutIntent) {
     localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
       [requestId]: { email: 'expiry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
     }))
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
       if (String(input).endsWith('/consume')) return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken: ownershipToken, expiresAt: '2099-01-01T00:00:00Z' }))
-      if (String(input).endsWith('/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2099-01-01T00:00:00Z', disclosure: provider === 'none' ? noCardDisclosure : { ...noCardDisclosure, kind: 'card_trial', firstChargeAmountMinor: 3600, renewalAmountMinor: 3600, firstChargeAt: noCardDisclosure.trialEndsAt, cancelBy: noCardDisclosure.trialEndsAt, autoRenew: true, refundWindowDays: 30, periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2099-09-10T12:00:00Z', entitlementEndsAt: '2099-09-10T12:00:00Z' } }))
+      if (String(input).endsWith('/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: checkoutToken, expiresAt: '2099-01-01T00:00:00Z', disclosure: provider === 'none' ? noCardDisclosure : provider === 'btcpay' ? { ...noCardDisclosure, kind: 'prepaid', firstChargeAmountMinor: 3600, trialEndsAt: null, prepaid: true, refundWindowDays: 30, periodEndRule: 'confirmation_plus_1_utc_calendar_year', entitlementEndsAt: null } : { ...noCardDisclosure, kind: 'card_trial', firstChargeAmountMinor: 3600, renewalAmountMinor: 3600, firstChargeAt: noCardDisclosure.trialEndsAt, cancelBy: noCardDisclosure.trialEndsAt, autoRenew: true, refundWindowDays: 30, periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2099-09-10T12:00:00Z', entitlementEndsAt: '2099-09-10T12:00:00Z' } }))
       return new Response(JSON.stringify(offer))
     }))
     window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
@@ -150,8 +150,184 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(await screen.findByRole('button', { name: provider === 'none' ? /7 day free trial/i : /30-day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
     if (provider === 'stripe') fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
+    if (provider === 'btcpay') fireEvent.click(await screen.findByRole('button', { name: /^pay .* with bitcoin for/i }))
     return screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i })
   }
+
+  it.each(['none', 'stripe', 'btcpay'] as const)('explicitly cancels %s review with single-flight response-loss retry and fresh consent', async (provider) => {
+    await openConfirmation(provider)
+    const previousFetch = vi.mocked(fetch).getMockImplementation()!
+    const successorToken = signedAuthorityFixture('checkout-intent', {}, { jti: '885a9c19-3e5e-4462-b4c1-1c32fc7ac612' })
+    let release: ((response: Response) => void) | undefined
+    let cancels = 0
+    const payloads: unknown[] = []
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/cancel')) {
+        payloads.push(JSON.parse(String(init?.body)))
+        cancels++
+        if (cancels === 1) throw new Error('response lost')
+        return new Promise<Response>((resolve) => { release = resolve })
+      }
+      if (String(input).endsWith('/activate')) {
+        expect(JSON.parse(String(init?.body)).requestId).toBe(requestId)
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: successorToken,
+          expiresAt: '2099-01-01T00:00:00Z', disclosure: noCardDisclosure }))
+      }
+      return previousFetch(input, init)
+    }))
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+    expect(cancels).toBe(0)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel this selection and choose again' }))
+    expect(cancels).toBe(0)
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm cancellation' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Cancellation is not confirmed')
+    expect(screen.queryByRole('button', { name: 'Return to current selection' })).not.toBeInTheDocument()
+    const retry = screen.getByRole('button', { name: 'Retry cancellation' })
+    fireEvent.click(retry)
+    fireEvent.click(retry)
+    expect(cancels).toBe(2)
+    expect(payloads[0]).toEqual(payloads[1])
+    expect(screen.queryByRole('button', { name: /^back$/i })).not.toBeInTheDocument()
+    await act(async () => { window.dispatchEvent(new PopStateEvent('popstate', { state: { silentsuiteSignup: { version: 1, journey: 'other', phase: 'review', step: 'verifiedAccount', view: 'cards' } } })) })
+    expect(screen.getByRole('heading', { name: 'Cancel this selection?' })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
+    await act(async () => { release!(new Response(JSON.stringify({ contractVersion: 2, requestId,
+      checkoutIntentJti: 'a2c4f872-01b7-4176-8325-522486b20cae', state: 'released' }))) })
+    expect(screen.queryByRole('button', { name: 'Return to current selection' })).not.toBeInTheDocument()
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
+    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    await screen.findByRole('button', { name: /create account and start free trial/i })
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(authState.prepareSignupDraft).toHaveBeenCalledTimes(1)
+    const consent = screen.getByRole('button', { name: /create account and start free trial/i })
+    fireEvent.click(consent)
+    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(successorToken))
+    expect(authState.createEtebaseAccount).toHaveBeenCalledWith('expiry@example.test', 'ValidPass1', undefined)
+  })
+
+  it('ignores an independently delayed cancellation response from an unmounted predecessor', async () => {
+    await openConfirmation('none')
+    let deliverOldResponse!: (response: Response) => void
+    const oldFetch = vi.fn(() => new Promise<Response>((resolve) => { deliverOldResponse = resolve }))
+    vi.stubGlobal('fetch', oldFetch)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel this selection and choose again' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm cancellation' }))
+    expect(oldFetch).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: 'Checking selection...' })).toBeDisabled()
+    cleanup()
+
+    // A separate mounted continuation has acquired a successor. The old request
+    // is still unresolved, not a second resolve() on an already-settled promise.
+    const successorToken = signedAuthorityFixture('checkout-intent', {}, { jti: '885a9c19-3e5e-4462-b4c1-1c32fc7ac612' })
+    await openConfirmation('none', successorToken)
+    await act(async () => { deliverOldResponse(new Response(JSON.stringify({ contractVersion: 2, requestId,
+      checkoutIntentJti: 'a2c4f872-01b7-4176-8325-522486b20cae', state: 'released' }))) })
+    expect(screen.getByRole('button', { name: /create account and start free trial/i })).toBeEnabled()
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /create account and start free trial/i }))
+    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledExactlyOnceWith(successorToken))
+  })
+
+  it('continues cancellation with renewed same-request proof through a mocked email-link remount', async () => {
+    await openConfirmation('none')
+    const originalFetch = vi.mocked(fetch).getMockImplementation()!
+    const renewedProof = signedAuthorityFixture('email-ownership', {}, { jti: '885a9c19-3e5e-4462-b4c1-1c32fc7ac612' })
+    let proofRenewed = false
+    const cancellationPayloads: Record<string, unknown>[] = []
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/cancel')) {
+        const payload = JSON.parse(String(init?.body))
+        cancellationPayloads.push(payload)
+        if (payload.emailOwnershipToken !== renewedProof) return new Response(JSON.stringify({
+          type: 'https://api.silentsuite.io/errors/invalid-request',
+        }), { status: 400 })
+        return new Response(JSON.stringify({ contractVersion: 2, requestId,
+          checkoutIntentJti: 'a2c4f872-01b7-4176-8325-522486b20cae', state: 'released' }))
+      }
+      if (String(input).endsWith('/request')) {
+        expect(JSON.parse(String(init?.body)).requestId).toBe(requestId)
+        return new Response('{}', { status: 202 })
+      }
+      if (String(input).endsWith('/consume') && proofRenewed) return new Response(JSON.stringify({
+        contractVersion: 2, emailOwnershipToken: renewedProof, expiresAt: '2099-01-01T00:00:00Z',
+      }))
+      if (String(input).endsWith('/activate') && proofRenewed) {
+        expect(JSON.parse(String(init?.body)).emailOwnershipToken).toBe(renewedProof)
+        expect(JSON.parse(String(init?.body)).requestId).toBe(requestId)
+      }
+      return originalFetch(input, init)
+    }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel this selection and choose again' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm cancellation' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Verify ownership again' }))
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('same signup'))
+    const saved = JSON.parse(localStorage.getItem('silentsuite-signup-email-proof')!)
+    expect(Object.keys(saved)).toEqual([requestId])
+    expect(saved[requestId]).not.toHaveProperty('password')
+    expect(saved[requestId]).not.toHaveProperty('checkoutIntentToken')
+    // Model following a NEW link; no real email delivery or server release is
+    // exercised. No in-memory password or reservation is persisted across mounts.
+    cleanup()
+    proofRenewed = true
+    window.history.replaceState({}, '', `/signup?token=renewed-link-fixture&request_id=${requestId}`)
+    render(<SignupPage />)
+    await screen.findByRole('heading', { name: 'Choose your password' })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
+    const next = screen.getByRole('button', { name: /continue to trial options/i })
+    await waitFor(() => expect(next).toBeEnabled())
+    fireEvent.click(next)
+    fireEvent.click(await screen.findByRole('button', { name: /7 day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    await screen.findByRole('button', { name: /create account and start free trial/i })
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel this selection and choose again' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm cancellation' }))
+    await screen.findByRole('button', { name: /7 day free trial/i })
+    expect(cancellationPayloads).toHaveLength(2)
+    expect(cancellationPayloads[1]).toEqual({ ...cancellationPayloads[0], emailOwnershipToken: renewedProof })
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
+    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+  })
+
+  it.each([400, 409, 503, 'wrong-receipt'] as const)('retains the exact selection on cancellation %s without account/password reset', async (failure) => {
+    await openConfirmation('none')
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(failure === 'wrong-receipt'
+      ? { contractVersion: 2, requestId, checkoutIntentJti: requestId, state: 'released' }
+      : { type: `https://api.silentsuite.io/errors/${failure === 409 ? 'authority-in-progress' : failure === 400 ? 'invalid-request' : 'recovery-unavailable'}` }), { status: typeof failure === 'number' ? failure : 200 })))
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel this selection and choose again' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm cancellation' }))
+    await screen.findByRole('alert')
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(authState.prepareSignupDraft).toHaveBeenCalledTimes(1)
+    expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
+    if (failure === 409) {
+      fireEvent.click(screen.getByRole('button', { name: 'Continue current selection' }))
+      expect(screen.getByRole('button', { name: /create account and start free trial/i })).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Cancel this selection and choose again' })).not.toBeInTheDocument()
+    } else if (failure === 400) {
+      vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 202 })))
+      fireEvent.click(screen.getByRole('button', { name: 'Verify ownership again' }))
+      await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('same signup'))
+      expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)).requestId).toBe(requestId)
+      expect(screen.getByRole('button', { name: 'Retry cancellation' })).toBeInTheDocument()
+    }
+  })
+
+  it.each(['none', 'stripe'] as const)('never exposes reservation cancellation after uncertain %s account/payment creation', async (provider) => {
+    const confirm = await openConfirmation(provider)
+    authState.provisionAnnualNoCard.mockRejectedValue(new Error('Unknown outcome'))
+    authState.startAnnualSignupPayment.mockRejectedValue(new Error('Unknown outcome'))
+    fireEvent.click(confirm)
+    await screen.findByRole('alert')
+    expect(screen.queryByRole('button', { name: 'Cancel this selection and choose again' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+    expect(screen.queryByRole('button', { name: 'Cancel this selection and choose again' })).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
+  })
 
   it.each(['none', 'stripe'] as const)('renews expired unattempted %s confirmation before any mutation and requires consent again', async (provider) => {
     const confirm = await openConfirmation(provider)

--- a/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
@@ -1,6 +1,7 @@
 import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BillingResponseError } from '@/app/lib/billing-v2'
 import SignupPage from '../page'
 import VerificationCallbackPage from '../verify-email/page'
 import { StrictMode } from 'react'
@@ -46,10 +47,257 @@ vi.mock('next/link', () => ({ default: ({ children }: { children: React.ReactNod
 describe('email-link seven-day no-card continuation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    authState.provisionAnnualNoCard.mockReset()
+    authState.startAnnualSignupPayment.mockReset()
     vi.stubGlobal('scrollTo', vi.fn())
     sessionStorage.clear()
     localStorage.clear()
     window.history.replaceState({}, '', '/signup')
+  })
+
+  it.each(['review', 'setup', 'payment'])('recovers a refreshed %s checkpoint without replay or secrets', async (phase) => {
+    vi.stubGlobal('fetch', vi.fn())
+    window.history.replaceState({ silentsuiteSignup: { version: 1, journey: 'test-journey', phase, step: 'plan', view: 'confirm' } }, '', '/signup')
+    render(<SignupPage />)
+    expect(await screen.findByRole('heading', { name: 'Continue your signup safely' })).toBeInTheDocument()
+    expect(fetch).not.toHaveBeenCalled()
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
+    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
+    if (phase === 'review') {
+      fireEvent.click(screen.getByRole('button', { name: 'Verify email again' }))
+      expect(screen.getByLabelText(/^email$/i)).toBeInTheDocument()
+      expect(fetch).not.toHaveBeenCalled()
+    } else {
+      expect(screen.queryByRole('button', { name: 'Verify email again' })).not.toBeInTheDocument()
+    }
+  })
+
+  it('keeps setup recovery after Back to a pre-mutation history entry and refresh', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+    window.history.replaceState({ silentsuiteSignup: { version: 1, journey: 'test-journey', phase: 'review', step: 'plan', view: 'cards' } }, '', '/signup')
+    sessionStorage.setItem('silentsuiteSignup:test-journey', 'setup')
+    render(<SignupPage />)
+    await screen.findByRole('heading', { name: 'Continue your signup safely' })
+    expect(screen.queryByRole('button', { name: 'Verify email again' })).not.toBeInTheDocument()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('preserves a live review and only switches expired unclaimed terms after a successful activation', async () => {
+    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
+      [requestId]: { email: 'switch@example.test', requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
+    }))
+    let activations = 0
+    let rejectReplacement = true
+    const cardTerms = { ...noCardDisclosure, kind: 'card_trial', firstChargeAmountMinor: 3600, renewalAmountMinor: 3600, firstChargeAt: noCardDisclosure.trialEndsAt, cancelBy: noCardDisclosure.trialEndsAt, autoRenew: true, refundWindowDays: 30, periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2099-09-10T12:00:00Z', entitlementEndsAt: '2099-09-10T12:00:00Z' }
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/consume')) return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken: ownershipToken, expiresAt: '2099-01-01T00:00:00Z' }))
+      if (String(input).endsWith('/activate')) {
+        activations++
+        if (activations > 1 && rejectReplacement) throw new Error('Connection interrupted. Retry your selection.')
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2099-01-01T00:00:00Z', disclosure: activations === 1 ? noCardDisclosure : cardTerms }))
+      }
+      return new Response(JSON.stringify(offer))
+    }))
+    window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
+    render(<SignupPage />)
+    await screen.findByRole('heading', { name: 'Choose your password' })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
+    const next = screen.getByRole('button', { name: /continue to trial options/i })
+    await waitFor(() => expect(next).toBeEnabled())
+    fireEvent.click(next)
+    fireEvent.click(await screen.findByRole('button', { name: /7 day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    await screen.findByRole('button', { name: /create account and start free trial/i })
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /30-day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Your current option is held until')
+    expect(activations).toBe(1)
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2100-01-01T00:00:00Z'))
+    try {
+      fireEvent.click(screen.getByRole('button', { name: /continue to card payment/i }))
+      expect(await screen.findByRole('alert')).toHaveTextContent('Connection interrupted')
+      expect(screen.getByRole('button', { name: 'Return to current selection' })).toBeInTheDocument()
+      rejectReplacement = false
+      fireEvent.click(screen.getByRole('button', { name: /continue to card payment/i }))
+      await screen.findByRole('heading', { name: 'Confirm annual terms' })
+      expect(screen.getByText(/Add a card next. No charge today/)).toBeInTheDocument()
+      expect(activations).toBe(3)
+      expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+      expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+    } finally { clock.mockRestore() }
+  })
+
+  async function openConfirmation(provider: 'none' | 'stripe') {
+    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
+      [requestId]: { email: 'expiry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
+    }))
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/consume')) return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken: ownershipToken, expiresAt: '2099-01-01T00:00:00Z' }))
+      if (String(input).endsWith('/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2099-01-01T00:00:00Z', disclosure: provider === 'none' ? noCardDisclosure : { ...noCardDisclosure, kind: 'card_trial', firstChargeAmountMinor: 3600, renewalAmountMinor: 3600, firstChargeAt: noCardDisclosure.trialEndsAt, cancelBy: noCardDisclosure.trialEndsAt, autoRenew: true, refundWindowDays: 30, periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2099-09-10T12:00:00Z', entitlementEndsAt: '2099-09-10T12:00:00Z' } }))
+      return new Response(JSON.stringify(offer))
+    }))
+    window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
+    render(<SignupPage />)
+    await screen.findByRole('heading', { name: 'Choose your password' })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
+    const next = screen.getByRole('button', { name: /continue to trial options/i })
+    await waitFor(() => expect(next).toBeEnabled())
+    fireEvent.click(next)
+    fireEvent.click(await screen.findByRole('button', { name: provider === 'none' ? /7 day free trial/i : /30-day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    if (provider === 'stripe') fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
+    return screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i })
+  }
+
+  it.each(['none', 'stripe'] as const)('renews expired unattempted %s confirmation before any mutation and requires consent again', async (provider) => {
+    const confirm = await openConfirmation(provider)
+    const rejection = new BillingResponseError('Invalid request', 400, 'https://api.silentsuite.io/errors/invalid-request')
+    authState.provisionAnnualNoCard.mockRejectedValue(rejection)
+    authState.startAnnualSignupPayment.mockRejectedValue(rejection)
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2100-01-01T00:00:00Z'))
+    try {
+      fireEvent.click(confirm)
+      expect(await screen.findByRole('alert')).toHaveTextContent(/review.*choose.*again/i)
+      expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+      expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
+      expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+      clock.mockRestore()
+      fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
+      fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+      await screen.findByRole('button', { name: /create account and start free trial/i })
+      expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/activate'))).toHaveLength(2)
+      expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    } finally { clock.mockRestore() }
+  })
+
+  it.each(['none', 'stripe'] as const)('retains ambiguous 400 after a %s attempt even when its terms expire', async (provider) => {
+    const confirm = await openConfirmation(provider)
+    const rejection = new BillingResponseError('Invalid request', 400, 'https://api.silentsuite.io/errors/invalid-request')
+    authState.provisionAnnualNoCard.mockRejectedValue(rejection)
+    authState.startAnnualSignupPayment.mockRejectedValue(rejection)
+    fireEvent.click(confirm)
+    expect(await screen.findByRole('alert')).toHaveTextContent('Invalid request')
+    expect(authState.createEtebaseAccount).toHaveBeenCalledTimes(provider === 'none' ? 1 : 0)
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2100-01-01T00:00:00Z'))
+    try {
+      fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+      if (provider === 'stripe') fireEvent.click(screen.getByRole('button', { name: 'Back to plan selection', exact: true }))
+      fireEvent.click(screen.getByRole('button', { name: provider === 'none' ? /30-day free trial/i : /7 day free trial/i }))
+      fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+      if (provider === 'none') fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
+      expect(await screen.findByRole('alert')).toHaveTextContent('Setup may have started')
+      expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/activate'))).toHaveLength(1)
+    } finally { clock.mockRestore() }
+  })
+
+  it('fails navigation-marker quota before mutation, permits account edits, and retries after storage recovery', async () => {
+    const confirm = await openConfirmation('none')
+    const original = Storage.prototype.setItem
+    const storage = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key.startsWith('silentsuiteSignup:')) throw new DOMException('Full', 'QuotaExceededError')
+      original.call(this, key, value)
+    })
+    try {
+      fireEvent.click(confirm)
+      expect(await screen.findByRole('alert')).toHaveTextContent(/free.*storage.*retry/i)
+      expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+      expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
+      fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+      fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+      await screen.findByRole('heading', { name: 'Choose your password' })
+      expect(screen.getByLabelText(/^password$/i)).toHaveValue('ValidPass1')
+      expect(window.history.state.silentsuiteSignup.phase).toBe('review')
+      storage.mockRestore()
+      const next = screen.getByRole('button', { name: /continue to trial options/i })
+      await waitFor(() => expect(next).toBeEnabled())
+      fireEvent.click(next)
+      fireEvent.click(await screen.findByRole('button', { name: 'Return to current selection', exact: true }))
+      fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial/i }))
+      await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledTimes(1))
+      expect(authState.createEtebaseAccount).toHaveBeenCalledTimes(1)
+    } finally { storage.mockRestore() }
+  })
+
+  it('requests hosted email verification before asking for a password', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 202 })))
+    render(<SignupPage />)
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: 'fresh@example.test' } })
+    fireEvent.change(screen.getByLabelText(/^confirm email$/i), { target: { value: 'fresh@example.test' } })
+    const next = screen.getByRole('button', { name: /^continue$/i })
+    await waitFor(() => expect(next).toBeEnabled())
+    act(() => { fireEvent.click(next); fireEvent.click(next) })
+    expect(await screen.findByRole('status')).toHaveTextContent('Check your email')
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith('https://billing.test/auth/signup-email-verifications/v2', expect.objectContaining({ body: expect.not.stringContaining('password') }))
+  })
+
+  it('shows a failed no-card setup on confirmation and retries without hiding the failure', async () => {
+    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
+      [requestId]: { email: 'retry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
+    }))
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/consume')) return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken: ownershipToken, expiresAt: '2099-01-01T00:00:00Z' }))
+      if (String(input).endsWith('/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2099-01-01T00:00:00Z', disclosure: noCardDisclosure }))
+      return new Response(JSON.stringify(offer))
+    }))
+    authState.provisionAnnualNoCard.mockRejectedValueOnce(new Error('Could not start your trial. Please retry.')).mockResolvedValue(undefined)
+    window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
+    render(<SignupPage />)
+    await screen.findByRole('heading', { name: 'Choose your password' })
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
+    expect(screen.queryByLabelText(/confirm password/i)).not.toBeInTheDocument()
+    const next = screen.getByRole('button', { name: /continue to trial options/i })
+    await waitFor(() => expect(next).toBeEnabled())
+    fireEvent.click(next)
+    await screen.findByRole('heading', { name: /choose your plan/i })
+    act(() => window.history.back())
+    await screen.findByRole('heading', { name: 'Choose your password' })
+    act(() => window.history.forward())
+    await screen.findByRole('heading', { name: /choose your plan/i })
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
+    expect(screen.getByLabelText(/^password$/i)).toHaveValue('ValidPass1')
+    fireEvent.click(screen.getByRole('button', { name: /continue to trial options/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /7 day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    await screen.findByRole('button', { name: /create account and start free trial/i })
+    act(() => window.history.back())
+    await screen.findByRole('heading', { name: /choose your plan/i })
+    act(() => window.history.forward())
+    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not start your trial. Please retry.')
+    expect(screen.queryByText('Not applicable')).not.toBeInTheDocument()
+    expect(screen.getByText(/No card required. No automatic charge or renewal/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+    expect(await screen.findByRole('heading', { name: /choose your plan/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    await screen.findByRole('button', { name: /create account and start free trial/i })
+    expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/activate'))).toHaveLength(1)
+    const leave = new Event('beforeunload', { cancelable: true })
+    window.dispatchEvent(leave)
+    expect(leave.defaultPrevented).toBe(true)
+    act(() => window.dispatchEvent(new PopStateEvent('popstate')))
+    expect(screen.getByRole('status')).toHaveTextContent('Finish or recover your current setup')
+    expect(authState.provisionAnnualNoCard).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(window.history.state)).not.toContain('ValidPass1')
+    expect(JSON.stringify(sessionStorage)).not.toContain('ValidPass1')
+    let finish!: () => void
+    authState.provisionAnnualNoCard.mockImplementationOnce(() => new Promise<void>((resolve) => { finish = resolve }))
+    const retry = screen.getByRole('button', { name: /create account and start free trial/i })
+    act(() => { fireEvent.click(retry); fireEvent.click(retry) })
+    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole('button', { name: /^back$/i })).toBeDisabled()
+    await act(async () => finish())
+    const completedLeave = new Event('beforeunload', { cancelable: true })
+    window.dispatchEvent(completedLeave)
+    expect(completedLeave.defaultPrevented).toBe(false)
   })
 
   it('retries an offer failure without consuming the email link again', async () => {
@@ -76,7 +324,7 @@ describe('email-link seven-day no-card continuation', () => {
     render(<StrictMode><SignupPage /></StrictMode>)
 
     fireEvent.click(await screen.findByRole('button', { name: 'Retry loading trial options' }))
-    expect(await screen.findByRole('heading', { name: 'Re-enter your account details' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
     expect(consumptions).toBe(1)
     expect(offers).toBe(2)
     expect(window.location.search).not.toContain('link-token')
@@ -178,7 +426,7 @@ describe('email-link seven-day no-card continuation', () => {
       }
       if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify(offer))
       if (url.endsWith('/auth/offers/v2/activate')) {
-        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: noCardDisclosure }))
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: new Date(Date.now() + 60_000).toISOString().replace(/\.\d{3}Z$/, 'Z'), disclosure: noCardDisclosure }))
       }
       return new Response('{}', { status: 404 })
     }))
@@ -189,16 +437,16 @@ describe('email-link seven-day no-card continuation', () => {
     const Page = callbackPath === '/signup' ? SignupPage : VerificationCallbackPage
     render(<Page />)
 
-    expect(await screen.findByRole('heading', { name: 'Re-enter your account details' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
-    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'ValidPass1' } })
+    expect(screen.queryByLabelText(/confirm password/i)).not.toBeInTheDocument()
     const continuation = screen.getByRole('button', { name: /continue to trial options/i })
     await waitFor(() => expect(continuation).toBeEnabled())
     fireEvent.click(continuation)
     expect(await screen.findByRole('heading', { name: /choose your plan/i })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i }))
 
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('customer@example.test', 'ValidPass1', undefined)
@@ -221,7 +469,7 @@ describe('email-link seven-day no-card continuation', () => {
       }
       if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify(offer))
       if (url.endsWith('/auth/offers/v2/activate')) {
-        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: noCardDisclosure }))
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: new Date(Date.now() + 60_000).toISOString().replace(/\.\d{3}Z$/, 'Z'), disclosure: noCardDisclosure }))
       }
       return new Response('{}', { status: 404 })
     }))
@@ -229,16 +477,16 @@ describe('email-link seven-day no-card continuation', () => {
     window.history.replaceState({}, '', '/signup?email_verification_token=link-token')
     render(<SignupPage />)
 
-    expect(await screen.findByRole('heading', { name: 'Re-enter your account details' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
-    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'ValidPass1' } })
+    expect(screen.queryByLabelText(/confirm password/i)).not.toBeInTheDocument()
     const continuation = screen.getByRole('button', { name: /continue to trial options/i })
     await waitFor(() => expect(continuation).toBeEnabled())
     fireEvent.click(continuation)
     expect(await screen.findByRole('heading', { name: /choose your plan/i })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i }))
 
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('newtab@example.test', 'ValidPass1', undefined)
@@ -294,7 +542,7 @@ describe('email-link seven-day no-card continuation', () => {
     // No email is known here, so the token must not be spent guessing one.
     expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes('/consume'))).toBe(false)
     // The account form stays available as the recovery path.
-    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument()
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
     // A spent-looking token must not linger in the address bar or in history.
     expect(window.location.search).not.toContain('link-token')
   })
@@ -329,7 +577,7 @@ describe('email-link seven-day no-card continuation', () => {
       if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify(standardOffer))
       if (url.endsWith('/auth/offers/v2/activate')) {
         return new Response(JSON.stringify({
-          contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z',
+          contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: new Date(Date.now() + 60_000).toISOString().replace(/\.\d{3}Z$/, 'Z'),
           disclosure: { ...standardDisclosure, kind: 'card_trial', firstChargeAmountMinor: 4800, renewalAmountMinor: 4800, trialEndsAt: '2026-09-10T12:00:00Z', firstChargeAt: '2026-09-10T12:00:00Z', cancelBy: '2026-09-10T12:00:00Z', autoRenew: true, refundWindowDays: 30, periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2027-09-10T12:00:00Z', entitlementEndsAt: '2027-09-10T12:00:00Z' },
         }))
       }
@@ -344,9 +592,9 @@ describe('email-link seven-day no-card continuation', () => {
       'https://billing.test/auth/offers/v2',
       expect.objectContaining({ method: 'POST' }),
     ))
-    expect(await screen.findByRole('heading', { name: 'Re-enter your account details' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
-    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'ValidPass1' } })
+    expect(screen.queryByLabelText(/confirm password/i)).not.toBeInTheDocument()
     const continuation = await screen.findByRole('button', { name: /continue to trial options/i })
     await waitFor(() => expect(continuation).toBeEnabled())
     fireEvent.click(continuation)
@@ -370,8 +618,9 @@ describe('email-link seven-day no-card continuation', () => {
     expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
     expect(await screen.findByText('Confirm annual terms')).toBeInTheDocument()
     expect(screen.getAllByText('2026-09-10 12:00 UTC')).toHaveLength(2)
-    expect(screen.getAllByText('2027-09-10 12:00 UTC')).toHaveLength(2)
-    fireEvent.click(screen.getByRole('button', { name: /confirm annual terms and continue/i }))
+    expect(screen.getByText('2027-09-10 12:00 UTC')).toBeInTheDocument()
+    expect(screen.getByText('€48.00/year from 2027-09-10 12:00 UTC')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i }))
     await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(
       signedCheckoutIntent,
       'stripe',
@@ -419,7 +668,7 @@ describe('email-link seven-day no-card continuation', () => {
             detail: 'The selected annual checkout is unavailable.',
           }), { status: 409 })
         }
-        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: { ...noCardDisclosure, annualAmountMinor: 4800, monthlyEquivalentMinor: 400 } }))
+        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: new Date(Date.now() + 60_000).toISOString().replace(/\.\d{3}Z$/, 'Z'), disclosure: { ...noCardDisclosure, annualAmountMinor: 4800, monthlyEquivalentMinor: 400 } }))
       }
       return new Response('{}', { status: 404 })
     }))
@@ -429,9 +678,9 @@ describe('email-link seven-day no-card continuation', () => {
     initialMount.unmount()
     window.history.replaceState({}, '', '/signup?email_verification_token=link-token')
     render(<SignupPage />)
-    expect(await screen.findByRole('heading', { name: 'Re-enter your account details' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
-    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'ValidPass1' } })
+    expect(screen.queryByLabelText(/confirm password/i)).not.toBeInTheDocument()
     const continuation = await screen.findByRole('button', { name: /continue to trial options/i })
     await waitFor(() => expect(continuation).toBeEnabled())
     fireEvent.click(continuation)
@@ -446,7 +695,7 @@ describe('email-link seven-day no-card continuation', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /confirm annual terms and continue/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i }))
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('renew@example.test', 'ValidPass1', undefined)
   })
@@ -495,9 +744,9 @@ describe('email-link seven-day no-card continuation', () => {
     initialMount.unmount()
     window.history.replaceState({}, '', '/signup?email_verification_token=link-token')
     render(<SignupPage />)
-    expect(await screen.findByRole('heading', { name: 'Re-enter your account details' })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
-    fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: 'ValidPass1' } })
+    expect(screen.queryByLabelText(/confirm password/i)).not.toBeInTheDocument()
     const continuation = screen.getByRole('button', { name: /continue to trial options/i })
     await waitFor(() => expect(continuation).toBeEnabled())
     fireEvent.click(continuation)

--- a/apps/web/app/(auth)/signup/components/annual-confirmation-summary.tsx
+++ b/apps/web/app/(auth)/signup/components/annual-confirmation-summary.tsx
@@ -1,0 +1,29 @@
+import type { AnnualDisclosure } from '@/app/lib/billing-v2'
+
+const money = (minor: number) => `€${(minor / 100).toFixed(2)}`
+const timestamp = (value: string) => `${value.slice(0, 10)} ${value.slice(11, 16)} UTC`
+
+/** Only the server disclosure kind determines whether the next step charges. */
+export function AnnualConfirmationSummary({ disclosure }: { disclosure: AnnualDisclosure }) {
+  const noCard = disclosure.kind === 'no_auto_charge'
+  const cardTrial = disclosure.kind === 'card_trial'
+  return <>
+    <p className="text-sm text-[rgb(var(--muted))]">
+      {noCard ? 'Start your 7-day free trial. No card required. No automatic charge or renewal.'
+        : cardTrial ? 'Add a card next. No charge today. Cancel before the deadline below to avoid the annual charge.'
+          : disclosure.kind === 'charge_now' ? `Pay ${money(disclosure.firstChargeAmountMinor)} now by card. This is an annual purchase, not a free trial.`
+            : `Pay ${money(disclosure.firstChargeAmountMinor)} in Bitcoin. This is a prepaid annual purchase, not a free trial. No automatic renewal.`}
+    </p>
+    <dl className="space-y-2 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 text-sm">
+      {!noCard && <>
+        <div className="flex justify-between gap-4"><dt>{cardTrial ? 'After your trial' : 'Payment'}</dt><dd>{money(disclosure.firstChargeAmountMinor)}{cardTrial ? '/year' : ''}</dd></div>
+        {disclosure.firstChargeAt && <div className="flex justify-between gap-4"><dt>First charge</dt><dd>{timestamp(disclosure.firstChargeAt)}</dd></div>}
+        {disclosure.cancelBy && <div className="flex justify-between gap-4"><dt>Cancel before</dt><dd>{timestamp(disclosure.cancelBy)}</dd></div>}
+        {disclosure.autoRenew && <div className="flex justify-between gap-4"><dt>Automatic renewal</dt><dd>{disclosure.renewalAmountMinor !== null ? `${money(disclosure.renewalAmountMinor)}/year` : 'Annual'}{disclosure.renewalAt ? ` from ${timestamp(disclosure.renewalAt)}` : ', one year after payment confirmation'}</dd></div>}
+        {disclosure.refundWindowDays && <div className="flex justify-between gap-4"><dt>Refund window</dt><dd>{disclosure.refundWindowDays} days</dd></div>}
+      </>}
+      {disclosure.entitlementEndsAt && <div className="flex justify-between gap-4"><dt>{noCard ? 'Free until' : 'Access through'}</dt><dd>{timestamp(disclosure.entitlementEndsAt)}</dd></div>}
+      {!disclosure.entitlementEndsAt && <div className="flex justify-between gap-4"><dt>Access</dt><dd>One year from payment confirmation{disclosure.bonusDays ? `, plus ${disclosure.bonusDays} bonus days` : ''}</dd></div>}
+    </dl>
+  </>
+}

--- a/apps/web/app/(auth)/signup/components/step-create-paid-account.tsx
+++ b/apps/web/app/(auth)/signup/components/step-create-paid-account.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -73,22 +73,29 @@ export function StepCreatePaidAccount({
   onNext,
   initialError,
   continuation = 'payment-confirmed',
+  initialData,
 }: {
   email: string
   onNext: (data: PaidAccountFormData) => Promise<void>
   initialError?: string | null
-  /** Passwords for a verified no-card continuation stay in this component only. */
+  initialData?: PaidAccountFormData
+  /** Verified signup chooses a password once; the parent retains it only in memory. */
   continuation?: 'payment-confirmed' | 'verified-no-card'
 }) {
   const [submitError, setSubmitError] = useState<string | null>(initialError ?? null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const submittingRef = useRef(false)
+  const [showPassword, setShowPassword] = useState(false)
   const {
     register,
     handleSubmit,
     watch,
     formState: { errors, isValid },
   } = useForm<PaidAccountFormData>({
-    resolver: zodResolver(paidAccountSchema) as any,
+    resolver: zodResolver(continuation === 'verified-no-card'
+      ? z.object({ password: paidAccountSchema.shape.password })
+      : paidAccountSchema) as any,
+    defaultValues: initialData,
     mode: 'onChange',
   })
   const password = watch('password', '')
@@ -97,23 +104,26 @@ export function StepCreatePaidAccount({
     <div className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
       <div className="space-y-2 text-center">
         <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">
-          {continuation === 'verified-no-card' ? 'Re-enter your account details' : 'Create your account'}
+          {continuation === 'verified-no-card' ? 'Choose your password' : 'Create your account'}
         </h2>
         <p className="text-sm text-[rgb(var(--muted))]">
           {continuation === 'verified-no-card'
-            ? <>Your email is verified. Enter a password to continue with the 7-day no-card trial for <span className="font-medium text-[rgb(var(--foreground))]">{email}</span>.</>
+            ? <>Your email is verified. Choose a password, then select a trial or payment option for <span className="font-medium text-[rgb(var(--foreground))]">{email}</span>.</>
             : <>Payment is confirmed. Choose the password for <span className="font-medium text-[rgb(var(--foreground))]">{email}</span>.</>}
         </p>
       </div>
 
       <form onSubmit={handleSubmit(async (data) => {
+        if (submittingRef.current) return
+        submittingRef.current = true
         setSubmitError(null)
         setIsSubmitting(true)
         try {
-          await onNext(data)
+          await onNext(continuation === 'verified-no-card' ? { ...data, confirmPassword: data.password } : data)
         } catch (err) {
           setSubmitError(err instanceof Error ? err.message : 'Could not create account. Please try again.')
         } finally {
+          submittingRef.current = false
           setIsSubmitting(false)
         }
       })} className="space-y-4">
@@ -128,7 +138,8 @@ export function StepCreatePaidAccount({
           </label>
           <Input
             id="paid-signup-password"
-            type="password"
+            type={showPassword ? "text" : "password"}
+            autoComplete="new-password"
             aria-invalid={!!errors.password}
             aria-describedby={errors.password ? 'paid-signup-password-error' : undefined}
             {...register('password')}
@@ -138,7 +149,9 @@ export function StepCreatePaidAccount({
           <PasswordStrength password={password} />
         </div>
 
-        <div className="space-y-2">
+        <button type="button" aria-pressed={showPassword} onClick={() => setShowPassword(!showPassword)} className="text-sm underline">{showPassword ? 'Hide password' : 'Show password'}</button>
+
+        {continuation !== 'verified-no-card' && <div className="space-y-2">
           <label htmlFor="paid-signup-confirm-password" className="block text-sm font-medium text-[rgb(var(--foreground))]/80">
             Confirm password
           </label>
@@ -151,10 +164,10 @@ export function StepCreatePaidAccount({
             className="bg-[rgb(var(--surface))] text-[rgb(var(--foreground))] border-[rgb(var(--border))]"
           />
           {errors.confirmPassword && <p id="paid-signup-confirm-password-error" role="alert" className="text-xs text-red-400">{errors.confirmPassword.message}</p>}
-        </div>
+        </div>}
 
         {submitError && (
-          <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+          <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
             <p className="text-sm text-red-400">{submitError}</p>
           </div>
         )}

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -33,6 +33,8 @@ import {
   activateAnnualCheckout,
   consumeSignupEmailOwnership,
   fetchAnonymousAnnualOffer,
+  cancelUnclaimedAnnualSelection,
+  BillingResponseError,
   isRenewableAnnualOfferError,
   requestSignupEmailOwnership,
   type AnnualCheckoutActivation,
@@ -1392,6 +1394,11 @@ export default function SignupPage() {
   const [annualOffer, setAnnualOffer] = useState<AnnualOfferResponse | null>(null)
   const [annualOfferRequestId, setAnnualOfferRequestId] = useState<string | null>(null)
   const [pendingAnnualClaim, setPendingAnnualClaim] = useState<PendingAnnualClaim | null>(null)
+  // Reservation cancellation never resolves Etebase/account or provider authority.
+  // Keep this bounded UI pre-claim; partial/uncertain creation keeps its continuation.
+  const [selectionCancellation, setSelectionCancellation] = useState<'confirm' | 'unknown' | 'refused' | 'verify' | null>(null)
+  const pendingAnnualClaimRef = useRef(pendingAnnualClaim)
+  pendingAnnualClaimRef.current = pendingAnnualClaim
   const [recoveredSignupEmail, setRecoveredSignupEmail] = useState<string | null>(null)
   const [awaitingEmailProof, setAwaitingEmailProof] = useState(false)
   const [emailProofUnavailable, setEmailProofUnavailable] = useState(false)
@@ -1412,7 +1419,7 @@ export default function SignupPage() {
     step,
     view: planView,
     restore: (checkpoint) => {
-      if (operationRef.current) return false
+      if (operationRef.current || selectionCancellation) return false
       if (checkpoint.step === 'verifiedAccount' && !claimAttemptedRef.current) {
         setStep('verifiedAccount')
         return true
@@ -1893,6 +1900,64 @@ export default function SignupPage() {
     }
   }, [clientSecret, cryptoPaymentSession, pendingAnnualClaim, planView])
 
+  const handleCancelSelection = useCallback(async () => {
+    const pending = pendingAnnualClaim
+    if (!pending || !annualOfferRequestId || !recoveredSignupEmail || !emailOwnershipToken
+      || operationRef.current || claimAttemptedRef.current || clientSecret || cryptoPaymentSession) return
+    operationRef.current = true
+    setProvisioning(true)
+    setProvisionError(null)
+    const ownsSelection = () => mountedRef.current && pendingAnnualClaimRef.current === pending
+    try {
+      await cancelUnclaimedAnnualSelection({
+        fetcher: fetch, billingApiUrl: BILLING_API_URL,
+        email: recoveredSignupEmail, requestId: annualOfferRequestId,
+        checkoutIntentToken: pending.activation.checkoutIntentToken, emailOwnershipToken,
+      })
+      if (!ownsSelection()) return
+      // Only this exact reservation is released. Never reset pendingSignup,
+      // credentials, session attestation, or a payment recovery capability.
+      setPendingAnnualClaim(null)
+      setSelectionCancellation(null)
+      setPlanView('cards')
+    } catch (error) {
+      if (!ownsSelection()) return
+      if (error instanceof BillingResponseError && error.billingStatus === 409
+        && error.billingProblemType === 'https://api.silentsuite.io/errors/authority-in-progress') {
+        claimAttemptedRef.current = true
+        setSelectionCancellation('refused')
+        setProvisionError('Setup or payment has already started. Your selection was not cancelled. Continue or recover the existing setup; do not start another payment.')
+      } else if (error instanceof BillingResponseError && error.billingStatus === 400) {
+        setSelectionCancellation('verify')
+        setProvisionError('Cancellation could not be verified. Your selection is retained. Verify ownership again using the same signup request, then retry.')
+      } else {
+        setSelectionCancellation('unknown')
+        setProvisionError('Cancellation is not confirmed. Your selection is retained. Retry cancellation to check this exact selection before choosing again.')
+      }
+    } finally {
+      operationRef.current = false
+      if (mountedRef.current) setProvisioning(false)
+    }
+  }, [annualOfferRequestId, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail])
+
+  const handleVerifySelectionOwnership = useCallback(async () => {
+    if (operationRef.current || !annualOfferRequestId || !recoveredSignupEmail) return
+    operationRef.current = true
+    setProvisioning(true)
+    try {
+      saveEmailProofContext({ email: recoveredSignupEmail, requestId: annualOfferRequestId,
+        wantsProductUpdates, rememberDevice, returnTo, expiresAt: Date.now() + 15 * 60_000 })
+      await requestSignupEmailOwnership({ fetcher: fetch, billingApiUrl: BILLING_API_URL,
+        email: recoveredSignupEmail, requestId: annualOfferRequestId })
+      if (mountedRef.current) setProvisionError('Check your email for a verification link for this same signup. Your selection has not been cleared or replaced.')
+    } catch {
+      if (mountedRef.current) setProvisionError('A verification email could not be confirmed. Your selection is retained; retry verification.')
+    } finally {
+      operationRef.current = false
+      if (mountedRef.current) setProvisioning(false)
+    }
+  }, [annualOfferRequestId, recoveredSignupEmail, rememberDevice, returnTo, wantsProductUpdates])
+
   const createAndFinalizePaidAccount = useCallback(async (password?: string) => {
     const data = formDataRef.current
     if (!data?.email) throw new Error('Please enter your account details again.')
@@ -1966,10 +2031,34 @@ export default function SignupPage() {
       <ProgressStepper currentStep={provisioning && step === 'plan' && claimAttemptedRef.current ? 'paidAccount' : step} steps={activeSteps} />
       <div className="mx-auto w-full max-w-md min-w-0 md:mx-0 md:flex-1">
         {navigation.notice && <p role="status" className="mb-4 text-sm text-[rgb(var(--muted))]">Finish or recover your current setup before changing account details. Your password has not been saved.</p>}
-        {step === 'plan' && planView !== 'confirm' && pendingAnnualClaim && <Button variant="outline" disabled={provisioning} className="mb-4 w-full" onClick={() => { setProvisionError(null); setPlanView('confirm') }}>Return to current selection</Button>}
+        {step === 'plan' && pendingAnnualClaim && !claimAttemptedRef.current && !clientSecret && !cryptoPaymentSession && !selectionCancellation && (
+          <Button variant="outline" className="mb-4 w-full" disabled={provisioning} onClick={() => {
+            if (operationRef.current) return
+            setProvisionError(null)
+            setSelectionCancellation('confirm')
+          }}>Cancel this selection and choose again</Button>
+        )}
+        {step === 'plan' && selectionCancellation && <section className="space-y-4" aria-label="Cancel selection">
+          <h2 className="text-xl font-semibold">Cancel this selection?</h2>
+          <p>This releases only your trial or payment selection. It does not cancel a payment or subscription, delete an account, or start another trial. You will choose again and review new terms before continuing.</p>
+          {provisionError && <p role="alert">{provisionError}</p>}
+          {selectionCancellation !== 'refused' && <Button disabled={provisioning} onClick={handleCancelSelection}>
+            {provisioning ? 'Checking selection...' : selectionCancellation === 'confirm' ? 'Confirm cancellation' : 'Retry cancellation'}
+          </Button>}
+          {selectionCancellation === 'confirm' && <Button variant="outline" disabled={provisioning} onClick={() => {
+            if (!operationRef.current) setSelectionCancellation(null)
+          }}>Keep current selection</Button>}
+          {selectionCancellation === 'verify' && <Button variant="outline" disabled={provisioning} onClick={handleVerifySelectionOwnership}>Verify ownership again</Button>}
+          {selectionCancellation === 'refused' && <>
+            <Button onClick={() => { setSelectionCancellation(null); setPlanView('confirm') }}>Continue current selection</Button>
+            <Link href="/signup/pending-payment" className="block underline">Recover existing payment</Link>
+          </>}
+        </section>}
+        {step === 'plan' && !selectionCancellation && planView !== 'confirm' && pendingAnnualClaim && <Button variant="outline" disabled={provisioning} className="mb-4 w-full" onClick={() => { setProvisionError(null); setPlanView('confirm') }}>Return to current selection</Button>}
         {step === 'plan' && (clientSecret || cryptoPaymentSession) && planView !== 'payment' && planView !== 'crypto' && <div className="mb-4 space-y-2">
           <Button variant="outline" disabled={provisioning} onClick={() => setPlanView(clientSecret ? 'payment' : 'crypto')}>Resume pending payment</Button>
-          <Link href="/signup/pending-payment" className="block text-sm underline">Recover or cancel pending payment</Link>
+          <Link href="/signup/pending-payment" className="block text-sm underline">Recover pending payment</Link>
+          {cryptoPaymentSession && <p className="text-sm">A live Bitcoin invoice must expire before another payment can be started. Returning here does not cancel it.</p>}
         </div>}
         {step === 'account' && (
           <>
@@ -2025,7 +2114,7 @@ export default function SignupPage() {
         {step === 'admin' && (
           <StepAdminInfo serverUrl={serverUrl.trim()} onNext={handleAdminInfoComplete} />
         )}
-        {step === 'plan' && (
+        {step === 'plan' && !selectionCancellation && (
           annualOffer ? <StepChoosePlan
             key={`${annualOffer.requestId}:${annualOffer.offer.offerToken}`}
             annualOffer={annualOffer}

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -22,6 +22,8 @@ import { DISPLAY_VERSION } from '@/app/lib/constants'
 import { findCommonEmailDomainTypo, normalizeEmailForComparison, signupEmailSchema } from '@/app/lib/email-recovery'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
+import { AnnualConfirmationSummary } from './components/annual-confirmation-summary'
+import { useSignupNavigation } from './use-signup-navigation'
 import { StepCreateVault } from './components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from './components/step-create-paid-account'
 import { QRCodeSVG } from 'qrcode.react'
@@ -272,6 +274,8 @@ function StepCreateAccount({
 }) {
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const submittingRef = useRef(false)
+  const needsPassword = isSelfHosted || isCustomServer(serverUrl.trim() ? normalizeServerUrl(serverUrl) : undefined)
 
   const {
     register,
@@ -284,7 +288,7 @@ function StepCreateAccount({
     // causing a type mismatch. The runtime works fine — only the types clash.
     // Remove this cast once @hookform/resolvers ships native zod v4 support.
     // Tracking: https://github.com/react-hook-form/resolvers/issues
-    resolver: zodResolver(signupSchema) as any,
+    resolver: zodResolver(needsPassword ? signupSchema : signupEmailSchema) as any,
     mode: 'onChange',
     defaultValues: initialData ?? undefined,
   })
@@ -302,14 +306,17 @@ function StepCreateAccount({
       </div>
 
       <form onSubmit={handleSubmit(async (data) => {
+        if (submittingRef.current) return
+        submittingRef.current = true
         setSubmitError(null)
         setIsSubmitting(true)
         try {
-          await onNext(data)
+          await onNext(needsPassword ? data : { email: data.email, confirmEmail: data.confirmEmail, password: '', confirmPassword: '' })
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : 'Account creation failed. Please try again.'
           setSubmitError(message)
         } finally {
+          submittingRef.current = false
           setIsSubmitting(false)
         }
       })} className="space-y-4">
@@ -359,7 +366,7 @@ function StepCreateAccount({
           )}
         </div>
 
-        <div className="space-y-2">
+        {needsPassword && <><div className="space-y-2">
           <label
             htmlFor="password"
             className="block text-sm font-medium text-[rgb(var(--foreground))]/80"
@@ -401,6 +408,8 @@ function StepCreateAccount({
             </p>
           )}
         </div>
+
+        </>}
 
         {/* Product updates opt-in */}
         <label className="flex items-start gap-2.5 cursor-pointer">
@@ -453,7 +462,7 @@ function StepCreateAccount({
         </details>
 
         {submitError && (
-          <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+          <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
             <p className="text-sm text-red-600 dark:text-red-400">{submitError}</p>
           </div>
         )}
@@ -471,7 +480,7 @@ function StepCreateAccount({
 
         <p className="flex items-center justify-center gap-1.5 text-xs text-[rgb(var(--muted))]">
           <KeyRound className="h-3 w-3 text-emerald-500" />
-          No phone number required. Just email and password.
+          {needsPassword ? 'No phone number required. Just email and password.' : 'First verify your email. You will choose a password next.'}
         </p>
       </form>
 
@@ -493,11 +502,6 @@ type PlanView = 'cards' | 'method' | 'confirm' | 'payment' | 'crypto'
 type PendingAnnualClaim = {
   activation: AnnualCheckoutActivation
   provider: 'none' | 'stripe' | 'btcpay'
-}
-
-function formatDisclosureTimestamp(value: string | null): string {
-  if (!value) return 'Not applicable'
-  return `${value.slice(0, 10)} ${value.slice(11, 16)} UTC`
 }
 
 function CryptoPaymentPanel({
@@ -750,7 +754,7 @@ function StepChoosePlan({
 
   const handleSelectCard = useCallback(() => {
     if (!stripeAvailable) {
-      setPaymentMethodError('Card checkout is not available for this server-owned annual offer.')
+      setPaymentMethodError('Card checkout is not available for this annual offer.')
       return
     }
     setPaymentMethodError(null)
@@ -760,7 +764,7 @@ function StepChoosePlan({
 
   const handleSelectBitcoin = useCallback(() => {
     if (!bitcoinAvailable) {
-      setPaymentMethodError('Bitcoin checkout is not available for this server-owned annual offer.')
+      setPaymentMethodError('Bitcoin checkout is not available for this annual offer.')
       return
     }
     setPaymentMethodError(null)
@@ -781,24 +785,13 @@ function StepChoosePlan({
       <div ref={contentRef} className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
         <div className="space-y-2 text-center">
           <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Confirm annual terms</h2>
-          <p className="text-sm text-[rgb(var(--muted))]">Review the exact server-issued schedule before this checkout authority is claimed.</p>
         </div>
-        <dl className="space-y-2 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 text-sm">
-          <div className="flex justify-between gap-4"><dt>Annual price</dt><dd>€{(disclosure.annualAmountMinor / 100).toFixed(2)}/year</dd></div>
-          <div className="flex justify-between gap-4"><dt>First charge amount</dt><dd>€{(disclosure.firstChargeAmountMinor / 100).toFixed(2)}</dd></div>
-          <div className="flex justify-between gap-4"><dt>First charge time</dt><dd>{formatDisclosureTimestamp(disclosure.firstChargeAt)}</dd></div>
-          <div className="flex justify-between gap-4"><dt>Cancel before</dt><dd>{formatDisclosureTimestamp(disclosure.cancelBy)}</dd></div>
-          <div className="flex justify-between gap-4"><dt>Renews</dt><dd>{formatDisclosureTimestamp(disclosure.renewalAt)}</dd></div>
-          <div className="flex justify-between gap-4"><dt>Renewal amount</dt><dd>{disclosure.renewalAmountMinor === null ? 'Not applicable' : `€${(disclosure.renewalAmountMinor / 100).toFixed(2)}/year`}</dd></div>
-          <div className="flex justify-between gap-4"><dt>Refund window</dt><dd>{disclosure.refundWindowDays ? `${disclosure.refundWindowDays} days` : 'Not applicable'}</dd></div>
-          <div className="flex justify-between gap-4"><dt>Auto-renewal</dt><dd>{disclosure.autoRenew ? 'On' : 'Off'}</dd></div>
-          <div className="flex justify-between gap-4"><dt>Prepaid</dt><dd>{disclosure.prepaid ? 'Yes' : 'No'}</dd></div>
-          <div className="flex justify-between gap-4"><dt>Access through</dt><dd>{formatDisclosureTimestamp(disclosure.entitlementEndsAt)}</dd></div>
-        </dl>
+        <AnnualConfirmationSummary disclosure={disclosure} />
+        {provisionError && <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">{provisionError}</div>}
         <Button type="button" className="w-full" disabled={provisioning} onClick={onConfirmAnnualClaim}>
-          {provisioning ? 'Starting…' : 'Confirm annual terms and continue'}
+          {provisioning ? 'Starting…' : pendingAnnualClaim.provider === 'none' ? 'Create account and start free trial' : 'Confirm annual terms and continue'}
         </Button>
-        <button type="button" onClick={onBack} className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
+        <button type="button" disabled={provisioning} onClick={onBack} className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
           <ArrowLeft className="h-4 w-4" /> Back
         </button>
       </div>
@@ -809,7 +802,7 @@ function StepChoosePlan({
     if (!bitcoinAvailable) {
       return (
         <div className="space-y-4" role="alert">
-          <p className="text-sm text-red-600 dark:text-red-400">Bitcoin checkout is not available for this server-owned annual offer.</p>
+          <p className="text-sm text-red-600 dark:text-red-400">Bitcoin checkout is not available for this annual offer.</p>
           <Button type="button" variant="outline" onClick={onBack}>Back to payment methods</Button>
         </div>
       )
@@ -896,13 +889,13 @@ function StepChoosePlan({
 
           {!stripeAvailable && !bitcoinAvailable && (
             <p role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">
-              No payment method is authorized for this server-owned annual offer.
+              No payment method is authorized for this annual offer.
             </p>
           )}
         </div>
 
         {(paymentMethodError || provisionError) && (
-          <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+          <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
             <p className="text-sm text-red-600 dark:text-red-400">{paymentMethodError ?? provisionError}</p>
           </div>
         )}
@@ -1106,7 +1099,7 @@ function StepChoosePlan({
 
       {/* Error display */}
       {provisionError && (
-        <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+        <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
           <p className="text-sm text-red-600 dark:text-red-400">{provisionError}</p>
           <button
             onClick={onClearError}
@@ -1259,9 +1252,11 @@ function StepAdminInfo({ serverUrl, onNext }: { serverUrl: string; onNext: () =>
 type Step = 'account' | 'verifiedAccount' | 'plan' | 'selfhost' | 'admin' | 'paidAccount' | 'vault'
 
 const STEPS_HOSTED = [
-  { key: 'account' as const, label: 'Account', number: 1 },
-  { key: 'plan' as const, label: 'Plan', number: 2 },
-  { key: 'vault' as const, label: 'Setup', number: 3 },
+  { key: 'account' as const, label: 'Email', number: 1 },
+  { key: 'verifiedAccount' as const, label: 'Password', number: 2 },
+  { key: 'plan' as const, label: 'Plan', number: 3 },
+  { key: 'paidAccount' as const, label: 'Account setup', number: 4 },
+  { key: 'vault' as const, label: 'Finish', number: 5 },
 ]
 
 const STEPS_SELFHOST = [
@@ -1385,12 +1380,14 @@ export default function SignupPage() {
   const [cryptoPaymentSession, setCryptoPaymentSession] = useState<CryptoPaymentSession | null>(null)
   const [provisionError, setProvisionError] = useState<string | null>(null)
   const [provisioning, setProvisioning] = useState(false)
+  const operationRef = useRef(false)
   const [usingSelfHostedServer, setUsingSelfHostedServer] = useState(false)
   const [planView, setPlanView] = useState<PlanView>('cards')
   const [wantsProductUpdates, setWantsProductUpdates] = useState(false)
   const [rememberDevice, setRememberDevice] = useState(false)
   const [returnTo, setReturnTo] = useState<string | null>(null)
   const [showReturnFallback, setShowReturnFallback] = useState(false)
+  const claimAttemptedRef = useRef(false)
   const [emailOwnershipToken, setEmailOwnershipToken] = useState<string | null>(null)
   const [annualOffer, setAnnualOffer] = useState<AnnualOfferResponse | null>(null)
   const [annualOfferRequestId, setAnnualOfferRequestId] = useState<string | null>(null)
@@ -1409,6 +1406,30 @@ export default function SignupPage() {
     continuation: ReturnType<typeof createEmailLinkContinuation>
   } | null>(null)
   const formDataRef = useRef<SignupFormData | null>(null)
+
+  const navigation = useSignupNavigation({
+    enabled: !usingSelfHostedServer && !!emailOwnershipToken && step !== 'vault',
+    step,
+    view: planView,
+    restore: (checkpoint) => {
+      if (operationRef.current) return false
+      if (checkpoint.step === 'verifiedAccount' && !claimAttemptedRef.current) {
+        setStep('verifiedAccount')
+        return true
+      }
+      if (checkpoint.step !== 'plan' || !annualOffer || !formDataRef.current?.password) return false
+      const view = checkpoint.view
+      if (view === 'cards' || view === 'method'
+        || (view === 'confirm' && pendingAnnualClaim)
+        || (view === 'payment' && clientSecret)
+        || (view === 'crypto' && cryptoPaymentSession)) {
+        setPlanView(view as PlanView)
+        setStep('plan')
+        return true
+      }
+      return false
+    },
+  })
 
   useEffect(() => {
     mountedRef.current = true
@@ -1585,7 +1606,7 @@ export default function SignupPage() {
 
   const handleVerifiedAccountComplete = useCallback(async (data: PaidAccountFormData) => {
     if (!annualOffer || !emailOwnershipToken || !recoveredSignupEmail) {
-      throw new Error('Your verified annual offer is no longer available. Request a new email link.')
+      throw new Error('Your trial options are no longer available. Request a new email link.')
     }
     const email = normalizeEmailForComparison(recoveredSignupEmail)
     if (!email) throw new Error('Your verified email is unavailable. Request a new email link.')
@@ -1632,6 +1653,19 @@ export default function SignupPage() {
   }, [annualOfferRequestId, recoveredSignupEmail])
 
   const handleSelectFree = useCallback(async () => {
+    if (operationRef.current) return
+    if (clientSecret || cryptoPaymentSession) {
+      setProvisionError('A payment is already pending. Resume it below, or use payment recovery to cancel it before choosing another option.')
+      return
+    }
+    if (pendingAnnualClaim && (claimAttemptedRef.current || Date.parse(pendingAnnualClaim.activation.expiresAt) > Date.now())) {
+      if (pendingAnnualClaim.provider === 'none') setPlanView('confirm')
+      else setProvisionError(claimAttemptedRef.current
+        ? 'Setup may have started. Return to your current selection below to finish or retry safely.'
+        : `Your current option is held until ${new Date(pendingAnnualClaim.activation.expiresAt).toUTCString()}. After that time, choose a different option and continue. Or return to your current selection below.`)
+      return
+    }
+    operationRef.current = true
     setProvisioning(true)
     setProvisionError(null)
     try {
@@ -1658,16 +1692,31 @@ export default function SignupPage() {
       const message = err instanceof Error ? err.message : 'Failed to set up your account'
       setProvisionError(message)
     } finally {
+      operationRef.current = false
       setProvisioning(false)
     }
-  }, [annualOffer, emailOwnershipToken, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
+  }, [annualOffer, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
 
   const handleSelectPaid = useCallback(async () => {
+    if (operationRef.current) return
+    if (clientSecret) { setPlanView('payment'); return }
+    if (cryptoPaymentSession) {
+      setProvisionError('A Bitcoin payment is already pending. Use payment recovery to cancel it before choosing card payment.')
+      return
+    }
+    if (pendingAnnualClaim && (claimAttemptedRef.current || Date.parse(pendingAnnualClaim.activation.expiresAt) > Date.now())) {
+      if (pendingAnnualClaim.provider === 'stripe') setPlanView('confirm')
+      else setProvisionError(claimAttemptedRef.current
+        ? 'Setup may have started. Return to your current selection below to finish or retry safely.'
+        : `Your current option is held until ${new Date(pendingAnnualClaim.activation.expiresAt).toUTCString()}. After that time, choose a different option and continue. Or return to your current selection below.`)
+      return
+    }
+    operationRef.current = true
     setProvisionError(null)
     setProvisioning(true)
     try {
       if (!annualOffer || !emailOwnershipToken || !recoveredSignupEmail) throw new Error('Verify your email before selecting a trial.')
-      if (!isAnnualOfferProviderAvailable(annualOffer.offer, 'stripe')) throw new Error('Card checkout is not available for this server-owned annual offer.')
+      if (!isAnnualOfferProviderAvailable(annualOffer.offer, 'stripe')) throw new Error('Card checkout is not available for this annual offer.')
       const authority = await activateAnnualCheckout({
         fetcher: fetch,
         billingApiUrl: BILLING_API_URL,
@@ -1689,16 +1738,31 @@ export default function SignupPage() {
       setProvisionError(message)
       setPlanView('method')
     } finally {
+      operationRef.current = false
       setProvisioning(false)
     }
-  }, [annualOffer, emailOwnershipToken, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
+  }, [annualOffer, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
 
   const handleSelectCrypto = useCallback(async () => {
+    if (operationRef.current) return
+    if (cryptoPaymentSession) { setPlanView('crypto'); return }
+    if (clientSecret) {
+      setProvisionError('A card payment is already pending. Use payment recovery to cancel it before choosing Bitcoin.')
+      return
+    }
+    if (pendingAnnualClaim && (claimAttemptedRef.current || Date.parse(pendingAnnualClaim.activation.expiresAt) > Date.now())) {
+      if (pendingAnnualClaim.provider === 'btcpay') setPlanView('confirm')
+      else setProvisionError(claimAttemptedRef.current
+        ? 'Setup may have started. Return to your current selection below to finish or retry safely.'
+        : `Your current option is held until ${new Date(pendingAnnualClaim.activation.expiresAt).toUTCString()}. After that time, choose a different option and continue. Or return to your current selection below.`)
+      return
+    }
+    operationRef.current = true
     setProvisionError(null)
     setProvisioning(true)
     try {
       if (!annualOffer || !emailOwnershipToken || !recoveredSignupEmail) throw new Error('Verify your email before selecting a payment method.')
-      if (!isAnnualOfferProviderAvailable(annualOffer.offer, 'btcpay', CRYPTO_CHECKOUT_ENABLED)) throw new Error('Bitcoin checkout is not available for this server-owned annual offer.')
+      if (!isAnnualOfferProviderAvailable(annualOffer.offer, 'btcpay', CRYPTO_CHECKOUT_ENABLED)) throw new Error('Bitcoin checkout is not available for this annual offer.')
       if (cryptoPaymentSession) {
         setPlanView('crypto')
         return
@@ -1722,16 +1786,28 @@ export default function SignupPage() {
       }
       setProvisionError(err instanceof Error ? err.message : 'Failed to start crypto checkout')
     } finally {
+      operationRef.current = false
       setProvisioning(false)
     }
-  }, [annualOffer, cryptoPaymentSession, emailOwnershipToken, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
+  }, [annualOffer, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
 
   const handleConfirmAnnualClaim = useCallback(async () => {
     const pending = pendingAnnualClaim
-    if (!pending || !annualOffer) return
+    if (!pending || !annualOffer || operationRef.current) return
+    // Only unattempted authority can be discarded. An expired token after a
+    // dispatched request may still own an account or payment with an unknown outcome.
+    if (!claimAttemptedRef.current && Date.parse(pending.activation.expiresAt) <= Date.now()) {
+      setPendingAnnualClaim(null)
+      setPlanView('cards')
+      setProvisionError('Your selected terms expired. Review the options and choose again before continuing.')
+      return
+    }
+    operationRef.current = true
     setProvisioning(true)
     setProvisionError(null)
     try {
+      navigation.markMutation(pending.provider === 'none' ? 'setup' : 'payment')
+      claimAttemptedRef.current = true
       if (pending.provider === 'none') {
         const data = formDataRef.current
         if (!data) throw new Error('Please enter your account details again.')
@@ -1790,14 +1866,16 @@ export default function SignupPage() {
       const message = err instanceof Error ? err.message : 'Failed to start crypto checkout'
       setProvisionError(message)
     } finally {
+      operationRef.current = false
       setProvisioning(false)
     }
-  }, [annualOffer, createEtebaseAccount, pendingAnnualClaim, provisionAnnualNoCard, recoveredSignupEmail, renewAnnualOfferAndRequireConsent, returnTo, serverUrl, startAnnualSignupPayment])
+  }, [annualOffer, createEtebaseAccount, navigation, pendingAnnualClaim, provisionAnnualNoCard, recoveredSignupEmail, renewAnnualOfferAndRequireConsent, returnTo, serverUrl, startAnnualSignupPayment])
 
   const handlePlanBack = useCallback(() => {
+    if (operationRef.current) return
     if (planView === 'confirm') {
-      setPendingAnnualClaim(null)
-      setPlanView('method')
+      // Back is navigation, not cancellation of the server reservation.
+      setPlanView(pendingAnnualClaim?.provider === 'none' ? 'cards' : 'method')
     } else if (planView === 'crypto') {
       setPlanView('method')
     } else if (planView === 'payment') {
@@ -1805,10 +1883,15 @@ export default function SignupPage() {
     } else if (planView === 'method') {
       setPlanView('cards')
     } else {
-      // Back from cards view goes to account step
-      setStep('account')
+      // A claim may already have created the encrypted account. Do not let
+      // navigation change its password while that outcome is unresolved.
+      if (claimAttemptedRef.current || clientSecret || cryptoPaymentSession) {
+        setProvisionError('Continue your current selection to finish setup. Your account details are retained while setup is pending.')
+        return
+      }
+      setStep('verifiedAccount')
     }
-  }, [planView])
+  }, [clientSecret, cryptoPaymentSession, pendingAnnualClaim, planView])
 
   const createAndFinalizePaidAccount = useCallback(async (password?: string) => {
     const data = formDataRef.current
@@ -1819,6 +1902,8 @@ export default function SignupPage() {
   }, [createEtebaseAccount, finalizePaidSignup, serverUrl])
 
   const handlePaymentComplete = useCallback(async () => {
+    if (operationRef.current) return
+    operationRef.current = true
     setProvisioning(true)
     setProvisionError(null)
     try {
@@ -1829,6 +1914,7 @@ export default function SignupPage() {
       setProvisionError(err instanceof Error ? err.message : 'Payment succeeded, but account creation needs one more step.')
       setStep('paidAccount')
     } finally {
+      operationRef.current = false
       setProvisioning(false)
     }
   }, [createAndFinalizePaidAccount])
@@ -1841,6 +1927,7 @@ export default function SignupPage() {
   const handleVaultComplete = useCallback(() => {
     // Finalize authentication — only NOW does the user become authenticated.
     completeSignup()
+    navigation.clear()
     if (returnTo) {
       setShowReturnFallback(false)
       window.location.href = returnTo
@@ -1850,7 +1937,7 @@ export default function SignupPage() {
       return
     }
     router.push('/')
-  }, [completeSignup, returnTo, router])
+  }, [completeSignup, navigation, returnTo, router])
 
   const email = formDataRef.current?.email || ''
 
@@ -1858,10 +1945,32 @@ export default function SignupPage() {
     ? STEPS_SELFHOST
     : STEPS_HOSTED
 
+  if (navigation.recovery) {
+    return <div className="mx-auto w-full max-w-md space-y-4">
+      <h1 className="text-xl font-semibold">Continue your signup safely</h1>
+      <p role="status">Your password and verification proof were not saved. Refreshing has not repeated account creation or started another payment.</p>
+      {navigation.recovery === 'review' ? <>
+        <p>Verify your email again to continue. If you already chose a trial, it may remain reserved briefly; we will not replace a pending payment.</p>
+        <Button onClick={() => navigation.clear()}>Verify email again</Button>
+      </> : <>
+        <p>Setup may already have started. Do not start a second signup or payment. {navigation.recovery === 'payment' ? 'Recover your existing payment to check its status.' : 'Try signing in with the password you chose. If setup is incomplete, contact support to recover it.'}</p>
+        {navigation.recovery === 'payment' && <Link href="/signup/pending-payment" className="block underline">Recover existing payment</Link>}
+        <Link href="/login" className="block underline">Sign in to your account</Link>
+        <a href="mailto:support@silentsuite.io" className="block underline">Contact support</a>
+      </>}
+    </div>
+  }
+
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col items-stretch justify-center md:flex-row md:items-start">
-      <ProgressStepper currentStep={step === 'paidAccount' ? 'vault' : step === 'verifiedAccount' ? 'account' : step} steps={activeSteps} />
+      <ProgressStepper currentStep={provisioning && step === 'plan' && claimAttemptedRef.current ? 'paidAccount' : step} steps={activeSteps} />
       <div className="mx-auto w-full max-w-md min-w-0 md:mx-0 md:flex-1">
+        {navigation.notice && <p role="status" className="mb-4 text-sm text-[rgb(var(--muted))]">Finish or recover your current setup before changing account details. Your password has not been saved.</p>}
+        {step === 'plan' && planView !== 'confirm' && pendingAnnualClaim && <Button variant="outline" disabled={provisioning} className="mb-4 w-full" onClick={() => { setProvisionError(null); setPlanView('confirm') }}>Return to current selection</Button>}
+        {step === 'plan' && (clientSecret || cryptoPaymentSession) && planView !== 'payment' && planView !== 'crypto' && <div className="mb-4 space-y-2">
+          <Button variant="outline" disabled={provisioning} onClick={() => setPlanView(clientSecret ? 'payment' : 'crypto')}>Resume pending payment</Button>
+          <Link href="/signup/pending-payment" className="block text-sm underline">Recover or cancel pending payment</Link>
+        </div>}
         {step === 'account' && (
           <>
             {emailProofBusy && <p role="status" className="mb-4 text-sm text-[rgb(var(--muted))]">{requestingEmailProof ? 'Requesting a new verification email...' : 'Verifying your email and loading trial options...'}</p>}
@@ -1898,7 +2007,7 @@ export default function SignupPage() {
               rememberDevice={rememberDevice}
               onRememberDeviceChange={setRememberDevice}
             />}
-            {awaitingEmailProof && <p role="status" className="mt-4 text-center text-sm text-[rgb(var(--muted))]">Check your email and open the verification link in this browser. Your password is not saved while you open the link.</p>}
+            {awaitingEmailProof && <p role="status" className="mt-4 text-center text-sm text-[rgb(var(--muted))]">Check your email and open the verification link in this browser. Then choose your password.</p>}
           </>
         )}
         {step === 'verifiedAccount' && (
@@ -1907,6 +2016,7 @@ export default function SignupPage() {
             onNext={handleVerifiedAccountComplete}
             initialError={provisionError}
             continuation="verified-no-card"
+            initialData={formDataRef.current ?? undefined}
           />
         )}
         {step === 'selfhost' && (
@@ -1935,7 +2045,7 @@ export default function SignupPage() {
             pendingAnnualClaim={pendingAnnualClaim}
             onConfirmAnnualClaim={handleConfirmAnnualClaim}
           /> : <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">
-            <p>{provisionError ?? 'Your server-owned annual offer is unavailable. Verify your email to request a new offer.'}</p>
+            <p>{provisionError ?? 'Your annual offer is unavailable. Verify your email to request a new offer.'}</p>
             {annualOfferRequestId && recoveredSignupEmail && (
               <button
                 type="button"

--- a/apps/web/app/(auth)/signup/success/page.tsx
+++ b/apps/web/app/(auth)/signup/success/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback, Suspense } from 'react'
+import { useEffect, useState, useCallback, useRef, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { CheckCircle, AlertTriangle, Lock } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
@@ -14,7 +14,7 @@ import { CheckoutReturnAnalytics } from '../commercial-funnel-analytics'
 // Inner component that reads searchParams (must be inside <Suspense>)
 // ---------------------------------------------------------------------------
 
-type RedirectState = 'loading' | 'account' | 'vault' | 'failed' | 'expired' | 'none'
+type RedirectState = 'loading' | 'session' | 'account' | 'vault' | 'failed' | 'expired' | 'none'
 
 function SignupSuccessInner() {
   const router = useRouter()
@@ -22,6 +22,7 @@ function SignupSuccessInner() {
   const completeSignup = useAuthStore((s) => s.completeSignup)
   const createEtebaseAccount = useAuthStore((s) => s.createEtebaseAccount)
   const finalizePaidSignup = useAuthStore((s) => s.finalizePaidSignup)
+  const recoverCompletedSignupSession = useAuthStore((s) => s.recoverCompletedSignupSession)
   const restoreSignupStateFromRedirect = useAuthStore((s) => s.restoreSignupStateFromRedirect)
   const redirectStatus = searchParams.get('redirect_status')
   const setupIntent = searchParams.get('setup_intent')
@@ -32,9 +33,31 @@ function SignupSuccessInner() {
   const [state, setState] = useState<RedirectState>(isStripeRedirect ? 'loading' : 'none')
   const [restoredEmail, setRestoredEmail] = useState<string>('')
   const [showReturnFallback, setShowReturnFallback] = useState(false)
+  const [sessionError, setSessionError] = useState<string | null>(null)
+  const [password, setPassword] = useState('')
+  const recoveryInFlight = useRef(false)
+  const restoredOnce = useRef(false)
+
+  const recoverSession = useCallback(async (credential?: string) => {
+    if (recoveryInFlight.current) return
+    recoveryInFlight.current = true
+    setSessionError(null)
+    setState('loading')
+    try {
+      await recoverCompletedSignupSession(credential)
+      setPassword('')
+      setState('vault')
+    } catch (error) {
+      setSessionError(error instanceof Error ? error.message : 'Could not finish signing in. Please retry.')
+      setState('session')
+    } finally {
+      recoveryInFlight.current = false
+    }
+  }, [recoverCompletedSignupSession])
 
   useEffect(() => {
-    if (!isStripeRedirect) return
+    if (!isStripeRedirect || restoredOnce.current) return
+    restoredOnce.current = true
 
     if (redirectStatus === 'failed') {
       setState('failed')
@@ -45,7 +68,7 @@ function SignupSuccessInner() {
       const restored = restoreSignupStateFromRedirect()
       if (restored?.pendingSignup.provisionedUser) {
         setRestoredEmail(restored.pendingSignup.email)
-        setState('vault')
+        void recoverSession()
       } else if (restored?.pendingSignup.paymentSessionToken) {
         setRestoredEmail(restored.pendingSignup.email)
         setState('account')
@@ -100,6 +123,22 @@ function SignupSuccessInner() {
         {checkoutReturn}
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-[rgb(var(--primary))] border-t-transparent" />
         <p className="mt-4 text-sm text-[rgb(var(--muted))]">Completing setup...</p>
+      </div>
+    )
+  }
+
+  if (state === 'session') {
+    return (
+      <div className="max-w-md mx-auto space-y-6">
+        {checkoutReturn}
+        <h2 className="text-xl font-semibold">Finish signing in</h2>
+        <p className="text-sm text-[rgb(var(--muted))]">Your account is already set up. Retry signing in, or enter the existing password for {restoredEmail} if this browser no longer has your account session. Your payment will not be submitted again.</p>
+        {sessionError && <p role="alert" className="text-sm text-red-500">{sessionError}</p>}
+        <form className="space-y-4" onSubmit={(event) => { event.preventDefault(); void recoverSession(password || undefined) }}>
+          <label htmlFor="recovery-password" className="block text-sm">Existing account password</label>
+          <input id="recovery-password" type="password" autoComplete="current-password" value={password} onChange={(event) => setPassword(event.target.value)} className="w-full rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--background))] p-3" />
+          <Button type="submit" className="w-full">Retry sign in</Button>
+        </form>
       </div>
     )
   }

--- a/apps/web/app/(auth)/signup/use-signup-navigation.ts
+++ b/apps/web/app/(auth)/signup/use-signup-navigation.ts
@@ -1,0 +1,95 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+type Checkpoint = { step: string; view: string }
+type Recovery = 'review' | 'setup' | 'payment'
+const KEY = 'silentsuiteSignup'
+
+/** History contains presentation state only, never proof, password or payment capabilities. */
+export function useSignupNavigation({ enabled, step, view, restore }: {
+  enabled: boolean
+  step: string
+  view: string
+  restore: (checkpoint: Checkpoint) => boolean
+}) {
+  const journey = useRef<string | null>(null)
+  const phase = useRef<Recovery>('review')
+  const latest = useRef({ step, view, restore })
+  latest.current = { step, view, restore }
+  const [recovery, setRecovery] = useState<Recovery | null>(null)
+  const [notice, setNotice] = useState(false)
+
+  useEffect(() => {
+    const saved = window.history.state?.[KEY]
+    const params = new URLSearchParams(window.location.search)
+    // A fresh delivered link has its own validated continuation. Never replay
+    // the old link or a mutation merely because the page was refreshed.
+    if (!params.has('token') && !params.has('email_verification_token') && saved?.version === 1) {
+      let mutation: string | null = null
+      try { mutation = sessionStorage.getItem(`${KEY}:${saved.journey}`) } catch { /* Fall back to the current checkpoint. */ }
+      const previousPhase = mutation ?? saved.phase
+      setRecovery(previousPhase === 'setup' || previousPhase === 'payment' ? previousPhase : 'review')
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!enabled || recovery) return
+    if (!journey.current) journey.current = crypto.randomUUID()
+    const saved = window.history.state?.[KEY]
+    const checkpoint = { version: 1, journey: journey.current, step, view, phase: phase.current }
+    if (saved?.journey !== journey.current) {
+      window.history.replaceState({ ...window.history.state, [KEY]: checkpoint }, '')
+    } else if (saved.step !== step || saved.view !== view) {
+      window.history.pushState({ ...window.history.state, [KEY]: checkpoint }, '')
+    }
+  }, [enabled, recovery, step, view])
+
+  useEffect(() => {
+    if (!enabled || recovery) return
+    const onPop = (event: PopStateEvent) => {
+      const saved = event.state?.[KEY]
+      if (saved?.journey === journey.current && latest.current.restore(saved)) {
+        setNotice(false)
+        return
+      }
+      // Unsupported/irreversible checkpoints are not permission to rerun setup.
+      setNotice(true)
+      window.history.replaceState({ ...window.history.state, [KEY]: {
+        version: 1, journey: journey.current, step: latest.current.step,
+        view: latest.current.view, phase: phase.current,
+      } }, '')
+    }
+    const onLeave = (event: BeforeUnloadEvent) => { event.preventDefault(); event.returnValue = '' }
+    window.addEventListener('popstate', onPop)
+    window.addEventListener('beforeunload', onLeave)
+    return () => {
+      window.removeEventListener('popstate', onPop)
+      window.removeEventListener('beforeunload', onLeave)
+    }
+  }, [enabled, recovery])
+
+  const markMutation = (next: 'setup' | 'payment') => {
+    try {
+      sessionStorage.setItem(`${KEY}:${journey.current}`, next)
+    } catch {
+      throw new Error('Unable to save signup recovery progress. Free up browser storage or enable site storage, then retry.')
+    }
+    phase.current = next
+    // Synchronous: a refresh during the very first request must be recovery,
+    // even before React publishes loading state. This marker grants no authority.
+    window.history.replaceState({ ...window.history.state, [KEY]: {
+      version: 1, journey: journey.current, step, view, phase: next,
+    } }, '')
+  }
+  const clear = () => {
+    const state = { ...window.history.state }
+    try { sessionStorage.removeItem(`${KEY}:${journey.current ?? state[KEY]?.journey}`) } catch { /* No authority is stored here. */ }
+    delete state[KEY]
+    window.history.replaceState(state, '')
+    journey.current = null
+    phase.current = 'review'
+    setRecovery(null)
+  }
+  return { recovery, notice, markMutation, clear }
+}

--- a/apps/web/app/lib/__tests__/billing-v2.test.ts
+++ b/apps/web/app/lib/__tests__/billing-v2.test.ts
@@ -1,6 +1,6 @@
 import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import { describe, expect, it, vi } from 'vitest'
-import { BillingResponseError, activateAnnualCheckout, activateAuthenticatedAnnualCheckout, buildSameOriginReturnUrl, cancelAnonymousPaymentSessionRecovery, consumeSignupEmailOwnership, fetchAnonymousAnnualOffer, fetchAuthenticatedAnnualOffer, getAnonymousPaymentSessionRecovery, isRenewableAnnualOfferError, reconcileAnonymousPaymentSessionRecovery, requestSignupEmailOwnership, startAuthenticatedAnnualPayment, startSignupAnnualPayment, type BillingV2Fetch } from '../billing-v2'
+import { BillingResponseError, cancelUnclaimedAnnualSelection, activateAnnualCheckout, activateAuthenticatedAnnualCheckout, buildSameOriginReturnUrl, cancelAnonymousPaymentSessionRecovery, consumeSignupEmailOwnership, fetchAnonymousAnnualOffer, fetchAuthenticatedAnnualOffer, getAnonymousPaymentSessionRecovery, isRenewableAnnualOfferError, reconcileAnonymousPaymentSessionRecovery, requestSignupEmailOwnership, startAuthenticatedAnnualPayment, startSignupAnnualPayment, type BillingV2Fetch } from '../billing-v2'
 
 const requestId = 'e91a6d70-0d4e-4352-9bdc-426d1f76d771'
 const requestKey = '5fd4d86d-34de-4b82-9a66-9598ddf6e02f'
@@ -10,6 +10,39 @@ const prepaidDisclosure = { kind: 'prepaid', annualAmountMinor: 3600, firstCharg
 const chargeNowDisclosure = { ...prepaidDisclosure, kind: 'charge_now', renewalAmountMinor: 3600, autoRenew: true, prepaid: false }
 
 describe('billing v2 public authority client', () => {
+  it('cancels only an exact bound selection receipt, replaying identical expired authority after response loss', async () => {
+    const receipt = { contractVersion: 2, requestId, checkoutIntentJti: 'a2c4f872-01b7-4176-8325-522486b20cae', state: 'released' }
+    const fetcher = vi.fn<BillingV2Fetch>(function (this: unknown) {
+      expect(this === undefined || this === globalThis).toBe(true)
+      return Promise.resolve(new Response(JSON.stringify(receipt)))
+    }).mockRejectedValueOnce(new Error('response lost'))
+    const params = { fetcher, billingApiUrl: 'https://billing.example.test', email: 'customer@example.test', requestId,
+      checkoutIntentToken: signedCheckoutIntent, emailOwnershipToken: signedEmailProof }
+    await expect(cancelUnclaimedAnnualSelection(params)).rejects.toThrow('response lost')
+    await expect(cancelUnclaimedAnnualSelection(params)).resolves.toEqual(receipt)
+    expect(fetcher.mock.calls[0]).toEqual(fetcher.mock.calls[1])
+    expect(fetcher.mock.calls[1][0]).toBe('https://billing.example.test/auth/offers/v2/cancel')
+    expect(JSON.parse(String(fetcher.mock.calls[1][1]?.body))).toEqual({ contractVersion: 2, email: params.email,
+      requestId, checkoutIntentToken: signedCheckoutIntent, emailOwnershipToken: signedEmailProof })
+  })
+
+  it.each([
+    { status: 201 }, { status: 202 }, { contractVersion: 3 }, { state: 'closed' },
+    { requestId: requestKey }, { checkoutIntentJti: requestKey }, { extra: 'not-canonical' },
+    { checkoutIntentJti: null },
+  ])('rejects nonauthoritative cancellation receipt %j', async ({ status = 200, ...changes }) => {
+    const fetcher = vi.fn<BillingV2Fetch>().mockResolvedValue(new Response(JSON.stringify({ contractVersion: 2,
+      requestId, checkoutIntentJti: 'a2c4f872-01b7-4176-8325-522486b20cae', state: 'released', ...changes }), { status }))
+    await expect(cancelUnclaimedAnnualSelection({ fetcher, billingApiUrl: 'https://billing.example.test',
+      email: 'customer@example.test', requestId, checkoutIntentToken: signedCheckoutIntent, emailOwnershipToken: signedEmailProof })).rejects.toThrow('exact selection')
+  })
+
+  it.each([400, 409, 429, 503])('retains the cancellation error boundary for HTTP %s', async (status) => {
+    const fetcher = vi.fn<BillingV2Fetch>().mockResolvedValue(new Response(JSON.stringify({ type: 'https://api.silentsuite.io/errors/authority-in-progress' }), { status }))
+    await expect(cancelUnclaimedAnnualSelection({ fetcher, billingApiUrl: 'https://billing.example.test',
+      email: 'customer@example.test', requestId, checkoutIntentToken: signedCheckoutIntent, emailOwnershipToken: signedEmailProof })).rejects.toMatchObject({ billingStatus: status })
+  })
+
   it('builds only absolute same-origin HTTP(S) return URLs', () => {
     expect(buildSameOriginReturnUrl('/signup', 'https://app.example.test')).toBe('https://app.example.test/signup')
     expect(buildSameOriginReturnUrl('/signup/pending-payment', 'https://app.example.test')).toBe('https://app.example.test/signup/pending-payment')

--- a/apps/web/app/lib/billing-v2.ts
+++ b/apps/web/app/lib/billing-v2.ts
@@ -61,6 +61,8 @@ export interface AnnualCheckoutActivation {
 
 export interface EmailOwnership { contractVersion: 2; emailOwnershipToken: string; expiresAt: string }
 
+export interface AnnualSelectionRelease { contractVersion: 2; requestId: string; checkoutIntentJti: string; state: 'released' }
+
 export type SignupAnnualPayment =
   | { contractVersion: 2; kind: 'stripe'; clientSecret: string; paymentSessionToken: string }
   | { contractVersion: 2; kind: 'btcpay'; cryptoCheckoutUrl: string; cryptoInvoiceId: string; cryptoInvoiceLookupToken: string; paymentSessionToken: string }
@@ -221,6 +223,32 @@ async function jsonOrThrow(response: Response): Promise<unknown> {
 
 function api(url: string, path: string) { return `${url.replace(/\/$/, '')}${path}` }
 function jsonInit(method: 'POST' | 'GET', body?: object): RequestInit { return { method, credentials: 'include', headers: { 'content-type': 'application/json' }, ...(body ? { body: JSON.stringify(body) } : {}) } }
+
+export async function cancelUnclaimedAnnualSelection(params: {
+  fetcher: BillingV2Fetch; billingApiUrl: string; email: string; requestId: string;
+  checkoutIntentToken: string; emailOwnershipToken: string;
+}): Promise<AnnualSelectionRelease> {
+  const { fetcher } = params
+  if (!isUuid(params.requestId) || !isSignedAuthorityToken(params.checkoutIntentToken, 'checkout-intent')
+    || !isSignedAuthorityToken(params.emailOwnershipToken, 'email-ownership')) throw new Error('Invalid selection cancellation request')
+  // Decode only a bounded transport-validated identity for response correlation.
+  // This is not signature/expiry authority: Billing checks the exact stored token
+  // and live ownership proof, including replay after checkout expiry.
+  const claims: unknown = JSON.parse(atob(params.checkoutIntentToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')))
+  if (!isObject(claims) || !isUuid(claims.jti) || claims.requestId !== params.requestId) throw new Error('Invalid selection cancellation identity')
+  const response = await fetcher(api(params.billingApiUrl, '/auth/offers/v2/cancel'), jsonInit('POST', {
+    contractVersion: 2, email: params.email, requestId: params.requestId,
+    checkoutIntentToken: params.checkoutIntentToken, emailOwnershipToken: params.emailOwnershipToken,
+  }))
+  const body = await jsonOrThrow(response)
+  if (response.status !== 200 || !isObject(body)
+    || !hasExactKeys(body, ['contractVersion', 'requestId', 'checkoutIntentJti', 'state'])
+    || body.contractVersion !== 2 || body.state !== 'released'
+    || body.requestId !== params.requestId || body.checkoutIntentJti !== claims.jti) {
+    throw new Error('Billing did not confirm cancellation of this exact selection')
+  }
+  return body as unknown as AnnualSelectionRelease
+}
 
 export async function fetchAnonymousAnnualOffer(params: {
   fetcher: BillingV2Fetch

--- a/apps/web/app/stores/__tests__/signup-billing-session.test.ts
+++ b/apps/web/app/stores/__tests__/signup-billing-session.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuthStore } from '../use-auth-store'
+
+const mocks = vi.hoisted(() => ({
+  session: null as string | null,
+  signup: vi.fn(async () => ({ savedSession: 'encrypted-session', authToken: 'unused' })),
+  login: vi.fn(),
+  proof: vi.fn(),
+}))
+vi.mock('@/app/lib/secure-storage', () => ({
+  secureGet: vi.fn(async () => mocks.session),
+  secureSet: vi.fn(async (_key: string, value: string) => { mocks.session = value }),
+  secureRemove: vi.fn(), secureClear: vi.fn(), migrateFromLocalStorage: vi.fn(),
+}))
+vi.mock('@/app/lib/etebase-auth', () => ({ etebaseSignUp: mocks.signup, etebaseLogIn: mocks.login, issueBillingLinkProof: mocks.proof }))
+vi.mock('@/app/lib/self-hosted', () => ({ isSelfHosted: false, isCustomServer: (url?: string) => !!url && url !== 'https://server.silentsuite.io' }))
+
+const email = 'signup@example.test'
+const id = '5fd4d86d-34de-4b82-9a66-9598ddf6e02f'
+const capability = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG'
+const completed = {
+  contractVersion: 2, id, email, provisioningStatus: 'trialing_no_card', emailVerified: true,
+  earlyAdopter: true, rememberDevice: false, createdAt: '2026-08-11T00:00:00Z',
+  clientSecret: null, cryptoCheckoutUrl: null, cryptoInvoiceId: null, cryptoInvoiceLookupToken: null,
+}
+const profile = { id, email, provisioningStatus: 'trialing_no_card', isAdmin: false, emailVerified: true, rememberDevice: false }
+const json = (value: unknown, status = 200) => new Response(JSON.stringify(value), { status })
+
+beforeEach(() => {
+  useAuthStore.setState({ pendingSignup: null, user: null, isAuthenticated: false, isLoading: false, error: null, subscriptionStatus: null })
+  localStorage.clear(); sessionStorage.clear()
+  mocks.session = null
+  mocks.signup.mockClear(); mocks.login.mockReset(); mocks.proof.mockReset()
+  let sequence = 0
+  mocks.proof.mockImplementation(async () => `fresh-proof-${++sequence}`)
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+describe('signup Billing session boundary', () => {
+  it.each([undefined, false, true])('sends explicit no-card and paid opt-in for %s', async (consent) => {
+    useAuthStore.getState().prepareSignupDraft(email, consent)
+    await useAuthStore.getState().createEtebaseAccount(email, 'test-password')
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const path = new URL(String(url)).pathname
+      return json(path === '/auth/provision/v2' ? completed : profile)
+    })
+    await useAuthStore.getState().provisionAnnualNoCard(capability)
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body)).wantsProductUpdates).toBe(consent === true)
+    useAuthStore.setState({ pendingSignup: { email, wantsProductUpdates: consent } })
+    vi.mocked(fetch).mockImplementation(async (_url, init) => {
+      const body = JSON.parse(String(init?.body))
+      expect(body.wantsProductUpdates).toBe(consent === true)
+      return json({ contractVersion: 2, kind: 'stripe', clientSecret: 'pi_secret', paymentSessionToken: body.recoverySecret })
+    })
+    await useAuthStore.getState().startAnnualSignupPayment(capability, 'stripe', window.location.origin + '/signup')
+  })
+
+  it('shares duplicate create/provision clicks rather than superseding an identical signup', async () => {
+    useAuthStore.getState().prepareSignupDraft(email)
+    await import('@/app/lib/etebase-auth')
+    const creation = await Promise.allSettled([useAuthStore.getState().createEtebaseAccount(email, 'test-password'), useAuthStore.getState().createEtebaseAccount(email, 'test-password')])
+    expect(mocks.signup).toHaveBeenCalledTimes(1)
+    expect(creation.map((result) => result.status)).toEqual(['fulfilled', 'fulfilled'])
+    vi.mocked(fetch).mockImplementation(async (url) => json(String(url).endsWith('/auth/provision/v2') ? completed : profile))
+    await Promise.all([useAuthStore.getState().provisionAnnualNoCard(capability), useAuthStore.getState().provisionAnnualNoCard(capability)])
+    expect(fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('retains paid completion and the exact recovery capability while duplicate retries establish only a session', async () => {
+    useAuthStore.setState({ pendingSignup: { email, billingContractVersion: 2, paymentSessionToken: capability, paymentSessionRequestKey: 'request-lineage' } })
+    await useAuthStore.getState().createEtebaseAccount(email, 'test-password')
+    const paths: string[] = []
+    let fail = true
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const path = new URL(String(url)).pathname
+      paths.push(path)
+      if (path === '/auth/signup/finalize-payment/v2') return json({ ...completed, provisioningStatus: 'active', planId: 'early_annual', isAdmin: false })
+      return fail ? json({}, 503) : json({ ...profile, provisioningStatus: 'active' })
+    })
+    await expect(useAuthStore.getState().finalizePaidSignup()).rejects.toThrow(/session/i)
+    expect(useAuthStore.getState().pendingSignup).toMatchObject({ paymentSessionToken: capability, paymentSessionRequestKey: 'request-lineage', provisionedUser: { id } })
+    fail = false
+    await useAuthStore.getState().createEtebaseAccount(email, 'test-password')
+    await Promise.all([useAuthStore.getState().finalizePaidSignup(), useAuthStore.getState().finalizePaidSignup()])
+    expect(paths).toEqual(['/auth/signup/finalize-payment/v2', '/auth/token-exchange', '/auth/token-exchange', '/auth/session'])
+    expect(mocks.signup).toHaveBeenCalledTimes(1)
+    useAuthStore.getState().completeSignup()
+    expect(useAuthStore.getState().user?.id).toBe(id)
+  })
+
+  it('does not publish a session into a replacement signup', async () => {
+    useAuthStore.getState().prepareSignupDraft(email)
+    await useAuthStore.getState().createEtebaseAccount(email, 'test-password')
+    let resolveSession!: (response: Response) => void
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const path = new URL(String(url)).pathname
+      if (path === '/auth/provision/v2') return json(completed)
+      if (path === '/auth/token-exchange') return json(profile)
+      return new Promise<Response>((resolve) => { resolveSession = resolve })
+    })
+    const operation = useAuthStore.getState().provisionAnnualNoCard(capability)
+    await vi.waitFor(() => expect(resolveSession).toBeDefined())
+    useAuthStore.getState().prepareSignupDraft('replacement@example.test')
+    resolveSession(json(profile))
+    await expect(operation).rejects.toThrow('superseded')
+    expect(useAuthStore.getState().pendingSignup?.email).toBe('replacement@example.test')
+    expect(useAuthStore.getState().pendingSignup?.billingSessionUserId).toBeUndefined()
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+  })
+
+  it('invalidates a prior session attestation before a failed session-only retry', async () => {
+    useAuthStore.getState().prepareSignupDraft(email)
+    await useAuthStore.getState().createEtebaseAccount(email, 'test-password')
+    vi.mocked(fetch).mockImplementation(async (url) => json(String(url).endsWith('/auth/provision/v2') ? completed : profile))
+    await useAuthStore.getState().provisionAnnualNoCard(capability)
+    vi.mocked(fetch).mockResolvedValue(json({}, 503))
+    await expect(useAuthStore.getState().provisionAnnualNoCard(capability)).rejects.toThrow(/session/i)
+    expect(() => useAuthStore.getState().completeSignup()).toThrow(/session/i)
+  })
+
+  it.each(['exchange-id', 'exchange-email', 'session-id', 'session-email', 'session-401', 'session-network'])('rejects %s without losing completed identity', async (failure) => {
+    useAuthStore.getState().prepareSignupDraft(email)
+    await useAuthStore.getState().createEtebaseAccount(email, 'test-password')
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const path = new URL(String(url)).pathname
+      if (path === '/auth/provision/v2') return json(completed)
+      if (path === '/auth/token-exchange') return json({ ...profile, ...(failure === 'exchange-id' ? { id: 'other' } : failure === 'exchange-email' ? { email: 'other@example.test' } : {}) })
+      if (failure === 'session-network') throw new TypeError('Failed to fetch')
+      return json({ ...profile, ...(failure === 'session-id' ? { id: 'other' } : failure === 'session-email' ? { email: 'other@example.test' } : {}) }, failure === 'session-401' ? 401 : 200)
+    })
+    await expect(useAuthStore.getState().provisionAnnualNoCard(capability)).rejects.toThrow(/session/i)
+    expect(useAuthStore.getState().pendingSignup?.provisionedUser?.id).toBe(id)
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+    expect(() => useAuthStore.getState().completeSignup()).toThrow(/session/i)
+  })
+
+  it('retains completed no-card provisioning on exchange failure and retries only the session with a fresh proof', async () => {
+    useAuthStore.getState().prepareSignupDraft(email, false, false)
+    await useAuthStore.getState().createEtebaseAccount(email, 'test-password')
+    const calls: string[] = []
+    let exchangeFails = true
+    vi.mocked(fetch).mockImplementation(async (url, init) => {
+      const path = new URL(String(url)).pathname
+      calls.push(path)
+      expect(init?.credentials).toBe('include')
+      if (path === '/auth/provision/v2') return json(completed)
+      if (path === '/auth/token-exchange') return exchangeFails ? json({}, 503) : json(profile)
+      if (path === '/auth/session') return json({ id, email, emailVerified: true })
+      throw new Error('Unexpected endpoint')
+    })
+    await expect(useAuthStore.getState().provisionAnnualNoCard(capability)).rejects.toThrow(/session/i)
+    expect(useAuthStore.getState().pendingSignup?.provisionedUser?.id).toBe(id)
+    expect(useAuthStore.getState().isLoading).toBe(false)
+    expect(() => useAuthStore.getState().completeSignup()).toThrow(/session/i)
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+    expect(sessionStorage.getItem('silentsuite-signup-in-progress')).toBe('true')
+    exchangeFails = false
+    // The real page invokes account creation again before retrying provisioning.
+    await useAuthStore.getState().createEtebaseAccount(email, 'test-password')
+    await useAuthStore.getState().provisionAnnualNoCard(capability)
+    expect(mocks.signup).toHaveBeenCalledTimes(1)
+    expect(calls).toEqual(['/auth/provision/v2', '/auth/token-exchange', '/auth/token-exchange', '/auth/session'])
+    expect(mocks.proof).toHaveBeenCalledTimes(3)
+    const exchangeBodies = vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/auth/token-exchange')).map(([, init]) => JSON.parse(String(init?.body)))
+    expect(exchangeBodies).toEqual([{ etebaseLinkProof: 'fresh-proof-2', rememberDevice: false }, { etebaseLinkProof: 'fresh-proof-3', rememberDevice: false }])
+    useAuthStore.getState().completeSignup()
+    expect(useAuthStore.getState().user?.id).toBe(id)
+    expect(useAuthStore.getState().isAuthenticated).toBe(true)
+  })
+})

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -108,6 +108,20 @@ function resetStore() {
   })
 }
 
+function mockSignupBillingSession(id: string, email: string, isAdmin = false, emailVerified = true) {
+  vi.mocked(fetch)
+    .mockImplementationOnce(async (url, init) => {
+      expect(String(url)).toContain('/auth/token-exchange')
+      expect(init?.credentials).toBe('include')
+      return new Response(JSON.stringify({ id, email, isAdmin, emailVerified, rememberDevice: false }))
+    })
+    .mockImplementationOnce(async (url, init) => {
+      expect(String(url)).toContain('/auth/session')
+      expect(init?.credentials).toBe('include')
+      return new Response(JSON.stringify({ id, email, emailVerified }))
+    })
+}
+
 function paidSignupRequestBody(callIndex = 0) {
   const [, init] = vi.mocked(fetch).mock.calls[callIndex]
   return JSON.parse(init?.body as string) as Record<string, unknown>
@@ -452,6 +466,7 @@ describe('useAuthStore', () => {
       useAuthStore.setState({
         pendingSignup: {
           email: 'completed@example.com',
+          billingSessionUserId: 'user-1',
           provisionedUser: { id: 'user-1', planId: 'early_annual', isAdmin: false },
           provisionedSubscriptionStatus: 'active',
         },
@@ -579,6 +594,7 @@ describe('useAuthStore', () => {
         cryptoInvoiceLookupToken: null,
       })))
 
+      mockSignupBillingSession('5fd4d86d-34de-4b82-9a66-9598ddf6e02f', 'finalize@example.com')
       await useAuthStore.getState().finalizePaidSignup()
 
       expect(fetch).toHaveBeenCalledWith(
@@ -659,6 +675,7 @@ describe('useAuthStore', () => {
       }),
     } as Response)
 
+    mockSignupBillingSession('user-1', 'paid@example.com', true, false)
     await useAuthStore.getState().finalizePaidSignup()
 
     expect(fetch).toHaveBeenCalledWith(
@@ -733,6 +750,7 @@ describe('useAuthStore', () => {
       createdAt: '2026-08-11T00:00:00Z', clientSecret: null, cryptoCheckoutUrl: null,
       cryptoInvoiceId: null, cryptoInvoiceLookupToken: null,
     })))
+    mockSignupBillingSession('5fd4d86d-34de-4b82-9a66-9598ddf6e02f', 'recover-no-card@example.test')
     await useAuthStore.getState().provisionAnnualNoCard('abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG')
 
     expect(etebaseLogIn).toHaveBeenCalledWith('recover-no-card@example.test', 'password123', undefined)
@@ -758,6 +776,7 @@ describe('useAuthStore', () => {
       rememberDevice: false, isAdmin: false, createdAt: '2026-08-11T00:00:00Z', clientSecret: null,
       cryptoCheckoutUrl: null, cryptoInvoiceId: null, cryptoInvoiceLookupToken: null,
     })))
+    mockSignupBillingSession('5fd4d86d-34de-4b82-9a66-9598ddf6e02f', 'recover-paid@example.test')
     await useAuthStore.getState().finalizePaidSignup()
 
     expect(etebaseLogIn).toHaveBeenCalledWith('recover-paid@example.test', 'password123', undefined)
@@ -781,6 +800,7 @@ describe('useAuthStore', () => {
       cryptoInvoiceId: null,
       cryptoInvoiceLookupToken: null,
     })))
+    mockSignupBillingSession('5fd4d86d-34de-4b82-9a66-9598ddf6e02f', 'customer@example.test')
     await useAuthStore.getState().provisionAnnualNoCard('abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG')
     expect(useAuthStore.getState().pendingSignup?.provisionedUser?.planId).toBeNull()
     expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body))).toMatchObject({ contractVersion: 2, checkoutIntentToken: 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG' })
@@ -1016,6 +1036,7 @@ describe('useAuthStore', () => {
       useAuthStore.setState({
         pendingSignup: {
           email: 'new@user.com',
+          billingSessionUserId: 'new-1',
           provisionedUser: { id: 'new-1', planId: 'pro', isAdmin: false },
           provisionedSubscriptionStatus: 'trialing',
         },

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -40,6 +40,9 @@ interface PendingSignup {
   rememberDevice?: boolean
   paidSignupAttemptId?: string
   noCardProvisionAttemptId?: string
+  /** In-memory only; redirect storage must never attest a live session. */
+  billingSessionUserId?: string
+  etebaseAccountReady?: boolean
   /** v1 remains readable only for a persisted historical redirect/retry. */
   billingContractVersion?: 1 | 2
   /** Provisioned user data — stored here until the entire signup flow completes. */
@@ -105,6 +108,8 @@ interface AuthState {
   /** Clear only this exact authority after Billing proved it terminal/cancelled. */
   clearPendingSignupPaymentRecovery: (identity: PaidSignupRecoveryRelease) => void
   finalizePaidSignup: () => Promise<SignupResult>
+  /** Restore only session authority for an already completed signup receipt. */
+  recoverCompletedSignupSession: (password?: string) => Promise<void>
   /** Call after the entire signup flow (including payment + vault) to finalize authentication. */
   completeSignup: () => void
   login: (email: string, password: string, serverUrl?: string, rememberDevice?: boolean) => Promise<void>
@@ -839,6 +844,72 @@ async function deleteHostedServerSession(context: string) {
   }
 }
 
+const SIGNUP_SESSION_ERROR = 'Your account is set up, but we could not confirm the Billing session. Retry to finish signing in; your account and payment are retained.'
+
+/** Publish the promise before entering async work so duplicate clicks share it. */
+function signupSingleFlight<A extends unknown[], R>(operation: (...args: A) => Promise<R>): (...args: A) => Promise<R> {
+  let active: { args: A; promise: Promise<R> } | undefined
+  return (...args) => {
+    if (active) {
+      if (args.length === active.args.length && args.every((arg, index) => arg === active!.args[index])) return active.promise
+      return Promise.reject(new Error('Another signup operation is in progress.'))
+    }
+    const promise = Promise.resolve().then(() => operation(...args))
+    active = { args, promise }
+    void promise.then(() => { active = undefined }, () => { active = undefined })
+    return promise
+  }
+}
+
+/** Completion JSON is not a cookie: exchange a fresh proof and verify the protected identity. */
+async function establishSignupBillingSession(
+  pending: PendingSignup,
+  get: () => AuthState,
+  set: (state: Partial<AuthState>) => void,
+): Promise<void> {
+  if (get().pendingSignup !== pending) throw new Error('Signup was superseded.')
+  const expected = pending.provisionedUser
+  if (!expected?.id) throw new Error(SIGNUP_SESSION_ERROR)
+  pending = { ...pending, billingSessionUserId: undefined }
+  set({ pendingSignup: pending, isLoading: true, error: null })
+  const assertCurrent = () => {
+    if (get().pendingSignup !== pending) throw new Error('Signup was superseded.')
+  }
+  const matchesIdentity = (value: unknown): value is Record<string, unknown> => isRecord(value)
+    && value.id === expected.id && typeof value.email === 'string'
+    && value.email.trim().toLowerCase() === pending.email.trim().toLowerCase()
+  try {
+    const savedSession = await secureGet('etebase_session')
+    assertCurrent()
+    if (!savedSession) throw new Error(SIGNUP_SESSION_ERROR)
+    const { issueBillingLinkProof } = await import('@/app/lib/etebase-auth')
+    const etebaseLinkProof = await issueBillingLinkProof(savedSession, pending.serverUrl)
+    assertCurrent()
+    const exchange = await fetch(`${BILLING_API_URL}/auth/token-exchange`, {
+      method: 'POST', credentials: 'include',
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+      body: JSON.stringify({ etebaseLinkProof, rememberDevice: pending.rememberDevice === true }),
+    })
+    const profile: unknown = await exchange.json().catch(() => null)
+    assertCurrent()
+    if (!exchange.ok || !matchesIdentity(profile)
+      || profile.isAdmin !== expected.isAdmin
+      || profile.rememberDevice !== (pending.rememberDevice === true)) throw new Error(SIGNUP_SESSION_ERROR)
+    const session = await fetch(`${BILLING_API_URL}/auth/session`, { method: 'GET', credentials: 'include', cache: 'no-store' })
+    const identity: unknown = await session.json().catch(() => null)
+    assertCurrent()
+    if (!session.ok || !matchesIdentity(identity)
+      || (pending.billingContractVersion === 2 && identity.emailVerified !== true)
+      || await secureGet('etebase_session') !== savedSession) throw new Error(SIGNUP_SESSION_ERROR)
+    assertCurrent()
+    set({ pendingSignup: { ...pending, billingSessionUserId: expected.id }, isLoading: false, error: null })
+  } catch (error) {
+    if (get().pendingSignup === pending) set({ error: SIGNUP_SESSION_ERROR, isLoading: false })
+    // Never turn session failure into a renewable checkout Problem or clear recovery.
+    throw new Error(get().pendingSignup === pending ? SIGNUP_SESSION_ERROR : 'Signup was superseded.')
+  }
+}
+
 export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   isAuthenticated: false,
@@ -877,12 +948,18 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         paidSignupAttemptId: undefined,
         provisionedUser: undefined,
         provisionedSubscriptionStatus: undefined,
+        billingSessionUserId: undefined,
+        noCardProvisionAttemptId: undefined,
       },
       error: null,
     })
   },
 
-  createEtebaseAccount: async (email: string, password: string, serverUrl?: string) => {
+  createEtebaseAccount: signupSingleFlight(async (email: string, password: string, serverUrl?: string) => {
+    const existing = get().pendingSignup
+    if (existing?.etebaseAccountReady && existing.provisionedUser
+      && existing.email === email && existing.serverUrl === serverUrl
+      && await secureGet('etebase_session')) return
     set({ isLoading: true, error: null })
     try {
       const { etebaseSignUp, etebaseLogIn } = await import('@/app/lib/etebase-auth')
@@ -898,8 +975,10 @@ export const useAuthStore = create<AuthState>((set, get) => ({
         authResult = await etebaseLogIn(email, password, serverUrl)
       }
       const { savedSession } = authResult
+      if (get().pendingSignup !== existing) throw new Error('Signup was superseded.')
       if (!isSelfHosted && !isCustomServer(serverUrl)) clearHostedValidationMarkers()
       await secureSet('etebase_session', savedSession)
+      if (get().pendingSignup !== existing) throw new Error('Signup was superseded.')
       if (isCustomServer(serverUrl) && serverUrl) {
         localStorage.setItem('silentsuite-server-url', serverUrl)
       }
@@ -914,7 +993,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       set({
         // Hosted annual-v2 eligibility is server-authoritative and is returned only
         // by the closed provision/finalization responses. Do not infer it locally.
-        pendingSignup: { ...(reusablePending ?? {}), email, serverUrl },
+        pendingSignup: { ...(reusablePending ?? {}), email, serverUrl, etebaseAccountReady: true, billingSessionUserId: undefined },
         isLoading: false,
       })
     } catch (err) {
@@ -929,22 +1008,24 @@ export const useAuthStore = create<AuthState>((set, get) => ({
           message = err.message
         }
       }
-      set({ error: message, isLoading: false })
+      if (get().pendingSignup === existing) set({ error: message, isLoading: false })
       throw new Error(message)
     }
-  },
+  }),
 
-  provisionAnnualNoCard: async (checkoutIntentToken: string) => {
+  provisionAnnualNoCard: signupSingleFlight(async (checkoutIntentToken: string) => {
     const pending = get().pendingSignup
     if (!pending || isSelfHosted || isCustomServer(pending.serverUrl)) throw new Error('No hosted annual signup is ready to provision.')
+    if (pending.provisionedUser) return establishSignupBillingSession(pending, get, set)
     const savedEtebaseSession = await secureGet('etebase_session')
     if (!savedEtebaseSession) throw new Error('Create your account before starting the no-card trial.')
+    if (get().pendingSignup !== pending) throw new Error('Signup was superseded.')
     const attemptId = crypto.randomUUID()
     set({ pendingSignup: { ...pending, noCardProvisionAttemptId: attemptId }, isLoading: true, error: null })
     try {
       const { issueBillingLinkProof } = await import('@/app/lib/etebase-auth')
       const etebaseLinkProof = await issueBillingLinkProof(savedEtebaseSession)
-      const response = await fetch(`${BILLING_API_URL}/auth/provision/v2`, { method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }, body: JSON.stringify({ contractVersion: 2, checkoutIntentToken, etebaseLinkProof, wantsProductUpdates: pending.wantsProductUpdates !== false, rememberDevice: pending.rememberDevice === true }) })
+      const response = await fetch(`${BILLING_API_URL}/auth/provision/v2`, { method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' }, body: JSON.stringify({ contractVersion: 2, checkoutIntentToken, etebaseLinkProof, wantsProductUpdates: pending.wantsProductUpdates === true, rememberDevice: pending.rememberDevice === true }) })
       const data = await response.json().catch(() => null)
       if (!response.ok) throw new BillingResponseError(
         typeof (data as { detail?: unknown } | null)?.detail === 'string' ? (data as { detail: string }).detail : 'Billing did not confirm the no-card annual trial.',
@@ -954,13 +1035,15 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       if (!isExactNoCardProvision(data, pending.email)) throw new Error('Billing did not confirm the no-card annual trial.')
       const current = get().pendingSignup
       if (!current || current.noCardProvisionAttemptId !== attemptId || current.email.trim().toLowerCase() !== pending.email.trim().toLowerCase()) throw new Error('Signup was superseded.')
-      syncAdminCookie(false, data.rememberDevice)
-      set({ pendingSignup: { ...current, noCardProvisionAttemptId: undefined, billingContractVersion: 2, earlyAdopter: data.earlyAdopter, provisionedUser: { id: data.id, planId: null, isAdmin: false }, provisionedSubscriptionStatus: data.provisioningStatus, rememberDevice: data.rememberDevice }, isLoading: false })
+      const completed: PendingSignup = { ...current, noCardProvisionAttemptId: undefined, billingContractVersion: 2, earlyAdopter: data.earlyAdopter, provisionedUser: { id: data.id, planId: null, isAdmin: false }, provisionedSubscriptionStatus: data.provisioningStatus, rememberDevice: data.rememberDevice }
+      // Retain completion even if the separate cookie boundary fails.
+      set({ pendingSignup: completed })
+      await establishSignupBillingSession(completed, get, set)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Could not start the no-card annual trial.'
       if (get().pendingSignup?.noCardProvisionAttemptId === attemptId) set({ error: message, isLoading: false }); throw err
     }
-  },
+  }),
 
   startAnnualSignupPayment: async (checkoutIntentToken: string, provider: 'stripe' | 'btcpay', returnUrl: string) => {
     const pending = get().pendingSignup
@@ -973,7 +1056,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const parsedReturnUrl = new URL(returnUrl, window.location.origin)
       if (parsedReturnUrl.origin !== window.location.origin) throw new Error('Annual signup return URL must stay on this origin.')
       const absoluteReturnUrl = parsedReturnUrl.toString()
-      const payment = await startSignupAnnualPayment({ fetcher: fetch, billingApiUrl: BILLING_API_URL, checkoutIntentToken, email: pending.email, requestKey: recovery.requestKey, recoverySecret: recovery.recoverySecret, wantsProductUpdates: pending.wantsProductUpdates !== false, rememberDevice: pending.rememberDevice === true, returnUrl: absoluteReturnUrl })
+      const payment = await startSignupAnnualPayment({ fetcher: fetch, billingApiUrl: BILLING_API_URL, checkoutIntentToken, email: pending.email, requestKey: recovery.requestKey, recoverySecret: recovery.recoverySecret, wantsProductUpdates: pending.wantsProductUpdates === true, rememberDevice: pending.rememberDevice === true, returnUrl: absoluteReturnUrl })
       if (payment.kind !== provider) throw new Error('Billing returned the wrong payment provider.')
       const current = get().pendingSignup
       if (!current || current.paidSignupAttemptId !== attemptId || paidSignupRecoveryScope(current.email, current.wantsProductUpdates, current.rememberDevice) !== recoveryScope) throw new Error('Signup was superseded.')
@@ -1058,7 +1141,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     throw new Error('Hosted signup requires a fresh annual offer and checkout authority.')
   },
 
-  finalizePaidSignup: async () => {
+  finalizePaidSignup: signupSingleFlight(async () => {
     const pending = get().pendingSignup
     if (isCustomServer(pending?.serverUrl)) {
       throw new Error('Paid signup is not available for custom servers.')
@@ -1067,6 +1150,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     if (!pending || !savedEtebaseSession || !pending.paymentSessionToken) {
       throw new Error('No completed payment session. Please start signup again.')
     }
+    if (pending.provisionedUser) {
+      await establishSignupBillingSession(pending, get, set)
+      return { clientSecret: null, cryptoCheckoutUrl: null, cryptoInvoiceId: null, cryptoInvoiceLookupToken: null, paymentSessionToken: null }
+    }
+    if (get().pendingSignup !== pending) throw new Error('Signup was superseded.')
     const expectedPaymentSessionToken = pending.paymentSessionToken
     const expectedRequestKey = pending.paymentSessionRequestKey
     const attemptId = crypto.randomUUID()
@@ -1099,17 +1187,16 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const isAdmin = completion.isAdmin === true
       const current = get().pendingSignup
       if (!current || current.paidSignupAttemptId !== attemptId || current.paymentSessionToken !== expectedPaymentSessionToken || current.paymentSessionRequestKey !== expectedRequestKey) throw new Error('Signup was superseded.')
-      set({
-        pendingSignup: {
+      const completed: PendingSignup = {
           ...current,
           paidSignupAttemptId: undefined,
           provisionedUser: { id: typeof completion.id === 'string' ? completion.id : '', planId: typeof completion.planId === 'string' ? completion.planId : null, isAdmin },
           provisionedSubscriptionStatus: typeof completion.provisioningStatus === 'string' ? completion.provisioningStatus : 'active',
           earlyAdopter: completion.earlyAdopter === true,
           rememberDevice: completion.rememberDevice === true,
-        },
-        isLoading: false,
-      })
+      }
+      set({ pendingSignup: completed })
+      await establishSignupBillingSession(completed, get, set)
       return {
         clientSecret: null,
         cryptoCheckoutUrl: null,
@@ -1122,13 +1209,49 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       if (get().pendingSignup?.paidSignupAttemptId === attemptId) set({ error: message, isLoading: false })
       throw err
     }
-  },
+  }),
+
+  recoverCompletedSignupSession: signupSingleFlight(async (password?: string) => {
+    let pending = get().pendingSignup
+    if (!pending?.provisionedUser) throw new Error('No completed signup is available to recover.')
+    // Local-server completion never requires a hosted Billing session.
+    if (isSelfHosted || isCustomServer(pending.serverUrl)) return
+    pending = { ...pending, billingSessionUserId: undefined }
+    set({ pendingSignup: pending, isLoading: true, error: null })
+    try {
+      if (password) {
+        // Recover the existing account, never sign up or re-submit payment.
+        const { etebaseLogIn } = await import('@/app/lib/etebase-auth')
+        const { savedSession } = await etebaseLogIn(pending.email, password, pending.serverUrl)
+        if (get().pendingSignup !== pending) throw new Error('Signup was superseded.')
+        await secureSet('etebase_session', savedSession)
+      }
+      if (get().pendingSignup !== pending) throw new Error('Signup was superseded.')
+      if (!await secureGet('etebase_session')) {
+        throw new Error('Enter your existing account password to finish signing in. Your payment will not be submitted again.')
+      }
+      await establishSignupBillingSession(pending, get, set)
+    } catch (error) {
+      if (get().pendingSignup === pending) {
+        const message = password
+          ? 'Could not sign in. Check your existing account password and try again. Your payment will not be submitted again.'
+          : error instanceof Error ? error.message : SIGNUP_SESSION_ERROR
+        set({ error: message, isLoading: false })
+        throw new Error(message)
+      }
+      throw error
+    }
+  }),
 
   completeSignup: () => {
     const pending = get().pendingSignup
     if (!pending?.provisionedUser) {
       logger.warn('completeSignup called without provisioned data')
       return
+    }
+    if (!isSelfHosted && !isCustomServer(pending.serverUrl)
+      && pending.billingSessionUserId !== pending.provisionedUser.id) {
+      throw new Error('Your account is set up, but the Billing session is not confirmed. Retry to finish signing in.')
     }
     // Clear the signup-in-progress flag so restoreSession works normally
     clearPaidSignupRecoveryIdentity()


### PR DESCRIPTION
## Summary
- Verify hosted email before password selection and preserve navigation/recovery state.
- Require a fresh matching Billing session before completing signup.
- Add explicit cancellation of an exact unclaimed selection, retaining uncertain outcomes and requiring fresh consent for a successor.

## Verification
- Final candidate: `8fb0151535de2ba060ff8025c01bb08b68bf22ac` against `16f8eee0852d6619cc0e76721115179f2c1d16be`.
- Independent final source review: GREEN on this exact candidate.
- Exact-head CI passed: Tests, Lint & Type Check, Build Web App, Dependency Audit, Android Privacy Guardrail Fixtures and Public Analytics Boundary. PR preview image build passed; shared-preview deployment jobs were skipped for the PR event.
- CI: https://github.com/silent-suite/silentsuite/actions/runs/34239347282
- Focused final regressions: 181 tests across 6 files passed.
- Earlier canonical build exited 0 with a standalone client-reference-manifest copy warning; complete standalone packaging is not certified.

## Acceptance boundary
Approved for feature integration only. Real delivered-email/account/payment/session/logout-login browser QA remains outstanding; mocked continuation and a passing image build are not real email E2E. Merging to main automatically updates the non-production shared preview and requires QA to bind to its new immutable image identity. No production deployment is included; backend session-admission support must be deployed and verified before the public dependency is exposed in production.
