### PR TITLE
fix(web): preserve signup recovery across document navigation

### DIFF
--- a/apps/web/app/(auth)/signup/__tests__/completed-redirect-session.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/completed-redirect-session.test.tsx
@@ -91,6 +91,8 @@ describe('completed historical redirect session recovery', () => {
     fireEvent.change(screen.getByLabelText('Existing account password'), { target: { value: 'correct-password' } })
     fireEvent.click(screen.getByRole('button', { name: 'Retry sign in' }))
     await screen.findByText('Complete vault')
+    expect(sessionStorage.getItem(key)).not.toBeNull() // Retained until vault completion, not merely session recovery.
+    fireEvent.click(screen.getByText('Complete vault'))
     expect(mocks.login).toHaveBeenLastCalledWith(email, 'correct-password', undefined)
     expect(mocks.signup).not.toHaveBeenCalled()
     expect(vi.mocked(fetch).mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual(['/auth/token-exchange', '/auth/session'])

--- a/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
@@ -1,7 +1,7 @@
 import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent, signedAuthorityFixture } from '@/src/__tests__/fixtures/annual-authority'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { BillingResponseError } from '@/app/lib/billing-v2'
+import { BillingResponseError, type AnnualDisclosure } from '@/app/lib/billing-v2'
 import SignupPage from '../page'
 import VerificationCallbackPage from '../verify-email/page'
 import { StrictMode } from 'react'
@@ -42,6 +42,7 @@ vi.mock('@/app/stores/use-etebase-store', () => ({ normalizeServerUrl: (value: s
 vi.mock('@/app/lib/config', () => ({ BILLING_API_URL: 'https://billing.test' }))
 vi.mock('@/app/lib/self-hosted', () => ({ isSelfHosted: false, isCustomServer: () => false }))
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('@/app/components/stripe-payment-form', () => ({ default: ({ submitLabel, mode }: { submitLabel: string; mode: string }) => <button data-testid="card-submit" data-mode={mode}>{submitLabel}</button> }))
 vi.mock('next/link', () => ({ default: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
 
 describe('email-link seven-day no-card continuation', () => {
@@ -161,7 +162,7 @@ describe('email-link seven-day no-card continuation', () => {
     await openConfirmation('none')
     fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
     expect(await screen.findByRole('alert')).toHaveTextContent('Cancellation is not confirmed')
-    expect(screen.queryByRole('button', { name: /30-day free trial/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /annual plan/i })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Continue current selection' }))
     expect(screen.getByRole('button', { name: /create account and start free trial/i })).toBeEnabled()
     expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/activate'))).toHaveLength(1)
@@ -265,10 +266,21 @@ describe('email-link seven-day no-card continuation', () => {
     await traverseHistory('back')
     expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument()
     await traverseHistory('forward')
-    const retry = await screen.findByRole('button', { name: /confirm annual terms and continue/i })
+    const retry = await screen.findByRole('button', { name: /^continue to (bitcoin payment|card setup|card payment)$/i })
     fireEvent.click(retry)
     await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledTimes(2))
     expect(authState.startAnnualSignupPayment.mock.calls[0]).toEqual(authState.startAnnualSignupPayment.mock.calls[1])
+  })
+
+  it('describes Bitcoin settlement separately from unfinished account and vault setup', async () => {
+    const confirm = await openConfirmation('btcpay')
+    authState.startAnnualSignupPayment.mockResolvedValue({ cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/settled', cryptoInvoiceId: 'settled', cryptoInvoiceLookupToken: 'lookup' })
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => new Response(JSON.stringify(String(input).endsWith('/payment-methods') ? { paymentMethods: [{ id: 'BTC', address: 'test-address' }] } : { status: 'settled' }))))
+    fireEvent.click(confirm)
+    expect(await screen.findByText(/Payment confirmed for your Early Adopter Plan/)).toHaveTextContent('Account and vault setup still need to finish')
+    expect(screen.queryByText(/access is active|early_annual|Plan ID/)).not.toBeInTheDocument()
+    expect(authState.finalizePaidSignup).not.toHaveBeenCalled()
+    expect(authState.completeSignup).not.toHaveBeenCalled()
   })
 
   async function traverseHistory(direction: 'back' | 'forward') {
@@ -276,13 +288,14 @@ describe('email-link seven-day no-card continuation', () => {
     await act(async () => { window.history[direction](); await observed })
   }
 
-  async function openConfirmation(provider: 'none' | 'stripe' | 'btcpay', checkoutToken = signedCheckoutIntent) {
+  async function openConfirmation(provider: 'none' | 'stripe' | 'btcpay', checkoutToken = signedCheckoutIntent, selectedDisclosure?: AnnualDisclosure) {
     localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
       [requestId]: { email: 'expiry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
     }))
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const requestedProvider = init?.body ? JSON.parse(String(init.body)).provider : undefined
       if (String(input).endsWith('/consume')) return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken: ownershipToken, expiresAt: '2099-01-01T00:00:00Z' }))
-      if (String(input).endsWith('/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: checkoutToken, expiresAt: '2099-01-01T00:00:00Z', disclosure: provider === 'none' ? noCardDisclosure : provider === 'btcpay' ? { ...noCardDisclosure, kind: 'prepaid', firstChargeAmountMinor: 3600, trialEndsAt: null, prepaid: true, refundWindowDays: 30, periodEndRule: 'confirmation_plus_1_utc_calendar_year', entitlementEndsAt: null } : { ...noCardDisclosure, kind: 'card_trial', firstChargeAmountMinor: 3600, renewalAmountMinor: 3600, firstChargeAt: noCardDisclosure.trialEndsAt, cancelBy: noCardDisclosure.trialEndsAt, autoRenew: true, refundWindowDays: 30, periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2099-09-10T12:00:00Z', entitlementEndsAt: '2099-09-10T12:00:00Z' } }))
+      if (String(input).endsWith('/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: checkoutToken, expiresAt: '2099-01-01T00:00:00Z', disclosure: selectedDisclosure ?? (requestedProvider === 'none' ? noCardDisclosure : requestedProvider === 'btcpay' ? { ...noCardDisclosure, kind: 'prepaid', firstChargeAmountMinor: 3600, trialEndsAt: null, prepaid: true, refundWindowDays: 30, periodEndRule: 'confirmation_plus_1_utc_calendar_year', entitlementEndsAt: null } : { ...noCardDisclosure, kind: 'card_trial', firstChargeAmountMinor: 3600, renewalAmountMinor: 3600, firstChargeAt: noCardDisclosure.trialEndsAt, cancelBy: noCardDisclosure.trialEndsAt, autoRenew: true, refundWindowDays: 30, periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2099-09-10T12:00:00Z', entitlementEndsAt: '2099-09-10T12:00:00Z' }) }))
       return new Response(JSON.stringify(offer))
     }))
     window.history.replaceState({}, '', `/signup?token=link-token&request_id=${requestId}`)
@@ -294,12 +307,36 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(next)
     await screen.findByRole('heading', { name: /choose your plan/i })
     expect(screen.queryByText('Annual access only. Exact price and renewal terms are confirmed by Billing before checkout.')).not.toBeInTheDocument()
-    fireEvent.click(await screen.findByRole('button', { name: provider === 'none' ? /7 day free trial/i : /30-day free trial/i }))
+    expect(screen.queryByText(/before day 30|no charge until|30-day free trial/i)).not.toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('button', { name: provider === 'none' ? /7 day free trial/i : /annual plan/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
     if (provider === 'stripe') fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
     if (provider === 'btcpay') fireEvent.click(await screen.findByRole('button', { name: /^pay .* with bitcoin for/i }))
-    return screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i })
+    return screen.findByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i })
   }
+
+  it.each(['charge_now', 'card_trial'] as const)('keeps the validated %s disclosure through card confirmation', async (kind) => {
+    const disclosure: AnnualDisclosure = {
+      kind, annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,
+      monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null,
+      cancelBy: null, cancelByInclusive: false, autoRenew: true, prepaid: false, refundWindowDays: 30,
+      bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null,
+      ...(kind === 'card_trial' ? { trialEndsAt: '2099-09-10T12:00:00Z', firstChargeAt: '2099-09-10T12:00:00Z', cancelBy: '2099-09-10T12:00:00Z', periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2100-09-10T12:00:00Z', entitlementEndsAt: '2100-09-10T12:00:00Z' } : {}),
+    }
+    const confirm = await openConfirmation('stripe', signedCheckoutIntent, disclosure)
+    expect(screen.queryByText(/early_annual|Plan ID|Confirm annual terms/)).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: kind === 'card_trial' ? 'Review your free trial' : 'Review your card payment' })).toBeVisible()
+    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+    authState.startAnnualSignupPayment.mockResolvedValue({ clientSecret: kind === 'card_trial' ? 'seti_fixture' : 'pi_fixture' })
+    fireEvent.click(confirm)
+    const submit = await screen.findByTestId('card-submit')
+    expect(submit).toHaveAttribute('data-mode', kind === 'card_trial' ? 'setup' : 'payment')
+    expect(submit).toHaveTextContent(kind === 'card_trial' ? 'Start free trial — no charge today' : 'Pay €36.00 now')
+    expect(screen.queryByText(/early_annual|Plan ID|30-day|day 30/)).not.toBeInTheDocument()
+    if (kind === 'charge_now') expect(screen.queryByText(/No charge today|after.*trial/i)).not.toBeInTheDocument()
+    else expect(screen.getAllByText('2099-09-10 12:00 UTC')).toHaveLength(2)
+    expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(signedCheckoutIntent, 'stripe', 'http://localhost:3000/signup', offer.offer.billingInterval)
+  })
 
   it.each(['none', 'stripe', 'btcpay'] as const)('explicitly cancels %s review with single-flight response-loss retry and fresh consent', async (provider) => {
     await openConfirmation(provider)
@@ -753,7 +790,7 @@ describe('email-link seven-day no-card continuation', () => {
     expect(await screen.findByRole('heading', { name: /choose your plan/i })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i }))
 
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('customer@example.test', 'ValidPass1', undefined)
@@ -793,7 +830,7 @@ describe('email-link seven-day no-card continuation', () => {
     expect(await screen.findByRole('heading', { name: /choose your plan/i })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i }))
 
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('newtab@example.test', 'ValidPass1', undefined)
@@ -907,7 +944,7 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(continuation)
 
     expect(await screen.findByText('Standard Plan pricing')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /then €48\.00\/year.*€4\.00\/month/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /annual plan.*€48\.00\/year.*€4\.00\/month/i })).toBeInTheDocument()
     expect(screen.queryByText(/Early Adopter/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/€36/)).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
@@ -923,15 +960,16 @@ describe('email-link seven-day no-card continuation', () => {
     ))
     expect(vi.mocked(fetch).mock.calls.some(([, init]) => String((init as RequestInit | undefined)?.body).includes('"provider":"btcpay"'))).toBe(false)
     expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
-    expect(await screen.findByText('Confirm annual terms')).toBeInTheDocument()
+    expect(await screen.findByText('Review your free trial')).toBeInTheDocument()
     expect(screen.getAllByText('2026-09-10 12:00 UTC')).toHaveLength(2)
     expect(screen.getByText('2027-09-10 12:00 UTC')).toBeInTheDocument()
     expect(screen.getByText('€48.00/year from 2027-09-10 12:00 UTC')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i }))
     await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(
       signedCheckoutIntent,
       'stripe',
       'http://localhost:3000/signup',
+      'annual',
     ))
     expect(await screen.findByText('Add your payment method')).toBeInTheDocument()
     expect(screen.getByText('Standard Plan')).toBeInTheDocument()
@@ -996,13 +1034,13 @@ describe('email-link seven-day no-card continuation', () => {
 
     expect(await screen.findByText(/annual terms changed/i)).toBeInTheDocument()
     expect(screen.getByText('Standard Plan pricing')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /then €48\.00\/year.*€4\.00\/month/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /annual plan.*€48\.00\/year.*€4\.00\/month/i })).toBeInTheDocument()
     expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
     expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial|confirm annual terms and continue/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i }))
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('renew@example.test', 'ValidPass1', undefined)
   })

--- a/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
@@ -64,7 +64,13 @@ describe('email-link seven-day no-card continuation', () => {
     const next = screen.getByRole('button', { name: /^continue$/i })
     await waitFor(() => expect(next).toBeEnabled())
     fireEvent.click(next)
-    await screen.findByText('Check your email and open the verification link in this browser. Then choose your password.')
+    const message = await screen.findByText('Check your email and open the verification link in this browser. Then choose your password.')
+    const panel = screen.getByRole('region', { name: 'Email verification' })
+    expect(panel).toContainElement(message)
+    expect(panel).toContainElement(screen.getByRole('button', { name: /^back$/i }))
+    expect(panel).toHaveClass('flex', 'flex-col', 'items-center', 'justify-center')
+    expect(screen.queryByText('Account setup')).not.toBeInTheDocument()
+    expect(screen.getAllByText('Finish')).toHaveLength(2)
     expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument()
     expect(localStorage.getItem('silentsuite-signup-email-proof')).not.toBeNull()
     fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
@@ -138,7 +144,7 @@ describe('email-link seven-day no-card continuation', () => {
       return prior(input, init)
     }))
     if (back === 'app') fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
-    else act(() => window.history.back())
+    else await traverseHistory('back')
     await screen.findByRole('heading', { name: /choose your plan/i })
     expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/cancel'))).toHaveLength(1)
     act(() => window.dispatchEvent(new PopStateEvent('popstate', { state: oldCheckpoint })))
@@ -236,6 +242,40 @@ describe('email-link seven-day no-card continuation', () => {
     expect(screen.queryByRole('heading', { name: /choose your plan/i })).not.toBeInTheDocument()
   })
 
+  it('keeps Bitcoin terms on the payment panel and exposes no instructions before consent', async () => {
+    const confirm = await openConfirmation('btcpay')
+    expect(screen.getByRole('heading', { name: /pay .* with bitcoin/i })).toBeVisible()
+    expect(screen.queryByText('Confirm annual terms')).not.toBeInTheDocument()
+    expect(screen.queryByText('Copy payment details')).not.toBeInTheDocument()
+    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+    authState.startAnnualSignupPayment.mockResolvedValue({ cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/terms', cryptoInvoiceId: 'terms', cryptoInvoiceLookupToken: 'lookup' })
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => new Response(JSON.stringify(String(input).endsWith('/payment-methods') ? { paymentMethods: [{ id: 'BTC', address: 'test-address' }] } : { status: 'new' }))))
+    fireEvent.click(confirm)
+    await screen.findByText('Copy payment details')
+    expect(screen.getByText(/Request a full refund within 30 days/)).toBeVisible()
+    expect(screen.getByText(/This is a prepaid annual purchase/)).toHaveTextContent('€36.00')
+  })
+
+  it('retains a usable same-attempt retry after failed Bitcoin start and browser Back/Forward', async () => {
+    const confirm = await openConfirmation('btcpay')
+    authState.startAnnualSignupPayment.mockRejectedValue(new BillingResponseError('Payment provider confirmation is pending. Retry with the same recovery secret.', 503, 'https://api.silentsuite.io/errors/provider-unavailable'))
+    fireEvent.click(confirm)
+    await screen.findByText(/Payment creation is not yet confirmed/)
+    expect(screen.queryByText(/webhook|secret/i)).not.toBeInTheDocument()
+    await traverseHistory('back')
+    expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument()
+    await traverseHistory('forward')
+    const retry = await screen.findByRole('button', { name: /confirm annual terms and continue/i })
+    fireEvent.click(retry)
+    await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledTimes(2))
+    expect(authState.startAnnualSignupPayment.mock.calls[0]).toEqual(authState.startAnnualSignupPayment.mock.calls[1])
+  })
+
+  async function traverseHistory(direction: 'back' | 'forward') {
+    const observed = new Promise<void>((resolve) => window.addEventListener('popstate', () => resolve(), { once: true }))
+    await act(async () => { window.history[direction](); await observed })
+  }
+
   async function openConfirmation(provider: 'none' | 'stripe' | 'btcpay', checkoutToken = signedCheckoutIntent) {
     localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
       [requestId]: { email: 'expiry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
@@ -252,6 +292,8 @@ describe('email-link seven-day no-card continuation', () => {
     const next = screen.getByRole('button', { name: /continue to trial options/i })
     await waitFor(() => expect(next).toBeEnabled())
     fireEvent.click(next)
+    await screen.findByRole('heading', { name: /choose your plan/i })
+    expect(screen.queryByText('Annual access only. Exact price and renewal terms are confirmed by Billing before checkout.')).not.toBeInTheDocument()
     fireEvent.click(await screen.findByRole('button', { name: provider === 'none' ? /7 day free trial/i : /30-day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
     if (provider === 'stripe') fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
@@ -459,7 +501,9 @@ describe('email-link seven-day no-card continuation', () => {
     const clock = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2100-01-01T00:00:00Z'))
     try {
       fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
-      expect(await screen.findByRole('alert')).toHaveTextContent('Cancellation is not confirmed')
+      expect(await screen.findByRole('alert')).toHaveTextContent(provider === 'none'
+        ? 'Cancellation is not confirmed'
+        : 'Payment creation is not yet confirmed')
       expect(screen.queryByRole('button', { name: /7 day free trial/i })).not.toBeInTheDocument()
       expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/activate'))).toHaveLength(1)
     } finally { clock.mockRestore() }
@@ -518,9 +562,9 @@ describe('email-link seven-day no-card continuation', () => {
     await waitFor(() => expect(next).toBeEnabled())
     fireEvent.click(next)
     await screen.findByRole('heading', { name: /choose your plan/i })
-    act(() => window.history.back())
+    await traverseHistory('back')
     await screen.findByRole('heading', { name: 'Choose your password' })
-    act(() => window.history.forward())
+    await traverseHistory('forward')
     await screen.findByRole('heading', { name: /choose your plan/i })
     expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
     fireEvent.click(screen.getByRole('button', { name: /back/i }))
@@ -530,7 +574,7 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(await screen.findByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
     await screen.findByRole('button', { name: /create account and start free trial/i })
-    act(() => window.history.back())
+    await traverseHistory('back')
     expect(await screen.findByRole('alert')).toHaveTextContent('Cancellation is not confirmed')
     fireEvent.click(screen.getByRole('button', { name: 'Continue current selection' }))
     fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial/i }))

--- a/apps/web/app/(auth)/signup/__tests__/pending-document-recovery.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/pending-document-recovery.test.tsx
@@ -1,0 +1,298 @@
+import { StrictMode } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, expect, it, vi } from 'vitest'
+import SignupPage from '../page'
+import PendingPaymentPage from '../pending-payment/page'
+import { useAuthStore } from '@/app/stores/use-auth-store'
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('../commercial-funnel-analytics', () => ({ CheckoutReturnAnalytics: () => null }))
+vi.mock('../components/step-create-paid-account', () => ({ StepCreatePaidAccount: () => <div>Recovered account continuation</div> }))
+vi.mock('@/app/lib/secure-storage', () => ({ secureGet: vi.fn(), secureSet: vi.fn(), secureRemove: vi.fn(), secureClear: vi.fn(), migrateFromLocalStorage: vi.fn() }))
+const key = 'silentsuite-signup-redirect-state'
+const email = 'recovery@example.test'
+const requestKey = '5fd4d86d-34de-4b82-9a66-9598ddf6e02f'
+const token = 'A'.repeat(43)
+beforeEach(() => {
+  vi.clearAllMocks()
+  sessionStorage.clear(); localStorage.clear()
+  useAuthStore.setState({ pendingSignup: null, user: null, isAuthenticated: false, isLoading: false, error: null })
+  window.history.replaceState({}, '', '/signup/pending-payment')
+})
+
+it.each(['btcpay', 'stripe'] as const)('restores the exact %s attempt after full-document Back, refresh and return with the real store', async (paymentMethod) => {
+  let confirmed = false
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: confirmed ? 'confirmed' : 'open', flow: { provider: paymentMethod, status: confirmed ? 'provider_confirmed' : 'provider_pending' } }))))
+  useAuthStore.setState({ pendingSignup: { email, password: 'NeverPersist1', serverUrl: 'https://server.silentsuite.io', paymentSessionToken: token, paymentSessionRequestKey: requestKey, paymentMethod, billingContractVersion: 2 } })
+  let document = render(<PendingPaymentPage />)
+  await screen.findByRole('button', { name: /check payment status again/i })
+  const href = screen.getByRole('link', { name: /back to signup/i }).getAttribute('href')!
+  expect(href).toBe('/signup?recovery=payment')
+  const snapshot = sessionStorage.getItem(key)!
+  expect(snapshot).not.toContain('NeverPersist1')
+  // jsdom cannot navigate documents: discard all runtime state and remount the
+  // actual destination at the anchor URL, retaining only browser sessionStorage.
+  for (const target of [href, href, '/signup/pending-payment']) {
+    document.unmount()
+    useAuthStore.setState({ pendingSignup: null })
+    window.history.replaceState({}, '', target)
+    document = render(<StrictMode>{target === '/signup/pending-payment' ? <PendingPaymentPage /> : <SignupPage />}</StrictMode>)
+    await screen.findByRole('button', { name: /check payment status again/i })
+    expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Your invoice is available/)).not.toBeInTheDocument()
+    expect(useAuthStore.getState().pendingSignup).toMatchObject({ email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, paymentMethod })
+    expect(useAuthStore.getState().pendingSignup).not.toHaveProperty('password')
+    expect(JSON.parse(sessionStorage.getItem(key)!)).toEqual(JSON.parse(snapshot))
+  }
+  confirmed = true
+  fireEvent.click(screen.getByRole('button', { name: /check payment status again/i }))
+  await screen.findByText('Recovered account continuation')
+  expect(screen.queryByText(/Bitcoin payment settled/)).not.toBeInTheDocument()
+  expect(useAuthStore.getState().isAuthenticated).toBe(false)
+  for (const [url, init] of vi.mocked(fetch).mock.calls) {
+    expect(String(url)).toMatch(/\/auth\/signup\/payment-session\/v2\/(current|reconcile)$/)
+    expect(String(url)).not.toContain(token)
+    expect(JSON.parse(String(init?.body))).toEqual({ contractVersion: 2, email, requestKey, recoverySecret: token })
+  }
+})
+
+it('blocks full-document Back if its persisted continuation is lost', async () => {
+  useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, paymentMethod: 'btcpay', billingContractVersion: 2 } })
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }))))
+  render(<PendingPaymentPage />)
+  await screen.findByRole('heading', { name: /payment release not confirmed/i })
+  sessionStorage.removeItem(key)
+  expect(fireEvent.click(screen.getByRole('link', { name: /back to signup/i }))).toBe(false)
+  await screen.findByText(/This browser could not retain payment recovery/)
+  expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe(token)
+})
+
+it('guarded Back and payment checks cannot hide the memory-only warning', async () => {
+  useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, billingContractVersion: 2 } })
+  const closed = () => new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }))
+  let finishTerminalRead!: (response: Response) => void
+  const terminalRead = new Promise<Response>((resolve) => { finishTerminalRead = resolve })
+  // Entering the terminal state starts a final effect-owned read. Hold it so
+  // the Back interaction deterministically overlaps that real loading state.
+  const fetcher = vi.fn().mockResolvedValueOnce(closed()).mockReturnValueOnce(terminalRead).mockImplementation(async () => closed())
+  vi.stubGlobal('fetch', fetcher)
+  const write = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('quota') })
+  try {
+    render(<PendingPaymentPage />)
+    await screen.findByRole('heading', { name: /payment release not confirmed/i })
+    expect(screen.getByText(/Stay in this tab/)).toBeVisible()
+    expect(await screen.findByRole('button', { name: /checking current payment/i })).toBeDisabled()
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(fireEvent.click(screen.getByRole('link', { name: /back to signup/i }))).toBe(false)
+    expect(screen.getByText(/Stay in this tab/)).toBeVisible()
+    finishTerminalRead(closed())
+    // The terminal heading is committed before the effect keyed by that new
+    // state finishes its final recovery read. Back does not await that read.
+    // Await the enabled retry control, not just the earlier heading render.
+    const retry = await screen.findByRole('button', { name: /check payment status again/i })
+    expect(retry).toBeEnabled()
+    fireEvent.click(retry)
+    await screen.findByRole('button', { name: /check payment status again/i })
+    expect(fetcher).toHaveBeenCalledTimes(3)
+    expect(screen.getByText(/Stay in this tab/)).toBeVisible()
+    expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe(token)
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+  } finally { write.mockRestore() }
+})
+
+it('an expired persisted capability is not renewed or treated as payment authority', async () => {
+  sessionStorage.setItem(key, JSON.stringify({ pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, billingContractVersion: 2 }, selectedInterval: 'annual', savedAt: 0 }))
+  window.history.replaceState({}, '', '/signup?recovery=payment')
+  vi.stubGlobal('fetch', vi.fn())
+  render(<SignupPage />)
+  await screen.findByRole('heading', { name: /recovery details unavailable/i })
+  expect(sessionStorage.getItem(key)).toBeNull()
+  expect(fetch).not.toHaveBeenCalled()
+})
+
+it('a route hint alone cannot create fresh signup or grant payment authority', async () => {
+  window.history.replaceState({}, '', '/signup?recovery=payment')
+  vi.stubGlobal('fetch', vi.fn())
+  render(<SignupPage />)
+  await screen.findByRole('heading', { name: /recovery details unavailable/i })
+  expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument()
+  expect(fetch).not.toHaveBeenCalled()
+  expect(useAuthStore.getState().isAuthenticated).toBe(false)
+})
+
+it('independent: completing signup consumes the newly retained recovery capability', () => {
+  useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, paymentMethod: 'btcpay', billingContractVersion: 2, rememberDevice: false } })
+  useAuthStore.getState().saveSignupStateForRedirect('annual')
+  useAuthStore.setState({ pendingSignup: null })
+  useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })
+  useAuthStore.setState({ pendingSignup: { ...useAuthStore.getState().pendingSignup!, provisionedUser: {id:'completed-user', planId:'early_annual', isAdmin:false}, billingSessionUserId:'completed-user', provisionedSubscriptionStatus:'active' } })
+  useAuthStore.getState().completeSignup()
+  expect(useAuthStore.getState().isAuthenticated).toBe(true)
+  expect(sessionStorage.getItem(key)).toBeNull()
+})
+it('independent: an expired retained snapshot is not renewed by an in-memory remount', async () => {
+  useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, paymentMethod: 'btcpay', billingContractVersion: 2 } })
+  sessionStorage.setItem(key, JSON.stringify({ pendingSignup: useAuthStore.getState().pendingSignup, selectedInterval: 'annual', savedAt: Date.now() - 3 * 60 * 60 * 1000 }))
+  const before = sessionStorage.getItem(key)
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({contractVersion:2, state:'closed', flow:null}))))
+  render(<PendingPaymentPage />)
+  await screen.findByRole('heading', { name: /payment release not confirmed/i })
+  expect(sessionStorage.getItem(key)).toBe(before)
+})
+it('independent: mismatched stored identity and closed server recovery do not unlock or create', async () => {
+ sessionStorage.setItem(key, JSON.stringify({pendingSignup:{email:'other@example.test',paymentSessionToken:token,paymentSessionRequestKey:requestKey,billingContractVersion:2},selectedInterval:'annual',savedAt:Date.now()}))
+ vi.stubGlobal('fetch',vi.fn(async () => new Response(JSON.stringify({contractVersion:2,state:'closed',flow:null}))))
+ render(<PendingPaymentPage />)
+ await screen.findByRole('heading',{name:/payment release not confirmed/i})
+ expect(screen.queryByText('Recovered account continuation')).not.toBeInTheDocument()
+ expect(useAuthStore.getState().isAuthenticated).toBe(false)
+ expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe(token)
+ for (const [url] of vi.mocked(fetch).mock.calls) expect(String(url)).toMatch(/payment-session\/v2\/current$/)
+})
+
+it('independent: paid completion receipt survives recovery document reset', async () => {
+ useAuthStore.setState({pendingSignup:{email,paymentSessionToken:token,paymentSessionRequestKey:requestKey,billingContractVersion:2,paymentMethod:'btcpay'}})
+ vi.stubGlobal('fetch',vi.fn(async () => new Response(JSON.stringify({contractVersion:2,state:'confirmed',flow:{provider:'btcpay',status:'provider_confirmed'}}))))
+ const first=render(<PendingPaymentPage />)
+ await screen.findByText('Recovered account continuation')
+ // Model the real store's successful finalization + failed session state:
+ // its completion receipt is retained in memory but session authority is absent.
+ useAuthStore.setState({pendingSignup:{...useAuthStore.getState().pendingSignup!,provisionedUser:{id:'completed-user',planId:'early_annual',isAdmin:false},provisionedSubscriptionStatus:'active'}})
+ first.unmount()
+ useAuthStore.setState({pendingSignup:null})
+ vi.stubGlobal('fetch',vi.fn(async () => new Response(JSON.stringify({contractVersion:2,state:'closed',flow:null}))))
+ render(<PendingPaymentPage />)
+ await screen.findByRole('heading',{name:/finish signing in/i})
+ expect(screen.queryByText('Recovered account continuation')).not.toBeInTheDocument()
+ expect(useAuthStore.getState().pendingSignup?.provisionedUser?.id).toBe('completed-user')
+})
+
+const receipt = { id: 'completed-user', planId: 'early_annual', isAdmin: false }
+function checkpoint() {
+  useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, paymentMethod: 'stripe', billingContractVersion: 2 } })
+  useAuthStore.getState().saveSignupStateForRedirect('annual')
+  return JSON.parse(sessionStorage.getItem(key)!)
+}
+
+it('publishes a monotonic sanitized completion receipt at the original issuance time', () => {
+  const original = checkpoint()
+  const pending = useAuthStore.getState().pendingSignup!
+  useAuthStore.setState({ pendingSignup: { ...pending, password: 'NotStored1', billingSessionUserId: receipt.id, provisionedUser: receipt, provisionedSubscriptionStatus: 'active' } })
+  useAuthStore.setState({ pendingSignup: { ...pending } })
+  const saved = JSON.parse(sessionStorage.getItem(key)!)
+  expect(saved.savedAt).toBe(original.savedAt)
+  expect(saved.pendingSignup).toMatchObject({ provisionedUser: receipt, provisionedSubscriptionStatus: 'active' })
+  expect(saved.pendingSignup).not.toHaveProperty('password')
+  expect(saved.pendingSignup).not.toHaveProperty('billingSessionUserId')
+})
+
+it.each(['email', 'paymentSessionToken', 'paymentSessionRequestKey', 'serverUrl'] as const)('does not copy a receipt across a mismatched %s', (field) => {
+  checkpoint()
+  useAuthStore.setState({ pendingSignup: { ...useAuthStore.getState().pendingSignup!, provisionedUser: receipt } })
+  const original = sessionStorage.getItem(key)
+  useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, billingContractVersion: 2, [field]: 'different' } })
+  expect(sessionStorage.getItem(key)).toBe(original)
+  expect(useAuthStore.getState().signupRecoveryDurability).toBe('none')
+  useAuthStore.getState().saveSignupStateForRedirect('annual')
+  expect(JSON.parse(sessionStorage.getItem(key)!).pendingSignup).not.toHaveProperty('provisionedUser')
+})
+
+it.each([-1, 0, 1])('enforces the exact original expiry boundary %d milliseconds', (offset) => {
+  const original = checkpoint()
+  const clock = vi.spyOn(Date, 'now').mockReturnValue(original.savedAt + 2 * 60 * 60 * 1000 + offset)
+  try {
+    useAuthStore.getState().saveSignupStateForRedirect('annual')
+    expect(JSON.parse(sessionStorage.getItem(key)!).savedAt).toBe(original.savedAt)
+    expect(useAuthStore.getState().signupRecoveryDurability).toBe(offset < 0 ? 'persisted' : 'memory-only')
+    useAuthStore.setState({ pendingSignup: null })
+    expect(Boolean(useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true }))).toBe(offset < 0)
+  } finally { clock.mockRestore() }
+})
+
+it('rejects future-issued snapshots', () => {
+  const original = checkpoint()
+  sessionStorage.setItem(key, JSON.stringify({ ...original, savedAt: Date.now() + 10000 }))
+  useAuthStore.setState({ pendingSignup: null })
+  expect(useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })).toBeNull()
+})
+
+it('retains latest in-memory receipt and original lifetime when writing fails', () => {
+  const original = checkpoint()
+  const write = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('quota') })
+  try {
+    expect(() => useAuthStore.setState({ pendingSignup: { ...useAuthStore.getState().pendingSignup!, provisionedUser: receipt } })).not.toThrow()
+    expect(sessionStorage.getItem(key)).toBeNull()
+    expect(useAuthStore.getState().pendingSignup?.provisionedUser).toEqual(receipt)
+    expect(useAuthStore.getState().signupRecoveryDurability).toBe('memory-only')
+  } finally { write.mockRestore() }
+  useAuthStore.getState().saveSignupStateForRedirect('annual')
+  expect(JSON.parse(sessionStorage.getItem(key)!)).toMatchObject({ savedAt: original.savedAt, pendingSignup: { provisionedUser: receipt } })
+  expect(useAuthStore.getState().signupRecoveryDurability).toBe('persisted')
+})
+
+it('cannot mint a new expiry after a failed first storage write', () => {
+  const issued = Date.now()
+  const clock = vi.spyOn(Date, 'now').mockReturnValue(issued)
+  const write = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('quota') })
+  try {
+    useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: requestKey, billingContractVersion: 2 } })
+    useAuthStore.getState().saveSignupStateForRedirect('annual')
+    write.mockRestore()
+    clock.mockReturnValue(issued + 2 * 60 * 60 * 1000)
+    useAuthStore.getState().saveSignupStateForRedirect('annual')
+    expect(sessionStorage.getItem(key)).toBeNull()
+    expect(useAuthStore.getState().signupRecoveryDurability).toBe('memory-only')
+  } finally { write.mockRestore(); clock.mockRestore() }
+})
+
+it('retained restore is readable even when all storage writes fail', () => {
+  checkpoint()
+  const original = sessionStorage.getItem(key)
+  useAuthStore.setState({ pendingSignup: null })
+  const write = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('quota') })
+  try {
+    expect(useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })?.pendingSignup.email).toBe(email)
+    expect(sessionStorage.getItem(key)).toBe(original)
+    expect(useAuthStore.getState().signupRecoveryDurability).toBe('persisted')
+  } finally { write.mockRestore() }
+})
+
+it('failed completion retains recovery; successful completion disposes it for both remember choices', () => {
+  for (const rememberDevice of [false, true]) {
+    checkpoint()
+    useAuthStore.setState({ pendingSignup: { ...useAuthStore.getState().pendingSignup!, provisionedUser: receipt, rememberDevice } })
+    expect(() => useAuthStore.getState().completeSignup()).toThrow(/session/i)
+    expect(sessionStorage.getItem(key)).not.toBeNull()
+    useAuthStore.setState({ pendingSignup: { ...useAuthStore.getState().pendingSignup!, billingSessionUserId: receipt.id } })
+    useAuthStore.getState().completeSignup()
+    expect(useAuthStore.getState().signupRecoveryDurability).toBe('none')
+    expect(sessionStorage.getItem(key)).toBeNull()
+    expect(useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })).toBeNull()
+  }
+})
+
+it('completed pending recovery only offers session login and never retries payment', async () => {
+  checkpoint()
+  useAuthStore.setState({ pendingSignup: { ...useAuthStore.getState().pendingSignup!, provisionedUser: receipt } })
+  useAuthStore.setState({ pendingSignup: null })
+  vi.stubGlobal('fetch', vi.fn())
+  render(<PendingPaymentPage />)
+  await screen.findByRole('heading', { name: 'Finish signing in' })
+  fireEvent.click(screen.getByRole('button', { name: 'Retry sign in' }))
+  expect(await screen.findByRole('alert')).toHaveTextContent('Enter your existing account password')
+  expect(fetch).not.toHaveBeenCalled()
+  expect(screen.queryByText('Recovered account continuation')).not.toBeInTheDocument()
+  expect(useAuthStore.getState().isAuthenticated).toBe(false)
+  expect(sessionStorage.getItem(key)).not.toBeNull()
+})
+
+it('discarding an expired persisted copy cannot renew its still-live runtime attempt', () => {
+  const original = checkpoint()
+  const clock = vi.spyOn(Date, 'now').mockReturnValue(original.savedAt + 2 * 60 * 60 * 1000)
+  try {
+    expect(useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })).toBeNull()
+    expect(sessionStorage.getItem(key)).toBeNull()
+    useAuthStore.getState().saveSignupStateForRedirect('annual')
+    expect(sessionStorage.getItem(key)).toBeNull()
+  } finally { clock.mockRestore() }
+})

--- a/apps/web/app/(auth)/signup/__tests__/pending-document-recovery.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/pending-document-recovery.test.tsx
@@ -26,7 +26,7 @@ it.each(['btcpay', 'stripe'] as const)('restores the exact %s attempt after full
   useAuthStore.setState({ pendingSignup: { email, password: 'NeverPersist1', serverUrl: 'https://server.silentsuite.io', paymentSessionToken: token, paymentSessionRequestKey: requestKey, paymentMethod, billingContractVersion: 2 } })
   let document = render(<PendingPaymentPage />)
   await screen.findByRole('button', { name: /check payment status again/i })
-  const href = screen.getByRole('link', { name: /back to signup/i }).getAttribute('href')!
+  const href = screen.getByRole('link', { name: /reload this payment recovery/i }).getAttribute('href')!
   expect(href).toBe('/signup?recovery=payment')
   const snapshot = sessionStorage.getItem(key)!
   expect(snapshot).not.toContain('NeverPersist1')
@@ -62,7 +62,7 @@ it('blocks full-document Back if its persisted continuation is lost', async () =
   render(<PendingPaymentPage />)
   await screen.findByRole('heading', { name: /payment release not confirmed/i })
   sessionStorage.removeItem(key)
-  expect(fireEvent.click(screen.getByRole('link', { name: /back to signup/i }))).toBe(false)
+  expect(fireEvent.click(screen.getByRole('link', { name: /reload this payment recovery/i }))).toBe(false)
   await screen.findByText(/This browser could not retain payment recovery/)
   expect(useAuthStore.getState().pendingSignup?.paymentSessionToken).toBe(token)
 })
@@ -83,7 +83,7 @@ it('guarded Back and payment checks cannot hide the memory-only warning', async 
     expect(screen.getByText(/Stay in this tab/)).toBeVisible()
     expect(await screen.findByRole('button', { name: /checking current payment/i })).toBeDisabled()
     expect(fetcher).toHaveBeenCalledTimes(2)
-    expect(fireEvent.click(screen.getByRole('link', { name: /back to signup/i }))).toBe(false)
+    expect(fireEvent.click(screen.getByRole('link', { name: /reload this payment recovery/i }))).toBe(false)
     expect(screen.getByText(/Stay in this tab/)).toBeVisible()
     finishTerminalRead(closed())
     // The terminal heading is committed before the effect keyed by that new

--- a/apps/web/app/(auth)/signup/__tests__/stripe-document-return.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/stripe-document-return.test.tsx
@@ -1,0 +1,188 @@
+import { StrictMode } from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import SignupSuccessPage from '../success/page'
+import SignupPage from '../page'
+import { useAuthStore } from '@/app/stores/use-auth-store'
+import { paymentReturnUrl } from '@/app/lib/signup-return'
+
+const mocks = vi.hoisted(() => ({ session: null as string | null, signup: vi.fn(), proof: vi.fn(), push: vi.fn() }))
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: mocks.push }), useSearchParams: () => new URLSearchParams(window.location.search) }))
+vi.mock('../commercial-funnel-analytics', () => ({ CheckoutReturnAnalytics: () => null }))
+vi.mock('../components/step-create-vault', () => ({ StepCreateVault: ({ onComplete }: { onComplete: () => void }) => <button onClick={onComplete}>Complete vault</button> }))
+vi.mock('@/app/lib/secure-storage', () => ({
+  secureGet: vi.fn(async () => mocks.session), secureSet: vi.fn(async (_key: string, value: string) => { mocks.session = value }),
+  secureRemove: vi.fn(), secureClear: vi.fn(), migrateFromLocalStorage: vi.fn(),
+}))
+vi.mock('@/app/lib/etebase-auth', () => ({ etebaseSignUp: mocks.signup, etebaseLogIn: vi.fn(), issueBillingLinkProof: mocks.proof }))
+vi.mock('@/app/lib/self-hosted', () => ({ isSelfHosted: false, isCustomServer: (url?: string) => !!url && url !== 'https://server.silentsuite.io' }))
+const key = 'silentsuite-signup-redirect-state'
+const email = 'callback@example.test'
+const id = '5fd4d86d-34de-4b82-9a66-9598ddf6e02f'
+const token = 'A'.repeat(43)
+const profile = { id, email, isAdmin: false, emailVerified: true, rememberDevice: false }
+const completed = { ...profile, contractVersion: 2, planId: 'early_annual', provisioningStatus: 'active', earlyAdopter: false,
+  createdAt: '2026-09-09T00:00:00.000Z', clientSecret: null, cryptoCheckoutUrl: null, cryptoInvoiceId: null, cryptoInvoiceLookupToken: null }
+const json = (data: unknown, status = 200) => new Response(JSON.stringify(data), { status })
+function checkpoint(receipt = false, paymentMethod: 'stripe' | 'btcpay' = 'stripe') {
+  useAuthStore.setState({ pendingSignup: { email, serverUrl: 'https://server.silentsuite.io', paymentSessionToken: token, paymentSessionRequestKey: id, paymentMethod, billingContractVersion: 2,
+    password: 'NeverPersist1', ...(receipt ? { provisionedUser: { id, planId: 'early_annual', isAdmin: false }, provisionedSubscriptionStatus: 'active', billingSessionUserId: id } : {}),
+  } })
+  useAuthStore.getState().saveSignupStateForRedirect('annual')
+  const original = JSON.parse(sessionStorage.getItem(key)!)
+  expect(sessionStorage.getItem(key)).not.toMatch(/NeverPersist1|billingSessionUserId/)
+  useAuthStore.setState({ pendingSignup: null })
+  return original
+}
+function returnDocument(intent: string, status?: string) {
+  const url = new URL(paymentReturnUrl(window.location.origin, undefined, 'silentsuite://signup-complete'))
+  url.searchParams.set(intent, 'untrusted-provider-id')
+  if (status) url.searchParams.set('redirect_status', status)
+  url.searchParams.set('email', 'wrong@example.test')
+  url.searchParams.set('payment_session_token', 'untrusted-query-token')
+  window.history.replaceState({}, '', url)
+  return render(<StrictMode><SignupSuccessPage /></StrictMode>)
+}
+async function submitAccount() {
+  fireEvent.change(await screen.findByLabelText(/^Password$/), { target: { value: 'CallbackPass1' } })
+  fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'CallbackPass1' } })
+  const submit = screen.getByRole('button', { name: 'Create account and continue' })
+  await waitFor(() => expect(submit).toBeEnabled())
+  fireEvent.click(submit)
+}
+beforeEach(() => {
+  vi.clearAllMocks()
+  useAuthStore.setState({ pendingSignup: null, user: null, isAuthenticated: false, isLoading: false, error: null })
+  sessionStorage.clear(); localStorage.clear()
+  mocks.session = null
+  mocks.signup.mockResolvedValue({ savedSession: 'encrypted-session', authToken: 'unused' })
+  mocks.proof.mockResolvedValue('fresh-proof')
+  vi.stubGlobal('fetch', vi.fn(async (url) => json(String(url).endsWith('/finalize-payment/v2') ? completed : profile)))
+})
+afterEach(() => { vi.restoreAllMocks() })
+
+describe.each(['setup_intent', 'payment_intent'])('%s full-document callback', (intent) => {
+  it.each(['succeeded', 'processing'])('retains the original checkpoint for %s and uses real finalization/session checks before vault', async (status) => {
+    const original = checkpoint()
+    const document = returnDocument(intent, status)
+    await screen.findByRole('heading', { name: 'Create your account' })
+    expect(screen.queryByText(/Card verified successfully|Payment is confirmed/)).not.toBeInTheDocument()
+    expect(useAuthStore.getState().pendingSignup).toEqual(original.pendingSignup)
+    expect(JSON.parse(sessionStorage.getItem(key)!)).toEqual(original)
+    expect(fetch).not.toHaveBeenCalled()
+    expect(mocks.push).not.toHaveBeenCalled()
+    await submitAccount()
+    await screen.findByText('Complete vault')
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual(['/auth/signup/finalize-payment/v2', '/auth/token-exchange', '/auth/session'])
+    expect(JSON.parse(String(vi.mocked(fetch).mock.calls[0][1]?.body))).toEqual({ contractVersion: 2, etebaseLinkProof: 'fresh-proof', paymentSessionToken: token })
+    const receipt = JSON.parse(sessionStorage.getItem(key)!)
+    expect(receipt).toMatchObject({ savedAt: original.savedAt, pendingSignup: { ...original.pendingSignup, provisionedUser: { id } } })
+    expect(sessionStorage.getItem(key)).not.toMatch(/billingSessionUserId|encrypted-session|CallbackPass1|untrusted/)
+    expect(mocks.signup).toHaveBeenCalledWith(email, 'CallbackPass1', original.pendingSignup.serverUrl)
+    document.unmount()
+    useAuthStore.setState({ pendingSignup: null })
+    vi.mocked(fetch).mockClear()
+    returnDocument(intent, status)
+    await screen.findByText('Complete vault')
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual(['/auth/token-exchange', '/auth/session'])
+    expect(mocks.signup).toHaveBeenCalledTimes(1)
+    expect(JSON.parse(sessionStorage.getItem(key)!)).toEqual(receipt)
+  })
+  it.each(['failed', 'processing', 'succeeded', undefined])('recovers a completed receipt even with %s URL status, without payment or account creation', async (status) => {
+    const original = checkpoint(true)
+    mocks.session = 'encrypted-session'
+    returnDocument(intent, status)
+    await screen.findByText('Complete vault')
+    expect(mocks.signup).not.toHaveBeenCalled()
+    expect(vi.mocked(fetch).mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual(['/auth/token-exchange', '/auth/session'])
+    expect(JSON.parse(sessionStorage.getItem(key)!)).toMatchObject({ savedAt: original.savedAt, pendingSignup: original.pendingSignup })
+    expect(useAuthStore.getState().pendingSignup?.billingSessionUserId).toBe(id)
+  })
+  it.each(['failed', 'unknown', undefined])('keeps unresolved %s returns on usable recovery navigation', async (status) => {
+    const original = checkpoint()
+    const document = returnDocument(intent, status)
+    fireEvent.click(await screen.findByRole('button', { name: 'Open payment recovery' }))
+    expect(mocks.push).toHaveBeenCalledWith('/signup?recovery=payment')
+    expect(mocks.push).not.toHaveBeenCalledWith('/')
+    expect(JSON.parse(sessionStorage.getItem(key)!)).toEqual(original)
+    expect(fetch).not.toHaveBeenCalled()
+    expect(mocks.signup).not.toHaveBeenCalled()
+    document.unmount()
+    useAuthStore.setState({ pendingSignup: null })
+    window.history.replaceState({}, '', '/signup?recovery=payment')
+    vi.mocked(fetch).mockResolvedValue(json({ contractVersion: 2, state: 'closed', flow: null }))
+    render(<SignupPage />)
+    await screen.findByRole('heading', { name: 'Payment release not confirmed' })
+    expect(useAuthStore.getState().pendingSignup).toEqual(original.pendingSignup)
+    for (const [url, init] of vi.mocked(fetch).mock.calls) {
+      expect(String(url)).toMatch(/payment-session\/v2\/current$/)
+      expect(JSON.parse(String(init?.body))).toEqual({ contractVersion: 2, email, requestKey: id, recoverySecret: token })
+    }
+  })
+  it.each(['missing', 'expired'])('does not trust succeeded with a %s checkpoint; recovery destination remains usable', async (kind) => {
+    if (kind === 'expired') {
+      const original = checkpoint()
+      sessionStorage.setItem(key, JSON.stringify({ ...original, savedAt: Date.now() - 2 * 60 * 60 * 1000 }))
+    }
+    const document = returnDocument(intent, 'succeeded')
+    expect(screen.queryByText(/saved successfully|Card verified|Payment is confirmed/)).not.toBeInTheDocument()
+    fireEvent.click(await screen.findByRole('button', { name: 'Open payment recovery' }))
+    expect(mocks.push).toHaveBeenCalledWith('/signup?recovery=payment')
+    expect(useAuthStore.getState().pendingSignup).toBeNull()
+    expect(fetch).not.toHaveBeenCalled()
+    document.unmount()
+    window.history.replaceState({}, '', '/signup?recovery=payment')
+    render(<SignupPage />)
+    await screen.findByRole('heading', { name: 'Payment recovery details unavailable' })
+    expect(screen.getByRole('link', { name: /support/i })).toBeVisible()
+    expect(fetch).not.toHaveBeenCalled()
+  })
+  it.each(['unsettled', 'receipt-email', 'session-identity'])('rejects %s despite a succeeded URL', async (failure) => {
+    const original = checkpoint()
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      if (String(url).endsWith('/finalize-payment/v2')) return failure === 'unsettled' ? json({ detail: 'Payment is still processing.' }, 409)
+        : json(failure === 'receipt-email' ? { ...completed, email: 'wrong@example.test' } : completed)
+      return json(String(url).endsWith('/auth/session') ? { ...profile, id: 'wrong-user' } : profile)
+    })
+    returnDocument(intent, 'succeeded')
+    await submitAccount()
+    await screen.findByRole('alert')
+    expect(screen.queryByText('Complete vault')).not.toBeInTheDocument()
+    expect(useAuthStore.getState().isAuthenticated).toBe(false)
+    expect(useAuthStore.getState().pendingSignup?.billingSessionUserId).toBeUndefined()
+    expect(mocks.push).not.toHaveBeenCalled()
+    expect(JSON.parse(sessionStorage.getItem(key)!)).toMatchObject({ savedAt: original.savedAt, pendingSignup: { email, paymentSessionToken: token, paymentSessionRequestKey: id } })
+    if (failure === 'session-identity') expect(useAuthStore.getState().pendingSignup?.provisionedUser?.id).toBe(id)
+    else expect(useAuthStore.getState().pendingSignup?.provisionedUser).toBeUndefined()
+  })
+})
+
+it.each(['stripe', 'btcpay'] as const)('publishes expired durability before the unchanged restored %s object shortcut without renewing TTL', (provider) => {
+  const original = checkpoint(false, provider)
+  const restored = useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })!
+  expect(useAuthStore.getState().pendingSignup).toBe(restored.pendingSignup)
+  vi.spyOn(Date, 'now').mockReturnValue(original.savedAt + 2 * 60 * 60 * 1000)
+  act(() => useAuthStore.getState().saveSignupStateForRedirect('annual'))
+  expect(useAuthStore.getState().signupRecoveryDurability).toBe('memory-only')
+  expect(JSON.parse(sessionStorage.getItem(key)!)).toEqual(original)
+  expect(useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })).toBeNull()
+  expect(sessionStorage.getItem(key)).toBeNull()
+})
+
+it.each([false, true])('direct navigation uses retained receipt (%s), never URL completion authority', async (receipt) => {
+  if (receipt) { checkpoint(true); mocks.session = 'encrypted-session' }
+  window.history.replaceState({}, '', '/signup/success')
+  render(<SignupSuccessPage />)
+  if (receipt) {
+    const finish = await screen.findByText('Complete vault')
+    // A cleared runtime (e.g. logout) must not leave a stale completion control
+    // able to navigate home when completeSignup has no provisioned account.
+    act(() => useAuthStore.setState({ pendingSignup: null }))
+    fireEvent.click(finish)
+  }
+  fireEvent.click(await screen.findByRole('button', { name: 'Open payment recovery' }))
+  expect(mocks.push).toHaveBeenCalledWith('/signup?recovery=payment')
+  expect(mocks.push).not.toHaveBeenCalledWith('/')
+  expect(useAuthStore.getState().isAuthenticated).toBe(false)
+})

--- a/apps/web/app/(auth)/signup/components/annual-confirmation-summary.tsx
+++ b/apps/web/app/(auth)/signup/components/annual-confirmation-summary.tsx
@@ -3,6 +3,22 @@ import type { AnnualDisclosure } from '@/app/lib/billing-v2'
 const money = (minor: number) => `€${(minor / 100).toFixed(2)}`
 const timestamp = (value: string) => `${value.slice(0, 10)} ${value.slice(11, 16)} UTC`
 
+export function annualConfirmationTitle(disclosure: AnnualDisclosure): string {
+  return disclosure.kind === 'no_auto_charge' ? 'Start your free trial'
+    : disclosure.kind === 'card_trial' ? 'Review your free trial'
+      : disclosure.kind === 'charge_now' ? 'Review your card payment' : 'Review your Bitcoin payment'
+}
+
+export function annualConfirmationAction(disclosure: AnnualDisclosure): string {
+  return disclosure.kind === 'no_auto_charge' ? 'Create account and start free trial'
+    : disclosure.kind === 'card_trial' ? 'Continue to card setup'
+      : disclosure.kind === 'charge_now' ? 'Continue to card payment' : 'Continue to Bitcoin payment'
+}
+
+export function annualCardSubmitLabel(disclosure: AnnualDisclosure): string {
+  return disclosure.kind === 'card_trial' ? 'Start free trial — no charge today' : `Pay ${money(disclosure.firstChargeAmountMinor)} now`
+}
+
 /** Only the server disclosure kind determines whether the next step charges. */
 export function AnnualConfirmationSummary({ disclosure }: { disclosure: AnnualDisclosure }) {
   const noCard = disclosure.kind === 'no_auto_charge'

--- a/apps/web/app/(auth)/signup/components/signup-recovery-warning.tsx
+++ b/apps/web/app/(auth)/signup/components/signup-recovery-warning.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { useAuthStore } from '@/app/stores/use-auth-store'
+
+/** Independent of transient request errors and guarded Back/navigation notices. */
+export function SignupRecoveryWarning() {
+  const durability = useAuthStore((state) => state.signupRecoveryDurability)
+  if (durability !== 'memory-only') return null
+  return <p role="alert" className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-[rgb(var(--foreground))]">
+    Stay in this tab. This browser could not retain your signup recovery details. Refreshing, closing, or leaving this tab can lose this continuation. Continue the existing setup here; do not start another signup or payment.
+  </p>
+}

--- a/apps/web/app/(auth)/signup/components/step-create-paid-account.tsx
+++ b/apps/web/app/(auth)/signup/components/step-create-paid-account.tsx
@@ -80,7 +80,7 @@ export function StepCreatePaidAccount({
   initialError?: string | null
   initialData?: PaidAccountFormData
   /** Verified signup chooses a password once; the parent retains it only in memory. */
-  continuation?: 'payment-confirmed' | 'verified-no-card'
+  continuation?: 'payment-confirmed' | 'payment-return' | 'verified-no-card'
 }) {
   const [submitError, setSubmitError] = useState<string | null>(initialError ?? null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -109,6 +109,8 @@ export function StepCreatePaidAccount({
         <p className="text-sm text-[rgb(var(--muted))]">
           {continuation === 'verified-no-card'
             ? <>Your email is verified. Choose a password, then select a trial or payment option for <span className="font-medium text-[rgb(var(--foreground))]">{email}</span>.</>
+            : continuation === 'payment-return'
+            ? <>Choose the password for <span className="font-medium text-[rgb(var(--foreground))]">{email}</span>. Billing must confirm the original payment before access is activated.</>
             : <>Payment is confirmed. Choose the password for <span className="font-medium text-[rgb(var(--foreground))]">{email}</span>.</>}
         </p>
       </div>

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -23,7 +23,9 @@ import { findCommonEmailDomainTypo, normalizeEmailForComparison, signupEmailSche
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
 import { AnnualConfirmationSummary } from './components/annual-confirmation-summary'
+import PendingPaymentPage from './pending-payment/page'
 import { useSignupNavigation } from './use-signup-navigation'
+import { SignupRecoveryWarning } from './components/signup-recovery-warning'
 import { StepCreateVault } from './components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from './components/step-create-paid-account'
 import { QRCodeSVG } from 'qrcode.react'
@@ -154,6 +156,7 @@ type CryptoPaymentMethod = {
 }
 
 type CryptoPaymentSession = {
+  disclosure: AnnualCheckoutActivation['disclosure']
   invoiceId: string
   lookupToken: string
   checkoutUrl: string
@@ -510,13 +513,19 @@ function CryptoPaymentPanel({
   annualOffer,
   session,
   onBack,
-  onInvoiceInactive,
+  disclosure,
+  onConfirm,
+  provisioning = false,
+  provisionError,
   onPaymentComplete,
 }: {
   annualOffer: AnnualOfferResponse['offer']
-  session: CryptoPaymentSession
+  session: CryptoPaymentSession | null
+  disclosure: AnnualCheckoutActivation['disclosure']
+  onConfirm?: () => void
+  provisioning?: boolean
+  provisionError?: string | null
   onBack: () => void
-  onInvoiceInactive: () => void
   onPaymentComplete: () => void
 }) {
   const saveSignupStateForRedirect = useAuthStore((s) => s.saveSignupStateForRedirect)
@@ -530,6 +539,7 @@ function CryptoPaymentPanel({
     let cancelled = false
 
     async function loadPaymentMethods() {
+      if (!session) return
       try {
         const res = await fetch(`${BILLING_API_URL}/subscription/crypto/invoice/${session.invoiceId}/payment-methods`, {
           credentials: 'include',
@@ -555,13 +565,14 @@ function CryptoPaymentPanel({
 
     loadPaymentMethods()
     return () => { cancelled = true }
-  }, [session.invoiceId, session.lookupToken])
+  }, [session])
 
   useEffect(() => {
     let cancelled = false
     let timer: number | undefined
 
     async function poll() {
+      if (!session) return
       try {
         const res = await fetch(`${BILLING_API_URL}/subscription/crypto/invoice/${session.invoiceId}`, {
           credentials: 'include',
@@ -593,7 +604,7 @@ function CryptoPaymentPanel({
       cancelled = true
       if (timer) window.clearTimeout(timer)
     }
-  }, [onPaymentComplete, session.invoiceId, session.lookupToken])
+  }, [onPaymentComplete, session])
 
   const selectedMethod = paymentMethods.find((method) => method.id === selectedMethodId) ?? paymentMethods[0]
   const qrValue = selectedMethod?.qrValue ?? selectedMethod?.paymentLink ?? selectedMethod?.address ?? ''
@@ -623,7 +634,13 @@ function CryptoPaymentPanel({
         </p>
       </div>
 
-      {status === 'settled' ? (
+      <AnnualConfirmationSummary disclosure={disclosure} />
+      {provisionError && <p role="alert">{provisionError}</p>}
+      {!session ? (
+        <Button type="button" className="w-full" disabled={provisioning} onClick={onConfirm}>
+          {provisioning ? 'Starting…' : 'Confirm annual terms and continue'}
+        </Button>
+      ) : status === 'settled' ? (
         <div className="space-y-4 text-center">
           <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-300">
             Payment settled. Your {annualOfferPlanLabel(annualOffer)} annual access ({annualOffer.planId}) is active. Taking you to vault setup...
@@ -692,10 +709,11 @@ function CryptoPaymentPanel({
 
       <button
         onClick={handleBack}
+        disabled={provisioning}
         className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors"
       >
         <ArrowLeft className="h-4 w-4" />
-        Back to payment methods
+        {session ? 'Back to payment methods' : 'Back'}
       </button>
     </div>
   )
@@ -783,6 +801,10 @@ function StepChoosePlan({
   // --- Payment sub-step ---
   if (planView === 'confirm' && pendingAnnualClaim) {
     const disclosure = pendingAnnualClaim.activation.disclosure
+    if (pendingAnnualClaim.provider === 'btcpay') return <CryptoPaymentPanel
+      annualOffer={annualOfferDetails} session={null} disclosure={disclosure}
+      onConfirm={onConfirmAnnualClaim} provisioning={provisioning} provisionError={provisionError}
+      onBack={onBack} onPaymentComplete={onPaymentComplete} />
     return (
       <div ref={contentRef} className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
         <div className="space-y-2 text-center">
@@ -814,7 +836,7 @@ function StepChoosePlan({
         annualOffer={annualOfferDetails}
         session={cryptoPaymentSession}
         onBack={onBack}
-        onInvoiceInactive={onClearCryptoPaymentSession}
+        disclosure={cryptoPaymentSession.disclosure}
         onPaymentComplete={onPaymentComplete}
       />
     )
@@ -1003,10 +1025,6 @@ function StepChoosePlan({
           {annualOfferPlanLabel(annualOfferDetails)} pricing
         </p>
       </div>
-
-      <p className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-4 py-3 text-center text-sm text-[rgb(var(--muted))]">
-        Annual access only. Exact price and renewal terms are confirmed by Billing before checkout.
-      </p>
 
       <div className="space-y-3 sm:space-y-4">
         {/* Card A: 7 Day Free Trial — no card */}
@@ -1257,8 +1275,7 @@ const STEPS_HOSTED = [
   { key: 'account' as const, label: 'Email', number: 1 },
   { key: 'verifiedAccount' as const, label: 'Password', number: 2 },
   { key: 'plan' as const, label: 'Plan', number: 3 },
-  { key: 'paidAccount' as const, label: 'Account setup', number: 4 },
-  { key: 'vault' as const, label: 'Finish', number: 5 },
+  { key: 'vault' as const, label: 'Finish', number: 4 },
 ]
 
 const STEPS_SELFHOST = [
@@ -1363,6 +1380,16 @@ function ProgressStepper({ currentStep, steps }: { currentStep: Step; steps: rea
 // ---------------------------------------------------------------------------
 
 export default function SignupPage() {
+  const [paymentRecovery, setPaymentRecovery] = useState<boolean | null>(null)
+  useEffect(() => {
+    // This nonsecret route hint selects a recovery screen, never payment authority.
+    setPaymentRecovery(new URLSearchParams(window.location.search).get('recovery') === 'payment')
+  }, [])
+  if (paymentRecovery === null) return null
+  return paymentRecovery ? <PendingPaymentPage /> : <SignupJourney />
+}
+
+function SignupJourney() {
   const router = useRouter()
   const prepareSignupDraft = useAuthStore((s) => s.prepareSignupDraft)
   const createEtebaseAccount = useAuthStore((s) => s.createEtebaseAccount)
@@ -1887,6 +1914,7 @@ export default function SignupPage() {
         sessionStorage.removeItem('silentsuite-pending-crypto-return-to')
       }
       setCryptoPaymentSession({
+        disclosure: pending.activation.disclosure,
         invoiceId: result.cryptoInvoiceId,
         lookupToken: result.cryptoInvoiceLookupToken,
         checkoutUrl: checkoutUrl.toString(),
@@ -1899,7 +1927,10 @@ export default function SignupPage() {
         await renewAnnualOfferAndRequireConsent(annualOffer)
         return
       }
-      const message = err instanceof Error ? err.message : 'Failed to start crypto checkout'
+      const message = err instanceof BillingResponseError
+        && err.billingProblemType === 'https://api.silentsuite.io/errors/provider-unavailable'
+        ? 'Payment creation is not yet confirmed. Retry this same payment, or recover its status. Do not start another payment.'
+        : err instanceof Error ? err.message : 'Failed to start crypto checkout'
       setProvisionError(message)
     } finally {
       operationRef.current = false
@@ -1960,6 +1991,12 @@ export default function SignupPage() {
     if (operationRef.current) return
     if (useAuthStore.getState().pendingSignup?.provisionedUser) {
       setProvisionError('Your account is already created. Continue setup to establish your session; no new trial or payment is needed.')
+      return
+    }
+    if (pendingAnnualClaim && pendingAnnualClaim.provider !== 'none' && claimAttemptedRef.current) {
+      setSelectionCancellation(null)
+      setPlanView('confirm')
+      setProvisionError('Payment creation is not yet confirmed. Retry this same payment below, or recover its status. Back cannot confirm cancellation.')
       return
     }
     if (pendingAnnualClaim) { void handleCancelSelection(); return }
@@ -2061,6 +2098,7 @@ export default function SignupPage() {
 
   if (navigation.recovery) {
     return <div className="mx-auto w-full max-w-md space-y-4">
+      <SignupRecoveryWarning />
       <h1 className="text-xl font-semibold">Continue your signup safely</h1>
       <p role="status">Your password and verification proof were not saved. Refreshing has not repeated account creation or started another payment.</p>
       {navigation.recovery === 'review' ? <>
@@ -2076,9 +2114,10 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col items-stretch justify-center md:flex-row md:items-start">
-      <ProgressStepper currentStep={provisioning && step === 'plan' && claimAttemptedRef.current ? 'paidAccount' : step} steps={activeSteps} />
-      <div className="mx-auto w-full max-w-md min-w-0 md:mx-0 md:flex-1">
+    <div className="mx-auto flex w-full max-w-2xl flex-col items-stretch justify-center md:flex-row">
+      <ProgressStepper currentStep={!usingSelfHostedServer && (step === 'paidAccount' || (provisioning && step === 'plan' && claimAttemptedRef.current)) ? 'vault' : step} steps={activeSteps} />
+      <div className={`mx-auto w-full max-w-md min-w-0 md:mx-0 md:flex-1 ${step === 'account' && (awaitingEmailProof || sendingEmail) ? 'flex flex-col justify-center' : ''}`}>
+        <SignupRecoveryWarning />
         {navigation.notice && <p role="status" className="mb-4 text-sm text-[rgb(var(--muted))]">Finish or recover your current setup before changing account details. Your password has not been saved.</p>}
         {step === 'plan' && selectionCancellation && <section className="space-y-4" aria-label="Cancel selection">
           <h2 className="text-xl font-semibold">Cancel this selection?</h2>
@@ -2097,9 +2136,9 @@ export default function SignupPage() {
           </>}
         </section>}
         {step === 'plan' && !selectionCancellation && planView !== 'confirm' && pendingAnnualClaim && <Button variant="outline" disabled={provisioning} className="mb-4 w-full" onClick={() => { setProvisionError(null); setPlanView('confirm') }}>Return to current selection</Button>}
-        {step === 'plan' && (clientSecret || cryptoPaymentSession) && <div className="mb-4 space-y-2">
-          {provisionError && <p role="alert">{provisionError}</p>}
-          {planView !== 'payment' && planView !== 'crypto' && <Button variant="outline" disabled={provisioning} onClick={() => setPlanView(clientSecret ? 'payment' : 'crypto')}>Resume pending payment</Button>}
+        {step === 'plan' && (clientSecret || cryptoPaymentSession || (pendingAnnualClaim?.provider !== 'none' && claimAttemptedRef.current)) && <div className="mb-4 space-y-2">
+          {provisionError && planView !== 'confirm' && <p role="alert">{provisionError}</p>}
+          {(clientSecret || cryptoPaymentSession) && planView !== 'payment' && planView !== 'crypto' && <Button variant="outline" disabled={provisioning} onClick={() => setPlanView(clientSecret ? 'payment' : 'crypto')}>Resume pending payment</Button>}
           <Link href="/signup/pending-payment" className="block text-sm underline">Recover pending payment</Link>
           {cryptoPaymentSession && <p className="text-sm">Returning here does not cancel your Bitcoin invoice. Recover the existing payment to check its status; another payment cannot be started here.</p>}
         </div>}
@@ -2139,8 +2178,10 @@ export default function SignupPage() {
               rememberDevice={rememberDevice}
               onRememberDeviceChange={setRememberDevice}
             />}
-            {sendingEmail && <><Button variant="outline" onClick={handleEmailBack}>Back</Button><p role="status">Sending verification email...</p></>}
-            {awaitingEmailProof && <><Button variant="outline" onClick={handleEmailBack}>Back</Button><p role="status" className="mt-4 text-center text-sm text-[rgb(var(--muted))]">Check your email and open the verification link in this browser. Then choose your password.</p></>}
+            {(sendingEmail || awaitingEmailProof) && <section aria-label="Email verification" className="flex flex-col items-center justify-center gap-5 py-8 text-center">
+              <p role="status" className="text-sm text-[rgb(var(--muted))]">{sendingEmail ? 'Sending verification email...' : 'Check your email and open the verification link in this browser. Then choose your password.'}</p>
+              <Button variant="outline" onClick={handleEmailBack}>Back</Button>
+            </section>}
           </>
         )}
         {step === 'verifiedAccount' && (

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -22,7 +22,7 @@ import { DISPLAY_VERSION } from '@/app/lib/constants'
 import { findCommonEmailDomainTypo, normalizeEmailForComparison, signupEmailSchema } from '@/app/lib/email-recovery'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
-import { AnnualConfirmationSummary } from './components/annual-confirmation-summary'
+import { AnnualConfirmationSummary, annualConfirmationTitle, annualConfirmationAction, annualCardSubmitLabel } from './components/annual-confirmation-summary'
 import PendingPaymentPage from './pending-payment/page'
 import { useSignupNavigation } from './use-signup-navigation'
 import { SignupRecoveryWarning } from './components/signup-recovery-warning'
@@ -243,13 +243,13 @@ function PasswordStrength({ password }: { password: string }) {
 
 // ---------------------------------------------------------------------------
 // Price display helper — used inline in the trial subhead, intentionally
-// modest in size so it doesn't dominate the "30-day free trial" headline.
+// modest in size so it doesn't dominate the plan heading.
 // ---------------------------------------------------------------------------
 
 function PriceDisplay({ offer }: { offer: AnnualOfferResponse['offer'] }) {
   return (
     <span className="text-sm text-[rgb(var(--muted))]">
-      Then <span className="font-semibold text-[rgb(var(--foreground))]">{annualOfferAnnualLabel(offer)}</span>, billed annually ({formatAnnualOfferMonthlyEquivalent(offer)}/month). Cancel anytime before day 30, no charge.
+      <span className="font-semibold text-[rgb(var(--foreground))]">{annualOfferAnnualLabel(offer)}</span>, billed annually ({formatAnnualOfferMonthlyEquivalent(offer)}/month).
     </span>
   )
 }
@@ -608,7 +608,7 @@ function CryptoPaymentPanel({
 
   const selectedMethod = paymentMethods.find((method) => method.id === selectedMethodId) ?? paymentMethods[0]
   const qrValue = selectedMethod?.qrValue ?? selectedMethod?.paymentLink ?? selectedMethod?.address ?? ''
-  const handleExternalCheckout = () => saveSignupStateForRedirect('annual')
+  const handleExternalCheckout = () => saveSignupStateForRedirect(annualOffer.billingInterval)
 
   async function handleCopyPaymentDetails() {
     try {
@@ -630,7 +630,7 @@ function CryptoPaymentPanel({
       <div className="space-y-2 text-center">
         <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Pay {annualOfferAnnualLabel(annualOffer)} with Bitcoin</h2>
         <p className="text-sm text-[rgb(var(--muted))]">
-          Scan the QR code or copy the payment details to pay {annualOfferRenewalCopy(annualOffer)} for your {annualOfferPlanLabel(annualOffer)} (Plan ID: {annualOffer.planId}). Access unlocks after settlement confirms.
+          Scan the QR code or copy the payment details to pay {annualOfferRenewalCopy(annualOffer)} for your {annualOfferPlanLabel(annualOffer)}. Access unlocks after settlement confirms.
         </p>
       </div>
 
@@ -638,12 +638,12 @@ function CryptoPaymentPanel({
       {provisionError && <p role="alert">{provisionError}</p>}
       {!session ? (
         <Button type="button" className="w-full" disabled={provisioning} onClick={onConfirm}>
-          {provisioning ? 'Starting…' : 'Confirm annual terms and continue'}
+          {provisioning ? 'Starting…' : annualConfirmationAction(disclosure)}
         </Button>
       ) : status === 'settled' ? (
         <div className="space-y-4 text-center">
           <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-700 dark:text-emerald-300">
-            Payment settled. Your {annualOfferPlanLabel(annualOffer)} annual access ({annualOffer.planId}) is active. Taking you to vault setup...
+            Payment confirmed for your {annualOfferPlanLabel(annualOffer)}. Account and vault setup still need to finish.
           </div>
         </div>
       ) : status === 'expired' ? (
@@ -728,6 +728,7 @@ function StepChoosePlan({
   planView,
   onBack,
   clientSecret,
+  cardDisclosure,
   provisioning,
   provisionError,
   onClearError,
@@ -745,6 +746,7 @@ function StepChoosePlan({
   planView: PlanView
   onBack: () => void
   clientSecret: string | null
+  cardDisclosure: AnnualCheckoutActivation['disclosure'] | null
   provisioning: boolean
   provisionError: string | null
   onClearError: () => void
@@ -808,12 +810,12 @@ function StepChoosePlan({
     return (
       <div ref={contentRef} className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
         <div className="space-y-2 text-center">
-          <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Confirm annual terms</h2>
+          <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">{annualConfirmationTitle(disclosure)}</h2>
         </div>
         <AnnualConfirmationSummary disclosure={disclosure} />
         {provisionError && <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">{provisionError}</div>}
         <Button type="button" className="w-full" disabled={provisioning} onClick={onConfirmAnnualClaim}>
-          {provisioning ? 'Starting…' : pendingAnnualClaim.provider === 'none' ? 'Create account and start free trial' : 'Confirm annual terms and continue'}
+          {provisioning ? 'Starting…' : annualConfirmationAction(disclosure)}
         </Button>
         <button type="button" disabled={provisioning} onClick={onBack} className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
           <ArrowLeft className="h-4 w-4" /> Back
@@ -848,7 +850,7 @@ function StepChoosePlan({
         <div className="space-y-2 text-center">
           <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Choose how to pay</h2>
           <p className="text-sm text-[rgb(var(--muted))]">
-            Your 30-day trial starts after the payment method is set up. No charge today for card payments.
+            Choose a payment method to review its price and terms before continuing.
           </p>
         </div>
 
@@ -860,7 +862,7 @@ function StepChoosePlan({
             </div>
             <span className="text-sm text-[rgb(var(--foreground))]">{annualOfferAnnualLabel(annualOfferDetails)}</span>
           </div>
-          <p className="mt-1 text-xs text-[rgb(var(--muted))]">Plan ID: {annualOfferDetails.planId} · {annualOfferRenewalCopy(annualOfferDetails)}</p>
+          <p className="mt-1 text-xs text-[rgb(var(--muted))]">{annualOfferRenewalCopy(annualOfferDetails)}</p>
         </div>
 
         <div className="grid gap-3">
@@ -879,7 +881,7 @@ function StepChoosePlan({
                 <div className="flex-1">
                   <h3 className="font-semibold text-[rgb(var(--foreground))]">Card with Stripe</h3>
                   <p className="mt-1 text-sm text-[rgb(var(--muted))]">
-                    Start the 30-day trial now. Your card is charged {annualOfferAnnualLabel(annualOfferDetails)} after the trial unless you cancel.
+                    Review your card offer, including any free trial and the first charge date, before continuing.
                   </p>
                 </div>
               </div>
@@ -941,7 +943,7 @@ function StepChoosePlan({
         <div className="space-y-2 text-center">
           <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Add your payment method</h2>
           <p className="text-sm text-[rgb(var(--muted))]">
-            Your card will not be charged for 30 days. It renews at {annualOfferAnnualLabel(annualOfferDetails)} unless you cancel before then.
+            Review your selected terms below before confirming with Stripe.
           </p>
         </div>
 
@@ -954,9 +956,7 @@ function StepChoosePlan({
             </div>
             <span className="text-sm text-[rgb(var(--foreground))]">{annualOfferAnnualLabel(annualOfferDetails)}</span>
           </div>
-          <p className="mt-1 text-xs text-[rgb(var(--muted))]">
-            Plan ID: {annualOfferDetails.planId}. Card secures your trial — {annualOfferRenewalCopy(annualOfferDetails)} after day 30 unless you cancel before then.
-          </p>
+          {cardDisclosure && <AnnualConfirmationSummary disclosure={cardDisclosure} />}
           <div className="mt-2 flex items-center gap-1.5 text-xs text-[rgb(var(--muted))]">
             <Lock className="h-3 w-3 text-emerald-500" />
             <span>Secured by Stripe. We never see your card details.</span>
@@ -969,7 +969,7 @@ function StepChoosePlan({
             <div className="h-8 w-8 animate-spin rounded-full border-2 border-[rgb(var(--primary))] border-t-transparent" />
             <p className="mt-3 text-sm text-[rgb(var(--muted))]">Preparing payment form...</p>
           </div>
-        ) : clientSecret ? (
+        ) : clientSecret && cardDisclosure ? (
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <CreditCard className="h-4 w-4 text-[rgb(var(--muted))]" />
@@ -978,9 +978,9 @@ function StepChoosePlan({
             <StripePaymentForm
               clientSecret={clientSecret}
               onSuccess={onPaymentComplete}
-              submitLabel={`Start 30-day free trial — then ${annualOfferAnnualLabel(annualOfferDetails)}`}
-              mode="setup"
-              selectedInterval="annual"
+              submitLabel={annualCardSubmitLabel(cardDisclosure)}
+              mode={cardDisclosure.kind === 'card_trial' ? 'setup' : 'payment'}
+              selectedInterval={annualOfferDetails.billingInterval}
             />
             <p className="flex items-center justify-center gap-1.5 text-[10px] text-[rgb(var(--muted))]">
               <Lock className="h-3 w-3 text-emerald-500" />
@@ -1057,10 +1057,10 @@ function StepChoosePlan({
           </div>
         </button>
 
-        {/* Card B: 30 Day Free Trial — card secures the trial, no charge for 30 days */}
+        {/* Paid options are disclosed after the customer chooses a provider. */}
         <button
           onClick={() => setSelectedTrial('30day')}
-          aria-label={`30-day free trial — then ${annualOfferRenewalCopy(annualOfferDetails)}, cancel anytime before day 30 with no charge`}
+          aria-label={`Annual plan — ${annualOfferRenewalCopy(annualOfferDetails)}`}
           className={`group w-full rounded-xl border-2 p-4 sm:p-6 text-left transition-all ${
             selectedTrial === '30day'
               ? 'border-emerald-500 bg-emerald-500/5'
@@ -1073,7 +1073,7 @@ function StepChoosePlan({
             </div>
             <div className="flex-1">
               <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
-                <h3 className="text-xl sm:text-2xl font-bold text-[rgb(var(--foreground))] leading-tight">30-day free trial</h3>
+                <h3 className="text-xl sm:text-2xl font-bold text-[rgb(var(--foreground))] leading-tight">Annual plan</h3>
                 <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase tracking-wide">
                   Recommended
                 </span>
@@ -1088,11 +1088,11 @@ function StepChoosePlan({
                 </li>
                 <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
                   <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-                  Card secures your trial &mdash; no charge until day 30
+                  Review available payment methods
                 </li>
                 <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
                   <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-                  {annualOfferRenewalCopy(annualOfferDetails)} after trial
+                  Review payment and renewal terms before you confirm
                 </li>
               </ul>
             </div>
@@ -1133,7 +1133,7 @@ function StepChoosePlan({
       {/* Trust signals */}
       <div className="flex items-center justify-center gap-1.5 text-xs text-[rgb(var(--muted))]">
         <ShieldCheck className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-        <span className="text-center">Cancel anytime · Your data stays encrypted · Export anytime</span>
+        <span className="text-center">Your data stays encrypted · Export anytime</span>
       </div>
 
       {/* Back button — bottom-left */}
@@ -1385,7 +1385,7 @@ export default function SignupPage() {
     // This nonsecret route hint selects a recovery screen, never payment authority.
     setPaymentRecovery(new URLSearchParams(window.location.search).get('recovery') === 'payment')
   }, [])
-  if (paymentRecovery === null) return null
+  if (paymentRecovery === null) return <p role="status" className="py-12 text-center text-sm text-[rgb(var(--muted))]">Loading signup…</p>
   return paymentRecovery ? <PendingPaymentPage /> : <SignupJourney />
 }
 
@@ -1406,6 +1406,7 @@ function SignupJourney() {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [step])
   const [clientSecret, setClientSecret] = useState<string | null>(null)
+  const [cardDisclosure, setCardDisclosure] = useState<AnnualCheckoutActivation['disclosure'] | null>(null)
   const [cryptoPaymentSession, setCryptoPaymentSession] = useState<CryptoPaymentSession | null>(null)
   const [provisionError, setProvisionError] = useState<string | null>(null)
   const [provisioning, setProvisioning] = useState(false)
@@ -1620,6 +1621,7 @@ function SignupJourney() {
 
     prepareSignupDraft(identifier, wantsProductUpdates, rememberDevice)
     setClientSecret(null)
+    setCardDisclosure(null)
     setCryptoPaymentSession(null)
     setProvisionError(null)
     setPlanView('cards')
@@ -1686,6 +1688,7 @@ function SignupJourney() {
     // Provider choice, card secret, and Bitcoin checkout data are consent
     // derived from the rejected offer, so none may survive a refresh.
     setClientSecret(null)
+    setCardDisclosure(null)
     setCryptoPaymentSession(null)
     setPendingAnnualClaim(null)
     setPlanView('cards')
@@ -1717,7 +1720,7 @@ function SignupJourney() {
   const handleSelectFree = useCallback(async () => {
     if (operationRef.current) return
     if (clientSecret || cryptoPaymentSession) {
-      setProvisionError('A payment is already pending. Resume it below, or use payment recovery to cancel it before choosing another option.')
+      setProvisionError('A payment is already pending. Resume it below, or recover its status. Contact support for help with cancellation or switching payment methods.')
       return
     }
     if (pendingAnnualClaim && (claimAttemptedRef.current || Date.parse(pendingAnnualClaim.activation.expiresAt) > Date.now())) {
@@ -1763,7 +1766,7 @@ function SignupJourney() {
     if (operationRef.current) return
     if (clientSecret) { setPlanView('payment'); return }
     if (cryptoPaymentSession) {
-      setProvisionError('A Bitcoin payment is already pending. Use payment recovery to cancel it before choosing card payment.')
+      setProvisionError('A Bitcoin payment is already pending. Recover its status to continue. Contact support for help with cancellation or switching payment methods.')
       return
     }
     if (pendingAnnualClaim && (claimAttemptedRef.current || Date.parse(pendingAnnualClaim.activation.expiresAt) > Date.now())) {
@@ -1809,7 +1812,7 @@ function SignupJourney() {
     if (operationRef.current) return
     if (cryptoPaymentSession) { setPlanView('crypto'); return }
     if (clientSecret) {
-      setProvisionError('A card payment is already pending. Use payment recovery to cancel it before choosing Bitcoin.')
+      setProvisionError('A card payment is already pending. Recover its status to continue. Contact support for help with cancellation or switching payment methods.')
       return
     }
     if (pendingAnnualClaim && (claimAttemptedRef.current || Date.parse(pendingAnnualClaim.activation.expiresAt) > Date.now())) {
@@ -1882,10 +1885,11 @@ function SignupJourney() {
         return
       }
       const returnPath = pending.provider === 'stripe' ? '/signup' : '/signup/pending-payment'
-      const result = await startAnnualSignupPayment(pending.activation.checkoutIntentToken, pending.provider, new URL(returnPath, window.location.origin).toString())
+      const result = await startAnnualSignupPayment(pending.activation.checkoutIntentToken, pending.provider, new URL(returnPath, window.location.origin).toString(), annualOffer.offer.billingInterval)
       if (pending.provider === 'stripe') {
         if (result.clientSecret) {
           trackCheckoutInitiated(annualOffer.offer, 'stripe')
+          setCardDisclosure(pending.activation.disclosure)
           setClientSecret(result.clientSecret)
         }
         setPendingAnnualClaim(null)
@@ -2210,6 +2214,7 @@ function SignupJourney() {
             planView={planView}
             onBack={handlePlanBack}
             clientSecret={clientSecret}
+            cardDisclosure={cardDisclosure}
             provisioning={provisioning}
             provisionError={provisionError}
             onClearError={() => setProvisionError(null)}

--- a/apps/web/app/(auth)/signup/pending-payment/__tests__/page.test.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/__tests__/page.test.tsx
@@ -111,7 +111,7 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
     render(<PendingPaymentPage />)
     await waitFor(() => expect(screen.queryByText('Checking current payment...')).not.toBeInTheDocument())
     expect(screen.queryByText(/Waiting for BTCPay settlement|webhook activates|check your email to continue/i)).not.toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /back to signup/i })).toBeVisible()
+    expect(screen.getByRole('link', { name: /reload this payment recovery/i })).toBeVisible()
     expect(screen.queryByRole('button', { name: /start a new invoice|cancel and start/i })).not.toBeInTheDocument()
   })
 
@@ -169,7 +169,7 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
     render(<PendingPaymentPage />)
     await screen.findByRole('button', { name: /check payment status again/i })
     expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument()
-    expect(screen.getByText(/Cancellation and replacement cannot yet be confirmed safely/)).toBeVisible()
+    expect(screen.getByText(/Cancellation and switching payment methods are not available here/)).toBeVisible()
     expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).endsWith('/cancel'))).toBe(false)
   })
 
@@ -180,7 +180,7 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
 
     render(<PendingPaymentPage />)
 
-    expect(await screen.findByRole('link', { name: /back to signup/i })).toBeInTheDocument()
+    expect(await screen.findByRole('link', { name: /reload this payment recovery/i })).toBeInTheDocument()
     expect(fetch).not.toHaveBeenCalled()
   })
 
@@ -291,7 +291,7 @@ describe('PendingPaymentPage legacy restart links fail closed', () => {
     vi.stubGlobal('fetch', vi.fn())
     render(<PendingPaymentPage />)
     expect(await screen.findByText(/verification link could not be matched/i)).toBeVisible()
-    expect(screen.getByRole('link', { name: /back to signup/i })).toBeVisible()
+    expect(screen.getByRole('link', { name: /reload this payment recovery/i })).toBeVisible()
     expect(fetch).not.toHaveBeenCalled()
     expect(authState.prepareSignupDraft).not.toHaveBeenCalled()
     expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()

--- a/apps/web/app/(auth)/signup/pending-payment/__tests__/page.test.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/__tests__/page.test.tsx
@@ -1,4 +1,3 @@
-import { emailOwnershipToken as signedEmailProof, checkoutIntentToken as signedCheckoutIntent } from '@/src/__tests__/fixtures/annual-authority'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
@@ -92,6 +91,30 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
     vi.stubGlobal('location', { href: 'https://app.silentsuite.io/signup/pending-payment' })
   })
 
+  it('Stripe recovery must not claim Bitcoin settlement', async () => {
+    authState.pendingSignup = anonymousRecoverySignup({ paymentMethod: 'stripe' })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: 'confirmed', flow: { provider: 'stripe', status: 'provider_confirmed' } }))))
+    render(<PendingPaymentPage />)
+    await screen.findByTestId('step-create-paid-account')
+    expect(screen.queryByText('Bitcoin payment settled')).not.toBeInTheDocument()
+  })
+  it('stale local invoice must not establish available invoice', async () => {
+    sessionStorage.setItem('silentsuite-pending-crypto-invoice', 'stale-unbound-invoice')
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: 'open', flow: { provider: 'btcpay', status: 'provider_pending' } }))))
+    render(<PendingPaymentPage />)
+    await screen.findByRole('button', { name: /check payment status again/i })
+    expect(screen.queryByText(/Your invoice is available/)).not.toBeInTheDocument()
+  })
+  it.each([null, 'provider_pending', 'unrecognized'])('never claims settlement without invoice evidence (%s)', async (status) => {
+    if (!status) authState.pendingSignup = null
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: 'open', flow: { provider: 'btcpay', status } }))))
+    render(<PendingPaymentPage />)
+    await waitFor(() => expect(screen.queryByText('Checking current payment...')).not.toBeInTheDocument())
+    expect(screen.queryByText(/Waiting for BTCPay settlement|webhook activates|check your email to continue/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /back to signup/i })).toBeVisible()
+    expect(screen.queryByRole('button', { name: /start a new invoice|cancel and start/i })).not.toBeInTheDocument()
+  })
+
   it('uses only the anonymous current then reconcile recovery siblings with capability-only credentials', async () => {
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, state: 'open', flow: { provider: 'btcpay', status: 'provider_pending' } }), { status: 200 }))
@@ -103,7 +126,7 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
     expect(fetch).toHaveBeenNthCalledWith(1, 'https://billing.test/auth/signup/payment-session/v2/current', expect.objectContaining({ method: 'POST', credentials: 'omit', body: JSON.stringify(recoveryBody) }))
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://billing.test/auth/signup/payment-session/v2/reconcile', expect.objectContaining({ method: 'POST', credentials: 'omit', body: JSON.stringify(recoveryBody) }))
     expect(String((fetch as ReturnType<typeof vi.fn>).mock.calls[0][0])).not.toContain('/subscription/')
-    expect(screen.getByRole('button', { name: /cancel and start another invoice/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /cancel and start another invoice/i })).not.toBeInTheDocument()
   })
 
   it('fails closed for 404 and 401 recovery responses without releasing local recovery or calling authenticated subscription endpoints', async () => {
@@ -118,20 +141,15 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
     for (const [url] of (fetch as ReturnType<typeof vi.fn>).mock.calls) expect(String(url)).not.toContain('/subscription/')
   })
 
-  it('accepts a generic closed response for an unknown or terminal capability and clears it only after that authoritative response', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }), { status: 200 })))
-
+  it('retains exact recovery after generic closed, which is not a release receipt', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }))))
     render(<PendingPaymentPage />)
-
-    expect(await screen.findByRole('heading', { name: /invoice not completed/i })).toBeInTheDocument()
-    expect(authState.clearPendingSignupPaymentRecovery).toHaveBeenCalledTimes(1)
-    expect(authState.clearPendingSignupPaymentRecovery.mock.calls[0]?.[0]).toMatchObject({
-      email: 'customer@example.test',
-      requestKey: paymentSessionRequestKey,
-      recoverySecret: paymentSessionToken,
-    })
-    expect(fetch).toHaveBeenCalledWith('https://billing.test/auth/signup/payment-session/v2/current', expect.objectContaining({ credentials: 'omit', body: JSON.stringify(recoveryBody) }))
+    expect(await screen.findByRole('heading', { name: /payment release not confirmed/i })).toBeVisible()
+    expect(authState.clearPendingSignupPaymentRecovery).not.toHaveBeenCalled()
+    expect(authState.pendingSignup.paymentSessionToken).toBe(paymentSessionToken)
+    expect(screen.queryByRole('button', { name: /new invoice/i })).not.toBeInTheDocument()
   })
+
 
   it('routes an authoritative confirmed recovery into the account continuation without polling invoice or authenticated endpoints', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({ contractVersion: 2, state: 'confirmed', flow: { provider: 'btcpay', status: 'provider_confirmed' } }), { status: 200 })))
@@ -146,18 +164,15 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
     }
   })
 
-  it('uses the exact anonymous cancel route and only releases after its generic closed response', async () => {
-    vi.stubGlobal('fetch', vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, state: 'open', flow: { provider: 'btcpay', status: 'provider_pending' } }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, state: 'open', flow: { provider: 'btcpay', status: 'provider_pending' } }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }), { status: 200 })))
-
+  it('does not offer unsafe live Bitcoin cancellation or issue a cancel request', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: 'open', flow: { provider: 'btcpay', status: 'provider_pending' } }))))
     render(<PendingPaymentPage />)
-    fireEvent.click(await screen.findByRole('button', { name: /cancel and start another invoice/i }))
-
-    await waitFor(() => expect(authState.clearPendingSignupPaymentRecovery).toHaveBeenCalledTimes(1))
-    expect(fetch).toHaveBeenLastCalledWith('https://billing.test/auth/signup/payment-session/v2/cancel', expect.objectContaining({ method: 'POST', credentials: 'omit', body: JSON.stringify(recoveryBody) }))
+    await screen.findByRole('button', { name: /check payment status again/i })
+    expect(screen.queryByRole('button', { name: /cancel/i })).not.toBeInTheDocument()
+    expect(screen.getByText(/Cancellation and replacement cannot yet be confirmed safely/)).toBeVisible()
+    expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).endsWith('/cancel'))).toBe(false)
   })
+
 
   it('does not contact any recovery or authenticated endpoint when the local capability is absent', async () => {
     authState.pendingSignup = { email: 'customer@example.test', billingContractVersion: 2 }
@@ -165,7 +180,7 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
 
     render(<PendingPaymentPage />)
 
-    expect(await screen.findByRole('button', { name: /verify email to start a new invoice/i })).toBeInTheDocument()
+    expect(await screen.findByRole('link', { name: /back to signup/i })).toBeInTheDocument()
     expect(fetch).not.toHaveBeenCalled()
   })
 
@@ -200,31 +215,19 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
     })
   })
 
-  it('captures the verified v2 restart context before a closed or unknown recovery clears stale authority', async () => {
+  it('retains restored v2 authority and invoice on closed or unknown recovery', async () => {
     configureFullNavigationStore()
     persistRedirectState()
-    sessionStorage.setItem('silentsuite-pending-crypto-invoice', 'stale-invoice')
-    sessionStorage.setItem('silentsuite-pending-crypto-token', 'stale-provider-token')
-    sessionStorage.setItem('silentsuite-pending-crypto-recovery-context', JSON.stringify({ email: 'customer@example.test', requestKey: paymentSessionRequestKey }))
-    sessionStorage.setItem('silentsuite-signup-in-progress', 'true')
-    authState.clearPendingSignupPaymentRecovery.mockImplementation(() => { authState.pendingSignup = null })
-    vi.stubGlobal('fetch', vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ requestId: 'request-1' }), { status: 200 })))
-
+    sessionStorage.setItem('silentsuite-pending-crypto-invoice', 'retained-invoice')
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }))))
     render(<PendingPaymentPage />)
-
-    expect(await screen.findByRole('heading', { name: /invoice not completed/i })).toBeInTheDocument()
-    expect(authState.clearPendingSignupPaymentRecovery).toHaveBeenCalledTimes(1)
-    expect(sessionStorage.getItem('silentsuite-pending-crypto-invoice')).toBeNull()
-    expect(sessionStorage.getItem('silentsuite-pending-crypto-token')).toBeNull()
-    expect(sessionStorage.getItem('silentsuite-pending-crypto-recovery-context')).toBeNull()
-    expect(sessionStorage.getItem('silentsuite-signup-in-progress')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: /verify email to start a new invoice/i }))
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
-    expect(String((fetch as ReturnType<typeof vi.fn>).mock.calls[1][0])).toContain('/auth/signup-email-verifications/v2')
-    expect(screen.queryByText(/return to signup to verify your email/i)).not.toBeInTheDocument()
+    await screen.findByRole('heading', { name: /payment release not confirmed/i })
+    expect(authState.clearPendingSignupPaymentRecovery).not.toHaveBeenCalled()
+    expect(sessionStorage.getItem('silentsuite-pending-crypto-invoice')).toBe('retained-invoice')
+    expect(authState.pendingSignup.paymentSessionToken).toBe(paymentSessionToken)
+    expect(authState.prepareSignupDraft).not.toHaveBeenCalled()
   })
+
 
   it('keeps restored v2 authority intact while anonymous recovery remains open', async () => {
     configureFullNavigationStore()
@@ -235,7 +238,7 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
 
     render(<PendingPaymentPage />)
 
-    expect(await screen.findByText(/payment already in progress/i)).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /check payment status again/i })).toBeInTheDocument()
     expect(authState.pendingSignup).toMatchObject({
       paymentSessionToken,
       paymentSessionRequestKey,
@@ -278,187 +281,20 @@ describe('PendingPaymentPage anonymous payment-session recovery', () => {
   })
 })
 
-describe('PendingPaymentPage Bitcoin restart across the email navigation', () => {
-  const emailOwnershipToken = signedEmailProof
-  const rotatedRequestKey = '7c3f1a52-9a1e-4a1e-8b7c-2f4d6e8a0b12'
-  const checkoutUrl = 'https://btcpay.silentsuite.io/i/restarted-invoice'
-  const prepaidDisclosure = {
-    kind: 'prepaid', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: null,
-    monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null,
-    cancelBy: null, cancelByInclusive: false, autoRenew: false, prepaid: true, refundWindowDays: 30,
-    bonusDays: 14, periodEndRule: 'confirmation_bonus_then_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null,
-  }
-  const restartOffer = {
-    contractVersion: 2,
-    requestId: 'e91a6d70-0d4e-4352-9bdc-426d1f76d771',
-    offer: {
-      planId: 'early_annual', customerClass: 'early', billingInterval: 'annual', annualAmountMinor: 3600,
-      monthlyEquivalentMinor: 300, currency: 'EUR', providers: ['stripe', 'btcpay'], offerRevision: 1,
-      offerToken: 'signed-offer', expiresAt: '2026-08-11T12:10:00Z',
-    },
-  }
-
-  beforeEach(() => {
+describe('PendingPaymentPage legacy restart links fail closed', () => {
+  it.each(['link-token', 'malformed'])('does not consume %s or replace an uncertain payment via an email link', async (token) => {
     vi.clearAllMocks()
     sessionStorage.clear()
-    localStorage.clear()
     configureFullNavigationStore()
-    authState.prepareSignupDraft.mockImplementation((email: string, wantsProductUpdates?: boolean, rememberDevice?: boolean) => {
-      authState.pendingSignup = { email, wantsProductUpdates, rememberDevice: rememberDevice === true }
-    })
-    // Mirrors the store: a fresh recovery identity is minted for the new invoice.
-    authState.startAnnualSignupPayment.mockImplementation(async () => {
-      authState.pendingSignup = {
-        ...authState.pendingSignup,
-        billingContractVersion: 2,
-        paymentMethod: 'btcpay',
-        paymentSessionToken: 'D'.repeat(43),
-        paymentSessionRequestKey: rotatedRequestKey,
-      }
-      return {
-        clientSecret: null,
-        cryptoCheckoutUrl: checkoutUrl,
-        cryptoInvoiceId: 'invoice-restarted',
-        cryptoInvoiceLookupToken: 'E'.repeat(43),
-        paymentSessionToken: 'D'.repeat(43),
-      }
-    })
-  })
-
-  it('completes a restart whose email link lands in a new page load with no redirect snapshot', async () => {
-    // --- First page load: the invoice is terminal and the user asks for a link.
-    authState.pendingSignup = anonymousRecoverySignup({ wantsProductUpdates: true, rememberDevice: true })
-    vi.stubGlobal('location', { href: 'https://app.silentsuite.io/signup/pending-payment?return_to=silentsuite%3A%2F%2Fsignup-complete', search: '?return_to=silentsuite%3A%2F%2Fsignup-complete' })
-    vi.stubGlobal('fetch', vi.fn()
-      .mockResolvedValueOnce(new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(null, { status: 202 })))
-
-    const firstLoad = render(<PendingPaymentPage />)
-    expect(await screen.findByRole('heading', { name: /invoice not completed/i })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /verify email to start a new invoice/i }))
-    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
-    expect(String(vi.mocked(fetch).mock.calls[1]![0])).toContain('/auth/signup-email-verifications/v2')
-
-    // The continuation has to outlive the tab, not just the page.
-    const persistedByRequest = JSON.parse(localStorage.getItem('silentsuite-signup-email-proof') ?? 'null')
-    const persisted = persistedByRequest[Object.keys(persistedByRequest)[0]!]
-    expect(persisted).toMatchObject({ email: 'customer@example.test', wantsProductUpdates: true, rememberDevice: true })
-    firstLoad.unmount()
-
-    // --- Second page load: a fresh browsing context opened from the mail app.
-    // No sessionStorage, no pendingSignup, and the one-time redirect snapshot
-    // was already consumed by the previous load.
-    sessionStorage.clear()
     authState.pendingSignup = null
-    vi.stubGlobal('location', { href: `https://app.silentsuite.io/signup/pending-payment?email_verification_token=link-token&request_id=${persisted.requestId}`, search: `?email_verification_token=link-token&request_id=${persisted.requestId}` })
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url.endsWith('/auth/signup-email-verifications/v2/consume')) {
-        return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken, expiresAt: '2026-08-11T12:05:00Z' }), { status: 200 })
-      }
-      if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify({ ...restartOffer, requestId: persisted.requestId }), { status: 200 })
-      if (url.endsWith('/auth/offers/v2/activate')) {
-        return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: prepaidDisclosure }), { status: 200 })
-      }
-      return new Response('{}', { status: 404 })
-    }))
-
+    vi.stubGlobal('location', { href: 'https://app.silentsuite.io/signup/pending-payment', search: `?email_verification_token=${token}` })
+    vi.stubGlobal('fetch', vi.fn())
     render(<PendingPaymentPage />)
-
-    const restart = await screen.findByRole('button', { name: /start new bitcoin invoice/i })
-    // The verified continuation was rebuilt from the persisted proof context.
-    expect(authState.prepareSignupDraft).toHaveBeenCalledWith('customer@example.test', true, true)
-    fireEvent.click(restart)
-
-    expect(await screen.findByRole('heading', { name: /confirm prepaid annual terms/i })).toBeInTheDocument()
-    expect(screen.getAllByText(/€36\.00/i)).not.toHaveLength(0)
-    expect(screen.getByText(/€3\.00.*month/i)).toBeInTheDocument()
-    expect(screen.getByText(/first charge amount.*€36\.00/i)).toBeInTheDocument()
-    expect(screen.getByText(/first charge.*immediate/i)).toBeInTheDocument()
-    expect(screen.getByText(/access through.*provider confirmation/i)).toBeInTheDocument()
-    expect(screen.getByText(/period end rule.*confirmation bonus then 1 utc calendar year/i)).toBeInTheDocument()
-    expect(screen.getByText(/does not renew automatically/i)).toBeInTheDocument()
+    expect(await screen.findByText(/verification link could not be matched/i)).toBeVisible()
+    expect(screen.getByRole('link', { name: /back to signup/i })).toBeVisible()
+    expect(fetch).not.toHaveBeenCalled()
+    expect(authState.prepareSignupDraft).not.toHaveBeenCalled()
     expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
-    fireEvent.click(screen.getByRole('button', { name: /agree.*create bitcoin invoice/i }))
-    await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(signedCheckoutIntent, 'btcpay', 'https://app.silentsuite.io/signup/pending-payment'))
-    expect(screen.queryByText(/return to signup to verify your email/i)).not.toBeInTheDocument()
-    expect(window.location.href).toBe(checkoutUrl)
-    expect(sessionStorage.getItem('silentsuite-pending-crypto-invoice')).toBe('invoice-restarted')
-    expect(sessionStorage.getItem('silentsuite-pending-crypto-return-to')).toBe(persisted.returnTo)
-    expect(authState.saveSignupStateForRedirect).toHaveBeenCalledWith('annual')
-    // Rotated lineage: the replacement invoice never reuses the released key.
-    expect(JSON.parse(sessionStorage.getItem('silentsuite-pending-crypto-recovery-context') ?? 'null')).toEqual({
-      email: 'customer@example.test',
-      requestKey: rotatedRequestKey,
-    })
-    expect(rotatedRequestKey).not.toBe(paymentSessionRequestKey)
-    // Spent continuations must not linger in browser-profile storage.
-    expect(localStorage.getItem('silentsuite-signup-email-proof')).toBeNull()
-  })
-
-  it('reports a recoverable error when the link opens without any persisted continuation', async () => {
-    authState.pendingSignup = null
-    localStorage.clear()
-    vi.stubGlobal('location', { href: 'https://app.silentsuite.io/signup/pending-payment?email_verification_token=link-token', search: '?email_verification_token=link-token' })
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 404 })))
-
-    render(<PendingPaymentPage />)
-
-    expect(await screen.findByText(/verification link could not be matched/i)).toBeInTheDocument()
-    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes('/consume'))).toBe(false)
-  })
-
-  it('removes a consumed flat legacy continuation', async () => {
-    const requestId = '7823121e-8f4a-45ac-a217-82ba93209ca2'
-    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
-      email: 'legacy@example.test', requestId, wantsProductUpdates: false,
-      rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000,
-    }))
-    authState.pendingSignup = null
-    vi.stubGlobal('location', { href: `https://app.silentsuite.io/signup/pending-payment?email_verification_token=link-token&request_id=${requestId}`, search: `?email_verification_token=link-token&request_id=${requestId}` })
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input)
-      if (url.endsWith('/auth/signup-email-verifications/v2/consume')) return new Response(JSON.stringify({ contractVersion: 2, emailOwnershipToken, expiresAt: '2026-08-11T12:05:00Z' }))
-      if (url.endsWith('/auth/offers/v2')) return new Response(JSON.stringify({ ...restartOffer, requestId }))
-      if (url.endsWith('/auth/offers/v2/activate')) return new Response(JSON.stringify({ contractVersion: 2, checkoutIntentToken: signedCheckoutIntent, expiresAt: '2026-08-11T12:05:00Z', disclosure: prepaidDisclosure }))
-      return new Response('{}', { status: 404 })
-    }))
-
-    render(<PendingPaymentPage />)
-
-    expect(await screen.findByRole('button', { name: /start new bitcoin invoice/i })).toBeInTheDocument()
-    expect(localStorage.getItem('silentsuite-signup-email-proof')).toBeNull()
-  })
-
-  it('rejects a malformed request-id restart continuation before consuming its token', async () => {
-    const malformedRequestId = 'not-a-uuid'
-    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
-      [malformedRequestId]: { email: 'customer@example.test', requestId: malformedRequestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
-    }))
-    vi.stubGlobal('location', { href: `https://app.silentsuite.io/signup/pending-payment?email_verification_token=link-token&request_id=${malformedRequestId}`, search: `?email_verification_token=link-token&request_id=${malformedRequestId}` })
-    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 200 })))
-
-    render(<PendingPaymentPage />)
-
-    expect(await screen.findByText(/verification link could not be matched/i)).toBeInTheDocument()
-    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes('/consume'))).toBe(false)
-  })
-
-  it('rejects a non-expiring restart continuation without deleting another lineage', async () => {
-    const requestId = restartOffer.requestId
-    const otherRequestId = '7823121e-8f4a-45ac-a217-82ba93209ca2'
-    localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
-      [requestId]: { email: 'customer@example.test', requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null },
-      [otherRequestId]: { email: 'other@example.test', requestId: otherRequestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
-    }))
-    vi.stubGlobal('location', { href: `https://app.silentsuite.io/signup/pending-payment?email_verification_token=link-token&request_id=${requestId}`, search: `?email_verification_token=link-token&request_id=${requestId}` })
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ contractVersion: 2, state: 'closed', flow: null }), { status: 200 })))
-
-    render(<PendingPaymentPage />)
-
-    expect(await screen.findByText(/verification link could not be matched/i)).toBeInTheDocument()
-    expect(vi.mocked(fetch).mock.calls.some(([input]) => String(input).includes('/consume'))).toBe(false)
-    expect(JSON.parse(localStorage.getItem('silentsuite-signup-email-proof') ?? '{}')).toHaveProperty(otherRequestId)
   })
 })
 
@@ -495,7 +331,7 @@ describe('PendingPaymentPage BTCPay settlement polling', () => {
     await settle()
 
     expect(fetch).toHaveBeenCalledTimes(REQUESTS_PER_OPEN_POLL)
-    expect(screen.getByText(/payment already in progress/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /check payment status again/i })).toBeInTheDocument()
 
     await advance(10_000)
     expect(fetch).toHaveBeenCalledTimes(REQUESTS_PER_OPEN_POLL * 2)
@@ -528,7 +364,7 @@ describe('PendingPaymentPage BTCPay settlement polling', () => {
     // 180 attempts: 10s apart for the first 30, then 30s apart.
     await advance(30 * 10_000 + 150 * 30_000)
 
-    expect(screen.getByRole('heading', { name: /still waiting for settlement/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /payment status is still unconfirmed/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /check again/i })).toBeInTheDocument()
     expect(sessionStorage.getItem('silentsuite-signup-in-progress')).toBeNull()
 

--- a/apps/web/app/(auth)/signup/pending-payment/page.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/page.tsx
@@ -1,22 +1,16 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { AlertTriangle, Check, Loader2 } from 'lucide-react'
 import { BILLING_API_URL } from '@/app/lib/config'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import {
-  activateAnnualCheckout,
-  cancelAnonymousPaymentSessionRecovery,
-  consumeSignupEmailOwnership,
-  fetchAnonymousAnnualOffer,
+
   getAnonymousPaymentSessionRecovery,
   reconcileAnonymousPaymentSessionRecovery,
-  requestSignupEmailOwnership,
-  type AnnualCheckoutActivation,
-  type AnonymousPaymentSessionRecovery,
 } from '@/app/lib/billing-v2'
-import { isAnnualOfferProviderAvailable } from '@/app/lib/annual-offer-presentation'
+import { SignupRecoveryWarning } from '../components/signup-recovery-warning'
 import { StepCreateVault } from '../components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from '../components/step-create-paid-account'
 import { CheckoutReturnAnalytics } from '../commercial-funnel-analytics'
@@ -24,7 +18,6 @@ import { CheckoutReturnAnalytics } from '../commercial-funnel-analytics'
 type PaymentState = 'pending' | 'settled' | 'account' | 'vault' | 'expired' | 'timeout' | 'unknown'
 type PaymentFlowCheckState = 'idle' | 'loading' | 'ready' | 'failed'
 
-type CurrentPaymentFlow = NonNullable<AnonymousPaymentSessionRecovery['flow']>
 
 type PaymentSessionRecoveryContext = {
   email: string
@@ -34,24 +27,8 @@ type PaymentSessionRecoveryContext = {
 
 type PersistedPaymentSessionRecoveryContext = Omit<PaymentSessionRecoveryContext, 'paymentSessionToken'>
 
-type SignupPaymentContinuation = {
-  email: string
-  serverUrl?: string
-  paymentSessionToken?: string
-  paymentSessionRequestKey?: string
-  paymentMethod?: 'stripe' | 'btcpay'
-  billingContractVersion?: 1 | 2
-  wantsProductUpdates?: boolean
-  rememberDevice?: boolean
-}
+type SignupPaymentContinuation = import('@/app/stores/use-auth-store').RedirectSignupState['pendingSignup']
 
-type VerifiedAnnualRestartContext = Pick<
-  SignupPaymentContinuation,
-  'email' | 'paymentSessionRequestKey' | 'paymentMethod' | 'billingContractVersion' | 'wantsProductUpdates' | 'rememberDevice'
->
-
-const BTCPAY_CHECKOUT_ORIGIN = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ORIGIN ?? 'https://btcpay.silentsuite.io'
-const CRYPTO_CHECKOUT_ENABLED = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED === 'true'
 const PENDING_CRYPTO_RECOVERY_CONTEXT_KEY = 'silentsuite-pending-crypto-recovery-context'
 /**
  * Settlement can take a while, so the waiting screen re-checks the anonymous
@@ -70,66 +47,6 @@ type SettlementPollDisposition = 'poll' | 'stop'
 function settlementPollDelayMs(completedAttempts: number): number {
   return completedAttempts < SETTLEMENT_POLL_FAST_ATTEMPTS ? SETTLEMENT_POLL_FAST_DELAY_MS : SETTLEMENT_POLL_SLOW_DELAY_MS
 }
-const EMAIL_PROOF_CONTEXT_KEY = 'silentsuite-signup-email-proof'
-
-type EmailProofContext = {
-  email: string
-  requestId: string
-  wantsProductUpdates: boolean
-  rememberDevice: boolean
-  returnTo: string | null
-  expiresAt: number
-}
-
-/**
- * The restart continuation lives in localStorage, not sessionStorage. Opening
- * the verification link is a full page load — often in a brand new browsing
- * context — by which point `pendingSignup`, the restored continuation and the
- * one-time redirect snapshot are all gone. This is the only thing that carries
- * the restart across that navigation. It holds an email, a request id and two
- * booleans: no password and no payment capability.
- */
-function readEmailProofContext(requestId: string | null): EmailProofContext | null {
-  try {
-    const raw = localStorage.getItem(EMAIL_PROOF_CONTEXT_KEY)
-    if (!raw) return null
-    const parsed = JSON.parse(raw) as Partial<EmailProofContext> | Record<string, Partial<EmailProofContext>>
-    const candidate = requestId && requestId in parsed ? (parsed as Record<string, Partial<EmailProofContext>>)[requestId] : parsed as Partial<EmailProofContext>
-    if (isEmail(candidate.email) && isUuid(candidate.requestId)
-      && (!requestId || candidate.requestId === requestId)
-      && typeof candidate.wantsProductUpdates === 'boolean' && typeof candidate.rememberDevice === 'boolean'
-      && typeof candidate.expiresAt === 'number' && candidate.expiresAt > Date.now()) {
-      return candidate as EmailProofContext
-    }
-    return null
-  } catch {
-    return null
-  }
-}
-
-function persistEmailProofContext(context: EmailProofContext) {
-  const existing = (() => { try { return JSON.parse(localStorage.getItem(EMAIL_PROOF_CONTEXT_KEY) ?? '{}') as Record<string, EmailProofContext> } catch { return {} } })()
-  localStorage.setItem(EMAIL_PROOF_CONTEXT_KEY, JSON.stringify({ ...existing, [context.requestId]: context }))
-}
-
-function clearEmailProofContext(requestId: string | null) {
-  try {
-    if (!isUuid(requestId)) return
-    const raw = localStorage.getItem(EMAIL_PROOF_CONTEXT_KEY)
-    if (!raw) return
-    const contexts = JSON.parse(raw) as Record<string, unknown>
-    if (contexts.requestId === requestId && typeof contexts.email === 'string') {
-      localStorage.removeItem(EMAIL_PROOF_CONTEXT_KEY)
-      return
-    }
-    delete contexts[requestId]
-    if (Object.keys(contexts).length) localStorage.setItem(EMAIL_PROOF_CONTEXT_KEY, JSON.stringify(contexts))
-    else localStorage.removeItem(EMAIL_PROOF_CONTEXT_KEY)
-  } catch {
-    // A storage failure must not break the restart it was only annotating.
-  }
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }
@@ -146,22 +63,6 @@ function isEmail(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0 && value.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
 }
 
-function captureVerifiedAnnualRestartContext(
-  pending: SignupPaymentContinuation | null,
-  recovery: PaymentSessionRecoveryContext | null,
-): VerifiedAnnualRestartContext | null {
-  if (!pending || !recovery) return null
-  const context: VerifiedAnnualRestartContext = {
-    email: recovery.email,
-    paymentSessionRequestKey: recovery.requestKey,
-  }
-  if (pending.paymentMethod === 'stripe' || pending.paymentMethod === 'btcpay') context.paymentMethod = pending.paymentMethod
-  if (pending.billingContractVersion === 1 || pending.billingContractVersion === 2) context.billingContractVersion = pending.billingContractVersion
-  if (typeof pending.wantsProductUpdates === 'boolean') context.wantsProductUpdates = pending.wantsProductUpdates
-  if (typeof pending.rememberDevice === 'boolean') context.rememberDevice = pending.rememberDevice
-  return context
-}
-
 function readPersistedPaymentSessionRecoveryContext(): PersistedPaymentSessionRecoveryContext | null {
   try {
     const raw = sessionStorage.getItem(PENDING_CRYPTO_RECOVERY_CONTEXT_KEY)
@@ -172,6 +73,20 @@ function readPersistedPaymentSessionRecoveryContext(): PersistedPaymentSessionRe
   } catch {
     return null
   }
+}
+
+function hasPersistedRecovery(pending: SignupPaymentContinuation | null): boolean {
+  try {
+    const raw = sessionStorage.getItem('silentsuite-signup-redirect-state')
+    if (!raw || !pending) return false
+    const saved = JSON.parse(raw)
+    return saved.pendingSignup?.email === pending.email
+      && saved.pendingSignup?.paymentSessionToken === pending.paymentSessionToken
+      && saved.pendingSignup?.paymentSessionRequestKey === pending.paymentSessionRequestKey
+      && saved.pendingSignup?.serverUrl === pending.serverUrl
+      && typeof saved.savedAt === 'number' && Date.now() >= saved.savedAt
+      && Date.now() - saved.savedAt < 2 * 60 * 60 * 1000
+  } catch { return false }
 }
 
 function readPaymentSessionRecoveryContext(pending: {
@@ -187,29 +102,10 @@ function readPaymentSessionRecoveryContext(pending: {
   return { email, requestKey, paymentSessionToken }
 }
 
-function persistPaymentSessionRecoveryContext(context: PersistedPaymentSessionRecoveryContext) {
-  sessionStorage.setItem(PENDING_CRYPTO_RECOVERY_CONTEXT_KEY, JSON.stringify(context))
-}
-
-function clearPendingCryptoPaymentSession() {
-  sessionStorage.removeItem('silentsuite-pending-crypto-invoice')
-  sessionStorage.removeItem('silentsuite-pending-crypto-token')
-  sessionStorage.removeItem('silentsuite-pending-crypto-return-to')
-  sessionStorage.removeItem(PENDING_CRYPTO_RECOVERY_CONTEXT_KEY)
-}
-
-function clearPendingCryptoSignup() {
-  clearPendingCryptoPaymentSession()
-  sessionStorage.removeItem('silentsuite-signup-in-progress')
-}
-
 export default function PendingPaymentPage() {
   const completeSignup = useAuthStore((s) => s.completeSignup)
   const createEtebaseAccount = useAuthStore((s) => s.createEtebaseAccount)
   const finalizePaidSignup = useAuthStore((s) => s.finalizePaidSignup)
-  const prepareSignupDraft = useAuthStore((s) => s.prepareSignupDraft)
-  const startAnnualSignupPayment = useAuthStore((s) => s.startAnnualSignupPayment)
-  const clearPendingSignupPaymentRecovery = useAuthStore((s) => s.clearPendingSignupPaymentRecovery)
   const saveSignupStateForRedirect = useAuthStore((s) => s.saveSignupStateForRedirect)
   const restoreSignupStateFromRedirect = useAuthStore((s) => s.restoreSignupStateFromRedirect)
   const pendingSignup = useAuthStore((s) => s.pendingSignup)
@@ -217,55 +113,31 @@ export default function PendingPaymentPage() {
   const [showReturnFallback, setShowReturnFallback] = useState(false)
   const [state, setState] = useState<PaymentState>('pending')
   const [restoredEmail, setRestoredEmail] = useState('')
-  const [restarting, setRestarting] = useState(false)
   const [restartError, setRestartError] = useState<string | null>(null)
-  const [currentFlow, setCurrentFlow] = useState<CurrentPaymentFlow | null>(null)
+  const [sessionPassword, setSessionPassword] = useState('')
+  const [recoveringSession, setRecoveringSession] = useState(false)
+  const sessionInFlight = useRef(false)
+  const recoverCompletedSignupSession = useAuthStore((s) => s.recoverCompletedSignupSession)
   const [flowCheckState, setFlowCheckState] = useState<PaymentFlowCheckState>('idle')
-  const [emailOwnershipToken, setEmailOwnershipToken] = useState<string | null>(null)
-  const [emailProofRequestId, setEmailProofRequestId] = useState<string | null>(null)
-  const [emailProofRequested, setEmailProofRequested] = useState(false)
-  const [pendingRestartActivation, setPendingRestartActivation] = useState<AnnualCheckoutActivation | null>(null)
   // Kept out of `restartError`, which every flow check clears on entry.
   const [emailProofUnavailable, setEmailProofUnavailable] = useState(false)
   const [restoredContinuation, setRestoredContinuation] = useState<SignupPaymentContinuation | null>(null)
-  const [verifiedRestartContext, setVerifiedRestartContext] = useState<VerifiedAnnualRestartContext | null>(null)
   const [recoveryInitialized, setRecoveryInitialized] = useState(false)
   const redirectRestorationAttempted = useRef(false)
-  const terminalAuthorityReleased = useRef(false)
   const activePendingSignup = (pendingSignup ?? restoredContinuation) as SignupPaymentContinuation | null
-
-  const releaseTerminalPaymentSession = useCallback((
-    restartContext: VerifiedAnnualRestartContext | null,
-    recovery: PaymentSessionRecoveryContext,
-  ) => {
-    if (terminalAuthorityReleased.current) return
-    terminalAuthorityReleased.current = true
-    if (restartContext) setVerifiedRestartContext(restartContext)
-    clearPendingCryptoSignup()
-    clearPendingSignupPaymentRecovery({
-      email: recovery.email,
-      requestKey: recovery.requestKey,
-      recoverySecret: recovery.paymentSessionToken,
-      wantsProductUpdates: restartContext?.wantsProductUpdates,
-      rememberDevice: restartContext?.rememberDevice,
-    })
-    setCurrentFlow(null)
-    setFlowCheckState('ready')
-  }, [clearPendingSignupPaymentRecovery])
 
   const loadCurrentFlow = useCallback(async (isCancelled: () => boolean = () => false): Promise<SettlementPollDisposition> => {
     if (!isCancelled()) {
       setFlowCheckState('loading')
-      setCurrentFlow(null)
       setRestartError(null)
     }
     try {
+      if (activePendingSignup?.provisionedUser) return 'stop'
       if (activePendingSignup?.billingContractVersion !== 2
         && isEmail(activePendingSignup?.email)
         && isRecoveryToken(activePendingSignup.paymentSessionToken)) {
         if (!isCancelled()) {
           setRestoredEmail(activePendingSignup.email)
-          setCurrentFlow(null)
           setFlowCheckState('ready')
           setState('account')
         }
@@ -276,7 +148,6 @@ export default function PendingPaymentPage() {
         // Nothing local can be polled, and re-running this would only flicker
         // the recovery controls back into their "checking" state every tick.
         if (!isCancelled()) {
-          setCurrentFlow(null)
           setFlowCheckState('ready')
         }
         return 'stop'
@@ -301,18 +172,17 @@ export default function PendingPaymentPage() {
       }
       if (isCancelled()) return 'stop'
       if (result.state === 'closed') {
-        releaseTerminalPaymentSession(captureVerifiedAnnualRestartContext(activePendingSignup, recovery), recovery)
-        setState('expired')
+        // Generic closed is also returned for unknown proof: never release authority.
+        setFlowCheckState('ready')
+        setState('unknown')
         return 'stop'
       }
       if (result.state === 'confirmed') {
         setRestoredEmail(recovery.email)
-        setCurrentFlow(null)
         setFlowCheckState('ready')
         setState('account')
         return 'stop'
       }
-      setCurrentFlow(result.flow)
       setFlowCheckState('ready')
       return 'poll'
     } catch {
@@ -324,22 +194,26 @@ export default function PendingPaymentPage() {
       // schedule keeps its remaining attempts rather than stranding the user.
       return 'poll'
     }
-  }, [activePendingSignup, releaseTerminalPaymentSession])
+  }, [activePendingSignup])
 
   useEffect(() => {
     if (redirectRestorationAttempted.current) return
     redirectRestorationAttempted.current = true
     if (!pendingSignup) {
-      const restored = restoreSignupStateFromRedirect()
+      const restored = restoreSignupStateFromRedirect({ retainForRecovery: true })
       if (restored) setRestoredContinuation(restored.pendingSignup)
+    } else {
+      // Snapshot the in-memory continuation before any full-document departure.
+      // Do not renew a restored snapshot's bounded lifetime. Passwords/session
+      // attestations are excluded by the store's allowlisted serializer.
+      saveSignupStateForRedirect('annual')
     }
     setRecoveryInitialized(true)
-  }, [pendingSignup, restoreSignupStateFromRedirect])
+  }, [pendingSignup, restoreSignupStateFromRedirect, saveSignupStateForRedirect])
 
   useEffect(() => {
     setReturnTo(normalizeSignupReturnTo(sessionStorage.getItem('silentsuite-pending-crypto-return-to')))
     if (!recoveryInitialized) return
-    if (terminalAuthorityReleased.current) return
     if (state === 'vault' || state === 'account' || state === 'settled') return
 
     let cancelled = false
@@ -371,56 +245,8 @@ export default function PendingPaymentPage() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
-    const token = params.get('email_verification_token') ?? params.get('token')
-    if (!token) return
-    const requestId = params.get('request_id')
-    const context = readEmailProofContext(requestId)
-    if (!context) {
-      // Without the continuation there is no email to verify the token against,
-      // so the restart cannot proceed here. Say so instead of leaving the user
-      // on a button that will only ever answer "return to signup".
-      clearEmailProofContext(requestId)
-      setEmailProofRequested(false)
-      setEmailProofUnavailable(true)
-      return
-    }
-
-    let cancelled = false
-    void consumeSignupEmailOwnership({
-      fetcher: fetch,
-      billingApiUrl: BILLING_API_URL,
-      email: context.email,
-      token,
-    }).then((ownership) => {
-      if (cancelled) return
-      // Rebuild the signup draft the released terminal session took with it:
-      // `startAnnualSignupPayment` needs a pendingSignup, and its recovery
-      // scope must match the flags this continuation was requested under so a
-      // fresh requestKey/secret pair is minted for the replacement invoice.
-      prepareSignupDraft(context.email, context.wantsProductUpdates, context.rememberDevice)
-      setVerifiedRestartContext({
-        email: context.email,
-        paymentMethod: 'btcpay',
-        billingContractVersion: 2,
-        wantsProductUpdates: context.wantsProductUpdates,
-        rememberDevice: context.rememberDevice,
-      })
-      setEmailOwnershipToken(ownership.emailOwnershipToken)
-      setEmailProofRequestId(context.requestId)
-      setReturnTo(context.returnTo ?? null)
-      setEmailProofRequested(false)
-      setEmailProofUnavailable(false)
-      setRestartError(null)
-      clearEmailProofContext(requestId)
-      const cleaned = new URL(window.location.href)
-      cleaned.searchParams.delete('email_verification_token')
-      cleaned.searchParams.delete('token')
-      window.history.replaceState({}, '', `${cleaned.pathname}${cleaned.search}${cleaned.hash}`)
-    }).catch((err: unknown) => {
-      if (!cancelled) setRestartError(err instanceof Error ? err.message : 'Email verification could not be completed. Request a new link.')
-    })
-    return () => { cancelled = true }
-  }, [prepareSignupDraft])
+    if (params.has('email_verification_token') || params.has('token')) setEmailProofUnavailable(true)
+  }, [])
 
   function handleVaultComplete() {
     completeSignup()
@@ -436,6 +262,11 @@ export default function PendingPaymentPage() {
   }
 
   async function handlePaidAccountComplete(data: PaidAccountFormData) {
+    if (useAuthStore.getState().pendingSignup?.provisionedUser) {
+      await recoverCompletedSignupSession(data.password)
+      setState('vault')
+      return
+    }
     await createEtebaseAccount(restoredEmail, data.password)
     await finalizePaidSignup()
     setState('vault')
@@ -454,214 +285,46 @@ export default function PendingPaymentPage() {
   }
 
   const isWaiting = state === 'pending'
-  const title = state === 'settled'
-    ? 'Payment settled'
-    : state === 'expired'
-      ? 'Invoice not completed'
-      : state === 'timeout'
-        ? 'Still waiting for settlement'
-        : state === 'unknown'
-          ? 'Payment session not found'
-          : 'Waiting for BTCPay settlement'
-
+  const hasRecovery = Boolean(readPaymentSessionRecoveryContext(activePendingSignup))
+  // The recovery projection contains no correlated invoice readiness evidence.
+  // A local invoice string must never become an availability claim.
+  const title = state === 'settled' ? 'Payment settled'
+    : state === 'unknown' ? 'Payment release not confirmed'
+    : !hasRecovery ? 'Payment recovery details unavailable'
+    : state === 'timeout' ? 'Payment status is still unconfirmed'
+    : 'Checking checkout status'
   const description = state === 'settled'
-    ? 'Your annual prepaid access is active. Review the vault warning below, then continue into SilentSuite.'
-    : state === 'expired'
-      ? 'The invoice expired or was marked invalid. Verify your email to request a new Bitcoin invoice without creating another account.'
-      : state === 'timeout'
-        ? 'Settlement is taking longer than expected. You can check again manually or start a new Bitcoin invoice.'
-        : state === 'unknown'
-          ? 'This browser no longer has the invoice details needed to poll BTCPay. If your billing session is still active, you can start a new Bitcoin invoice.'
-          : 'Crypto payments can take a little time to settle. Your app access stays locked until the BTCPay webhook activates the account.'
+    ? 'Your annual prepaid access is active. Continue to vault setup.'
+    : !hasRecovery
+      ? 'This browser has no payment recovery capability. Return to the original signup tab to retry, or contact support if payment may have started. Do not start a second payment.'
+      : 'An invoice or payment has not been confirmed. Check the existing checkout status. Back keeps this same payment recovery; it does not cancel or start another payment.'
 
-  async function restartBitcoinCheckout() {
-    if (flowCheckState !== 'ready' || currentFlow) {
-      setRestartError('Check the current payment status before starting another invoice.')
-      return
+  function handleRecoveryBack(event: MouseEvent<HTMLAnchorElement>) {
+    if (hasRecovery && !hasPersistedRecovery(activePendingSignup)) {
+      event.preventDefault()
+      setRestartError('This browser could not retain payment recovery. Stay on this page to check the existing payment, or contact support. Do not start another payment.')
     }
-    const restartContinuation = verifiedRestartContext ?? activePendingSignup
-    const email = restartContinuation?.email
-    if (!email) {
-      setRestartError('Return to signup to verify your email before starting another invoice.')
-      return
-    }
-
-    setRestarting(true)
-    setRestartError(null)
-    try {
-      if (!emailOwnershipToken || !emailProofRequestId) {
-        const requestId = crypto.randomUUID()
-        const context: EmailProofContext = {
-          email,
-          requestId,
-          wantsProductUpdates: restartContinuation?.wantsProductUpdates === true,
-          rememberDevice: restartContinuation?.rememberDevice === true,
-          returnTo,
-          expiresAt: Date.now() + 15 * 60_000,
-        }
-        await requestSignupEmailOwnership({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email, requestId })
-        persistEmailProofContext(context)
-        setEmailProofRequestId(requestId)
-        setEmailProofRequested(true)
-        return
-      }
-
-      const offer = await fetchAnonymousAnnualOffer({ fetcher: fetch, billingApiUrl: BILLING_API_URL, email, requestId: emailProofRequestId })
-      if (!isAnnualOfferProviderAvailable(offer.offer, 'btcpay', CRYPTO_CHECKOUT_ENABLED)) {
-        throw new Error('Bitcoin checkout is not available for this server-owned annual offer.')
-      }
-      const authority = await activateAnnualCheckout({
-        fetcher: fetch, billingApiUrl: BILLING_API_URL, offer, email, emailOwnershipToken,
-        trialPath: 'immediate', provider: 'btcpay', behavior: 'prepaid_bitcoin',
-      })
-      setPendingRestartActivation(authority)
-    } catch (err) {
-      setRestartError(err instanceof Error ? err.message : 'Could not prepare a new Bitcoin invoice.')
-    } finally {
-      setRestarting(false)
-    }
-  }
-
-  async function confirmBitcoinRestart() {
-    const authority = pendingRestartActivation
-    if (!authority) return
-    const email = (verifiedRestartContext ?? activePendingSignup)?.email
-    if (!email) return
-    setRestarting(true)
-    setRestartError(null)
-    try {
-      const result = await startAnnualSignupPayment(
-        authority.checkoutIntentToken,
-        'btcpay',
-        new URL('/signup/pending-payment', window.location.href).toString(),
-      )
-      if (!result.cryptoCheckoutUrl || !result.cryptoInvoiceId || !result.cryptoInvoiceLookupToken) {
-        throw new Error('Billing did not return a complete Bitcoin payment authority.')
-      }
-      const checkoutUrl = new URL(result.cryptoCheckoutUrl)
-      if (checkoutUrl.origin !== BTCPAY_CHECKOUT_ORIGIN || checkoutUrl.protocol !== 'https:') {
-        throw new Error('Bitcoin checkout returned an unexpected payment URL.')
-      }
-      sessionStorage.setItem('silentsuite-pending-crypto-invoice', result.cryptoInvoiceId)
-      if (returnTo) sessionStorage.setItem('silentsuite-pending-crypto-return-to', returnTo)
-      const requestKey = useAuthStore.getState().pendingSignup?.paymentSessionRequestKey
-      if (!isUuid(requestKey)) throw new Error('Billing did not retain the payment recovery lineage.')
-      persistPaymentSessionRecoveryContext({ email, requestKey })
-      // The one-time redirect snapshot is the sole persisted payment-session
-      // capability for the full navigation to BTCPay.
-      saveSignupStateForRedirect('annual')
-      sessionStorage.setItem('silentsuite-signup-in-progress', 'true')
-      setPendingRestartActivation(null)
-      window.location.href = checkoutUrl.toString()
-    } catch (err) {
-      setRestartError(err instanceof Error ? err.message : 'Could not start a new Bitcoin invoice.')
-    } finally {
-      setRestarting(false)
-    }
-  }
-
-  async function cancelCurrentFlow() {
-    setRestarting(true)
-    setRestartError(null)
-    try {
-      const recovery = readPaymentSessionRecoveryContext(activePendingSignup)
-      if (!recovery) throw new Error('The payment recovery details are unavailable.')
-      const result = await cancelAnonymousPaymentSessionRecovery({
-        fetcher: fetch, billingApiUrl: BILLING_API_URL,
-        paymentSessionToken: recovery.paymentSessionToken, recoverySecret: recovery.paymentSessionToken,
-        requestKey: recovery.requestKey, email: recovery.email,
-      })
-      if (result.state !== 'closed') {
-        throw new Error('Billing did not confirm that the payment flow is terminal.')
-      }
-      releaseTerminalPaymentSession(captureVerifiedAnnualRestartContext(activePendingSignup, recovery), recovery)
-    } catch {
-      // Do not reveal recovery capability or provider detail, and do not
-      // release local state without an authoritative closed v2 response.
-      setRestartError('Could not cancel the payment in progress.')
-    } finally {
-      setRestarting(false)
-    }
-  }
-
-  function currentCheckoutUrl(): string | null {
-    // Recovery responses intentionally omit the original checkout URL. It is
-    // an untrusted cross-navigation authority and is never reconstructed here.
-    return null
   }
 
   function renderBitcoinRecoveryAction() {
-    if (pendingRestartActivation) {
-      const disclosure = pendingRestartActivation.disclosure
-      return (
-        <div className="space-y-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4 text-left">
-          <h2 className="text-base font-semibold text-[rgb(var(--foreground))]">Confirm prepaid annual terms</h2>
-          <p className="text-sm text-[rgb(var(--muted))]">€{(disclosure.annualAmountMinor / 100).toFixed(2)} for one prepaid year. This payment does not renew automatically.</p>
-          <p className="text-sm text-[rgb(var(--muted))]">€{(disclosure.monthlyEquivalentMinor / 100).toFixed(2)} per month equivalent, billed in {disclosure.currency}.</p>
-          <p className="text-sm text-[rgb(var(--muted))]">First charge amount: €{(disclosure.firstChargeAmountMinor / 100).toFixed(2)}.</p>
-          <p className="text-sm text-[rgb(var(--muted))]">First charge: {disclosure.firstChargeAt ?? 'Immediate on confirmation'}.</p>
-          <p className="text-sm text-[rgb(var(--muted))]">Access through: {disclosure.entitlementEndsAt ?? 'Determined from provider confirmation'}.</p>
-          <p className="text-sm text-[rgb(var(--muted))]">Period end rule: {disclosure.periodEndRule.replaceAll('_', ' ')}.</p>
-          <p className="text-sm text-[rgb(var(--muted))]">{disclosure.refundWindowDays}-day refund window and {disclosure.bonusDays} bonus days after settlement.</p>
-          <button type="button" onClick={() => { void confirmBitcoinRestart() }} disabled={restarting} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white disabled:opacity-60">
-            {restarting ? 'Creating invoice...' : 'I agree — create Bitcoin invoice'}
-          </button>
-          <button type="button" onClick={() => setPendingRestartActivation(null)} disabled={restarting} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 px-4 py-2 text-sm font-medium">Cancel</button>
-        </div>
-      )
-    }
-    if (flowCheckState === 'idle' || flowCheckState === 'loading') {
-      return (
-        <button type="button" disabled className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium opacity-60">
-          Checking current payment...
-        </button>
-      )
-    }
-    if (flowCheckState === 'failed') {
-      return (
-        <button type="button" onClick={() => { void loadCurrentFlow() }} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100">
-          Retry payment status
-        </button>
-      )
-    }
-    if (currentFlow) {
-      const checkoutUrl = currentCheckoutUrl()
-      return (
-        <div className="space-y-3 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-left">
-          <div>
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Payment already in progress</p>
-            <p className="mt-1 text-xs text-[rgb(var(--muted))]">Continue the existing payment or cancel it before starting another invoice.</p>
-          </div>
-          {checkoutUrl && (
-            <button type="button" onClick={() => { window.location.href = checkoutUrl }} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600">
-              Continue Bitcoin checkout
-            </button>
-          )}
-          <button type="button" onClick={cancelCurrentFlow} disabled={restarting} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100 disabled:cursor-not-allowed disabled:opacity-60">
-            {restarting ? 'Cancelling payment...' : 'Cancel and start another invoice'}
-          </button>
-          {!checkoutUrl && (
-            <button type="button" onClick={() => { void loadCurrentFlow() }} className="inline-flex h-9 w-full items-center justify-center rounded-md border border-navy-300 bg-transparent px-4 py-2 text-sm font-medium shadow-sm transition-colors hover:bg-navy-100">
-              Check payment status again
-            </button>
-          )}
-        </div>
-      )
-    }
-    return (
-      <button type="button" onClick={restartBitcoinCheckout} disabled={restarting} className="inline-flex h-9 w-full items-center justify-center rounded-md bg-teal-500 px-4 py-2 text-sm font-medium text-white shadow transition-colors hover:bg-teal-600 disabled:cursor-not-allowed disabled:opacity-60">
-        {restarting ? 'Starting new invoice...' : emailProofRequested ? 'Check your email to continue' : emailOwnershipToken ? 'Start new Bitcoin invoice' : 'Verify email to start a new invoice'}
-      </button>
-    )
+    return <div className="space-y-3">
+      {hasRecovery && <button type="button" onClick={() => { void loadCurrentFlow() }} disabled={flowCheckState === 'loading'} className="inline-flex min-h-9 w-full items-center justify-center rounded-md border border-[rgb(var(--border))] px-4 py-2 text-sm">
+        {flowCheckState === 'loading' ? 'Checking current payment...' : flowCheckState === 'failed' ? 'Retry payment status' : 'Check payment status again'}
+      </button>}
+      <p className="text-sm">Back does not cancel a payment. Cancellation and replacement cannot yet be confirmed safely here.</p>
+      <a href="/signup?recovery=payment" onClick={handleRecoveryBack} className="block underline">Back to signup</a>
+      <a href="mailto:support@silentsuite.io" className="block underline">Contact support</a>
+    </div>
   }
 
   if (state === 'vault') {
     return (
       <div className="mx-auto max-w-md space-y-6">
+        <SignupRecoveryWarning />
         <div className="flex items-center gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
           <Check className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
           <div>
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Bitcoin payment settled</p>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Continue account setup</p>
             <p className="text-xs text-[rgb(var(--muted))]">One last step - set up your vault.</p>
           </div>
         </div>
@@ -678,13 +341,45 @@ export default function PendingPaymentPage() {
     )
   }
 
+  if (activePendingSignup?.provisionedUser) {
+    return <div className="mx-auto max-w-md space-y-6">
+      <SignupRecoveryWarning />
+      <h1 className="text-xl font-semibold">Finish signing in</h1>
+      <p>Your account is already set up. Enter your existing account password to finish signing in. Your payment will not be submitted again.</p>
+      <form className="space-y-4" onSubmit={async (event) => {
+        event.preventDefault()
+        if (sessionInFlight.current) return
+        sessionInFlight.current = true
+        setRecoveringSession(true)
+        setRestartError(null)
+        try {
+          await recoverCompletedSignupSession(sessionPassword || undefined)
+          setSessionPassword('')
+          setRestoredEmail(activePendingSignup.email)
+          setState('vault')
+        } catch (error) {
+          setRestartError(error instanceof Error ? error.message : 'Could not finish signing in.')
+        } finally {
+          sessionInFlight.current = false
+          setRecoveringSession(false)
+        }
+      }}>
+        <label htmlFor="recovery-password">Existing account password</label>
+        <input id="recovery-password" type="password" autoComplete="current-password" value={sessionPassword} onChange={(event) => setSessionPassword(event.target.value)} />
+        <button type="submit" disabled={recoveringSession}>{recoveringSession ? 'Signing in...' : 'Retry sign in'}</button>
+        {restartError && <p role="alert">{restartError}</p>}
+      </form>
+    </div>
+  }
+
   if (state === 'account') {
     return (
       <div className="mx-auto max-w-md space-y-6">
+        <SignupRecoveryWarning />
         <div className="flex items-center gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
           <Check className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
           <div>
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Bitcoin payment settled</p>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Continue account setup</p>
             <p className="text-xs text-[rgb(var(--muted))]">One last account step before your vault setup.</p>
           </div>
         </div>
@@ -695,6 +390,7 @@ export default function PendingPaymentPage() {
 
   return (
     <div className="mx-auto flex min-h-[60vh] max-w-md flex-col justify-center space-y-6 text-center">
+      <SignupRecoveryWarning />
       <CheckoutReturnAnalytics outcome="pending" paymentMethod="btcpay" />
       <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl border border-amber-500/30 bg-amber-500/10">
         {state === 'settled' ? <Check className="h-7 w-7 text-emerald-400" /> : isWaiting ? <Loader2 className="h-7 w-7 animate-spin text-amber-300" /> : <AlertTriangle className="h-7 w-7 text-amber-300" />}
@@ -716,7 +412,7 @@ export default function PendingPaymentPage() {
         {emailProofUnavailable && (
           <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-left text-sm text-red-600 dark:text-red-400">
             <p className="font-medium">This verification link could not be matched to a payment in this browser.</p>
-            <p className="mt-1">Open the link in the browser you requested it from, or request a new one below.</p>
+            <p className="mt-1">Open the link in the browser you requested it from, or contact support for help with this payment.</p>
           </div>
         )}
         {state === 'settled' ? (

--- a/apps/web/app/(auth)/signup/pending-payment/page.tsx
+++ b/apps/web/app/(auth)/signup/pending-payment/page.tsx
@@ -311,8 +311,8 @@ export default function PendingPaymentPage() {
       {hasRecovery && <button type="button" onClick={() => { void loadCurrentFlow() }} disabled={flowCheckState === 'loading'} className="inline-flex min-h-9 w-full items-center justify-center rounded-md border border-[rgb(var(--border))] px-4 py-2 text-sm">
         {flowCheckState === 'loading' ? 'Checking current payment...' : flowCheckState === 'failed' ? 'Retry payment status' : 'Check payment status again'}
       </button>}
-      <p className="text-sm">Back does not cancel a payment. Cancellation and replacement cannot yet be confirmed safely here.</p>
-      <a href="/signup?recovery=payment" onClick={handleRecoveryBack} className="block underline">Back to signup</a>
+      <p className="text-sm">Reloading keeps this same payment. Cancellation and switching payment methods are not available here; contact support for help.</p>
+      <a href="/signup?recovery=payment" onClick={handleRecoveryBack} className="block underline">Reload this payment recovery</a>
       <a href="mailto:support@silentsuite.io" className="block underline">Contact support</a>
     </div>
   }

--- a/apps/web/app/(auth)/signup/success/page.tsx
+++ b/apps/web/app/(auth)/signup/success/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { CheckCircle, AlertTriangle, Lock } from 'lucide-react'
+import { CheckCircle, AlertTriangle } from 'lucide-react'
 import { Button } from '@silentsuite/ui'
 import { useAuthStore } from '@/app/stores/use-auth-store'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
@@ -15,7 +15,7 @@ import { SignupRecoveryWarning } from '../components/signup-recovery-warning'
 // Inner component that reads searchParams (must be inside <Suspense>)
 // ---------------------------------------------------------------------------
 
-type RedirectState = 'loading' | 'session' | 'account' | 'vault' | 'failed' | 'expired' | 'none'
+type RedirectState = 'loading' | 'session' | 'account' | 'vault' | 'recovery'
 
 function SignupSuccessInner() {
   const router = useRouter()
@@ -28,11 +28,13 @@ function SignupSuccessInner() {
   const redirectStatus = searchParams.get('redirect_status')
   const setupIntent = searchParams.get('setup_intent')
   const returnTo = normalizeSignupReturnTo(searchParams.get('return_to'))
-  const isStripeRedirect = !!(setupIntent && redirectStatus)
+  const paymentIntent = searchParams.get('payment_intent')
+  const isStripeRedirect = !!(setupIntent || paymentIntent)
   const checkoutReturn = <CheckoutReturnAnalytics outcome={redirectStatus === 'failed' ? 'failed' : 'returned'} paymentMethod={isStripeRedirect ? 'stripe' : 'unknown'} />
 
-  const [state, setState] = useState<RedirectState>(isStripeRedirect ? 'loading' : 'none')
+  const [state, setState] = useState<RedirectState>('loading')
   const [restoredEmail, setRestoredEmail] = useState<string>('')
+  const [restoredServerUrl, setRestoredServerUrl] = useState<string | undefined>()
   const [showReturnFallback, setShowReturnFallback] = useState(false)
   const [sessionError, setSessionError] = useState<string | null>(null)
   const [password, setPassword] = useState('')
@@ -57,35 +59,31 @@ function SignupSuccessInner() {
   }, [recoverCompletedSignupSession])
 
   useEffect(() => {
-    if (!isStripeRedirect || restoredOnce.current) return
+    if (restoredOnce.current) return
     restoredOnce.current = true
 
-    if (redirectStatus === 'failed') {
-      setState('failed')
-      return
+    // Provider IDs/status are routing hints only. The retained checkpoint owns
+    // continuation identity; Billing finalization and session checks own access.
+    // A completed receipt takes precedence even when URL hints are absent/failed.
+    const restored = restoreSignupStateFromRedirect({ retainForRecovery: true })
+    if (restored?.pendingSignup.provisionedUser) {
+      setRestoredEmail(restored.pendingSignup.email)
+      void recoverSession()
+    } else if (restored?.pendingSignup.paymentSessionToken && isStripeRedirect
+      && (redirectStatus === 'succeeded' || redirectStatus === 'processing')) {
+      setRestoredEmail(restored.pendingSignup.email)
+      setRestoredServerUrl(restored.pendingSignup.serverUrl)
+      setState('account')
+    } else {
+      setState('recovery')
     }
-
-    if (redirectStatus === 'succeeded' || redirectStatus === 'processing') {
-      const restored = restoreSignupStateFromRedirect({ retainForRecovery: true })
-      if (restored?.pendingSignup.provisionedUser) {
-        setRestoredEmail(restored.pendingSignup.email)
-        void recoverSession()
-      } else if (restored?.pendingSignup.paymentSessionToken) {
-        setRestoredEmail(restored.pendingSignup.email)
-        setState('account')
-      } else {
-        // State missing or expired — can't complete the flow
-        setState('expired')
-      }
-      return
-    }
-
-    // Unknown redirect_status — treat as failure
-    setState('failed')
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []) // Run once on mount
+  }, [isStripeRedirect, redirectStatus, recoverSession, restoreSignupStateFromRedirect])
 
   const handleVaultComplete = useCallback(() => {
+    if (!useAuthStore.getState().pendingSignup?.provisionedUser) {
+      setState('recovery')
+      return
+    }
     completeSignup()
     if (returnTo) {
       setShowReturnFallback(false)
@@ -99,23 +97,10 @@ function SignupSuccessInner() {
   }, [completeSignup, returnTo, router])
 
   const handlePaidAccountComplete = useCallback(async (data: PaidAccountFormData) => {
-    await createEtebaseAccount(restoredEmail, data.password)
+    await createEtebaseAccount(restoredEmail, data.password, restoredServerUrl)
     await finalizePaidSignup()
     setState('vault')
-  }, [createEtebaseAccount, finalizePaidSignup, restoredEmail])
-
-  const handleSuccessContinue = useCallback(() => {
-    completeSignup()
-    if (returnTo) {
-      setShowReturnFallback(false)
-      window.location.href = returnTo
-      window.setTimeout(() => {
-        if (document.visibilityState === 'visible') setShowReturnFallback(true)
-      }, 2000)
-      return
-    }
-    router.push('/')
-  }, [completeSignup, returnTo, router])
+  }, [createEtebaseAccount, finalizePaidSignup, restoredEmail, restoredServerUrl])
 
   // --- Stripe 3DS redirect: loading ---
   if (state === 'loading') {
@@ -151,11 +136,12 @@ function SignupSuccessInner() {
         <div className="flex items-center gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
           <CheckCircle className="h-5 w-5 text-emerald-500 shrink-0" />
           <div>
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Card verified successfully</p>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Continue account setup</p>
             <p className="text-xs text-[rgb(var(--muted))]">One last account step before your vault setup.</p>
           </div>
         </div>
-        <StepCreatePaidAccount email={restoredEmail} onNext={handlePaidAccountComplete} />
+        <StepCreatePaidAccount email={restoredEmail} continuation="payment-return" onNext={handlePaidAccountComplete} />
+        <Button onClick={() => router.push('/signup?recovery=payment')} className="w-full">Open payment recovery</Button>
       </div>
     )
   }
@@ -169,7 +155,7 @@ function SignupSuccessInner() {
         <div className="flex items-center gap-3 rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4">
           <CheckCircle className="h-5 w-5 text-emerald-500 shrink-0" />
           <div>
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Card verified successfully</p>
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">Account session confirmed</p>
             <p className="text-xs text-[rgb(var(--muted))]">One last step — set up your vault.</p>
           </div>
         </div>
@@ -190,80 +176,28 @@ function SignupSuccessInner() {
     )
   }
 
-  // --- Stripe 3DS redirect: payment failed ---
-  if (state === 'failed') {
-    return (
-      <div className="max-w-md mx-auto space-y-6 text-center">
-        {checkoutReturn}
-        <div className="flex flex-col items-center gap-4">
-          <div className="rounded-full bg-red-500/10 p-4">
-            <AlertTriangle className="h-12 w-12 text-red-400" />
-          </div>
-          <h2 className="text-xl font-semibold text-[rgb(var(--foreground))]">
-            Payment verification failed
-          </h2>
-          <p className="text-sm leading-relaxed text-[rgb(var(--muted))]">
-            Your bank could not verify the payment. Please try again with the same
-            or a different card.
-          </p>
-        </div>
-        <Button onClick={() => router.push('/signup')} className="w-full">
-          Back to signup
-        </Button>
-      </div>
-    )
-  }
-
-  // --- Stripe 3DS redirect: state expired / missing ---
-  if (state === 'expired') {
-    return (
-      <div className="max-w-md mx-auto space-y-6 text-center">
-        <div className="flex flex-col items-center gap-4">
-          <div className="rounded-full bg-amber-500/10 p-4">
-            <AlertTriangle className="h-12 w-12 text-amber-400" />
-          </div>
-          <h2 className="text-xl font-semibold text-[rgb(var(--foreground))]">
-            Session expired
-          </h2>
-          <p className="text-sm leading-relaxed text-[rgb(var(--muted))]">
-            Your signup session has expired. Your card was saved successfully, but
-            you&apos;ll need to start the signup process again to complete setup.
-          </p>
-        </div>
-        <Button onClick={() => router.push('/signup')} className="w-full">
-          Start again
-        </Button>
-      </div>
-    )
-  }
-
-  // --- Default: no Stripe params (direct navigation) ---
+  // Missing, expired and unresolved returns cannot authorize a new payment or
+  // account completion. Recovery rechecks only the original bound operation.
   return (
     <div className="max-w-md mx-auto space-y-6 text-center">
       {checkoutReturn}
       <div className="flex flex-col items-center gap-4">
-        <div className="rounded-full bg-[rgb(var(--primary))]/10 p-4">
-          <CheckCircle className="h-12 w-12 text-[rgb(var(--primary))]" />
+        <div className="rounded-full bg-amber-500/10 p-4">
+          <AlertTriangle className="h-12 w-12 text-amber-400" />
         </div>
         <h2 className="text-xl font-semibold text-[rgb(var(--foreground))]">
           Payment confirmation required
         </h2>
         <p className="text-sm leading-relaxed text-[rgb(var(--muted))]">
-          Return to your signup flow to confirm payment with Billing before access is activated.
+          This return does not confirm payment. Open payment recovery to check the original
+          signup. If recovery details are missing or expired, use the original signup tab
+          or contact support. Do not start another payment.
         </p>
       </div>
-
-      <Button onClick={handleSuccessContinue} className="w-full">
-        {returnTo ? 'Return to Android app' : 'Back to signup'}
+      <Button onClick={() => router.push('/signup?recovery=payment')} className="w-full">
+        Open payment recovery
       </Button>
-      {showReturnFallback && returnTo && (
-        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-[rgb(var(--foreground))]">
-          <p className="font-medium">Browser did not reopen the Android app automatically.</p>
-          <a href={returnTo} className="mt-2 inline-flex font-medium text-[rgb(var(--primary))] underline">
-            Tap here to return to Android
-          </a>
-        </div>
-      )}
+      <a href="mailto:support@silentsuite.io" className="block underline">Contact support</a>
     </div>
   )
 }

--- a/apps/web/app/(auth)/signup/success/page.tsx
+++ b/apps/web/app/(auth)/signup/success/page.tsx
@@ -9,6 +9,7 @@ import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import { StepCreateVault } from '../components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from '../components/step-create-paid-account'
 import { CheckoutReturnAnalytics } from '../commercial-funnel-analytics'
+import { SignupRecoveryWarning } from '../components/signup-recovery-warning'
 
 // ---------------------------------------------------------------------------
 // Inner component that reads searchParams (must be inside <Suspense>)
@@ -65,7 +66,7 @@ function SignupSuccessInner() {
     }
 
     if (redirectStatus === 'succeeded' || redirectStatus === 'processing') {
-      const restored = restoreSignupStateFromRedirect()
+      const restored = restoreSignupStateFromRedirect({ retainForRecovery: true })
       if (restored?.pendingSignup.provisionedUser) {
         setRestoredEmail(restored.pendingSignup.email)
         void recoverSession()
@@ -273,15 +274,19 @@ function SignupSuccessInner() {
 
 export default function SignupSuccessPage() {
   return (
-    <Suspense
-      fallback={
-        <div className="max-w-md mx-auto flex flex-col items-center justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-2 border-[rgb(var(--primary))] border-t-transparent" />
-          <p className="mt-4 text-sm text-[rgb(var(--muted))]">Loading...</p>
-        </div>
-      }
-    >
-      <SignupSuccessInner />
-    </Suspense>
+    <>
+      {/* Keep recovery disclosure mounted across every status and Suspense fallback. */}
+      <div className="max-w-md mx-auto"><SignupRecoveryWarning /></div>
+      <Suspense
+        fallback={
+          <div className="max-w-md mx-auto flex flex-col items-center justify-center py-12">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-[rgb(var(--primary))] border-t-transparent" />
+            <p className="mt-4 text-sm text-[rgb(var(--muted))]">Loading...</p>
+          </div>
+        }
+      >
+        <SignupSuccessInner />
+      </Suspense>
+    </>
   )
 }

--- a/apps/web/app/stores/__tests__/signup-billing-session.test.ts
+++ b/apps/web/app/stores/__tests__/signup-billing-session.test.ts
@@ -3,7 +3,7 @@ import { useAuthStore } from '../use-auth-store'
 import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 import { createElement } from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import SignupPage from '../../(auth)/signup/page'
 import { checkoutIntentToken, emailOwnershipToken } from '@/src/__tests__/fixtures/annual-authority'
 
@@ -52,6 +52,74 @@ beforeEach(() => {
 })
 
 describe('signup Billing session boundary', () => {
+  it('keeps a visible memory-only warning through real finalization and failed session exchange, then clears it only after a durable receipt write', async () => {
+    const key = 'silentsuite-signup-redirect-state'
+    mocks.session = 'encrypted-session'
+    useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: capability, paymentSessionRequestKey: id, billingContractVersion: 2 } })
+    useAuthStore.getState().saveSignupStateForRedirect('annual')
+    const issued = JSON.parse(sessionStorage.getItem(key)!).savedAt
+    window.history.replaceState({}, '', '/signup?recovery=payment')
+    vi.mocked(fetch).mockResolvedValue(json({ contractVersion: 2, state: 'closed', flow: null }))
+    render(createElement(SignupPage))
+    await screen.findByRole('heading', { name: 'Payment release not confirmed' })
+
+    const originalWrite = Storage.prototype.setItem
+    let failReceiptWrite = false
+    const write = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (failReceiptWrite && key === 'silentsuite-signup-redirect-state') throw new Error('quota')
+      return originalWrite.call(this, key, value)
+    })
+    const paths: string[] = []
+    let exchangeStartedWithVisibleWarning = false
+    let failExchange!: () => void
+    const exchange = new Promise<Response>((resolve) => { failExchange = () => resolve(json({}, 503)) })
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const pathname = new URL(String(url)).pathname
+      if (pathname.endsWith('/payment-session/v2/current')) return json({ contractVersion: 2, state: 'closed', flow: null })
+      paths.push(pathname)
+      if (pathname.endsWith('/finalize-payment/v2')) {
+        failReceiptWrite = true
+        return json({ ...completed, provisioningStatus: 'active', planId: 'early_annual', isAdmin: false })
+      }
+      expect(useAuthStore.getState().signupRecoveryDurability).toBe('memory-only')
+      expect(screen.getByText(/Stay in this tab/)).toBeVisible()
+      expect(useAuthStore.getState().pendingSignup?.provisionedUser?.id).toBe(id)
+      expect(sessionStorage.getItem(key)).toBeNull()
+      exchangeStartedWithVisibleWarning = true
+      return exchange
+    })
+    try {
+      const finalization = useAuthStore.getState().finalizePaidSignup().catch((error) => error as Error)
+      const warning = await screen.findByText(/Stay in this tab/)
+      expect(warning).toBeVisible()
+      expect(warning).toHaveTextContent(/Refreshing, closing, or leaving this tab can lose this continuation/)
+      expect(warning).toHaveTextContent(/do not start another signup or payment/)
+      await screen.findByRole('heading', { name: 'Finish signing in' })
+      expect(screen.queryByRole('link', { name: 'Back to signup' })).not.toBeInTheDocument()
+      await act(async () => { failExchange(); expect(await finalization).toBeInstanceOf(Error) })
+      expect(warning).toBeVisible()
+      expect(exchangeStartedWithVisibleWarning).toBe(true)
+      expect(paths).toEqual(['/auth/signup/finalize-payment/v2', '/auth/token-exchange'])
+      expect(mocks.signup).not.toHaveBeenCalled()
+      expect(useAuthStore.getState().pendingSignup?.billingSessionUserId).toBeUndefined()
+      act(() => useAuthStore.getState().clearError())
+      expect(warning).toBeVisible()
+
+      // The original receipt's lifetime and identity survive a successful retry.
+      failReceiptWrite = false
+      act(() => useAuthStore.getState().saveSignupStateForRedirect('annual'))
+      expect(useAuthStore.getState().signupRecoveryDurability).toBe('persisted')
+      expect(screen.queryByText(/Stay in this tab/)).not.toBeInTheDocument()
+      expect(JSON.parse(sessionStorage.getItem(key)!)).toMatchObject({ savedAt: issued, pendingSignup: {
+        email, paymentSessionToken: capability, paymentSessionRequestKey: id, billingContractVersion: 2, provisionedUser: { id },
+      } })
+      expect(sessionStorage.getItem(key)).not.toMatch(/billingSessionUserId|encrypted-session|signupRecoveryDurability/)
+      expect(useAuthStore.getState().pendingSignup?.billingSessionUserId).toBeUndefined()
+      expect(() => useAuthStore.getState().completeSignup()).toThrow(/session/i)
+      expect(useAuthStore.getState().signupRecoveryDurability).toBe('persisted')
+    } finally { write.mockRestore() }
+  })
+
   it('wires encrypted creation, failed proof, release and fresh consent without exposing replacement credentials', async () => {
     const requestId = 'e91a6d70-0d4e-4352-9bdc-426d1f76d771'
     const disclosure = {
@@ -331,4 +399,33 @@ describe('signup Billing session boundary', () => {
     expect(useAuthStore.getState().user?.id).toBe(id)
     expect(useAuthStore.getState().isAuthenticated).toBe(true)
   })
+})
+
+
+it('checkpoints actual paid finalization before failed exchange and only recovers session after document reset', async () => {
+  const key = 'silentsuite-signup-redirect-state'
+  mocks.session = 'encrypted-session'
+  useAuthStore.setState({ pendingSignup: { email, paymentSessionToken: capability, paymentSessionRequestKey: id, billingContractVersion: 2 } })
+  useAuthStore.getState().saveSignupStateForRedirect('annual')
+  const issued = JSON.parse(sessionStorage.getItem(key)!).savedAt
+  const paths: string[] = []
+  vi.mocked(fetch).mockImplementation(async (url) => {
+    const pathname = new URL(String(url)).pathname
+    paths.push(pathname)
+    if (pathname.endsWith('/finalize-payment/v2')) return json({ ...completed, provisioningStatus: 'active', planId: 'early_annual', isAdmin: false })
+    // The receipt must already be durable before this later fallible exchange.
+    expect(JSON.parse(sessionStorage.getItem(key)!)).toMatchObject({ savedAt: issued, pendingSignup: { provisionedUser: { id }, provisionedSubscriptionStatus: 'active' } })
+    return json({}, 503)
+  })
+  await expect(useAuthStore.getState().finalizePaidSignup()).rejects.toThrow(/session/i)
+  useAuthStore.setState({ pendingSignup: null })
+  expect(useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })?.pendingSignup.provisionedUser?.id).toBe(id)
+  expect(useAuthStore.getState().pendingSignup).not.toHaveProperty('billingSessionUserId')
+  vi.mocked(fetch).mockImplementation(async (url) => { paths.push(new URL(String(url)).pathname); return json({ ...profile, provisioningStatus: 'active' }) })
+  await useAuthStore.getState().recoverCompletedSignupSession()
+  useAuthStore.getState().completeSignup()
+  expect(paths.filter((p) => p.endsWith('/finalize-payment/v2'))).toHaveLength(1)
+  expect(paths.every((p) => ['/auth/signup/finalize-payment/v2', '/auth/token-exchange', '/auth/session'].includes(p))).toBe(true)
+  expect(mocks.signup).not.toHaveBeenCalled()
+  expect(sessionStorage.getItem(key)).toBeNull()
 })

--- a/apps/web/app/stores/__tests__/signup-billing-session.test.ts
+++ b/apps/web/app/stores/__tests__/signup-billing-session.test.ts
@@ -7,12 +7,14 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import SignupPage from '../../(auth)/signup/page'
 import { checkoutIntentToken, emailOwnershipToken } from '@/src/__tests__/fixtures/annual-authority'
 
+vi.hoisted(() => { process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED = 'true' })
+
 vi.mock('@/app/lib/config', async (importOriginal) => ({
   ...await importOriginal<typeof import('@/app/lib/config')>(),
   BILLING_API_URL: 'https://billing.test',
 }))
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }))
-vi.mock('next/link', () => ({ default: ({ children }: { children: React.ReactNode }) => children }))
+vi.mock('next/link', () => ({ default: ({ children, href }: { children: React.ReactNode; href: string }) => createElement('a', { href }, children) }))
 
 const mocks = vi.hoisted(() => ({
   session: null as string | null,
@@ -284,7 +286,7 @@ describe('signup Billing session boundary', () => {
       expect(body.wantsProductUpdates).toBe(consent === true)
       return json({ contractVersion: 2, kind: 'stripe', clientSecret: 'pi_secret', paymentSessionToken: body.recoverySecret })
     })
-    await useAuthStore.getState().startAnnualSignupPayment(capability, 'stripe', window.location.origin + '/signup')
+    await useAuthStore.getState().startAnnualSignupPayment(capability, 'stripe', window.location.origin + '/signup', 'annual')
   })
 
   it('shares duplicate create/provision clicks rather than superseding an identical signup', async () => {
@@ -428,4 +430,104 @@ it('checkpoints actual paid finalization before failed exchange and only recover
   expect(paths.every((p) => ['/auth/signup/finalize-payment/v2', '/auth/token-exchange', '/auth/session'].includes(p))).toBe(true)
   expect(mocks.signup).not.toHaveBeenCalled()
   expect(sessionStorage.getItem(key)).toBeNull()
+})
+
+// Fresh rendered signup: no redirect checkpoint or legacy crypto token is seeded.
+it.each(['lost response', 'inline Bitcoin', 'storage failure'] as const)('retains the first payment across document loss: %s', async (scenario) => {
+  const requestId = 'e91a6d70-0d4e-4352-9bdc-426d1f76d771'
+  const key = 'silentsuite-signup-redirect-state'
+  localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({ [requestId]: {
+    email, requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000,
+  } }))
+  window.history.replaceState({}, '', `/signup?token=fixture&request_id=${requestId}`)
+  let started: Record<string, unknown> | undefined
+  let beforeDispatch: string | null = null
+  let warningBeforeDispatch = false
+  let confirmed = false
+  const disclosure = {
+    kind: 'prepaid', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: null,
+    monthlyEquivalentMinor: 300, currency: 'EUR', trialEndsAt: null, firstChargeAt: null,
+    cancelBy: null, cancelByInclusive: false, autoRenew: false, prepaid: true, refundWindowDays: 30,
+    bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null,
+  }
+  vi.mocked(fetch).mockImplementation(async (url, init) => {
+    const pathname = new URL(String(url)).pathname
+    if (pathname.endsWith('/consume')) return json({ contractVersion: 2, emailOwnershipToken, expiresAt: '2099-01-01T00:00:00Z' })
+    if (pathname.endsWith('/offers/v2')) return json({ contractVersion: 2, requestId, offer: {
+      planId: 'early_annual', customerClass: 'early', billingInterval: 'annual', annualAmountMinor: 3600,
+      monthlyEquivalentMinor: 300, currency: 'EUR', providers: ['stripe', 'btcpay'], offerRevision: 1,
+      offerToken: 'fixture-offer', expiresAt: '2099-01-01T00:00:00Z',
+    } })
+    if (pathname.endsWith('/activate')) return json({ contractVersion: 2, checkoutIntentToken, expiresAt: '2099-01-01T00:00:00Z', disclosure })
+    if (pathname.endsWith('/payment-session/v2')) {
+      started = JSON.parse(String(init?.body))
+      beforeDispatch = sessionStorage.getItem(key)
+      warningBeforeDispatch = screen.queryByText(/Stay in this tab/) !== null
+      if (scenario !== 'inline Bitcoin') throw new Error('Start response lost')
+      return json({ contractVersion: 2, kind: 'btcpay', paymentSessionToken: started!.recoverySecret,
+        cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/fixture', cryptoInvoiceId: 'fixture', cryptoInvoiceLookupToken: started!.recoverySecret })
+    }
+    if (pathname.endsWith('/payment-methods')) return json({ paymentMethods: [{ id: 'BTC', address: 'bc1-fixture', qrValue: 'bitcoin:bc1-fixture', amount: '0.001', currency: 'BTC' }] })
+    if (pathname.endsWith('/invoice/fixture')) return json({ status: 'new' })
+    if (/payment-session\/v2\/(current|reconcile)$/.test(pathname)) {
+      expect(JSON.parse(String(init?.body))).toEqual({ contractVersion: 2, email, requestKey: started!.requestKey, recoverySecret: started!.recoverySecret })
+      return json({ contractVersion: 2, state: confirmed ? 'confirmed' : 'open', flow: { provider: 'btcpay', status: confirmed ? 'provider_confirmed' : 'provider_pending' } })
+    }
+    throw new Error(`Unexpected test request: ${pathname}`)
+  })
+  let document = render(createElement(SignupPage))
+  fireEvent.change(await screen.findByLabelText(/^password$/i), { target: { value: 'OriginalPass1' } })
+  const next = screen.getByRole('button', { name: /continue to trial options/i })
+  await waitFor(() => expect(next).toBeEnabled())
+  fireEvent.click(next)
+  fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }))
+  fireEvent.click(await screen.findByRole('button', { name: /with bitcoin for/i }))
+  const confirm = await screen.findByRole('button', { name: /confirm annual terms and continue|continue to bitcoin payment/i })
+  expect(sessionStorage.getItem(key)).toBeNull()
+  const originalWrite = Storage.prototype.setItem
+  const write = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, name, value) {
+    if (scenario === 'storage failure' && name === key) throw new Error('quota')
+    return originalWrite.call(this, name, value)
+  })
+  try {
+    fireEvent.click(confirm)
+    if (scenario === 'inline Bitcoin') await screen.findByText('bc1-fixture')
+    else await screen.findByText('Start response lost')
+    expect(started).toBeDefined()
+    if (scenario === 'storage failure') {
+      expect(warningBeforeDispatch).toBe(true)
+      expect(screen.getByText(/Stay in this tab/)).toBeVisible()
+      expect(useAuthStore.getState().signupRecoveryDurability).toBe('memory-only')
+      expect(sessionStorage.getItem(key)).toBeNull()
+      return
+    }
+    expect(beforeDispatch).not.toBeNull()
+    const saved = JSON.parse(beforeDispatch!)
+    expect(saved).toMatchObject({ selectedInterval: 'annual', pendingSignup: { email, paymentSessionRequestKey: started!.requestKey, paymentSessionToken: started!.recoverySecret } })
+    expect(beforeDispatch).not.toMatch(/OriginalPass1|billingSessionUserId|encrypted-session|checkoutIntentToken|emailOwnershipToken/)
+    for (const destination of ['/signup', '/signup/pending-payment']) {
+      document.unmount()
+      useAuthStore.setState({ pendingSignup: null })
+      window.history.replaceState(window.history.state, '', destination)
+      document = render(createElement(SignupPage))
+      if (destination === '/signup') {
+        await screen.findByRole('link', { name: /recover existing payment/i })
+        document.unmount()
+        window.history.replaceState({}, '', '/signup?recovery=payment')
+        document = render(createElement(SignupPage))
+      } else {
+        document.unmount()
+        const { default: PendingPaymentPage } = await import('../../(auth)/signup/pending-payment/page')
+        document = render(createElement(PendingPaymentPage))
+      }
+      await screen.findByRole('button', { name: /check payment status again/i })
+      expect(useAuthStore.getState().pendingSignup).toMatchObject(saved.pendingSignup)
+      expect(JSON.parse(sessionStorage.getItem(key)!).savedAt).toBe(saved.savedAt)
+    }
+    confirmed = true
+    fireEvent.click(screen.getByRole('button', { name: /check payment status again/i }))
+    await screen.findByLabelText(/^password$/i)
+    expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/payment-session/v2'))).toHaveLength(1)
+    expect(mocks.signup).not.toHaveBeenCalled()
+  } finally { write.mockRestore() }
 })

--- a/apps/web/app/stores/__tests__/stripe-success-recovery.test.ts
+++ b/apps/web/app/stores/__tests__/stripe-success-recovery.test.ts
@@ -48,14 +48,14 @@ beforeEach(() => {
 
 
 import SignupSuccessPage from '../../(auth)/signup/success/page';
-it.each(['succeeded','processing'])('review4: Stripe %s discloses undurable completed receipt before exchange and loss', async (status) => {
+it.each(['setup_intent', 'payment_intent'].flatMap((intent) => ['succeeded', 'processing'].map((status) => [intent, status])))('review4: Stripe %s %s discloses undurable completed receipt before exchange and loss', async (intent, status) => {
  const key='silentsuite-signup-redirect-state'; mocks.session='encrypted-session';
  useAuthStore.setState({pendingSignup:{email,paymentSessionToken:capability,paymentSessionRequestKey:id,paymentMethod:'stripe',billingContractVersion:2}});
  useAuthStore.getState().saveSignupStateForRedirect('annual');
  useAuthStore.setState({pendingSignup:null});
- window.history.replaceState({},'',`/signup/success?setup_intent=fixture&redirect_status=${status}`);
+ window.history.replaceState({},'',`/signup/success?${intent}=fixture&redirect_status=${status}`);
  const view=render(createElement(SignupSuccessPage));
- await screen.findByText('Card verified successfully');
+ await screen.findByText('Continue account setup');
  const original=Storage.prototype.setItem; let failReceipt=false;
  const spy=vi.spyOn(Storage.prototype,'setItem').mockImplementation(function(this:Storage,k,v){if(failReceipt&&k===key)throw new Error('quota'); return original.call(this,k,v)});
  let atExchange=false; let warningAtExchange=false;
@@ -76,7 +76,7 @@ it.each(['succeeded','processing'])('review4: Stripe %s discloses undurable comp
   const warningAfterFailure=Boolean(screen.queryByText(/Stay in this tab/));
   view.unmount(); useAuthStore.setState({pendingSignup:null}); mocks.session=null;
   render(createElement(SignupSuccessPage));
-  await screen.findByRole('heading',{name:'Session expired'});
+  await screen.findByRole('heading',{name:'Payment confirmation required'});
   expect(useAuthStore.getState().pendingSignup).toBeNull();
   expect({warningAtExchange,warningAfterFailure}).toEqual({warningAtExchange:true,warningAfterFailure:true});
  } finally {spy.mockRestore()}

--- a/apps/web/app/stores/__tests__/stripe-success-recovery.test.ts
+++ b/apps/web/app/stores/__tests__/stripe-success-recovery.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+import { useAuthStore } from '../use-auth-store'
+import { createElement } from 'react'
+import { act, render, screen } from '@testing-library/react'
+
+vi.mock('@/app/lib/config', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/app/lib/config')>(),
+  BILLING_API_URL: 'https://billing.test',
+}))
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }), useSearchParams: () => new URLSearchParams(window.location.search) }))
+vi.mock('next/link', () => ({ default: ({ children }: { children: React.ReactNode }) => children }))
+
+const mocks = vi.hoisted(() => ({
+  session: null as string | null,
+  signup: vi.fn(async () => ({ savedSession: 'encrypted-session', authToken: 'unused' })),
+  login: vi.fn(),
+  proof: vi.fn(),
+}))
+vi.mock('@/app/lib/secure-storage', () => ({
+  secureGet: vi.fn(async () => mocks.session),
+  secureSet: vi.fn(async (_key: string, value: string) => { mocks.session = value }),
+  secureRemove: vi.fn(), secureClear: vi.fn(), migrateFromLocalStorage: vi.fn(),
+}))
+vi.mock('@/app/lib/etebase-auth', () => ({ etebaseSignUp: mocks.signup, etebaseLogIn: mocks.login, issueBillingLinkProof: mocks.proof }))
+vi.mock('@/app/lib/self-hosted', () => ({ isSelfHosted: false, isCustomServer: (url?: string) => !!url && url !== 'https://server.silentsuite.io' }))
+
+const email = 'signup@example.test'
+const id = '5fd4d86d-34de-4b82-9a66-9598ddf6e02f'
+const capability = 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG'
+const completed = {
+  contractVersion: 2, id, email, provisioningStatus: 'trialing_no_card', emailVerified: true,
+  earlyAdopter: true, rememberDevice: false, createdAt: '2026-08-11T00:00:00Z',
+  clientSecret: null, cryptoCheckoutUrl: null, cryptoInvoiceId: null, cryptoInvoiceLookupToken: null,
+}
+const json = (value: unknown, status = 200) => new Response(JSON.stringify(value), { status })
+
+beforeEach(() => {
+  useAuthStore.setState({ pendingSignup: null, user: null, isAuthenticated: false, isLoading: false, error: null, subscriptionStatus: null })
+  localStorage.clear(); sessionStorage.clear()
+  window.history.replaceState({}, '', '/signup')
+  vi.stubGlobal('scrollTo', vi.fn())
+  mocks.session = null
+  mocks.signup.mockClear(); mocks.login.mockReset().mockResolvedValue({ savedSession: 'encrypted-session', authToken: 'unused' }); mocks.proof.mockReset()
+  let sequence = 0
+  mocks.proof.mockImplementation(async () => `fresh-proof-${++sequence}`)
+  vi.stubGlobal('fetch', vi.fn())
+})
+
+
+import SignupSuccessPage from '../../(auth)/signup/success/page';
+it.each(['succeeded','processing'])('review4: Stripe %s discloses undurable completed receipt before exchange and loss', async (status) => {
+ const key='silentsuite-signup-redirect-state'; mocks.session='encrypted-session';
+ useAuthStore.setState({pendingSignup:{email,paymentSessionToken:capability,paymentSessionRequestKey:id,paymentMethod:'stripe',billingContractVersion:2}});
+ useAuthStore.getState().saveSignupStateForRedirect('annual');
+ useAuthStore.setState({pendingSignup:null});
+ window.history.replaceState({},'',`/signup/success?setup_intent=fixture&redirect_status=${status}`);
+ const view=render(createElement(SignupSuccessPage));
+ await screen.findByText('Card verified successfully');
+ const original=Storage.prototype.setItem; let failReceipt=false;
+ const spy=vi.spyOn(Storage.prototype,'setItem').mockImplementation(function(this:Storage,k,v){if(failReceipt&&k===key)throw new Error('quota'); return original.call(this,k,v)});
+ let atExchange=false; let warningAtExchange=false;
+ vi.mocked(fetch).mockImplementation(async(url)=>{
+  const p=new URL(String(url)).pathname;
+  if(p.endsWith('/finalize-payment/v2')){failReceipt=true;return json({...completed,provisioningStatus:'active',planId:'early_annual',isAdmin:false})}
+  expect(p).toBe('/auth/token-exchange');
+  expect(useAuthStore.getState().signupRecoveryDurability).toBe('memory-only');
+  expect(useAuthStore.getState().pendingSignup?.provisionedUser?.id).toBe(id);
+  expect(sessionStorage.getItem(key)).toBeNull();
+  atExchange=true; warningAtExchange=Boolean(screen.queryByText(/Stay in this tab/));
+  return json({},503);
+ });
+ try {
+  await act(async()=>{await expect(useAuthStore.getState().finalizePaidSignup()).rejects.toThrow(/session/i)});
+  expect(atExchange).toBe(true);
+  expect(useAuthStore.getState().signupRecoveryDurability).toBe('memory-only');
+  const warningAfterFailure=Boolean(screen.queryByText(/Stay in this tab/));
+  view.unmount(); useAuthStore.setState({pendingSignup:null}); mocks.session=null;
+  render(createElement(SignupSuccessPage));
+  await screen.findByRole('heading',{name:'Session expired'});
+  expect(useAuthStore.getState().pendingSignup).toBeNull();
+  expect({warningAtExchange,warningAfterFailure}).toEqual({warningAtExchange:true,warningAfterFailure:true});
+ } finally {spy.mockRestore()}
+});

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -307,7 +307,7 @@ describe('useAuthStore', () => {
       return useAuthStore.getState().startAnnualSignupPayment(
         checkoutIntentToken,
         provider,
-        'http://localhost:3000/signup/return',
+        'http://localhost:3000/signup/return', 'annual',
       )
     }
 
@@ -372,9 +372,28 @@ describe('useAuthStore', () => {
     it('rejects cross-origin annual return URLs before contacting Billing', async () => {
       useAuthStore.getState().prepareSignupDraft('origin@example.com')
       await expect(useAuthStore.getState().startAnnualSignupPayment(
-        checkoutIntentToken, 'stripe', 'https://attacker.example/return',
+        checkoutIntentToken, 'stripe', 'https://attacker.example/return', 'annual',
       )).rejects.toThrow('must stay on this origin')
       expect(fetch).not.toHaveBeenCalled()
+    })
+
+    it('cannot resurrect a logged-out attempt from a late payment response', async () => {
+      useAuthStore.getState().prepareSignupDraft('logout@example.test')
+      let deliver!: (response: Response) => void
+      let recoverySecret = ''
+      vi.mocked(fetch).mockImplementation(async (input, init) => {
+        if (String(input).endsWith('/auth/session')) return new Response('{}')
+        recoverySecret = JSON.parse(String(init?.body)).recoverySecret
+        return new Promise<Response>((resolve) => { deliver = resolve })
+      })
+      const pending = startAnnualPayment().catch((error) => error as Error)
+      expect(sessionStorage.getItem('silentsuite-signup-redirect-state')).not.toBeNull()
+      await useAuthStore.getState().logout()
+      deliver(new Response(JSON.stringify(stripePayment(recoverySecret))))
+      expect(await pending).toBeInstanceOf(Error)
+      expect(useAuthStore.getState().pendingSignup).toBeNull()
+      expect(sessionStorage.getItem('silentsuite-signup-redirect-state')).toBeNull()
+      expect(persistedPaidSignupIdentities()).toHaveLength(0)
     })
 
     it('does not commit an in-flight authority into a superseding signup draft', async () => {
@@ -769,7 +788,7 @@ describe('useAuthStore', () => {
         paymentSessionToken: request.recoverySecret,
       }))
     })
-    const result = await useAuthStore.getState().startAnnualSignupPayment('abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG', 'stripe', 'http://localhost:3000/signup/success')
+    const result = await useAuthStore.getState().startAnnualSignupPayment('abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG', 'stripe', 'http://localhost:3000/signup/success', 'annual')
     expect(result.clientSecret).toBe('pi_secret')
     const [, init] = vi.mocked(fetch).mock.calls[0]
     expect(JSON.parse(String(init?.body))).toMatchObject({ contractVersion: 2, checkoutIntentToken: 'abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG', email: 'customer@example.test' })
@@ -1184,12 +1203,17 @@ describe('useAuthStore', () => {
     })
   })
 
-  it('logout clears state', async () => {
+  it('logout clears state and the retained tab payment checkpoint', async () => {
     // Set up logged-in state
     useAuthStore.setState({
       user: { id: 'user-1', email: 'test@example.com', planId: 'pro' },
       isAuthenticated: true,
+      pendingSignup: { email: 'test@example.com', paymentSessionToken: 'r'.repeat(43), billingContractVersion: 2 },
     })
+    useAuthStore.getState().saveSignupStateForRedirect('annual')
+    sessionStorage.setItem('silentsuite-pending-crypto-token', 'r'.repeat(43))
+    sessionStorage.setItem('silentsuite-pending-crypto-recovery-context', JSON.stringify({ email: 'test@example.com', requestKey: '5fd4d86d-34de-4b82-9a66-9598ddf6e02f' }))
+    expect(sessionStorage.getItem('silentsuite-signup-redirect-state')).not.toBeNull()
 
     vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response)
 
@@ -1198,6 +1222,12 @@ describe('useAuthStore', () => {
     const state = useAuthStore.getState()
     expect(state.user).toBeNull()
     expect(state.isAuthenticated).toBe(false)
+    expect(state.pendingSignup).toBeNull()
+    expect(state.signupRecoveryDurability).toBe('none')
+    expect(sessionStorage.getItem('silentsuite-signup-redirect-state')).toBeNull()
+    expect(state.restoreSignupStateFromRedirect({ retainForRecovery: true })).toBeNull()
+    expect(sessionStorage.getItem('silentsuite-pending-crypto-token')).toBeNull()
+    expect(sessionStorage.getItem('silentsuite-pending-crypto-recovery-context')).toBeNull()
   })
 
   it('logout clears decrypted account stores before another account can authenticate', async () => {

--- a/apps/web/app/stores/__tests__/use-auth-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-auth-store.test.ts
@@ -347,6 +347,28 @@ describe('useAuthStore', () => {
       })
     })
 
+    it.each(['stripe', 'btcpay'] as const)('retains exact %s recovery before dispatch and after a lost start response', async (provider) => {
+      useAuthStore.getState().prepareSignupDraft('lost@example.com')
+      vi.mocked(fetch).mockImplementation(async (_input, init) => {
+        const body = JSON.parse(String(init?.body))
+        expect(useAuthStore.getState().pendingSignup).toMatchObject({
+          billingContractVersion: 2, paymentMethod: provider,
+          paymentSessionToken: body.recoverySecret, paymentSessionRequestKey: body.requestKey,
+        })
+        throw new TypeError('Network response lost')
+      })
+      await expect(startAnnualPayment(provider)).rejects.toThrow('Network response lost')
+      const first = paidSignupRequestBody()
+      expect(useAuthStore.getState().pendingSignup).toMatchObject({
+        email: 'lost@example.com', paymentMethod: provider,
+        paymentSessionToken: first.recoverySecret, paymentSessionRequestKey: first.requestKey,
+      })
+      expect(useAuthStore.getState().pendingSignup?.provisionedUser).toBeUndefined()
+      await expect(startAnnualPayment(provider)).rejects.toThrow('Network response lost')
+      expect(paidSignupRequestBody(1)).toEqual(first)
+      expect(persistedPaidSignupIdentities()).toHaveLength(1)
+    })
+
     it('rejects cross-origin annual return URLs before contacting Billing', async () => {
       useAuthStore.getState().prepareSignupDraft('origin@example.com')
       await expect(useAuthStore.getState().startAnnualSignupPayment(
@@ -1682,6 +1704,26 @@ describe('useAuthStore', () => {
       email: 'user@example.com',
       paymentSessionToken: 'payment-session-token',
     }
+
+    it('retains a recovery snapshot across document resets without persisting credentials or renewing its TTL', () => {
+      useAuthStore.setState({ pendingSignup: {
+        email: 'customer@example.test', password: 'NeverPersistThis1',
+        serverUrl: 'https://server.silentsuite.io', billingContractVersion: 2,
+        paymentMethod: 'btcpay', paymentSessionToken: 'A'.repeat(43),
+        paymentSessionRequestKey: '5fd4d86d-34de-4b82-9a66-9598ddf6e02f',
+      } })
+      useAuthStore.getState().saveSignupStateForRedirect('annual')
+      const original = sessionStorage.getItem('silentsuite-signup-redirect-state')!
+      expect(original).not.toContain('NeverPersistThis1')
+      for (let document = 0; document < 3; document += 1) {
+        useAuthStore.setState({ pendingSignup: null })
+        const restored = useAuthStore.getState().restoreSignupStateFromRedirect({ retainForRecovery: true })
+        expect(restored?.pendingSignup).toMatchObject({ email: 'customer@example.test', paymentSessionToken: 'A'.repeat(43), paymentSessionRequestKey: '5fd4d86d-34de-4b82-9a66-9598ddf6e02f' })
+        expect(restored?.pendingSignup).not.toHaveProperty('password')
+        expect(JSON.parse(sessionStorage.getItem('silentsuite-signup-redirect-state')!)).toEqual(JSON.parse(original))
+        expect(useAuthStore.getState().isAuthenticated).toBe(false)
+      }
+    })
 
     it('saves redirect state to sessionStorage, not localStorage', () => {
       useAuthStore.setState({ pendingSignup: pending })

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { create } from 'zustand'
+import { flushSync } from 'react-dom'
 import { isSelfHosted, isCustomServer } from '@/app/lib/self-hosted'
 import { logger } from '@/app/lib/logger'
 import { BILLING_API_URL, ETEBASE_SERVER_URL } from '@/app/lib/config'
@@ -11,7 +12,7 @@ import { clearAll as clearOfflineQueue } from '@/app/lib/offline-queue'
 import { createLoginSessionPersistenceDiagnostics } from '@/app/lib/sync-restore-diagnostics'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { bumpAccountEpoch } from '@/app/lib/account-epoch'
-import { BillingResponseError, startSignupAnnualPayment } from '@/app/lib/billing-v2'
+import { BillingResponseError, startSignupAnnualPayment, type AnnualOffer } from '@/app/lib/billing-v2'
 
 export interface User {
   isAdmin?: boolean
@@ -106,7 +107,7 @@ interface AuthState {
   /** Historical signature retained for callers; fresh hosted v1 creation rejects. */
   signup: (planId: string, trialPath: string) => Promise<SignupResult>
   provisionAnnualNoCard: (checkoutIntentToken: string) => Promise<void>
-  startAnnualSignupPayment: (checkoutIntentToken: string, provider: 'stripe' | 'btcpay', returnUrl: string) => Promise<SignupResult>
+  startAnnualSignupPayment: (checkoutIntentToken: string, provider: 'stripe' | 'btcpay', returnUrl: string, selectedInterval: AnnualOffer['billingInterval']) => Promise<SignupResult>
   /** Clear only this exact authority after Billing proved it terminal/cancelled. */
   clearPendingSignupPaymentRecovery: (identity: PaidSignupRecoveryRelease) => void
   finalizePaidSignup: () => Promise<SignupResult>
@@ -250,7 +251,10 @@ class SignupRedirectCheckpoint {
   }
 
   save(pending: PendingSignup, selectedInterval?: 'monthly' | 'annual') {
-    if (pending === this.current?.pendingSignup) return
+    if (pending === this.current?.pendingSignup) {
+      if (!this.live(this.current)) this.publishDurability('memory-only')
+      return
+    }
     const stored = this.read()
     const previous = this.current && this.same(this.current.pendingSignup, pending) ? this.current
       : stored && this.same(stored.pendingSignup, pending) ? stored : null
@@ -908,7 +912,8 @@ async function clearLocalAuthMaterial(reason: 'logout' | 'invalid-hosted-auth') 
   signupRedirectCheckpoint.clear()
   clearPaidSignupRecoveryIdentity()
   if (typeof window !== 'undefined') {
-    for (const key of ['silentsuite-signup-in-progress']) {
+    for (const key of ['silentsuite-signup-in-progress', 'silentsuite-pending-crypto-token',
+      'silentsuite-pending-crypto-invoice', 'silentsuite-pending-crypto-recovery-context', 'silentsuite-pending-crypto-return-to']) {
       try {
         sessionStorage.removeItem(key)
       } catch {
@@ -1169,7 +1174,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     }
   }),
 
-  startAnnualSignupPayment: async (checkoutIntentToken: string, provider: 'stripe' | 'btcpay', returnUrl: string) => {
+  startAnnualSignupPayment: async (checkoutIntentToken: string, provider: 'stripe' | 'btcpay', returnUrl: string, selectedInterval: AnnualOffer['billingInterval']) => {
+    if (selectedInterval !== 'annual') throw new Error('A validated annual offer is required.')
     const pending = get().pendingSignup
     if (!pending || isSelfHosted || isCustomServer(pending.serverUrl)) throw new Error('No hosted annual checkout is ready.')
     const recoveryScope = paidSignupRecoveryScope(pending.email, pending.wantsProductUpdates, pending.rememberDevice)
@@ -1183,9 +1189,14 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       // A lost start response is not evidence no payment authority exists.
       // Attach the exact existing recovery identity before dispatch so the
       // pending route can reconcile it without minting a replacement.
-      set({ pendingSignup: { ...pending, paidSignupAttemptId: attemptId,
-        billingContractVersion: 2, paymentSessionToken: recovery.recoverySecret,
-        paymentSessionRequestKey: recovery.requestKey, paymentMethod: provider } })
+      // Initialize before dispatch, even when this tab has never redirected.
+      // Flush the warning into the rendered UI before the next fallible operation.
+      flushSync(() => {
+        set({ pendingSignup: { ...pending, paidSignupAttemptId: attemptId,
+          billingContractVersion: 2, paymentSessionToken: recovery.recoverySecret,
+          paymentSessionRequestKey: recovery.requestKey, paymentMethod: provider } })
+        signupRedirectCheckpoint.save(get().pendingSignup!, selectedInterval)
+      })
       const payment = await startSignupAnnualPayment({ fetcher: fetch, billingApiUrl: BILLING_API_URL, checkoutIntentToken, email: pending.email, requestKey: recovery.requestKey, recoverySecret: recovery.recoverySecret, wantsProductUpdates: pending.wantsProductUpdates === true, rememberDevice: pending.rememberDevice === true, returnUrl: absoluteReturnUrl })
       if (payment.kind !== provider) throw new Error('Billing returned the wrong payment provider.')
       const current = get().pendingSignup
@@ -1524,7 +1535,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     // Stop rendering protected account data before any network request or
     // asynchronous storage cleanup can yield.
     syncAdminCookie(false)
-    set({ user: null, isAuthenticated: false, error: null, subscriptionStatus: null })
+    set({ user: null, isAuthenticated: false, pendingSignup: null, isLoading: false, error: null, subscriptionStatus: null })
 
     if (!isSelfHosted) {
       await deleteHostedServerSession('invalid-hosted-auth')

--- a/apps/web/app/stores/use-auth-store.ts
+++ b/apps/web/app/stores/use-auth-store.ts
@@ -95,6 +95,8 @@ interface AuthState {
   isLoading: boolean
   error: string | null
   pendingSignup: PendingSignup | null
+  /** Checkpoint durability only, never payment or authenticated-session authority. */
+  signupRecoveryDurability: 'none' | 'memory-only' | 'persisted'
   subscriptionStatus: string | null
   isDegraded: () => boolean
   isReadOnly: () => boolean
@@ -137,10 +139,11 @@ interface AuthState {
   saveSignupStateForRedirect: (selectedInterval: 'monthly' | 'annual') => void
   /**
    * Restore signup state saved before a Stripe 3DS redirect.
-   * Returns the saved data and removes it from sessionStorage (one-time use).
+   * Returns the saved data and consumes it by default. Pending recovery may
+   * retain the sanitized snapshot at its original expiry across document loads.
    * Returns null if no data exists or if it is older than 2 hours.
    */
-  restoreSignupStateFromRedirect: () => RedirectSignupState | null
+  restoreSignupStateFromRedirect: (options?: { retainForRecovery: boolean }) => RedirectSignupState | null
 }
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -198,6 +201,115 @@ function parseRedirectPendingSignup(value: unknown): RedirectPendingSignup | nul
   if (typeof value.provisionedSubscriptionStatus === 'string') redirect.provisionedSubscriptionStatus = value.provisionedSubscriptionStatus
   return redirect
 }
+
+/** One tab-local checkpoint lifecycle, independent of React mount ordering.
+ * savedAt is the immutable issuance time (expiry = savedAt + TTL), not a last-write time.
+ * A receipt is continuation data only: no passwords or session attestation enter storage.
+ */
+class SignupRedirectCheckpoint {
+  private current: RedirectSignupState | null = null
+
+  private same(a: RedirectPendingSignup, b: RedirectPendingSignup) {
+    return a.email === b.email && a.serverUrl === b.serverUrl
+      && a.paymentSessionToken === b.paymentSessionToken
+      && a.paymentSessionRequestKey === b.paymentSessionRequestKey
+      && a.billingContractVersion === b.billingContractVersion
+  }
+
+  private read(): RedirectSignupState | null {
+    try {
+      const raw = sessionStorage.getItem(REDIRECT_SIGNUP_STATE_KEY)
+      if (!raw) return null
+      const value: unknown = JSON.parse(raw)
+      if (!isRecord(value) || (value.selectedInterval !== 'monthly' && value.selectedInterval !== 'annual')
+        || typeof value.savedAt !== 'number' || !Number.isFinite(value.savedAt)) return null
+      const pendingSignup = parseRedirectPendingSignup(value.pendingSignup)
+      return pendingSignup ? { pendingSignup, selectedInterval: value.selectedInterval, savedAt: value.savedAt } : null
+    } catch { return null }
+  }
+
+  private live(data: RedirectSignupState) {
+    const age = Date.now() - data.savedAt
+    return age >= 0 && age < REDIRECT_SIGNUP_STATE_TTL_MS
+  }
+
+  private publishDurability(status: AuthState['signupRecoveryDurability']) {
+    if (useAuthStore.getState().signupRecoveryDurability !== status) {
+      useAuthStore.setState({ signupRecoveryDurability: status })
+    }
+  }
+
+  resetMemory() {
+    this.current = null
+    this.publishDurability('none')
+  }
+
+  clear() {
+    this.resetMemory()
+    try { sessionStorage.removeItem(REDIRECT_SIGNUP_STATE_KEY) } catch { /* Unavailable storage cannot block logout/completion. */ }
+  }
+
+  save(pending: PendingSignup, selectedInterval?: 'monthly' | 'annual') {
+    if (pending === this.current?.pendingSignup) return
+    const stored = this.read()
+    const previous = this.current && this.same(this.current.pendingSignup, pending) ? this.current
+      : stored && this.same(stored.pendingSignup, pending) ? stored : null
+    // Store publication only updates an existing matching checkpoint. Explicit
+    // redirect preparation may create one for a genuinely different attempt.
+    if (!previous && !selectedInterval) {
+      this.publishDurability('none')
+      return
+    }
+    const next = makeRedirectPendingSignup(pending)
+    if (previous?.pendingSignup.provisionedUser
+      && (!next.provisionedUser || next.provisionedUser.id !== previous.pendingSignup.provisionedUser.id)) {
+      // Never downgrade or cross-bind a completed receipt on a stale publication.
+      next.provisionedUser = previous.pendingSignup.provisionedUser
+      next.provisionedSubscriptionStatus = previous.pendingSignup.provisionedSubscriptionStatus
+    }
+    const data: RedirectSignupState = {
+      pendingSignup: next,
+      selectedInterval: previous?.selectedInterval ?? selectedInterval ?? 'annual',
+      savedAt: previous?.savedAt ?? Date.now(),
+    }
+    this.current = data
+    if (!this.live(data)) {
+      // Expired runtime state must not mint a fresh lifetime or claim durability.
+      this.publishDurability('memory-only')
+      return
+    }
+    let durability: AuthState['signupRecoveryDurability'] = 'persisted'
+    try {
+      sessionStorage.setItem(REDIRECT_SIGNUP_STATE_KEY, JSON.stringify(data))
+    } catch {
+      // Do not leave a known stale pre-completion capability promising safe Back.
+      // The latest receipt and original lifetime remain in memory for a later retry.
+      durability = 'memory-only'
+      try { sessionStorage.removeItem(REDIRECT_SIGNUP_STATE_KEY) } catch { /* best effort */ }
+    }
+    // Publish outside the storage exception boundary and before finalization
+    // continues to its fallible session exchange, independent of React effects.
+    this.publishDurability(durability)
+  }
+
+  restore(retain: boolean): RedirectSignupState | null {
+    const data = this.read()
+    if (!data || !this.live(data)) {
+      // Discard persistence without erasing an in-memory attempt's original lifetime.
+      this.current ??= data
+      try { sessionStorage.removeItem(REDIRECT_SIGNUP_STATE_KEY) } catch { /* best effort */ }
+      return null
+    }
+    this.current = data
+    // Retention needs no rewrite: quota failures must not destroy a readable receipt.
+    if (!retain) {
+      try { sessionStorage.removeItem(REDIRECT_SIGNUP_STATE_KEY) } catch { /* best effort */ }
+    }
+    return data
+  }
+}
+
+const signupRedirectCheckpoint = new SignupRedirectCheckpoint()
 
 function isUtcTimestamp(value: unknown): value is string {
   if (typeof value !== 'string' || !UTC_TIMESTAMP.test(value)) return false
@@ -793,9 +905,10 @@ async function clearLocalAuthMaterial(reason: 'logout' | 'invalid-hosted-auth') 
     logger.warn(`[auth-store] Failed to clear offline queue during ${reason}:`, err)
   }
 
+  signupRedirectCheckpoint.clear()
   clearPaidSignupRecoveryIdentity()
   if (typeof window !== 'undefined') {
-    for (const key of ['silentsuite-signup-in-progress', 'silentsuite-signup-redirect-state']) {
+    for (const key of ['silentsuite-signup-in-progress']) {
       try {
         sessionStorage.removeItem(key)
       } catch {
@@ -923,6 +1036,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   isLoading: false,
   error: null,
   pendingSignup: null,
+  signupRecoveryDurability: 'none',
   subscriptionStatus: null,
 
   isDegraded: () => get().subscriptionStatus === 'billing_unavailable',
@@ -1066,6 +1180,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       const parsedReturnUrl = new URL(returnUrl, window.location.origin)
       if (parsedReturnUrl.origin !== window.location.origin) throw new Error('Annual signup return URL must stay on this origin.')
       const absoluteReturnUrl = parsedReturnUrl.toString()
+      // A lost start response is not evidence no payment authority exists.
+      // Attach the exact existing recovery identity before dispatch so the
+      // pending route can reconcile it without minting a replacement.
+      set({ pendingSignup: { ...pending, paidSignupAttemptId: attemptId,
+        billingContractVersion: 2, paymentSessionToken: recovery.recoverySecret,
+        paymentSessionRequestKey: recovery.requestKey, paymentMethod: provider } })
       const payment = await startSignupAnnualPayment({ fetcher: fetch, billingApiUrl: BILLING_API_URL, checkoutIntentToken, email: pending.email, requestKey: recovery.requestKey, recoverySecret: recovery.recoverySecret, wantsProductUpdates: pending.wantsProductUpdates === true, rememberDevice: pending.rememberDevice === true, returnUrl: absoluteReturnUrl })
       if (payment.kind !== provider) throw new Error('Billing returned the wrong payment provider.')
       const current = get().pendingSignup
@@ -1263,6 +1383,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
       && pending.billingSessionUserId !== pending.provisionedUser.id) {
       throw new Error('Your account is set up, but the Billing session is not confirmed. Retry to finish signing in.')
     }
+    signupRedirectCheckpoint.clear()
     // Clear the signup-in-progress flag so restoreSession works normally
     clearPaidSignupRecoveryIdentity()
     if (typeof window !== 'undefined') {
@@ -1693,60 +1814,20 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   saveSignupStateForRedirect: (selectedInterval) => {
     const pending = get().pendingSignup
-    if (!pending) {
-      logger.warn('[auth-store] saveSignupStateForRedirect: no pendingSignup to save')
-      return
-    }
-    const data: RedirectSignupState = {
-      pendingSignup: makeRedirectPendingSignup(pending),
-      selectedInterval,
-      savedAt: Date.now(),
-    }
-    try {
-      sessionStorage.setItem(REDIRECT_SIGNUP_STATE_KEY, JSON.stringify(data))
-    } catch (err) {
-      logger.warn('[auth-store] Failed to save signup redirect state:', err)
-    }
+    if (pending) signupRedirectCheckpoint.save(pending, selectedInterval)
   },
 
-  restoreSignupStateFromRedirect: () => {
-    try {
-      const raw = sessionStorage.getItem(REDIRECT_SIGNUP_STATE_KEY)
-      if (!raw) return null
-      // Always remove immediately — one-time use
-      sessionStorage.removeItem(REDIRECT_SIGNUP_STATE_KEY)
-      const value = JSON.parse(raw) as unknown
-      if (!isRecord(value) || (value.selectedInterval !== 'monthly' && value.selectedInterval !== 'annual') || typeof value.savedAt !== 'number' || !Number.isFinite(value.savedAt)) {
-        logger.warn('[auth-store] Redirect signup state is malformed, discarding')
-        return null
-      }
-      const pendingSignup = parseRedirectPendingSignup(value.pendingSignup)
-      if (!pendingSignup) {
-        logger.warn('[auth-store] Redirect signup state is malformed, discarding')
-        return null
-      }
-      // Reject if older than 2 hours. Bitcoin settlement can outlive the old
-      // 10-minute Stripe-only window, but this is still tab-scoped sessionStorage.
-      if (Date.now() - value.savedAt >= REDIRECT_SIGNUP_STATE_TTL_MS) {
-        logger.warn('[auth-store] Redirect signup state expired (>2h old)')
-        return null
-      }
-      const data: RedirectSignupState = {
-        pendingSignup,
-        selectedInterval: value.selectedInterval,
-        savedAt: value.savedAt,
-      }
-      // Restore pendingSignup into the Zustand store and re-set the signup-in-progress
-      // flag so restoreSession() doesn't run concurrently and clobber the restored state.
-      set({ pendingSignup })
-      if (typeof window !== 'undefined') {
-        sessionStorage.setItem('silentsuite-signup-in-progress', 'true')
-      }
-      return data
-    } catch (err) {
-      logger.warn('[auth-store] Failed to restore signup redirect state:', err)
-      sessionStorage.removeItem(REDIRECT_SIGNUP_STATE_KEY)
-      return null
-    }
+  restoreSignupStateFromRedirect: (options) => {
+    const data = signupRedirectCheckpoint.restore(options?.retainForRecovery === true)
+    if (!data) return null
+    set({ pendingSignup: data.pendingSignup, signupRecoveryDurability: options?.retainForRecovery === true ? 'persisted' : 'memory-only' })
+    try { sessionStorage.setItem('silentsuite-signup-in-progress', 'true') } catch { /* best effort */ }
+    return data
   },
 }))
+
+useAuthStore.subscribe((state, previous) => {
+  if (!state.pendingSignup) { signupRedirectCheckpoint.resetMemory(); return }
+  if (state.pendingSignup === previous.pendingSignup) return
+  signupRedirectCheckpoint.save(state.pendingSignup)
+})

--- a/scripts/check-annual-billing-v2-contract.mjs
+++ b/scripts/check-annual-billing-v2-contract.mjs
@@ -3,6 +3,10 @@ import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { resolve } from 'node:path'
+import { createRequire } from 'node:module'
+
+// Use the web app's installed compiler without adding a second dependency.
+const ts = createRequire(new URL('../apps/web/package.json', import.meta.url))('typescript')
 
 const PIN_FILE = 'contracts/annual-only-billing-v2.schema.sha256'
 const SCHEMA_FILE = 'contracts/annual-only-billing-v2.schema.json'
@@ -38,6 +42,93 @@ function functionBlock(source, name) {
   const end = source.indexOf('\n}\n', start)
   assert(end >= 0, `Could not delimit ${name} exact-response guard`)
   return source.slice(start, end + 2)
+}
+
+function checkPendingPaymentRecovery(source) {
+  const requireContract = (condition, message) => assert(condition, `Pending payment contract: ${message}`)
+  const parse = (text) => ts.createSourceFile('pending.tsx', text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const tree = parse(source)
+  requireContract(tree.parseDiagnostics.length === 0, 'pending-payment source must parse')
+  const nodes = []
+  const visit = (node) => { nodes.push(node); ts.forEachChild(node, visit) }
+  visit(tree)
+  // Compare syntax trees, never comments or text-search sentinels. Leaf text is
+  // retained so changing a capability binding or state value is a real change.
+  const shape = (node) => {
+    const children = []
+    ts.forEachChild(node, (child) => { children.push(shape(child)) })
+    return [node.kind, children.length ? children : (node.text ?? node.getText())]
+  }
+  const same = (node, expected) => JSON.stringify(shape(node)) === JSON.stringify(shape(expected))
+  const statement = (text) => parse(text).statements[0]
+  const expression = (text) => statement(`const expected = ${text};`).declarationList.declarations[0].initializer
+  const exact = (node, text) => same(node, expression(text))
+  const one = (matches, message) => {
+    requireContract(matches.length === 1, message)
+    return matches[0]
+  }
+  const declarations = nodes.filter(ts.isVariableDeclaration)
+  const flow = one(declarations.filter((node) => node.name.getText(tree) === 'loadCurrentFlow'), 'one recovery callback is required')
+  requireContract(ts.isCallExpression(flow.initializer) && exact(flow.initializer.expression, 'useCallback'), 'recovery callback must remain explicit')
+  const callback = flow.initializer.arguments[0]
+  requireContract(ts.isArrowFunction(callback) && ts.isBlock(callback.body), 'recovery callback must have a block body')
+  const flowNodes = []
+  const walkFlow = (node) => { flowNodes.push(node); ts.forEachChild(node, walkFlow) }
+  walkFlow(callback.body)
+  for (const [condition, body] of [
+    ["result.state === 'closed'", "{ setFlowCheckState('ready'); setState('unknown'); return 'stop'; }"],
+    ['!recovery', "{ if (!isCancelled()) { setFlowCheckState('ready'); } return 'stop'; }"],
+  ]) {
+    const branch = one(flowNodes.filter((node) => ts.isIfStatement(node) && exact(node.expression, condition)), `${condition} must fail closed`)
+    requireContract(!branch.elseStatement && same(branch.thenStatement, statement(body)), `${condition} cannot release, restart, or confer payment authority`)
+  }
+  const recoveryReaders = ['getAnonymousPaymentSessionRecovery', 'reconcileAnonymousPaymentSessionRecovery']
+  for (const name of recoveryReaders) {
+    const call = one(flowNodes.filter((node) => ts.isCallExpression(node) && exact(node.expression, name)), `${name} must be called once`)
+    requireContract(call.arguments.length === 1 && exact(call.arguments[0], `({
+      fetcher: fetch, billingApiUrl: BILLING_API_URL,
+      paymentSessionToken: recovery.paymentSessionToken,
+      recoverySecret: recovery.paymentSessionToken,
+      requestKey: recovery.requestKey, email: recovery.email
+    })`.slice(1, -1)), `${name} must carry the same attempt's email, request key, and proof`)
+  }
+  // This page has no fresh-payment or release authority at all. Only the two
+  // proof-bound recovery readers may be imported from the billing client, and
+  // store selection cannot regain removed creation/release capabilities.
+  const storeCapabilities = new Set(['completeSignup', 'createEtebaseAccount', 'finalizePaidSignup', 'saveSignupStateForRedirect', 'restoreSignupStateFromRedirect', 'pendingSignup', 'recoverCompletedSignupSession'])
+  for (const node of nodes) {
+    if (ts.isImportDeclaration(node) && node.moduleSpecifier.text === '@/app/lib/billing-v2') {
+      const bindings = node.importClause?.namedBindings
+      requireContract(!node.importClause?.name && bindings && ts.isNamedImports(bindings)
+        && bindings.elements.length === 2
+        && bindings.elements.every((item) => !item.propertyName && recoveryReaders.includes(item.name.text)), 'billing imports are recovery-only; legacy restart must fail closed')
+    }
+    if (ts.isCallExpression(node) && exact(node.expression, 'useAuthStore')) {
+      const selector = node.arguments[0]
+      requireContract(node.arguments.length === 1 && ts.isArrowFunction(selector)
+        && ts.isPropertyAccessExpression(selector.body) && selector.parameters.length === 1
+        && same(selector.body.expression, selector.parameters[0].name)
+        && storeCapabilities.has(selector.body.name.text), 'store selectors cannot acquire fresh-payment or release authority')
+    }
+    if (ts.isPropertyAccessExpression(node) && ts.isCallExpression(node.expression)
+      && exact(node.expression.expression, 'useAuthStore.getState')) {
+      requireContract(node.name.text === 'pendingSignup', 'imperative store access is read-only')
+    }
+    if (ts.isCallExpression(node) && exact(node.expression, 'fetch')) {
+      requireContract(false, 'direct transport cannot bypass proof-bound recovery')
+    }
+    if ((ts.isIdentifier(node) || (ts.isStringLiteral(node) && ts.isCallExpression(node.parent)
+      && ts.isPropertyAccessExpression(node.parent.expression) && node.parent.expression.name.text === 'getItem')) && /invoice/i.test(node.text)) {
+      requireContract(false, 'unbound local invoice data cannot authorize checkout availability or fresh payment')
+    }
+  }
+  const linkEffect = one(nodes.filter((node) => ts.isVariableDeclaration(node)
+    && node.name.getText(tree) === 'params' && node.initializer
+    && exact(node.initializer, 'new URLSearchParams(window.location.search)')), 'legacy link handling must remain explicit')
+  requireContract(same(linkEffect.parent.parent.parent, statement(`{
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('email_verification_token') || params.has('token')) setEmailProofUnavailable(true);
+  }`)), 'legacy restart links must only disclose unavailable proof, not consume or create authority')
 }
 
 export function checkAnnualBillingV2Contract(root = process.cwd()) {
@@ -95,7 +186,7 @@ export function checkAnnualBillingV2Contract(root = process.cwd()) {
     assert(source.includes("isAnnualOfferProviderAvailable") && source.includes("'stripe'") && source.includes("'btcpay'"), 'Public annual UI must gate Stripe and BTCPay with canonical offer providers')
   }
   assert(signup.includes('annualOffer={annualOffer}'), 'Signup must pass the signed annual offer through StepChoosePlan')
-  assert(pendingPayment.includes("isAnnualOfferProviderAvailable(offer.offer, 'btcpay', CRYPTO_CHECKOUT_ENABLED)"), 'Bitcoin restart must fail closed when a refreshed offer does not authorize BTCPay')
+  checkPendingPaymentRecovery(pendingPayment)
   for (const forbiddenPresentationConstant of [/&euro;36/, /€36(?:\.00)?(?:\/year)?/, /€3(?:\.00)?(?:\/month)?/, /Early Adopter(?: Plan)?/]) {
     assert(!forbiddenPresentationConstant.test(signup) && !forbiddenPresentationConstant.test(paymentPanel), `Public annual UI contains reintroduced fixed offer copy: ${forbiddenPresentationConstant}`)
   }

--- a/scripts/check-annual-billing-v2-contract.test.mjs
+++ b/scripts/check-annual-billing-v2-contract.test.mjs
@@ -1,7 +1,69 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
 import { checkAnnualBillingV2Contract } from './check-annual-billing-v2-contract.mjs'
+
+const pendingPath = 'apps/web/app/(auth)/signup/pending-payment/page.tsx'
+const files = [
+  'contracts/annual-only-billing-v2.schema.sha256',
+  'contracts/annual-only-billing-v2.schema.json',
+  'apps/web/app/lib/billing-v2.ts',
+  'apps/web/app/stores/use-auth-store.ts',
+  'apps/web/app/components/payment-choice-panel.tsx',
+  'apps/web/app/(auth)/signup/page.tsx',
+  pendingPath,
+  'apps/web/app/lib/annual-offer-presentation.ts',
+  'apps/web/app/lib/public-analytics.ts',
+]
+
+function withPendingMutation(from, to, check) {
+  const root = mkdtempSync(join(tmpdir(), 'annual-contract-'))
+  try {
+    for (const file of files) {
+      let source = readFileSync(file, 'utf8')
+      if (file === pendingPath) {
+        assert.ok(source.includes(from), 'mutation must change actual source')
+        source = source.replace(from, to)
+      }
+      mkdirSync(dirname(join(root, file)), { recursive: true })
+      writeFileSync(join(root, file), source)
+    }
+    check(root)
+  } finally { rmSync(root, { recursive: true, force: true }) }
+}
 
 test('the public annual client, persistence, and authenticated UI stay compatible with the pinned closed v2 wire contract', () => {
   assert.doesNotThrow(() => checkAnnualBillingV2Contract())
+})
+
+const mutations = [
+  ['generic closed releases authority', "setState('unknown')", "useAuthStore.getState().clearPendingSignupPaymentRecovery(recovery); setState('unknown')"],
+  ['generic closed restarts payment', "setState('unknown')", "useAuthStore.getState().startAnnualSignupPayment('intent', 'btcpay', '/'); setState('unknown')"],
+  ['missing recovery authorizes restart', 'if (!recovery) {', "if (!recovery) { useAuthStore.getState().startAnnualSignupPayment('intent', 'btcpay', '/');"],
+  ['closed response becomes account authority', "setState('unknown')", "setState('account')"],
+  ['unbound local invoice enables checkout', "const isWaiting = state === 'pending'", "const isWaiting = Boolean(sessionStorage.getItem('silentsuite-pending-crypto-invoice'))"],
+  ['recovery token crosses attempts', 'paymentSessionToken: recovery.paymentSessionToken,', "paymentSessionToken: 'other-token',"],
+  ['reconcile proof crosses attempts', 'recoverySecret: recovery.paymentSessionToken,\n          requestKey:', "recoverySecret: 'other-proof',\n          requestKey:"],
+  ['recovery request key crosses attempts', 'requestKey: recovery.requestKey,', "requestKey: 'other-attempt',"],
+  ['recovery email crosses attempts', 'email: recovery.email,', "email: 'other@example.test',"],
+  ['legacy email link consumes fresh creation proof', '  getAnonymousPaymentSessionRecovery,', '  consumeAnnualEmailOwnershipProof,\n  getAnonymousPaymentSessionRecovery,'],
+  ['legacy link enables fresh checkout', 'setEmailProofUnavailable(true)', "useAuthStore.getState().startAnnualSignupPayment('intent', 'btcpay', '/')"],
+]
+for (const [name, from, to] of mutations) {
+  test(`rejects unsafe pending-payment mutation: ${name}`, () => {
+    withPendingMutation(from, to, (root) => {
+      assert.throws(() => checkAnnualBillingV2Contract(root), /Pending payment contract:/)
+    })
+  })
+}
+
+test('comments cannot satisfy the closed-flow invariant and harmless comments do not change it', () => {
+  withPendingMutation("setState('unknown')", "/* setState('account'); startAnnualSignupPayment(); */ setState('unknown')", (root) => {
+    assert.doesNotThrow(() => checkAnnualBillingV2Contract(root))
+  })
+  withPendingMutation("setState('unknown')", "/* setState('unknown') */ setState('account')", (root) => {
+    assert.throws(() => checkAnnualBillingV2Contract(root), /Pending payment contract:/)
+  })
 })


### PR DESCRIPTION
## Summary
- Preserve bounded signup continuation checkpoints across full document navigation without persisting passwords or encrypted sessions.
- Disclose memory-only recovery before navigation can lose it, including Stripe return and pending-payment routes.
- Add recovery, expiry, identity, guarded-Back, session-cleanup, and Stripe regression coverage.
- Align the annual contract guard with the recovery-only pending-payment route. Syntax-tree checks and unsafe-mutation tests preserve closed/null handling, attempt-bound proofs, and the absence of fresh-payment authority.

## Verification
- Independent frozen-source review passed for tree `9bd2e99dbe80cf7db037f456f27a4a38fe13aebe`, committed as `a97cd7fb6266cde1277be3b500650576c525f657`. All 12 previously reviewed feature files remain byte-for-byte unchanged by the guard correction.
- Fresh annual guard: 13 passed, including 11 unsafe mutations and comment-resistance coverage.
- Canonical web verification: 1152 passed across 80 files with the optional actual Billing serializer fixture enabled; both broad recovery probes passed 1154 tests. Root test also passed, with the four optional serializer cases skipped in that separate run.
- Independent focused recovery probes passed; the four actual Fastify serializer cases were explicitly rerun and passed separately.
- Type-check and lint passed (existing lint warnings). Explicit analytics-disabled and analytics-enabled web builds and source/bundle checks passed; hosted/self-hosted docs artifact checks passed. Existing standalone trace-copy warning is not container-runtime acceptance.
- Fresh canonical CI and trusted exact-head preview requested separately; results remain pending until their new runs complete. Earlier-head CI/preview is not evidence for this commit.

## Boundaries
Frontend recovery and contract-guard correction only. No backend, provider, production configuration, or Monero changes. This PR does not establish real account/payment, full-navigation/bfcache, protected-session, or complete-journey acceptance. No production deployment requested.
