### PR TITLE
fix(signup): simplify trial selection and payment entry

### DIFF
--- a/apps/web/app/(auth)/signup/__tests__/annual-confirmation-summary.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/annual-confirmation-summary.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import type { AnnualDisclosure } from '@/app/lib/billing-v2'
-import { AnnualConfirmationSummary } from '../components/annual-confirmation-summary'
+import { AnnualTermsSummary, annualCardSubmitLabel, annualRetryAction, noCardTrialConsequence } from '../components/annual-confirmation-summary'
 
 const base: AnnualDisclosure = {
   kind: 'charge_now', annualAmountMinor: 3600, firstChargeAmountMinor: 3600, renewalAmountMinor: 3600,
@@ -9,32 +9,39 @@ const base: AnnualDisclosure = {
   cancelBy: null, cancelByInclusive: false, autoRenew: true, prepaid: false, refundWindowDays: 30,
   bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null,
 }
-describe('server-disclosed confirmation copy', () => {
-  it('never promises no charge for immediate Stripe payment', () => {
-    render(<AnnualConfirmationSummary disclosure={base} />)
-    expect(screen.getByText(/Pay €36.00 now by card/)).toBeInTheDocument()
-    expect(screen.queryByText(/No charge today/)).not.toBeInTheDocument()
+describe('server-disclosed concise terms', () => {
+  it('never promises no charge or a trial for immediate Stripe payment', () => {
+    render(<AnnualTermsSummary disclosure={base} />)
+    expect(screen.getByText(/€36.00 is charged now by card/)).toHaveTextContent('not a free trial')
+    expect(screen.queryByText(/No charge today|30-day trial|Start.*free trial/)).not.toBeInTheDocument()
     expect(screen.queryByText('Not applicable')).not.toBeInTheDocument()
-    expect(screen.getByText(/one year after payment confirmation/)).toBeInTheDocument()
+    expect(screen.getByText(/Renews automatically each year at €36.00/)).toHaveTextContent('30-day refund window')
+    expect(annualCardSubmitLabel(base)).toBe('Pay €36.00 now')
+    expect(annualRetryAction(base)).toBe('Retry card payment')
   })
   it('describes Bitcoin as prepaid without renewal or fake dates', () => {
-    render(<AnnualConfirmationSummary disclosure={{ ...base, kind: 'prepaid', prepaid: true, autoRenew: false, renewalAmountMinor: null, bonusDays: 14 }} />)
-    expect(screen.getByText(/Pay €36.00 in Bitcoin/)).toHaveTextContent('No automatic renewal')
+    render(<AnnualTermsSummary disclosure={{ ...base, kind: 'prepaid', prepaid: true, autoRenew: false, renewalAmountMinor: null, bonusDays: 14 }} />)
+    expect(screen.getByText(/€36.00 paid now in Bitcoin/)).toHaveTextContent('No automatic renewal')
     expect(screen.getByText(/plus 14 bonus days/)).toBeInTheDocument()
-    expect(screen.queryByText('Cancel before')).not.toBeInTheDocument()
-    expect(screen.queryByText('Not applicable')).not.toBeInTheDocument()
+    expect(screen.getByText(/Full refund within 30 days/)).toBeInTheDocument()
+    expect(screen.queryByText(/Cancel before|Not applicable|UTC/)).not.toBeInTheDocument()
+    expect(annualRetryAction({ ...base, kind: 'prepaid' })).toBe('Retry Bitcoin payment')
   })
-  it('shows card-trial amount, exact charge deadline and no charge today', () => {
-    render(<AnnualConfirmationSummary disclosure={{ ...base, kind: 'card_trial', firstChargeAt: '2099-09-10T12:00:00Z', cancelBy: '2099-09-10T12:00:00Z' }} />)
-    expect(screen.getByText(/No charge today/)).toBeInTheDocument()
-    expect(screen.getAllByText('2099-09-10 12:00 UTC')).toHaveLength(2)
-    expect(screen.getByText('After your trial')).toBeInTheDocument()
+  it('shows card-trial amount, exact charge date and no charge today', () => {
+    const cardTrial: AnnualDisclosure = { ...base, kind: 'card_trial', firstChargeAt: '2099-09-10T12:00:00Z', cancelBy: '2099-09-10T12:00:00Z' }
+    render(<AnnualTermsSummary disclosure={cardTrial} />)
+    expect(screen.getByText(/No charge today/)).toHaveTextContent('€36.00/year is charged on 2099-09-10 12:00 UTC')
+    expect(screen.getByText(/Renews automatically each year at €36.00/)).toHaveTextContent('Cancel anytime')
+    expect(annualCardSubmitLabel(cardTrial)).toBe('Start free trial — no charge today')
+    expect(annualRetryAction(cardTrial)).toBe('Retry card setup')
   })
-  it('keeps the no-card review limited to free terms', () => {
-    render(<AnnualConfirmationSummary disclosure={{ ...base, kind: 'no_auto_charge', firstChargeAmountMinor: 0, renewalAmountMinor: null, autoRenew: false, refundWindowDays: null, entitlementEndsAt: '2099-09-10T12:00:00Z' }} />)
-    expect(screen.getByText(/7-day free trial/)).toHaveTextContent('No automatic charge or renewal')
-    expect(screen.getByText('Free until')).toBeInTheDocument()
-    expect(screen.queryByText('Payment')).not.toBeInTheDocument()
-    expect(screen.queryByText('Not applicable')).not.toBeInTheDocument()
+  it('keeps the no-card line limited to free terms and states that continuing creates the account', () => {
+    const noCard: AnnualDisclosure = { ...base, kind: 'no_auto_charge', firstChargeAmountMinor: 0, renewalAmountMinor: null, autoRenew: false, refundWindowDays: null, entitlementEndsAt: '2099-09-10T12:00:00Z' }
+    render(<AnnualTermsSummary disclosure={noCard} />)
+    expect(screen.getByText(/7-day free trial/)).toHaveTextContent('No card required. No automatic charge or renewal.')
+    expect(screen.getByText(/creates your account/)).toBeInTheDocument()
+    expect(screen.queryByText(/Payment|Free until|UTC|Not applicable/)).not.toBeInTheDocument()
+    expect(noCardTrialConsequence(noCard)).toMatch(/creates your account and starts your 7-day free trial/)
+    expect(noCardTrialConsequence(base)).toBeNull()
   })
 })

--- a/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
@@ -89,6 +89,12 @@ describe('email-link seven-day no-card continuation', () => {
     await screen.findByText(/Check your email and open/)
     const [currentRequest] = Object.keys(JSON.parse(localStorage.getItem('silentsuite-signup-email-proof')!))
     const preparedBeforeMarker = authState.prepareSignupDraft.mock.calls.length
+    const warnsOnLeave = () => {
+      const event = new Event('beforeunload', { cancelable: true })
+      window.dispatchEvent(event)
+      return event.defaultPrevented
+    }
+    expect(warnsOnLeave()).toBe(true)
     const publish = (id: string, expiresAt = Date.now() + 60_000) => act(() => {
       window.dispatchEvent(new StorageEvent('storage', {
         key: 'silentsuite-signup-email-verified', storageArea: localStorage,
@@ -98,8 +104,10 @@ describe('email-link seven-day no-card continuation', () => {
     publish(requestId)
     publish(currentRequest, Date.now() - 1)
     expect(screen.queryByText(/Email confirmed/)).not.toBeInTheDocument()
+    expect(warnsOnLeave()).toBe(true)
     publish(currentRequest)
     expect(screen.getByText('Email confirmed. Continue in the other tab. This tab is safe to close.')).toBeVisible()
+    expect(warnsOnLeave()).toBe(false)
     expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
     expect(authState.prepareSignupDraft).toHaveBeenCalledTimes(preparedBeforeMarker)
     expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
@@ -113,6 +121,7 @@ describe('email-link seven-day no-card continuation', () => {
     await waitFor(() => expect(again).toBeEnabled())
     fireEvent.click(again)
     await screen.findByText(/Check your email and open/)
+    expect(warnsOnLeave()).toBe(true)
     publish(currentRequest)
     expect(screen.queryByText(/Email confirmed/)).not.toBeInTheDocument()
     const [replacement] = Object.keys(JSON.parse(localStorage.getItem('silentsuite-signup-email-proof')!))

--- a/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
+++ b/apps/web/app/(auth)/signup/__tests__/email-link-no-card-continuation.test.tsx
@@ -79,6 +79,65 @@ describe('email-link seven-day no-card continuation', () => {
     expect(localStorage.getItem('silentsuite-signup-email-proof')).toBeNull()
   })
 
+  it('updates only the matching waiting tab without granting signup authority', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 202 })))
+    render(<SignupPage />)
+    fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: 'first@example.test' } })
+    const next = screen.getByRole('button', { name: /^continue$/i })
+    await waitFor(() => expect(next).toBeEnabled())
+    fireEvent.click(next)
+    await screen.findByText(/Check your email and open/)
+    const [currentRequest] = Object.keys(JSON.parse(localStorage.getItem('silentsuite-signup-email-proof')!))
+    const preparedBeforeMarker = authState.prepareSignupDraft.mock.calls.length
+    const publish = (id: string, expiresAt = Date.now() + 60_000) => act(() => {
+      window.dispatchEvent(new StorageEvent('storage', {
+        key: 'silentsuite-signup-email-verified', storageArea: localStorage,
+        newValue: JSON.stringify({ requestId: id, verifiedAt: Date.now(), expiresAt }),
+      }))
+    })
+    publish(requestId)
+    publish(currentRequest, Date.now() - 1)
+    expect(screen.queryByText(/Email confirmed/)).not.toBeInTheDocument()
+    publish(currentRequest)
+    expect(screen.getByText('Email confirmed. Continue in the other tab. This tab is safe to close.')).toBeVisible()
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
+    expect(authState.prepareSignupDraft).toHaveBeenCalledTimes(preparedBeforeMarker)
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(fetch).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+    publish(currentRequest)
+    expect(screen.getByLabelText(/^email$/i)).toBeVisible()
+    expect(screen.queryByText(/Email confirmed/)).not.toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: 'second@example.test' } })
+    const again = screen.getByRole('button', { name: /^continue$/i })
+    await waitFor(() => expect(again).toBeEnabled())
+    fireEvent.click(again)
+    await screen.findByText(/Check your email and open/)
+    publish(currentRequest)
+    expect(screen.queryByText(/Email confirmed/)).not.toBeInTheDocument()
+    const [replacement] = Object.keys(JSON.parse(localStorage.getItem('silentsuite-signup-email-proof')!))
+    publish(replacement)
+    expect(screen.getByText(/Email confirmed/)).toBeVisible()
+  })
+
+  it('requires the password acknowledgement before no-card creation, then does not ask twice', async () => {
+    await reachPlanScreen()
+    fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    const complete = await screen.findByRole('button', { name: /continue to your workspace/i })
+    expect(complete).toBeDisabled()
+    fireEvent.click(complete)
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+    expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Free until|Start your free trial/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('checkbox', { name: /cannot recover my password/i }))
+    fireEvent.click(complete)
+    await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(authState.completeSignup).toHaveBeenCalledTimes(1), { timeout: 4000 })
+    expect(authState.createEtebaseAccount).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('checkbox', { name: /cannot recover my password/i })).not.toBeInTheDocument()
+  })
+
   it('ignores a delayed email response after Back and rejects the retired link', async () => {
     let deliver!: (response: Response) => void
     vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>((resolve) => { deliver = resolve })))
@@ -132,7 +191,7 @@ describe('email-link seven-day no-card continuation', () => {
   })
 
   it.each(['app', 'browser'] as const)('releases Etebase-only failure using %s Back, requiring fresh consent and rejecting stale Forward', async (back) => {
-    const confirm = await openConfirmation('none')
+    const confirm = await openConfirmation()
     const prior = vi.mocked(fetch).getMockImplementation()!
     authState.createEtebaseAccount.mockRejectedValueOnce(new Error('Encrypted account connection failed'))
     fireEvent.click(confirm)
@@ -149,28 +208,27 @@ describe('email-link seven-day no-card continuation', () => {
     await screen.findByRole('heading', { name: /choose your plan/i })
     expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/cancel'))).toHaveLength(1)
     act(() => window.dispatchEvent(new PopStateEvent('popstate', { state: oldCheckpoint })))
-    expect(screen.queryByRole('button', { name: /create account and start free trial/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /continue to your workspace/i })).not.toBeInTheDocument()
     expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
-    fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    await screen.findByRole('button', { name: /create account and start free trial/i })
+    await chooseFreeTrial()
     expect(authState.createEtebaseAccount).toHaveBeenCalledTimes(1)
     expect(authState.prepareSignupDraft).toHaveBeenCalledTimes(1)
   })
 
   it('keeps the exact selection when Back cancellation is not confirmed', async () => {
-    await openConfirmation('none')
+    await openConfirmation()
     fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
     expect(await screen.findByRole('alert')).toHaveTextContent('Cancellation is not confirmed')
-    expect(screen.queryByRole('button', { name: /annual plan/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /30-day free trial/i })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Continue current selection' }))
-    expect(screen.getByRole('button', { name: /create account and start free trial/i })).toBeEnabled()
+    // Returning to the same reservation asks for the acknowledgement afresh; nothing was created.
+    expect(await acknowledgePasswordKey()).toBeEnabled()
     expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/activate'))).toHaveLength(1)
     expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
   })
 
   it('locks original credentials after encrypted creation, Billing failure and release while allowing fresh plans', async () => {
-    const confirm = await openConfirmation('none')
+    const confirm = await openConfirmation()
     authState.provisionAnnualNoCard.mockRejectedValueOnce(new Error('Billing proof unavailable'))
     fireEvent.click(confirm)
     expect(await screen.findByRole('alert')).toHaveTextContent('Billing proof unavailable')
@@ -185,9 +243,7 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
     expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument()
     expect(screen.getByText(/original password remains unchanged/i)).toBeVisible()
-    fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial/i }))
+    fireEvent.click(await chooseFreeTrial())
     await waitFor(() => expect(authState.createEtebaseAccount).toHaveBeenCalledTimes(2))
     expect(authState.createEtebaseAccount.mock.calls.every((call) => call[1] === 'ValidPass1')).toBe(true)
   })
@@ -221,7 +277,7 @@ describe('email-link seven-day no-card continuation', () => {
   })
 
   it.each(['card', 'pending', 'error', 'expired'] as const)('shows retained payment Back recovery on the actual %s panel', async (state) => {
-    const confirm = await openConfirmation(state === 'card' ? 'stripe' : 'btcpay')
+    await reachPlanScreen()
     authState.startAnnualSignupPayment.mockResolvedValue(state === 'card' ? { clientSecret: 'seti_retained_secret' } : {
       cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/retained', cryptoInvoiceId: 'retained', cryptoInvoiceLookupToken: 'lookup',
     })
@@ -231,52 +287,86 @@ describe('email-link seven-day no-card continuation', () => {
       if (String(input).endsWith('/invoice/retained')) return new Response(JSON.stringify({ status: state === 'expired' ? 'expired' : 'new' }))
       return prior(input, init)
     }))
-    fireEvent.click(confirm)
-    const back = await screen.findByRole('button', { name: state === 'card' ? /back to plan selection/i : /back to payment methods/i })
+    await choosePaymentMethod(state === 'card' ? 'stripe' : 'btcpay')
+    // Dynamic Stripe loading can replace its Suspense subtree. Wait for the
+    // actual form before acquiring its live Back control, not a detached node.
+    if (state === 'card') await screen.findByTestId('card-submit')
     if (state === 'expired') await screen.findByText(/This Bitcoin invoice expired/)
     if (state === 'error') await screen.findByText('Could not load Bitcoin payment details.')
+    const back = await screen.findByRole('button', { name: state === 'card' ? /back to plan selection/i : /back to payment methods/i })
+    await waitFor(() => expect(back).toBeEnabled())
     fireEvent.click(back)
-    expect(screen.getByRole('alert')).toHaveTextContent('Setup or payment has already started')
+    expect(await screen.findByRole('alert')).toHaveTextContent('Setup or payment has already started')
     expect(screen.getByText('Recover pending payment')).toBeVisible()
     expect(screen.queryByText(/Go back and start a new Bitcoin invoice/)).not.toBeInTheDocument()
     expect(authState.startAnnualSignupPayment).toHaveBeenCalledTimes(1)
     expect(screen.queryByRole('heading', { name: /choose your plan/i })).not.toBeInTheDocument()
   })
 
-  it('keeps Bitcoin terms on the payment panel and exposes no instructions before consent', async () => {
-    const confirm = await openConfirmation('btcpay')
-    expect(screen.getByRole('heading', { name: /pay .* with bitcoin/i })).toBeVisible()
-    expect(screen.queryByText('Confirm annual terms')).not.toBeInTheDocument()
+  it('states each method\'s terms on the choice screen, opens the invoice directly and keeps terms beside it', async () => {
+    await reachPlanScreen()
+    fireEvent.click(screen.getByRole('button', { name: /30-day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    const bitcoin = await screen.findByRole('button', { name: /^pay .* with bitcoin for/i })
+    expect(bitcoin).toHaveTextContent('Bitcoin, Lightning and Monero')
+    expect(bitcoin).toHaveTextContent('Payment has to be made with account creation, but we offer a 30-day, no-questions-asked money-back guarantee.')
+    expect(bitcoin).toHaveTextContent('€36.00 for one year, paid now. No automatic renewal.')
+    const card = screen.getByRole('button', { name: /^pay by card for/i })
+    expect(card).toHaveTextContent('Pay by Card (Powered by Stripe)')
+    expect(card).toHaveTextContent('Card gets billed after the 30-day trial. You can cancel anytime.')
+    expect(screen.getByText('€36.00/year')).toBeVisible()
+    expect(screen.queryByText(/Choose a payment method to review|Annual only|Card with Stripe|Bitcoin with BTCPay|billed annually/i)).not.toBeInTheDocument()
     expect(screen.queryByText('Copy payment details')).not.toBeInTheDocument()
     expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
     authState.startAnnualSignupPayment.mockResolvedValue({ cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/terms', cryptoInvoiceId: 'terms', cryptoInvoiceLookupToken: 'lookup' })
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => new Response(JSON.stringify(String(input).endsWith('/payment-methods') ? { paymentMethods: [{ id: 'BTC', address: 'test-address' }] } : { status: 'new' }))))
-    fireEvent.click(confirm)
+    const prior = vi.mocked(fetch).getMockImplementation()!
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/payment-methods')) return new Response(JSON.stringify({ paymentMethods: [{ id: 'BTC-LN', label: 'Bitcoin Lightning', address: 'lnbc-test' }, { id: 'BTC-CHAIN', label: 'Bitcoin on-chain', address: 'test-address' }] }))
+      if (String(input).endsWith('/invoice/terms')) return new Response(JSON.stringify({ status: 'new' }))
+      return prior(input, init)
+    }))
+    fireEvent.click(bitcoin)
     await screen.findByText('Copy payment details')
-    expect(screen.getByText(/Request a full refund within 30 days/)).toBeVisible()
-    expect(screen.getByText(/This is a prepaid annual purchase/)).toHaveTextContent('€36.00')
+    expect(screen.queryByText(/Review your Bitcoin payment|Continue to Bitcoin payment|Refund window|Access through/)).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /pay €36\.00 with bitcoin/i })).toBeVisible()
+    expect(screen.getByText(/paid now in Bitcoin/)).toHaveTextContent('€36.00')
+    expect(screen.getByText(/paid now in Bitcoin/)).toHaveTextContent('No automatic renewal')
+    expect(screen.getByText(/Full refund within 30 days/)).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Bitcoin Lightning' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Bitcoin on-chain' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Monero (soon)' })).toBeDisabled()
+    expect(authState.startAnnualSignupPayment).toHaveBeenCalledTimes(1)
+    expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(signedCheckoutIntent, 'btcpay', 'http://localhost:3000/signup/pending-payment', 'annual')
   })
 
   it('retains a usable same-attempt retry after failed Bitcoin start and browser Back/Forward', async () => {
-    const confirm = await openConfirmation('btcpay')
+    await reachPlanScreen()
     authState.startAnnualSignupPayment.mockRejectedValue(new BillingResponseError('Payment provider confirmation is pending. Retry with the same recovery secret.', 503, 'https://api.silentsuite.io/errors/provider-unavailable'))
-    fireEvent.click(confirm)
+    await choosePaymentMethod('btcpay')
     await screen.findByText(/Payment creation is not yet confirmed/)
     expect(screen.queryByText(/webhook|secret/i)).not.toBeInTheDocument()
+    expect(screen.queryByText('Copy payment details')).not.toBeInTheDocument()
+    expect(screen.getByText(/paid now in Bitcoin/)).toBeVisible()
     await traverseHistory('back')
     expect(screen.queryByLabelText(/^email$/i)).not.toBeInTheDocument()
     await traverseHistory('forward')
-    const retry = await screen.findByRole('button', { name: /^continue to (bitcoin payment|card setup|card payment)$/i })
+    const retry = await screen.findByRole('button', { name: /^retry bitcoin payment$/i })
     fireEvent.click(retry)
     await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledTimes(2))
     expect(authState.startAnnualSignupPayment.mock.calls[0]).toEqual(authState.startAnnualSignupPayment.mock.calls[1])
+    expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/activate'))).toHaveLength(1)
   })
 
   it('describes Bitcoin settlement separately from unfinished account and vault setup', async () => {
-    const confirm = await openConfirmation('btcpay')
+    await reachPlanScreen()
     authState.startAnnualSignupPayment.mockResolvedValue({ cryptoCheckoutUrl: 'https://btcpay.silentsuite.io/i/settled', cryptoInvoiceId: 'settled', cryptoInvoiceLookupToken: 'lookup' })
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => new Response(JSON.stringify(String(input).endsWith('/payment-methods') ? { paymentMethods: [{ id: 'BTC', address: 'test-address' }] } : { status: 'settled' }))))
-    fireEvent.click(confirm)
+    const prior = vi.mocked(fetch).getMockImplementation()!
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/payment-methods')) return new Response(JSON.stringify({ paymentMethods: [{ id: 'BTC', address: 'test-address' }] }))
+      if (String(input).endsWith('/invoice/settled')) return new Response(JSON.stringify({ status: 'settled' }))
+      return prior(input, init)
+    }))
+    await choosePaymentMethod('btcpay')
     expect(await screen.findByText(/Payment confirmed for your Early Adopter Plan/)).toHaveTextContent('Account and vault setup still need to finish')
     expect(screen.queryByText(/access is active|early_annual|Plan ID/)).not.toBeInTheDocument()
     expect(authState.finalizePaidSignup).not.toHaveBeenCalled()
@@ -288,7 +378,8 @@ describe('email-link seven-day no-card continuation', () => {
     await act(async () => { window.history[direction](); await observed })
   }
 
-  async function openConfirmation(provider: 'none' | 'stripe' | 'btcpay', checkoutToken = signedCheckoutIntent, selectedDisclosure?: AnnualDisclosure) {
+  /** Mount through a verified email link, choose the password once and reach plan selection. */
+  async function reachPlanScreen(checkoutToken = signedCheckoutIntent, selectedDisclosure?: AnnualDisclosure) {
     localStorage.setItem('silentsuite-signup-email-proof', JSON.stringify({
       [requestId]: { email: 'expiry@example.test', requestId, wantsProductUpdates: false, rememberDevice: false, returnTo: null, expiresAt: Date.now() + 60_000 },
     }))
@@ -307,12 +398,41 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(next)
     await screen.findByRole('heading', { name: /choose your plan/i })
     expect(screen.queryByText('Annual access only. Exact price and renewal terms are confirmed by Billing before checkout.')).not.toBeInTheDocument()
-    expect(screen.queryByText(/before day 30|no charge until|30-day free trial/i)).not.toBeInTheDocument()
-    fireEvent.click(await screen.findByRole('button', { name: provider === 'none' ? /7 day free trial/i : /annual plan/i }))
+    // The first choice screen carries no price, annual wording or charge-timing promise.
+    expect(screen.queryByText(/before day 30|no charge until|billed annually|annual plan|€36|€48|\/year/i)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /30-day free trial/i })).toHaveTextContent('Full access to all features')
+  }
+
+  /** Tick the password-loss acknowledgement and return its enabled action. */
+  async function acknowledgePasswordKey() {
+    const action = await screen.findByRole('button', { name: /continue to your workspace/i })
+    expect(action).toBeDisabled()
+    fireEvent.click(screen.getByRole('checkbox', { name: /cannot recover my password/i }))
+    expect(action).toBeEnabled()
+    return action
+  }
+
+  /** 7-day + Continue reserves the trial and lands on the acknowledgement without any review screen. */
+  async function chooseFreeTrial() {
+    fireEvent.click(await screen.findByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    if (provider === 'stripe') fireEvent.click(await screen.findByRole('button', { name: /continue to card payment/i }))
-    if (provider === 'btcpay') fireEvent.click(await screen.findByRole('button', { name: /^pay .* with bitcoin for/i }))
-    return screen.findByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i })
+    const action = await acknowledgePasswordKey()
+    expect(screen.queryByText(/Start your free trial|Free until|Create account and start free trial/)).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Your password is your only key' })).toBeVisible()
+    return action
+  }
+
+  /** 30-day + Continue, then the method click; payment start mocks must already be in place. */
+  async function choosePaymentMethod(provider: 'stripe' | 'btcpay') {
+    fireEvent.click(await screen.findByRole('button', { name: /30-day free trial/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    if (provider === 'stripe') fireEvent.click(await screen.findByRole('button', { name: /^pay by card for/i }))
+    else fireEvent.click(await screen.findByRole('button', { name: /^pay .* with bitcoin for/i }))
+  }
+
+  async function openConfirmation(checkoutToken = signedCheckoutIntent, selectedDisclosure?: AnnualDisclosure) {
+    await reachPlanScreen(checkoutToken, selectedDisclosure)
+    return chooseFreeTrial()
   }
 
   it.each(['charge_now', 'card_trial'] as const)('keeps the validated %s disclosure through card confirmation', async (kind) => {
@@ -323,23 +443,53 @@ describe('email-link seven-day no-card continuation', () => {
       bonusDays: 0, periodEndRule: 'confirmation_plus_1_utc_calendar_year', renewalAt: null, entitlementEndsAt: null,
       ...(kind === 'card_trial' ? { trialEndsAt: '2099-09-10T12:00:00Z', firstChargeAt: '2099-09-10T12:00:00Z', cancelBy: '2099-09-10T12:00:00Z', periodEndRule: 'first_charge_plus_1_utc_calendar_year', renewalAt: '2100-09-10T12:00:00Z', entitlementEndsAt: '2100-09-10T12:00:00Z' } : {}),
     }
-    const confirm = await openConfirmation('stripe', signedCheckoutIntent, disclosure)
-    expect(screen.queryByText(/early_annual|Plan ID|Confirm annual terms/)).not.toBeInTheDocument()
-    expect(screen.getByRole('heading', { name: kind === 'card_trial' ? 'Review your free trial' : 'Review your card payment' })).toBeVisible()
-    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+    await reachPlanScreen(signedCheckoutIntent, disclosure)
     authState.startAnnualSignupPayment.mockResolvedValue({ clientSecret: kind === 'card_trial' ? 'seti_fixture' : 'pi_fixture' })
-    fireEvent.click(confirm)
+    await choosePaymentMethod('stripe')
     const submit = await screen.findByTestId('card-submit')
+    expect(screen.queryByText(/early_annual|Plan ID|Confirm annual terms|Review your|Continue to card setup/)).not.toBeInTheDocument()
     expect(submit).toHaveAttribute('data-mode', kind === 'card_trial' ? 'setup' : 'payment')
     expect(submit).toHaveTextContent(kind === 'card_trial' ? 'Start free trial — no charge today' : 'Pay €36.00 now')
-    expect(screen.queryByText(/early_annual|Plan ID|30-day|day 30/)).not.toBeInTheDocument()
-    if (kind === 'charge_now') expect(screen.queryByText(/No charge today|after.*trial/i)).not.toBeInTheDocument()
-    else expect(screen.getAllByText('2099-09-10 12:00 UTC')).toHaveLength(2)
+    expect(screen.getByText('€36.00/year')).toBeVisible()
+    if (kind === 'charge_now') {
+      // The method screen's requested card trial is never repeated once Billing discloses an immediate charge.
+      expect(screen.queryByText(/No charge today|after.*trial|30-day trial|Start.*free trial/i)).not.toBeInTheDocument()
+      expect(screen.getByText(/€36\.00 is charged now by card/)).toHaveTextContent('not a free trial')
+    } else {
+      expect(screen.getByText(/No charge today/)).toHaveTextContent('€36.00/year is charged on 2099-09-10 12:00 UTC')
+      expect(screen.getByText(/Renews automatically each year at €36\.00/)).toHaveTextContent('30-day refund window')
+    }
     expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(signedCheckoutIntent, 'stripe', 'http://localhost:3000/signup', offer.offer.billingInterval)
   })
 
-  it.each(['none', 'stripe', 'btcpay'] as const)('explicitly cancels %s review with single-flight response-loss retry and fresh consent', async (provider) => {
-    await openConfirmation(provider)
+  it.each(['stripe', 'btcpay'] as const)('cancels a reserved %s selection whose payment start never dispatched', async (provider) => {
+    await reachPlanScreen()
+    const original = Storage.prototype.setItem
+    const storage = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
+      if (key.startsWith('silentsuiteSignup:')) throw new DOMException('Full', 'QuotaExceededError')
+      original.call(this, key, value)
+    })
+    try {
+      await choosePaymentMethod(provider)
+      expect(await screen.findByRole('alert')).toHaveTextContent(/free.*storage.*retry/i)
+    } finally { storage.mockRestore() }
+    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: provider === 'stripe' ? /^retry card setup$/i : /^retry bitcoin payment$/i })).toBeEnabled()
+    const prior = vi.mocked(fetch).getMockImplementation()!
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).endsWith('/cancel')) return new Response(JSON.stringify({ contractVersion: 2, requestId,
+        checkoutIntentJti: 'a2c4f872-01b7-4176-8325-522486b20cae', state: 'released' }))
+      return prior(input, init)
+    }))
+    fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
+    await screen.findByRole('heading', { name: /choose your plan/i })
+    expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/cancel'))).toHaveLength(1)
+    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
+  })
+
+  it('explicitly cancels the no-card acknowledgement with single-flight response-loss retry and fresh consent', async () => {
+    await openConfirmation()
     const previousFetch = vi.mocked(fetch).getMockImplementation()!
     const successorToken = signedAuthorityFixture('checkout-intent', {}, { jti: '885a9c19-3e5e-4462-b4c1-1c32fc7ac612' })
     let release: ((response: Response) => void) | undefined
@@ -378,19 +528,16 @@ describe('email-link seven-day no-card continuation', () => {
     expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
     expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
     expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
-    fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    await screen.findByRole('button', { name: /create account and start free trial/i })
+    const consent = await chooseFreeTrial()
     expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
     expect(authState.prepareSignupDraft).toHaveBeenCalledTimes(1)
-    const consent = screen.getByRole('button', { name: /create account and start free trial/i })
     fireEvent.click(consent)
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(successorToken))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('expiry@example.test', 'ValidPass1', undefined)
   })
 
   it('ignores an independently delayed cancellation response from an unmounted predecessor', async () => {
-    await openConfirmation('none')
+    await openConfirmation()
     let deliverOldResponse!: (response: Response) => void
     const oldFetch = vi.fn(() => new Promise<Response>((resolve) => { deliverOldResponse = resolve }))
     vi.stubGlobal('fetch', oldFetch)
@@ -402,17 +549,17 @@ describe('email-link seven-day no-card continuation', () => {
     // A separate mounted continuation has acquired a successor. The old request
     // is still unresolved, not a second resolve() on an already-settled promise.
     const successorToken = signedAuthorityFixture('checkout-intent', {}, { jti: '885a9c19-3e5e-4462-b4c1-1c32fc7ac612' })
-    await openConfirmation('none', successorToken)
+    const consent = await openConfirmation(successorToken)
     await act(async () => { deliverOldResponse(new Response(JSON.stringify({ contractVersion: 2, requestId,
       checkoutIntentJti: 'a2c4f872-01b7-4176-8325-522486b20cae', state: 'released' }))) })
-    expect(screen.getByRole('button', { name: /create account and start free trial/i })).toBeEnabled()
+    expect(consent).toBeEnabled()
     expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
-    fireEvent.click(screen.getByRole('button', { name: /create account and start free trial/i }))
+    fireEvent.click(consent)
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledExactlyOnceWith(successorToken))
   })
 
   it('continues cancellation with renewed same-request proof through a mocked email-link remount', async () => {
-    await openConfirmation('none')
+    await openConfirmation()
     const originalFetch = vi.mocked(fetch).getMockImplementation()!
     const renewedProof = signedAuthorityFixture('email-ownership', {}, { jti: '885a9c19-3e5e-4462-b4c1-1c32fc7ac612' })
     let proofRenewed = false
@@ -458,9 +605,7 @@ describe('email-link seven-day no-card continuation', () => {
     const next = screen.getByRole('button', { name: /continue to trial options/i })
     await waitFor(() => expect(next).toBeEnabled())
     fireEvent.click(next)
-    fireEvent.click(await screen.findByRole('button', { name: /7 day free trial/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    await screen.findByRole('button', { name: /create account and start free trial/i })
+    await chooseFreeTrial()
     fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
     await screen.findByRole('button', { name: /7 day free trial/i })
     expect(cancellationPayloads).toHaveLength(2)
@@ -471,7 +616,7 @@ describe('email-link seven-day no-card continuation', () => {
   })
 
   it.each([400, 409, 503, 'wrong-receipt'] as const)('retains the exact selection on cancellation %s without account/password reset', async (failure) => {
-    await openConfirmation('none')
+    await openConfirmation()
     vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify(failure === 'wrong-receipt'
       ? { contractVersion: 2, requestId, checkoutIntentJti: requestId, state: 'released' }
       : { type: `https://api.silentsuite.io/errors/${failure === 409 ? 'authority-in-progress' : failure === 400 ? 'invalid-request' : 'recovery-unavailable'}` }), { status: typeof failure === 'number' ? failure : 200 })))
@@ -483,7 +628,7 @@ describe('email-link seven-day no-card continuation', () => {
     expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
     if (failure === 409) {
       fireEvent.click(screen.getByRole('button', { name: 'Continue current selection' }))
-      expect(screen.getByRole('button', { name: /create account and start free trial/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /continue to your workspace/i })).toBeInTheDocument()
       expect(screen.queryByRole('button', { name: 'Cancel this selection and choose again' })).not.toBeInTheDocument()
     } else if (failure === 400) {
       vi.stubGlobal('fetch', vi.fn(async () => new Response('{}', { status: 202 })))
@@ -495,10 +640,10 @@ describe('email-link seven-day no-card continuation', () => {
   })
 
   it.each(['none', 'stripe'] as const)('never exposes reservation cancellation after uncertain %s account/payment creation', async (provider) => {
-    const confirm = await openConfirmation(provider)
     authState.provisionAnnualNoCard.mockRejectedValue(new Error('Unknown outcome'))
     authState.startAnnualSignupPayment.mockRejectedValue(new Error('Unknown outcome'))
-    fireEvent.click(confirm)
+    if (provider === 'none') fireEvent.click(await openConfirmation())
+    else { await reachPlanScreen(); await choosePaymentMethod('stripe') }
     await screen.findByRole('alert')
     expect(screen.queryByRole('button', { name: 'Cancel this selection and choose again' })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
@@ -507,32 +652,31 @@ describe('email-link seven-day no-card continuation', () => {
   })
 
   it.each(['none', 'stripe'] as const)('renews expired unattempted %s confirmation before any mutation and requires consent again', async (provider) => {
-    const confirm = await openConfirmation(provider)
     const rejection = new BillingResponseError('Invalid request', 400, 'https://api.silentsuite.io/errors/invalid-request')
     authState.provisionAnnualNoCard.mockRejectedValue(rejection)
     authState.startAnnualSignupPayment.mockRejectedValue(rejection)
+    const confirm = provider === 'none' ? await openConfirmation() : (await reachPlanScreen(), null)
     const clock = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2100-01-01T00:00:00Z'))
     try {
-      fireEvent.click(confirm)
+      if (confirm) fireEvent.click(confirm)
+      else await choosePaymentMethod('stripe')
       expect(await screen.findByRole('alert')).toHaveTextContent(/review.*choose.*again/i)
       expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
       expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
       expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
       clock.mockRestore()
-      fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
-      fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-      await screen.findByRole('button', { name: /create account and start free trial/i })
+      await chooseFreeTrial()
       expect(vi.mocked(fetch).mock.calls.filter(([url]) => String(url).endsWith('/activate'))).toHaveLength(2)
       expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
     } finally { clock.mockRestore() }
   })
 
   it.each(['none', 'stripe'] as const)('retains ambiguous 400 after a %s attempt even when its terms expire', async (provider) => {
-    const confirm = await openConfirmation(provider)
     const rejection = new BillingResponseError('Invalid request', 400, 'https://api.silentsuite.io/errors/invalid-request')
     authState.provisionAnnualNoCard.mockRejectedValue(rejection)
     authState.startAnnualSignupPayment.mockRejectedValue(rejection)
-    fireEvent.click(confirm)
+    if (provider === 'none') fireEvent.click(await openConfirmation())
+    else { await reachPlanScreen(); await choosePaymentMethod('stripe') }
     expect(await screen.findByRole('alert')).toHaveTextContent('Invalid request')
     expect(authState.createEtebaseAccount).toHaveBeenCalledTimes(provider === 'none' ? 1 : 0)
     const clock = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2100-01-01T00:00:00Z'))
@@ -547,7 +691,7 @@ describe('email-link seven-day no-card continuation', () => {
   })
 
   it('fails navigation-marker quota before mutation, permits account edits, and retries after storage recovery', async () => {
-    const confirm = await openConfirmation('none')
+    const confirm = await openConfirmation()
     const original = Storage.prototype.setItem
     const storage = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, key, value) {
       if (key.startsWith('silentsuiteSignup:')) throw new DOMException('Full', 'QuotaExceededError')
@@ -560,7 +704,8 @@ describe('email-link seven-day no-card continuation', () => {
       expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
       expect(window.history.state.silentsuiteSignup.phase).toBe('review')
       storage.mockRestore()
-      fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial/i }))
+      // The acknowledgement stays ticked on the same panel, so the retry is one click.
+      fireEvent.click(await screen.findByRole('button', { name: /continue to your workspace/i }))
       await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledTimes(1))
       expect(authState.createEtebaseAccount).toHaveBeenCalledTimes(1)
     } finally { storage.mockRestore() }
@@ -608,16 +753,18 @@ describe('email-link seven-day no-card continuation', () => {
     expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
     expect(screen.getByLabelText(/^password$/i)).toHaveValue('ValidPass1')
     fireEvent.click(screen.getByRole('button', { name: /continue to trial options/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /7 day free trial/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    await screen.findByRole('button', { name: /create account and start free trial/i })
+    await chooseFreeTrial()
+    expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
     await traverseHistory('back')
     expect(await screen.findByRole('alert')).toHaveTextContent('Cancellation is not confirmed')
     fireEvent.click(screen.getByRole('button', { name: 'Continue current selection' }))
-    fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial/i }))
+    fireEvent.click(await acknowledgePasswordKey())
     expect(await screen.findByRole('alert')).toHaveTextContent('Could not start your trial. Please retry.')
     expect(screen.queryByText('Not applicable')).not.toBeInTheDocument()
     expect(screen.getByText(/No card required. No automatic charge or renewal/)).toBeInTheDocument()
+    // The failed attempt stays on the same acknowledgement panel with the box still ticked.
+    expect(screen.getByRole('checkbox', { name: /cannot recover my password/i })).toBeChecked()
+    expect(screen.getByRole('heading', { name: 'Your password is your only key' })).toBeVisible()
     fireEvent.click(screen.getByRole('button', { name: /^back$/i }))
     expect(await screen.findByRole('alert')).toHaveTextContent('Cancellation is not confirmed')
     fireEvent.click(screen.getByRole('button', { name: 'Continue current selection' }))
@@ -634,7 +781,7 @@ describe('email-link seven-day no-card continuation', () => {
     expect(JSON.stringify(sessionStorage)).not.toContain('ValidPass1')
     let finish!: () => void
     authState.provisionAnnualNoCard.mockImplementationOnce(() => new Promise<void>((resolve) => { finish = resolve }))
-    const retry = screen.getByRole('button', { name: /create account and start free trial/i })
+    const retry = await acknowledgePasswordKey()
     act(() => { fireEvent.click(retry); fireEvent.click(retry) })
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledTimes(2))
     expect(screen.getByRole('button', { name: /^back$/i })).toBeDisabled()
@@ -732,6 +879,7 @@ describe('email-link seven-day no-card continuation', () => {
     await act(async () => { resolveOffer(new Response(JSON.stringify(offer))) })
     expect(authState.prepareSignupDraft).not.toHaveBeenCalled()
     expect(localStorage.getItem('silentsuite-signup-email-proof')).toContain(requestId)
+    expect(localStorage.getItem('silentsuite-signup-email-verified')).toBeNull()
   })
 
   it('preserves the new non-secret lineage when a resend acknowledgement is lost', async () => {
@@ -782,6 +930,10 @@ describe('email-link seven-day no-card continuation', () => {
     render(<Page />)
 
     expect(await screen.findByRole('heading', { name: 'Choose your password' })).toBeInTheDocument()
+    const marker = JSON.parse(localStorage.getItem('silentsuite-signup-email-verified')!)
+    expect(marker).toEqual({ requestId, verifiedAt: expect.any(Number), expiresAt: expect.any(Number) })
+    expect(JSON.stringify(marker)).not.toMatch(/customer@example|link-token|password|emailOwnershipToken/i)
+    expect(screen.queryByText(/Email confirmed/)).not.toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: 'ValidPass1' } })
     expect(screen.queryByLabelText(/confirm password/i)).not.toBeInTheDocument()
     const continuation = screen.getByRole('button', { name: /continue to trial options/i })
@@ -790,7 +942,7 @@ describe('email-link seven-day no-card continuation', () => {
     expect(await screen.findByRole('heading', { name: /choose your plan/i })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i }))
+    fireEvent.click(await acknowledgePasswordKey())
 
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('customer@example.test', 'ValidPass1', undefined)
@@ -830,7 +982,7 @@ describe('email-link seven-day no-card continuation', () => {
     expect(await screen.findByRole('heading', { name: /choose your plan/i })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i }))
+    fireEvent.click(await acknowledgePasswordKey())
 
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('newtab@example.test', 'ValidPass1', undefined)
@@ -943,8 +1095,9 @@ describe('email-link seven-day no-card continuation', () => {
     await waitFor(() => expect(continuation).toBeEnabled())
     fireEvent.click(continuation)
 
-    expect(await screen.findByText('Standard Plan pricing')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /annual plan.*€48\.00\/year.*€4\.00\/month/i })).toBeInTheDocument()
+    expect(await screen.findByText('Standard Plan')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /30-day free trial/i })).toBeInTheDocument()
+    expect(screen.queryByText(/€48|\/year|\/month/)).not.toBeInTheDocument()
     expect(screen.queryByText(/Early Adopter/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/€36/)).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
@@ -952,19 +1105,14 @@ describe('email-link seven-day no-card continuation', () => {
     expect(await screen.findByText('Standard Plan')).toBeInTheDocument()
     expect(screen.queryByText(/BTCPay/i)).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /bitcoin/i })).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /continue to card payment for standard plan, €48\.00\/year/i }))
+    expect(screen.getByText('€48.00/year')).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: /pay by card for standard plan, €48\.00\/year/i }))
 
     await waitFor(() => expect(fetch).toHaveBeenCalledWith(
       'https://billing.test/auth/offers/v2/activate',
       expect.objectContaining({ body: expect.stringContaining('"provider":"stripe"') }),
     ))
     expect(vi.mocked(fetch).mock.calls.some(([, init]) => String((init as RequestInit | undefined)?.body).includes('"provider":"btcpay"'))).toBe(false)
-    expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
-    expect(await screen.findByText('Review your free trial')).toBeInTheDocument()
-    expect(screen.getAllByText('2026-09-10 12:00 UTC')).toHaveLength(2)
-    expect(screen.getByText('2027-09-10 12:00 UTC')).toBeInTheDocument()
-    expect(screen.getByText('€48.00/year from 2027-09-10 12:00 UTC')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i }))
     await waitFor(() => expect(authState.startAnnualSignupPayment).toHaveBeenCalledWith(
       signedCheckoutIntent,
       'stripe',
@@ -972,6 +1120,9 @@ describe('email-link seven-day no-card continuation', () => {
       'annual',
     ))
     expect(await screen.findByText('Add your payment method')).toBeInTheDocument()
+    expect(screen.queryByText('Review your free trial')).not.toBeInTheDocument()
+    expect(screen.getByText(/No charge today/)).toHaveTextContent('€48.00/year is charged on 2026-09-10 12:00 UTC')
+    expect(screen.getByText(/Renews automatically/)).toHaveTextContent('€48.00')
     expect(screen.getByText('Standard Plan')).toBeInTheDocument()
     expect(screen.getAllByText(/€48\.00\/year/)).not.toHaveLength(0)
   })
@@ -1033,21 +1184,22 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
 
     expect(await screen.findByText(/annual terms changed/i)).toBeInTheDocument()
-    expect(screen.getByText('Standard Plan pricing')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /annual plan.*€48\.00\/year.*€4\.00\/month/i })).toBeInTheDocument()
+    expect(screen.getByText('Standard Plan')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /30-day free trial/i })).toBeInTheDocument()
+    expect(screen.queryByText(/€48|€36/)).not.toBeInTheDocument()
     expect(authState.createEtebaseAccount).not.toHaveBeenCalled()
     expect(authState.provisionAnnualNoCard).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByRole('button', { name: /7 day free trial/i }))
     fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-    fireEvent.click(await screen.findByRole('button', { name: /^(create account and start free trial|continue to (bitcoin payment|card setup|card payment))$/i }))
+    fireEvent.click(await acknowledgePasswordKey())
     await waitFor(() => expect(authState.provisionAnnualNoCard).toHaveBeenCalledWith(signedCheckoutIntent))
     expect(authState.createEtebaseAccount).toHaveBeenCalledWith('renew@example.test', 'ValidPass1', undefined)
   })
 
   it.each([
-    ['card', /continue to card payment for early adopter plan, €36\.00\/year/i],
-    ['bitcoin', /pay €36\.00\/year with bitcoin for early adopter plan/i],
+    ['card', /pay by card for early adopter plan, €36\.00\/year/i],
+    ['bitcoin', /pay €36\.00 with bitcoin for early adopter plan/i],
   ] as const)('returns expired signup %s selection to renewed consent without starting payment', async (_kind, paymentAction) => {
     const standardOffer = {
       ...offer,
@@ -1100,7 +1252,7 @@ describe('email-link seven-day no-card continuation', () => {
     fireEvent.click(await screen.findByRole('button', { name: paymentAction }))
 
     expect(await screen.findByText(/annual terms changed/i)).toBeInTheDocument()
-    expect(screen.getByText('Standard Plan pricing')).toBeInTheDocument()
+    expect(screen.getByText('Standard Plan')).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /bitcoin/i })).not.toBeInTheDocument()
     expect(authState.startAnnualSignupPayment).not.toHaveBeenCalled()
   })

--- a/apps/web/app/(auth)/signup/components/annual-confirmation-summary.tsx
+++ b/apps/web/app/(auth)/signup/components/annual-confirmation-summary.tsx
@@ -3,44 +3,61 @@ import type { AnnualDisclosure } from '@/app/lib/billing-v2'
 const money = (minor: number) => `€${(minor / 100).toFixed(2)}`
 const timestamp = (value: string) => `${value.slice(0, 10)} ${value.slice(11, 16)} UTC`
 
-export function annualConfirmationTitle(disclosure: AnnualDisclosure): string {
-  return disclosure.kind === 'no_auto_charge' ? 'Start your free trial'
-    : disclosure.kind === 'card_trial' ? 'Review your free trial'
-      : disclosure.kind === 'charge_now' ? 'Review your card payment' : 'Review your Bitcoin payment'
-}
-
-export function annualConfirmationAction(disclosure: AnnualDisclosure): string {
-  return disclosure.kind === 'no_auto_charge' ? 'Create account and start free trial'
-    : disclosure.kind === 'card_trial' ? 'Continue to card setup'
-      : disclosure.kind === 'charge_now' ? 'Continue to card payment' : 'Continue to Bitcoin payment'
+/** Label for retrying a payment start that did not complete for the same claim. */
+export function annualRetryAction(disclosure: AnnualDisclosure): string {
+  return disclosure.kind === 'card_trial' ? 'Retry card setup'
+    : disclosure.kind === 'charge_now' ? 'Retry card payment'
+      : disclosure.kind === 'prepaid' ? 'Retry Bitcoin payment' : 'Continue to your workspace'
 }
 
 export function annualCardSubmitLabel(disclosure: AnnualDisclosure): string {
   return disclosure.kind === 'card_trial' ? 'Start free trial — no charge today' : `Pay ${money(disclosure.firstChargeAmountMinor)} now`
 }
 
-/** Only the server disclosure kind determines whether the next step charges. */
-export function AnnualConfirmationSummary({ disclosure }: { disclosure: AnnualDisclosure }) {
-  const noCard = disclosure.kind === 'no_auto_charge'
-  const cardTrial = disclosure.kind === 'card_trial'
-  return <>
-    <p className="text-sm text-[rgb(var(--muted))]">
-      {noCard ? 'Start your 7-day free trial. No card required. No automatic charge or renewal.'
-        : cardTrial ? 'Add a card next. No charge today. Cancel before the deadline below to avoid the annual charge.'
-          : disclosure.kind === 'charge_now' ? `Pay ${money(disclosure.firstChargeAmountMinor)} now by card. This is an annual purchase, not a free trial.`
-            : `Pay ${money(disclosure.firstChargeAmountMinor)} in Bitcoin. This is a prepaid annual purchase, not a free trial. No automatic renewal.`}
-    </p>
-    {disclosure.kind === 'prepaid' && disclosure.refundWindowDays === 30 && <p className="text-sm">Request a full refund within 30 days of your first payment—no questions asked.</p>}
-    <dl className="space-y-2 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 text-sm">
-      {!noCard && <>
-        <div className="flex justify-between gap-4"><dt>{cardTrial ? 'After your trial' : 'Payment'}</dt><dd>{money(disclosure.firstChargeAmountMinor)}{cardTrial ? '/year' : ''}</dd></div>
-        {disclosure.firstChargeAt && <div className="flex justify-between gap-4"><dt>First charge</dt><dd>{timestamp(disclosure.firstChargeAt)}</dd></div>}
-        {disclosure.cancelBy && <div className="flex justify-between gap-4"><dt>Cancel before</dt><dd>{timestamp(disclosure.cancelBy)}</dd></div>}
-        {disclosure.autoRenew && <div className="flex justify-between gap-4"><dt>Automatic renewal</dt><dd>{disclosure.renewalAmountMinor !== null ? `${money(disclosure.renewalAmountMinor)}/year` : 'Annual'}{disclosure.renewalAt ? ` from ${timestamp(disclosure.renewalAt)}` : ', one year after payment confirmation'}</dd></div>}
-        {disclosure.refundWindowDays && <div className="flex justify-between gap-4"><dt>Refund window</dt><dd>{disclosure.refundWindowDays} days</dd></div>}
-      </>}
-      {disclosure.entitlementEndsAt && <div className="flex justify-between gap-4"><dt>{noCard ? 'Free until' : 'Access through'}</dt><dd>{timestamp(disclosure.entitlementEndsAt)}</dd></div>}
-      {!disclosure.entitlementEndsAt && <div className="flex justify-between gap-4"><dt>Access</dt><dd>One year from payment confirmation{disclosure.bonusDays ? `, plus ${disclosure.bonusDays} bonus days` : ''}</dd></div>}
-    </dl>
-  </>
+/** One line stating what continuing does on the no-card path; it is the only mutation there. */
+export function noCardTrialConsequence(disclosure: AnnualDisclosure): string | null {
+  if (disclosure.kind !== 'no_auto_charge') return null
+  return 'Continuing creates your account and starts your 7-day free trial. No card required. No automatic charge or renewal.'
+}
+
+/**
+ * Concise customer terms beside the payable controls. Only the server
+ * disclosure kind determines whether, when and how much the next step charges.
+ */
+export function AnnualTermsSummary({ disclosure }: { disclosure: AnnualDisclosure }) {
+  const access = `one year of access${disclosure.bonusDays ? ` plus ${disclosure.bonusDays} bonus days` : ''}`
+  if (disclosure.kind === 'no_auto_charge') {
+    return <p className="text-sm text-[rgb(var(--muted))]">{noCardTrialConsequence(disclosure)}</p>
+  }
+  if (disclosure.kind === 'card_trial') {
+    return (
+      <div className="space-y-1 text-sm text-[rgb(var(--muted))]">
+        <p>
+          No charge today. {money(disclosure.firstChargeAmountMinor)}/year is charged
+          {disclosure.firstChargeAt ? ` on ${timestamp(disclosure.firstChargeAt)}` : ' after your 30-day trial'}. Cancel before then and nothing is charged.
+        </p>
+        <p>
+          {disclosure.autoRenew ? `Renews automatically each year at ${money(disclosure.renewalAmountMinor ?? disclosure.annualAmountMinor)}. ` : 'No automatic renewal. '}
+          Cancel anytime.{disclosure.refundWindowDays ? ` ${disclosure.refundWindowDays}-day refund window.` : ''}
+        </p>
+      </div>
+    )
+  }
+  if (disclosure.kind === 'charge_now') {
+    return (
+      <div className="space-y-1 text-sm text-[rgb(var(--muted))]">
+        <p>{money(disclosure.firstChargeAmountMinor)} is charged now by card for {access}. This is an annual purchase, not a free trial.</p>
+        <p>
+          {disclosure.autoRenew ? `Renews automatically each year at ${money(disclosure.renewalAmountMinor ?? disclosure.annualAmountMinor)} unless you cancel. ` : 'No automatic renewal. '}
+          {disclosure.refundWindowDays ? `${disclosure.refundWindowDays}-day refund window.` : ''}
+        </p>
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-1 text-sm text-[rgb(var(--muted))]">
+      <p>{money(disclosure.firstChargeAmountMinor)} paid now in Bitcoin for {access}. This is a prepaid annual purchase, not a free trial. No automatic renewal.</p>
+      {disclosure.refundWindowDays === 30 && <p>Full refund within 30 days of your payment, no questions asked.</p>}
+    </div>
+  )
 }

--- a/apps/web/app/(auth)/signup/components/step-create-vault.tsx
+++ b/apps/web/app/(auth)/signup/components/step-create-vault.tsx
@@ -1,36 +1,141 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Shield, AlertTriangle, Lock } from 'lucide-react'
 
 /**
- * Step: Create Vault
- *
- * Shared between the main signup page and the 3DS redirect success page.
+ * The password-loss acknowledgement shared by every hosted path.
  *
  * SilentSuite is end-to-end encrypted: the user's password is the only
  * factor that unwraps their master key. We don't store it, can't reset it,
  * and currently have no recovery-key flow that wraps anything (see GitHub
- * issues for future work). This step's job is to make that contract explicit
- * before the user lands in the app — they tick a box acknowledging that
- * losing the password means losing access to encrypted data.
+ * issues for future work). This component's job is to make that contract
+ * explicit before the user lands in the app — they tick a box acknowledging
+ * that losing the password means losing access to encrypted data.
+ *
+ * Paid paths render it after their account exists (via `StepCreateVault`).
+ * The no-card trial renders it *before* account creation, so the same
+ * acknowledgement gates the only mutation on that path.
+ */
+export function PasswordKeyAcknowledgement({
+  onContinue,
+  busy = false,
+  error,
+  consequence,
+  children,
+}: {
+  onContinue: () => void
+  busy?: boolean
+  error?: string | null
+  /** One concise line stating what continuing does when it also creates the account. */
+  consequence?: React.ReactNode
+  children?: React.ReactNode
+}) {
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center space-y-3">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl border border-emerald-500/30 bg-emerald-500/10">
+          <Shield className="h-8 w-8 text-emerald-500" />
+        </div>
+        <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">
+          Your password is your only key
+        </h2>
+        <p className="text-sm text-[rgb(var(--muted))]">
+          SilentSuite is end-to-end encrypted. Your password unlocks your
+          data on your devices — we never see it.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
+              We can&apos;t reset your password or recover your data
+            </p>
+            <ul className="text-xs text-[rgb(var(--muted))] space-y-1 list-disc pl-4">
+              <li>If you forget your password, your encrypted data cannot be recovered.</li>
+              <li>
+                Use a password manager. Pick something long and unique.
+              </li>
+              <li>
+                You can change your password from Settings while signed in.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <label className="flex items-start gap-3 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={acknowledged}
+          disabled={busy}
+          onChange={(e) => setAcknowledged(e.target.checked)}
+          className="mt-0.5 h-4 w-4 shrink-0 accent-[rgb(var(--primary))] cursor-pointer"
+        />
+        <span className="text-sm text-[rgb(var(--foreground))]">
+          I understand that SilentSuite cannot recover my password or
+          decrypt my data on my behalf.
+        </span>
+      </label>
+
+      {consequence && <p className="text-sm text-[rgb(var(--muted))]">{consequence}</p>}
+
+      {error && (
+        <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        </div>
+      )}
+
+      <button
+        onClick={onContinue}
+        disabled={!acknowledged || busy}
+        className="w-full rounded-lg bg-[rgb(var(--primary))] px-4 py-3 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {busy ? 'Creating your account...' : 'Continue to your workspace'}
+      </button>
+
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Step: Create Vault
+ *
+ * Shared between the main signup page, the 3DS redirect success page and
+ * pending-payment recovery. Shows a brief key animation while the
+ * (already-created) Etebase account settles, then the acknowledgement above.
+ * When the caller already collected the acknowledgement before creating the
+ * account (`acknowledged`), the step completes after the animation instead of
+ * asking twice.
  */
 export function StepCreateVault({
   email: _email,
   onComplete,
+  acknowledged = false,
 }: {
   email: string
   onComplete: () => void
+  acknowledged?: boolean
 }) {
   const [phase, setPhase] = useState<'creating' | 'acknowledge'>('creating')
-  const [acknowledged, setAcknowledged] = useState(false)
+  // Callers may pass a fresh callback each render; the settle timer must not restart.
+  const completeRef = useRef(onComplete)
+  completeRef.current = onComplete
 
   useEffect(() => {
     if (phase !== 'creating') return
     // Brief animation while the (already-created) Etebase account settles.
-    const timer = setTimeout(() => setPhase('acknowledge'), 2500)
+    const timer = setTimeout(() => {
+      if (acknowledged) completeRef.current()
+      else setPhase('acknowledge')
+    }, 2500)
     return () => clearTimeout(timer)
-  }, [phase])
+  }, [acknowledged, phase])
 
   if (phase === 'creating') {
     return (
@@ -86,61 +191,5 @@ export function StepCreateVault({
     )
   }
 
-  return (
-    <div className="space-y-6">
-      <div className="text-center space-y-3">
-        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl border border-emerald-500/30 bg-emerald-500/10">
-          <Shield className="h-8 w-8 text-emerald-500" />
-        </div>
-        <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">
-          Your password is your only key
-        </h2>
-        <p className="text-sm text-[rgb(var(--muted))]">
-          SilentSuite is end-to-end encrypted. Your password unlocks your
-          data on your devices — we never see it.
-        </p>
-      </div>
-
-      <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-4">
-        <div className="flex items-start gap-3">
-          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-[rgb(var(--foreground))]">
-              We can&apos;t reset your password or recover your data
-            </p>
-            <ul className="text-xs text-[rgb(var(--muted))] space-y-1 list-disc pl-4">
-              <li>If you forget your password, your encrypted data cannot be recovered.</li>
-              <li>
-                Use a password manager. Pick something long and unique.
-              </li>
-              <li>
-                You can change your password from Settings while signed in.
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
-
-      <label className="flex items-start gap-3 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4 cursor-pointer">
-        <input
-          type="checkbox"
-          checked={acknowledged}
-          onChange={(e) => setAcknowledged(e.target.checked)}
-          className="mt-0.5 h-4 w-4 shrink-0 accent-[rgb(var(--primary))] cursor-pointer"
-        />
-        <span className="text-sm text-[rgb(var(--foreground))]">
-          I understand that SilentSuite cannot recover my password or
-          decrypt my data on my behalf.
-        </span>
-      </label>
-
-      <button
-        onClick={onComplete}
-        disabled={!acknowledged}
-        className="w-full rounded-lg bg-[rgb(var(--primary))] px-4 py-3 text-sm font-medium text-white hover:bg-[rgb(var(--primary-hover))] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        Continue to your workspace
-      </button>
-    </div>
-  )
+  return <PasswordKeyAcknowledgement onContinue={onComplete} />
 }

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -22,11 +22,11 @@ import { DISPLAY_VERSION } from '@/app/lib/constants'
 import { findCommonEmailDomainTypo, normalizeEmailForComparison, signupEmailSchema } from '@/app/lib/email-recovery'
 import { normalizeSignupReturnTo } from '@/app/lib/signup-return'
 import dynamic from 'next/dynamic'
-import { AnnualConfirmationSummary, annualConfirmationTitle, annualConfirmationAction, annualCardSubmitLabel } from './components/annual-confirmation-summary'
+import { AnnualTermsSummary, annualRetryAction, annualCardSubmitLabel, noCardTrialConsequence } from './components/annual-confirmation-summary'
 import PendingPaymentPage from './pending-payment/page'
 import { useSignupNavigation } from './use-signup-navigation'
 import { SignupRecoveryWarning } from './components/signup-recovery-warning'
-import { StepCreateVault } from './components/step-create-vault'
+import { PasswordKeyAcknowledgement, StepCreateVault } from './components/step-create-vault'
 import { StepCreatePaidAccount, type PaidAccountFormData } from './components/step-create-paid-account'
 import { QRCodeSVG } from 'qrcode.react'
 import { createEmailLinkContinuation } from '@/app/lib/signup-email-continuation'
@@ -45,14 +45,14 @@ import {
 import {
   annualOfferAnnualLabel,
   annualOfferPlanLabel,
-  annualOfferRenewalCopy,
-  formatAnnualOfferMonthlyEquivalent,
+  formatAnnualOfferAmount,
   isAnnualOfferProviderAvailable,
 } from '@/app/lib/annual-offer-presentation'
 
 const CRYPTO_CHECKOUT_ENABLED = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ENABLED === 'true'
 const BTCPAY_CHECKOUT_ORIGIN = process.env.NEXT_PUBLIC_BTCPAY_CHECKOUT_ORIGIN ?? 'https://btcpay.silentsuite.io'
 const EMAIL_PROOF_CONTEXT_KEY = 'silentsuite-signup-email-proof'
+const EMAIL_VERIFIED_MARKER_KEY = 'silentsuite-signup-email-verified'
 
 type EmailProofContext = {
   email: string
@@ -118,6 +118,38 @@ function saveEmailProofContext(context: EmailProofContext) {
     } catch { return {} }
   })()
   localStorage.setItem(EMAIL_PROOF_CONTEXT_KEY, JSON.stringify({ ...existing, [context.requestId]: context }))
+}
+
+/**
+ * Cross-tab presentation hint only. The tab that follows the emailed link
+ * records which verification request it completed so that the original
+ * "check your email" tab can say so. It carries no proof, token, password or
+ * offer, grants nothing, and is matched strictly against the request this tab
+ * is still waiting on.
+ */
+type EmailVerifiedMarker = { requestId: string; verifiedAt: number; expiresAt: number }
+
+function publishEmailVerifiedMarker(requestId: string) {
+  try {
+    const marker: EmailVerifiedMarker = { requestId, verifiedAt: Date.now(), expiresAt: Date.now() + 15 * 60_000 }
+    localStorage.setItem(EMAIL_VERIFIED_MARKER_KEY, JSON.stringify(marker))
+  } catch {
+    // The hint is optional; the callback tab continues regardless.
+  }
+}
+
+function readEmailVerifiedMarker(raw: string | null): EmailVerifiedMarker | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Partial<EmailVerifiedMarker>
+    if (isUuid(parsed.requestId) && typeof parsed.verifiedAt === 'number'
+      && typeof parsed.expiresAt === 'number' && parsed.expiresAt > Date.now()) {
+      return parsed as EmailVerifiedMarker
+    }
+    return null
+  } catch {
+    return null
+  }
 }
 
 /** Drops the single-use verification token from the address bar and history. */
@@ -187,6 +219,14 @@ function isUuid(value: unknown): value is string {
   return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
 }
 
+/** Customer-facing message for a payment start that did not complete; never a fresh-start hint. */
+function describePaymentStartError(err: unknown): string {
+  return err instanceof BillingResponseError
+    && err.billingProblemType === 'https://api.silentsuite.io/errors/provider-unavailable'
+    ? 'Payment creation is not yet confirmed. Retry this same payment, or recover its status. Do not start another payment.'
+    : err instanceof Error ? err.message : 'Failed to start checkout'
+}
+
 // ---------------------------------------------------------------------------
 // Password strength indicator
 // ---------------------------------------------------------------------------
@@ -238,19 +278,6 @@ function PasswordStrength({ password }: { password: string }) {
         ))}
       </ul>
     </div>
-  )
-}
-
-// ---------------------------------------------------------------------------
-// Price display helper — used inline in the trial subhead, intentionally
-// modest in size so it doesn't dominate the plan heading.
-// ---------------------------------------------------------------------------
-
-function PriceDisplay({ offer }: { offer: AnnualOfferResponse['offer'] }) {
-  return (
-    <span className="text-sm text-[rgb(var(--muted))]">
-      <span className="font-semibold text-[rgb(var(--foreground))]">{annualOfferAnnualLabel(offer)}</span>, billed annually ({formatAnnualOfferMonthlyEquivalent(offer)}/month).
-    </span>
   )
 }
 
@@ -628,17 +655,20 @@ function CryptoPaymentPanel({
   return (
     <div className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
       <div className="space-y-2 text-center">
-        <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Pay {annualOfferAnnualLabel(annualOffer)} with Bitcoin</h2>
+        <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Pay {formatAnnualOfferAmount(annualOffer)} with Bitcoin</h2>
         <p className="text-sm text-[rgb(var(--muted))]">
-          Scan the QR code or copy the payment details to pay {annualOfferRenewalCopy(annualOffer)} for your {annualOfferPlanLabel(annualOffer)}. Access unlocks after settlement confirms.
+          {session
+            ? <>Scan the QR code or copy the payment details for your {annualOfferPlanLabel(annualOffer)}. Access unlocks after settlement confirms.</>
+            : 'Your Bitcoin invoice could not be created yet. Retry the same payment below; a second invoice is never started here.'}
         </p>
       </div>
 
-      <AnnualConfirmationSummary disclosure={disclosure} />
-      {provisionError && <p role="alert">{provisionError}</p>}
+      {/* Terms stay beside the payable controls instead of on a separate review screen. */}
+      <AnnualTermsSummary disclosure={disclosure} />
+      {provisionError && <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">{provisionError}</div>}
       {!session ? (
         <Button type="button" className="w-full" disabled={provisioning} onClick={onConfirm}>
-          {provisioning ? 'Starting…' : annualConfirmationAction(disclosure)}
+          {provisioning ? 'Starting…' : annualRetryAction(disclosure)}
         </Button>
       ) : status === 'settled' ? (
         <div className="space-y-4 text-center">
@@ -659,7 +689,7 @@ function CryptoPaymentPanel({
         </div>
       ) : selectedMethod && qrValue ? (
         <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-2">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             {paymentMethods.map((method) => (
               <button
                 key={method.id}
@@ -674,6 +704,16 @@ function CryptoPaymentPanel({
                 {method.label}
               </button>
             ))}
+            {/* Monero is not a live rail: Billing's invoice allow-list is BTC-CHAIN and BTC-LN only. */}
+            <button
+              type="button"
+              disabled
+              aria-disabled="true"
+              title="Monero payments are not available yet"
+              className="cursor-not-allowed rounded-lg border border-dashed border-[rgb(var(--border))] bg-[rgb(var(--surface))] px-3 py-2 text-sm text-[rgb(var(--muted))] opacity-60"
+            >
+              Monero (soon)
+            </button>
           </div>
 
           <div className="rounded-xl border border-[rgb(var(--border))] bg-white p-4">
@@ -759,6 +799,7 @@ function StepChoosePlan({
   const contentRef = useRef<HTMLDivElement>(null)
   const [selectedTrial, setSelectedTrial] = useState<TrialPath>('30day')
   const [paymentMethodError, setPaymentMethodError] = useState<string | null>(null)
+  const [startingMethod, setStartingMethod] = useState<'stripe' | 'btcpay' | null>(null)
   const annualOfferDetails = annualOffer.offer
   const stripeAvailable = isAnnualOfferProviderAvailable(annualOfferDetails, 'stripe')
   const bitcoinAvailable = isAnnualOfferProviderAvailable(annualOfferDetails, 'btcpay', CRYPTO_CHECKOUT_ENABLED)
@@ -774,12 +815,16 @@ function StepChoosePlan({
     }
   }, [selectedTrial, onSelectFree, onChoosePaymentMethod, onClearError])
 
+  // Choosing a method with its price and charge timing visible is the
+  // affirmative step; the parent reserves the offer and opens the provider's
+  // own payment surface. No funds move until the customer confirms there.
   const handleSelectCard = useCallback(() => {
     if (!stripeAvailable) {
       setPaymentMethodError('Card checkout is not available for this annual offer.')
       return
     }
     setPaymentMethodError(null)
+    setStartingMethod('stripe')
     trackPlanSelected(annualOfferDetails)
     onSelectPaid()
   }, [annualOfferDetails, onSelectPaid, stripeAvailable])
@@ -790,6 +835,7 @@ function StepChoosePlan({
       return
     }
     setPaymentMethodError(null)
+    setStartingMethod('btcpay')
     trackPlanSelected(annualOfferDetails)
     onSelectCrypto()
   }, [annualOfferDetails, bitcoinAvailable, onSelectCrypto])
@@ -800,6 +846,10 @@ function StepChoosePlan({
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [planView])
 
+  useEffect(() => {
+    if (!provisioning) setStartingMethod(null)
+  }, [provisioning])
+
   // --- Payment sub-step ---
   if (planView === 'confirm' && pendingAnnualClaim) {
     const disclosure = pendingAnnualClaim.activation.disclosure
@@ -807,15 +857,36 @@ function StepChoosePlan({
       annualOffer={annualOfferDetails} session={null} disclosure={disclosure}
       onConfirm={onConfirmAnnualClaim} provisioning={provisioning} provisionError={provisionError}
       onBack={onBack} onPaymentComplete={onPaymentComplete} />
+    if (pendingAnnualClaim.provider === 'none') {
+      // The password-loss acknowledgement is the only gate before the no-card
+      // account is created; nothing is provisioned until it is ticked.
+      return (
+        <div ref={contentRef} className="animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
+          <PasswordKeyAcknowledgement
+            onContinue={onConfirmAnnualClaim}
+            busy={provisioning}
+            error={provisionError}
+            consequence={noCardTrialConsequence(disclosure)}
+          >
+            <button type="button" disabled={provisioning} onClick={onBack} className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
+              <ArrowLeft className="h-4 w-4" /> Back
+            </button>
+          </PasswordKeyAcknowledgement>
+        </div>
+      )
+    }
+    // A reserved card claim whose payment session did not start. Retry the
+    // same claim here; the card form itself opens once Stripe returns a secret.
     return (
       <div ref={contentRef} className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
         <div className="space-y-2 text-center">
-          <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">{annualConfirmationTitle(disclosure)}</h2>
+          <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Add your payment method</h2>
+          <p className="text-sm text-[rgb(var(--muted))]">The card form could not be opened yet. Retry below; your selection is kept and nothing has been charged.</p>
         </div>
-        <AnnualConfirmationSummary disclosure={disclosure} />
+        <AnnualTermsSummary disclosure={disclosure} />
         {provisionError && <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-sm text-red-600 dark:text-red-400">{provisionError}</div>}
         <Button type="button" className="w-full" disabled={provisioning} onClick={onConfirmAnnualClaim}>
-          {provisioning ? 'Starting…' : annualConfirmationAction(disclosure)}
+          {provisioning ? 'Starting…' : annualRetryAction(disclosure)}
         </Button>
         <button type="button" disabled={provisioning} onClick={onBack} className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors">
           <ArrowLeft className="h-4 w-4" /> Back
@@ -849,9 +920,6 @@ function StepChoosePlan({
       <div ref={contentRef} className="space-y-5 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
         <div className="space-y-2 text-center">
           <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Choose how to pay</h2>
-          <p className="text-sm text-[rgb(var(--muted))]">
-            Choose a payment method to review its price and terms before continuing.
-          </p>
         </div>
 
         <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
@@ -862,7 +930,6 @@ function StepChoosePlan({
             </div>
             <span className="text-sm text-[rgb(var(--foreground))]">{annualOfferAnnualLabel(annualOfferDetails)}</span>
           </div>
-          <p className="mt-1 text-xs text-[rgb(var(--muted))]">{annualOfferRenewalCopy(annualOfferDetails)}</p>
         </div>
 
         <div className="grid gap-3">
@@ -871,7 +938,7 @@ function StepChoosePlan({
               type="button"
               onClick={handleSelectCard}
               disabled={provisioning}
-              aria-label={`Continue to card payment for ${annualOfferPlanLabel(annualOfferDetails)}, ${annualOfferAnnualLabel(annualOfferDetails)}`}
+              aria-label={`Pay by card for ${annualOfferPlanLabel(annualOfferDetails)}, ${annualOfferAnnualLabel(annualOfferDetails)}, billed after the 30-day trial`}
               className="group w-full rounded-xl border-2 border-slate-700/50 bg-[rgb(var(--surface))] p-4 text-left transition-all hover:border-emerald-500/70 hover:bg-emerald-500/5 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <div className="flex items-start gap-3">
@@ -879,9 +946,9 @@ function StepChoosePlan({
                   <CreditCard className="h-5 w-5 text-emerald-400" />
                 </div>
                 <div className="flex-1">
-                  <h3 className="font-semibold text-[rgb(var(--foreground))]">Card with Stripe</h3>
+                  <h3 className="font-semibold text-[rgb(var(--foreground))]">Pay by Card (Powered by Stripe)</h3>
                   <p className="mt-1 text-sm text-[rgb(var(--muted))]">
-                    Review your card offer, including any free trial and the first charge date, before continuing.
+                    Card gets billed after the 30-day trial. You can cancel anytime.
                   </p>
                 </div>
               </div>
@@ -893,7 +960,7 @@ function StepChoosePlan({
               type="button"
               onClick={handleSelectBitcoin}
               disabled={provisioning}
-              aria-label={`Pay ${annualOfferAnnualLabel(annualOfferDetails)} with Bitcoin for ${annualOfferPlanLabel(annualOfferDetails)}`}
+              aria-label={`Pay ${formatAnnualOfferAmount(annualOfferDetails)} with Bitcoin for ${annualOfferPlanLabel(annualOfferDetails)}, paid now with a 30-day money-back guarantee`}
               className="group w-full rounded-xl border-2 border-slate-700/50 bg-[rgb(var(--surface))] p-4 text-left transition-all hover:border-amber-500/70 hover:bg-amber-500/5 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <div className="flex items-start gap-3">
@@ -901,12 +968,12 @@ function StepChoosePlan({
                   <Bitcoin className="h-5 w-5 text-amber-600 dark:text-amber-400" />
                 </div>
                 <div className="flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="font-semibold text-[rgb(var(--foreground))]">Bitcoin with BTCPay</h3>
-                    <span className="rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-300">Annual only</span>
-                  </div>
+                  <h3 className="font-semibold text-[rgb(var(--foreground))]">Bitcoin, Lightning and Monero</h3>
                   <p className="mt-1 text-sm text-[rgb(var(--muted))]">
-                    Pay {annualOfferRenewalCopy(annualOfferDetails)} once with Bitcoin. App access starts only after the invoice settles.
+                    Payment has to be made with account creation, but we offer a 30-day, no-questions-asked money-back guarantee.
+                  </p>
+                  <p className="mt-1 text-sm text-[rgb(var(--muted))]">
+                    {formatAnnualOfferAmount(annualOfferDetails)} for one year, paid now. No automatic renewal.
                   </p>
                 </div>
               </div>
@@ -919,6 +986,12 @@ function StepChoosePlan({
             </p>
           )}
         </div>
+
+        {provisioning && startingMethod && (
+          <p role="status" className="text-center text-sm text-[rgb(var(--muted))]">
+            {startingMethod === 'stripe' ? 'Opening the card form...' : 'Preparing your Bitcoin invoice...'}
+          </p>
+        )}
 
         {(paymentMethodError || provisionError) && (
           <div role="alert" className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
@@ -942,13 +1015,10 @@ function StepChoosePlan({
       <div ref={contentRef} className="space-y-6 animate-in fade-in slide-in-from-right-4 duration-300 motion-reduce:animate-none">
         <div className="space-y-2 text-center">
           <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Add your payment method</h2>
-          <p className="text-sm text-[rgb(var(--muted))]">
-            Review your selected terms below before confirming with Stripe.
-          </p>
         </div>
 
-        {/* Plan summary bar */}
-        <div className="rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
+        {/* Plan summary bar: the validated disclosure states price, charge timing, renewal and cancellation. */}
+        <div className="space-y-2 rounded-lg border border-[rgb(var(--border))] bg-[rgb(var(--surface))] p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Crown className="h-4 w-4 text-emerald-400" />
@@ -956,7 +1026,7 @@ function StepChoosePlan({
             </div>
             <span className="text-sm text-[rgb(var(--foreground))]">{annualOfferAnnualLabel(annualOfferDetails)}</span>
           </div>
-          {cardDisclosure && <AnnualConfirmationSummary disclosure={cardDisclosure} />}
+          {cardDisclosure && <AnnualTermsSummary disclosure={cardDisclosure} />}
           <div className="mt-2 flex items-center gap-1.5 text-xs text-[rgb(var(--muted))]">
             <Lock className="h-3 w-3 text-emerald-500" />
             <span>Secured by Stripe. We never see your card details.</span>
@@ -1007,6 +1077,7 @@ function StepChoosePlan({
         {/* Back button — bottom-left */}
         <button
           onClick={onBack}
+          disabled={provisioning}
           className="flex items-center gap-1.5 text-sm text-[rgb(var(--muted))] hover:text-[rgb(var(--foreground))] transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -1022,7 +1093,7 @@ function StepChoosePlan({
       <div className="space-y-2 text-center">
         <h2 className="text-lg sm:text-xl font-semibold text-[rgb(var(--foreground))]">Choose your plan</h2>
         <p className="text-sm text-[rgb(var(--muted))]">
-          {annualOfferPlanLabel(annualOfferDetails)} pricing
+          {annualOfferPlanLabel(annualOfferDetails)}
         </p>
       </div>
 
@@ -1057,10 +1128,12 @@ function StepChoosePlan({
           </div>
         </button>
 
-        {/* Paid options are disclosed after the customer chooses a provider. */}
+        {/* Card B: 30-day free trial. Heading, badge and feature bullet are the
+            pre-annual-rollout copy (82019158^, introduced by #123 8bff947d);
+            price and payment-method terms are stated on the next screen. */}
         <button
           onClick={() => setSelectedTrial('30day')}
-          aria-label={`Annual plan — ${annualOfferRenewalCopy(annualOfferDetails)}`}
+          aria-label="30-day free trial — full access to all features"
           className={`group w-full rounded-xl border-2 p-4 sm:p-6 text-left transition-all ${
             selectedTrial === '30day'
               ? 'border-emerald-500 bg-emerald-500/5'
@@ -1073,26 +1146,15 @@ function StepChoosePlan({
             </div>
             <div className="flex-1">
               <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
-                <h3 className="text-xl sm:text-2xl font-bold text-[rgb(var(--foreground))] leading-tight">Annual plan</h3>
+                <h3 className="text-xl sm:text-2xl font-bold text-[rgb(var(--foreground))] leading-tight">30-day free trial</h3>
                 <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400 uppercase tracking-wide">
                   Recommended
                 </span>
               </div>
-              <p className="mt-1.5 leading-snug">
-                <PriceDisplay offer={annualOfferDetails} />
-              </p>
               <ul className="mt-3 space-y-1.5">
                 <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
                   <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
                   Full access to all features
-                </li>
-                <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
-                  <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-                  Review available payment methods
-                </li>
-                <li className="flex items-center gap-2 text-sm text-[rgb(var(--muted))]">
-                  <Check className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
-                  Review payment and renewal terms before you confirm
                 </li>
               </ul>
             </div>
@@ -1433,6 +1495,10 @@ function SignupJourney() {
   // Account creation and reservation ownership have independent lifetimes.
   const encryptedAccountAttemptedRef = useRef(false)
   const [sendingEmail, setSendingEmail] = useState(false)
+  // Presentation only: another tab completed this exact verification request.
+  const [emailConfirmedElsewhere, setEmailConfirmedElsewhere] = useState(false)
+  // The no-card path collects the password-loss acknowledgement before creation.
+  const [noCardAcknowledged, setNoCardAcknowledged] = useState(false)
   const backRef = useRef<() => void>(() => {})
   const [selectionGeneration, setSelectionGeneration] = useState(0)
   const [emailProofUnavailable, setEmailProofUnavailable] = useState(false)
@@ -1489,6 +1555,30 @@ function SignupJourney() {
   }, [])
 
   useEffect(() => {
+    if (!awaitingEmailProof) {
+      setEmailConfirmedElsewhere(false)
+      return
+    }
+    // Only the request this tab is still waiting on counts. Back retires it,
+    // resend replaces it, and an old link names a different request, so none
+    // of those can mark this attempt confirmed. The marker grants nothing.
+    const matchesCurrentRequest = (raw: string | null) => {
+      const marker = readEmailVerifiedMarker(raw)
+      return marker !== null && sentRequestRef.current !== null && marker.requestId === sentRequestRef.current
+    }
+    try {
+      if (matchesCurrentRequest(localStorage.getItem(EMAIL_VERIFIED_MARKER_KEY))) setEmailConfirmedElsewhere(true)
+    } catch {
+      // Storage is optional for this hint.
+    }
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === EMAIL_VERIFIED_MARKER_KEY && matchesCurrentRequest(event.newValue)) setEmailConfirmedElsewhere(true)
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [awaitingEmailProof])
+
+  useEffect(() => {
     if (!emailContinuationRef.current) {
       const params = new URLSearchParams(window.location.search)
       const token = params.get('email_verification_token') ?? params.get('token')
@@ -1542,6 +1632,8 @@ function SignupJourney() {
       // browser-profile storage. Other concurrently requested lineages remain.
       clearEmailProofContext(context.requestId)
       stripEmailVerificationTokenFromUrl()
+      // Tell the original waiting tab, if any, that this request is done.
+      publishEmailVerifiedMarker(context.requestId)
     })().catch(() => {
       if (!cancelled) setEmailProofError(continuation.hasProof()
         ? 'Your email was verified, but trial options could not be loaded. Retry, or request a new link if verification has expired.'
@@ -1561,6 +1653,7 @@ function SignupJourney() {
     setEmailProofBusy(true)
     const context = { ...previous, requestId: crypto.randomUUID(), expiresAt: Date.now() + 15 * 60_000 }
     sentRequestRef.current = context.requestId
+    setEmailConfirmedElsewhere(false)
     try {
       // Persist the non-secret lineage before sending: a lost acknowledgement
       // must not make a successfully delivered replacement link unusable.
@@ -1638,6 +1731,7 @@ function SignupJourney() {
     // This full-navigation continuation intentionally contains no password, and
     // is browser-profile scoped so the emailed link works from a new tab.
     sentRequestRef.current = requestId
+    setEmailConfirmedElsewhere(false)
     setSendingEmail(true)
     try {
       saveEmailProofContext(context)
@@ -1762,6 +1856,69 @@ function SignupJourney() {
     }
   }, [annualOffer, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
 
+  /**
+   * Starts the provider payment for a reserved paid claim. The caller owns
+   * `operationRef`/`provisioning` and its own error surface. The same expiry,
+   * mutation-marker and single-attempt rules apply on first start and on
+   * retry, so a failed start is always retried with the same claim, the same
+   * checkout token and the same recovery secret — never a second invoice.
+   */
+  const startAnnualPayment = useCallback(async (pending: PendingAnnualClaim) => {
+    if (pending.provider === 'none' || !annualOffer) throw new Error('Verify your email before selecting a payment method.')
+    // Only unattempted authority can be discarded. An expired token after a
+    // dispatched request may still own a payment with an unknown outcome.
+    if (!claimAttemptedRef.current && Date.parse(pending.activation.expiresAt) <= Date.now()) {
+      setPendingAnnualClaim(null)
+      setPlanView('cards')
+      setProvisionError('Your selected terms expired. Review the options and choose again before continuing.')
+      return
+    }
+    navigation.markMutation('payment')
+    claimAttemptedRef.current = true
+    const returnPath = pending.provider === 'stripe' ? '/signup' : '/signup/pending-payment'
+    const result = await startAnnualSignupPayment(pending.activation.checkoutIntentToken, pending.provider, new URL(returnPath, window.location.origin).toString(), annualOffer.offer.billingInterval)
+    if (pending.provider === 'stripe') {
+      if (result.clientSecret) {
+        trackCheckoutInitiated(annualOffer.offer, 'stripe')
+        setCardDisclosure(pending.activation.disclosure)
+        setClientSecret(result.clientSecret)
+      }
+      setPendingAnnualClaim(null)
+      setPlanView('payment')
+      return
+    }
+    if (!result.cryptoCheckoutUrl) {
+      throw new Error('Crypto checkout did not return a payment URL.')
+    }
+    const checkoutUrl = new URL(result.cryptoCheckoutUrl)
+    if (checkoutUrl.origin !== BTCPAY_CHECKOUT_ORIGIN || checkoutUrl.protocol !== 'https:') {
+      throw new Error('Crypto checkout returned an unexpected payment URL.')
+    }
+    if (result.cryptoInvoiceId) {
+      sessionStorage.setItem('silentsuite-pending-crypto-invoice', result.cryptoInvoiceId)
+    }
+    if (!result.cryptoInvoiceId || !result.cryptoInvoiceLookupToken) {
+      throw new Error('Crypto checkout did not return a complete payment session.')
+    }
+    const requestKey = useAuthStore.getState().pendingSignup?.paymentSessionRequestKey
+    if (!isUuid(requestKey)) throw new Error('Billing did not retain the payment recovery lineage.')
+    sessionStorage.setItem('silentsuite-pending-crypto-recovery-context', JSON.stringify({ email: recoveredSignupEmail, requestKey }))
+    if (returnTo) {
+      sessionStorage.setItem('silentsuite-pending-crypto-return-to', returnTo)
+    } else {
+      sessionStorage.removeItem('silentsuite-pending-crypto-return-to')
+    }
+    setCryptoPaymentSession({
+      disclosure: pending.activation.disclosure,
+      invoiceId: result.cryptoInvoiceId,
+      lookupToken: result.cryptoInvoiceLookupToken,
+      checkoutUrl: checkoutUrl.toString(),
+    })
+    setPendingAnnualClaim(null)
+    trackCheckoutInitiated(annualOffer.offer, 'btcpay')
+    setPlanView('crypto')
+  }, [annualOffer, navigation, recoveredSignupEmail, returnTo, startAnnualSignupPayment])
+
   const handleSelectPaid = useCallback(async () => {
     if (operationRef.current) return
     if (clientSecret) { setPlanView('payment'); return }
@@ -1779,6 +1936,7 @@ function SignupJourney() {
     operationRef.current = true
     setProvisionError(null)
     setProvisioning(true)
+    let claim: PendingAnnualClaim | null = null
     try {
       if (!annualOffer || !emailOwnershipToken || !recoveredSignupEmail) throw new Error('Verify your email before selecting a trial.')
       if (!isAnnualOfferProviderAvailable(annualOffer.offer, 'stripe')) throw new Error('Card checkout is not available for this annual offer.')
@@ -1792,21 +1950,24 @@ function SignupJourney() {
         provider: 'stripe',
         behavior: 'card_trial',
       })
-      setPendingAnnualClaim({ activation: authority, provider: 'stripe' })
-      setPlanView('confirm')
+      claim = { activation: authority, provider: 'stripe' }
+      setPendingAnnualClaim(claim)
+      // The card choice was made with price and charge timing visible; open
+      // the card form directly. Nothing is charged until it is confirmed there.
+      await startAnnualPayment(claim)
     } catch (err: unknown) {
       if (isRenewableAnnualOfferError(err)) {
         await renewAnnualOfferAndRequireConsent(annualOffer)
         return
       }
-      const message = err instanceof Error ? err.message : 'Failed to set up your account'
-      setProvisionError(message)
-      setPlanView('method')
+      setProvisionError(claim ? describePaymentStartError(err) : err instanceof Error ? err.message : 'Failed to set up your account')
+      // A reserved claim keeps its retry surface; a failed reservation returns to the methods.
+      setPlanView(claim ? 'confirm' : 'method')
     } finally {
       operationRef.current = false
       setProvisioning(false)
     }
-  }, [annualOffer, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
+  }, [annualOffer, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail, renewAnnualOfferAndRequireConsent, startAnnualPayment])
 
   const handleSelectCrypto = useCallback(async () => {
     if (operationRef.current) return
@@ -1825,6 +1986,7 @@ function SignupJourney() {
     operationRef.current = true
     setProvisionError(null)
     setProvisioning(true)
+    let claim: PendingAnnualClaim | null = null
     try {
       if (!annualOffer || !emailOwnershipToken || !recoveredSignupEmail) throw new Error('Verify your email before selecting a payment method.')
       if (!isAnnualOfferProviderAvailable(annualOffer.offer, 'btcpay', CRYPTO_CHECKOUT_ENABLED)) throw new Error('Bitcoin checkout is not available for this annual offer.')
@@ -1842,19 +2004,24 @@ function SignupJourney() {
         provider: 'btcpay',
         behavior: 'prepaid_bitcoin',
       })
-      setPendingAnnualClaim({ activation: authority, provider: 'btcpay' })
-      setPlanView('confirm')
+      claim = { activation: authority, provider: 'btcpay' }
+      setPendingAnnualClaim(claim)
+      // The Bitcoin choice was made with price, upfront payment and refund
+      // terms visible; create the invoice and show it. Paying is still the
+      // customer's own action against the displayed address.
+      await startAnnualPayment(claim)
     } catch (err: unknown) {
       if (isRenewableAnnualOfferError(err)) {
         await renewAnnualOfferAndRequireConsent(annualOffer)
         return
       }
-      setProvisionError(err instanceof Error ? err.message : 'Failed to start crypto checkout')
+      setProvisionError(claim ? describePaymentStartError(err) : err instanceof Error ? err.message : 'Failed to start crypto checkout')
+      if (claim) setPlanView('confirm')
     } finally {
       operationRef.current = false
       setProvisioning(false)
     }
-  }, [annualOffer, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail, renewAnnualOfferAndRequireConsent])
+  }, [annualOffer, clientSecret, cryptoPaymentSession, emailOwnershipToken, pendingAnnualClaim, recoveredSignupEmail, renewAnnualOfferAndRequireConsent, startAnnualPayment])
 
   const handleConfirmAnnualClaim = useCallback(async () => {
     const pending = pendingAnnualClaim
@@ -1871,9 +2038,10 @@ function SignupJourney() {
     setProvisioning(true)
     setProvisionError(null)
     try {
-      navigation.markMutation(pending.provider === 'none' ? 'setup' : 'payment')
-      claimAttemptedRef.current = true
       if (pending.provider === 'none') {
+        // Reached only through the ticked password-loss acknowledgement.
+        navigation.markMutation('setup')
+        claimAttemptedRef.current = true
         const data = formDataRef.current
         if (!data) throw new Error('Please enter your account details again.')
         const normalizedUrl = serverUrl.trim() ? normalizeServerUrl(serverUrl) : undefined
@@ -1881,66 +2049,22 @@ function SignupJourney() {
         await createEtebaseAccount(data.email, data.password, normalizedUrl)
         await provisionAnnualNoCard(pending.activation.checkoutIntentToken)
         setPendingAnnualClaim(null)
+        setNoCardAcknowledged(true)
         setStep('vault')
         return
       }
-      const returnPath = pending.provider === 'stripe' ? '/signup' : '/signup/pending-payment'
-      const result = await startAnnualSignupPayment(pending.activation.checkoutIntentToken, pending.provider, new URL(returnPath, window.location.origin).toString(), annualOffer.offer.billingInterval)
-      if (pending.provider === 'stripe') {
-        if (result.clientSecret) {
-          trackCheckoutInitiated(annualOffer.offer, 'stripe')
-          setCardDisclosure(pending.activation.disclosure)
-          setClientSecret(result.clientSecret)
-        }
-        setPendingAnnualClaim(null)
-        setPlanView('payment')
-        return
-      }
-      if (!result.cryptoCheckoutUrl) {
-        throw new Error('Crypto checkout did not return a payment URL.')
-      }
-      const checkoutUrl = new URL(result.cryptoCheckoutUrl)
-      if (checkoutUrl.origin !== BTCPAY_CHECKOUT_ORIGIN || checkoutUrl.protocol !== 'https:') {
-        throw new Error('Crypto checkout returned an unexpected payment URL.')
-      }
-      if (result.cryptoInvoiceId) {
-        sessionStorage.setItem('silentsuite-pending-crypto-invoice', result.cryptoInvoiceId)
-      }
-      if (!result.cryptoInvoiceId || !result.cryptoInvoiceLookupToken) {
-        throw new Error('Crypto checkout did not return a complete payment session.')
-      }
-      const requestKey = useAuthStore.getState().pendingSignup?.paymentSessionRequestKey
-      if (!isUuid(requestKey)) throw new Error('Billing did not retain the payment recovery lineage.')
-      sessionStorage.setItem('silentsuite-pending-crypto-recovery-context', JSON.stringify({ email: recoveredSignupEmail, requestKey }))
-      if (returnTo) {
-        sessionStorage.setItem('silentsuite-pending-crypto-return-to', returnTo)
-      } else {
-        sessionStorage.removeItem('silentsuite-pending-crypto-return-to')
-      }
-      setCryptoPaymentSession({
-        disclosure: pending.activation.disclosure,
-        invoiceId: result.cryptoInvoiceId,
-        lookupToken: result.cryptoInvoiceLookupToken,
-        checkoutUrl: checkoutUrl.toString(),
-      })
-      setPendingAnnualClaim(null)
-      trackCheckoutInitiated(annualOffer.offer, 'btcpay')
-      setPlanView('crypto')
+      await startAnnualPayment(pending)
     } catch (err: unknown) {
       if (isRenewableAnnualOfferError(err)) {
         await renewAnnualOfferAndRequireConsent(annualOffer)
         return
       }
-      const message = err instanceof BillingResponseError
-        && err.billingProblemType === 'https://api.silentsuite.io/errors/provider-unavailable'
-        ? 'Payment creation is not yet confirmed. Retry this same payment, or recover its status. Do not start another payment.'
-        : err instanceof Error ? err.message : 'Failed to start crypto checkout'
-      setProvisionError(message)
+      setProvisionError(describePaymentStartError(err))
     } finally {
       operationRef.current = false
       setProvisioning(false)
     }
-  }, [annualOffer, createEtebaseAccount, navigation, pendingAnnualClaim, provisionAnnualNoCard, recoveredSignupEmail, renewAnnualOfferAndRequireConsent, returnTo, serverUrl, startAnnualSignupPayment])
+  }, [annualOffer, createEtebaseAccount, navigation, pendingAnnualClaim, provisionAnnualNoCard, renewAnnualOfferAndRequireConsent, serverUrl, startAnnualPayment])
 
   const handleCancelSelection = useCallback(async () => {
     const pending = pendingAnnualClaim
@@ -2024,6 +2148,7 @@ function SignupJourney() {
     setSendingEmail(false)
     emailContinuationRef.current = null
     setAwaitingEmailProof(false)
+    setEmailConfirmedElsewhere(false)
     setEmailProofError(null)
     navigation.clear()
   }
@@ -2183,7 +2308,11 @@ function SignupJourney() {
               onRememberDeviceChange={setRememberDevice}
             />}
             {(sendingEmail || awaitingEmailProof) && <section aria-label="Email verification" className="flex flex-col items-center justify-center gap-5 py-8 text-center">
-              <p role="status" className="text-sm text-[rgb(var(--muted))]">{sendingEmail ? 'Sending verification email...' : 'Check your email and open the verification link in this browser. Then choose your password.'}</p>
+              <p role="status" className="text-sm text-[rgb(var(--muted))]">{sendingEmail
+                ? 'Sending verification email...'
+                : emailConfirmedElsewhere
+                  ? 'Email confirmed. Continue in the other tab. This tab is safe to close.'
+                  : 'Check your email and open the verification link in this browser. Then choose your password.'}</p>
               <Button variant="outline" onClick={handleEmailBack}>Back</Button>
             </section>}
           </>
@@ -2246,7 +2375,7 @@ function SignupJourney() {
         )}
         {step === 'vault' && (
           <>
-            <StepCreateVault email={email} onComplete={handleVaultComplete} />
+            <StepCreateVault email={email} onComplete={handleVaultComplete} acknowledged={noCardAcknowledged} />
             {showReturnFallback && returnTo && (
               <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-[rgb(var(--foreground))]">
                 <p className="font-medium">Browser did not reopen the Android app automatically.</p>

--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -1516,6 +1516,7 @@ function SignupJourney() {
 
   const navigation = useSignupNavigation({
     enabled: !usingSelfHostedServer && (!!emailOwnershipToken || awaitingEmailProof || sendingEmail) && step !== 'vault',
+    warnOnLeave: !(awaitingEmailProof && emailConfirmedElsewhere),
     step,
     view: awaitingEmailProof ? 'sent' : sendingEmail ? 'sending' : planView,
     intercept: () => {

--- a/apps/web/app/(auth)/signup/use-signup-navigation.ts
+++ b/apps/web/app/(auth)/signup/use-signup-navigation.ts
@@ -7,8 +7,9 @@ type Recovery = 'review' | 'setup' | 'payment'
 const KEY = 'silentsuiteSignup'
 
 /** History contains presentation state only, never proof, password or payment capabilities. */
-export function useSignupNavigation({ enabled, step, view, restore, intercept }: {
+export function useSignupNavigation({ enabled, warnOnLeave = true, step, view, restore, intercept }: {
   enabled: boolean
+  warnOnLeave?: boolean
   step: string
   view: string
   intercept?: () => boolean
@@ -63,12 +64,12 @@ export function useSignupNavigation({ enabled, step, view, restore, intercept }:
     }
     const onLeave = (event: BeforeUnloadEvent) => { event.preventDefault(); event.returnValue = '' }
     window.addEventListener('popstate', onPop)
-    window.addEventListener('beforeunload', onLeave)
+    if (warnOnLeave) window.addEventListener('beforeunload', onLeave)
     return () => {
       window.removeEventListener('popstate', onPop)
       window.removeEventListener('beforeunload', onLeave)
     }
-  }, [enabled, recovery])
+  }, [enabled, recovery, warnOnLeave])
 
   const markMutation = (next: 'setup' | 'payment') => {
     try {

--- a/apps/web/app/stores/__tests__/signup-billing-session.test.ts
+++ b/apps/web/app/stores/__tests__/signup-billing-session.test.ts
@@ -165,7 +165,11 @@ describe('signup Billing session boundary', () => {
     const choose = async () => {
       fireEvent.click(await screen.findByRole('button', { name: /7 day free trial/i }))
       fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-      fireEvent.click(await screen.findByRole('button', { name: /create account and start free trial/i }))
+      // No review screen: the password-loss acknowledgement gates the only creation step.
+      const action = await screen.findByRole('button', { name: /continue to your workspace/i })
+      expect(action).toBeDisabled()
+      fireEvent.click(screen.getByRole('checkbox', { name: /cannot recover my password/i }))
+      fireEvent.click(action)
     }
     await choose()
     expect(await screen.findByRole('alert')).toHaveTextContent('Identity proof unavailable')
@@ -481,8 +485,7 @@ it.each(['lost response', 'inline Bitcoin', 'storage failure'] as const)('retain
   await waitFor(() => expect(next).toBeEnabled())
   fireEvent.click(next)
   fireEvent.click(await screen.findByRole('button', { name: /^continue$/i }))
-  fireEvent.click(await screen.findByRole('button', { name: /with bitcoin for/i }))
-  const confirm = await screen.findByRole('button', { name: /confirm annual terms and continue|continue to bitcoin payment/i })
+  const bitcoin = await screen.findByRole('button', { name: /with bitcoin for/i })
   expect(sessionStorage.getItem(key)).toBeNull()
   const originalWrite = Storage.prototype.setItem
   const write = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (this: Storage, name, value) {
@@ -490,7 +493,7 @@ it.each(['lost response', 'inline Bitcoin', 'storage failure'] as const)('retain
     return originalWrite.call(this, name, value)
   })
   try {
-    fireEvent.click(confirm)
+    fireEvent.click(bitcoin)
     if (scenario === 'inline Bitcoin') await screen.findByText('bc1-fixture')
     else await screen.findByText('Start response lost')
     expect(started).toBeDefined()

--- a/apps/web/signup-plan-selected-contract.test.mjs
+++ b/apps/web/signup-plan-selected-contract.test.mjs
@@ -7,7 +7,11 @@ function body(start, end) { return source.slice(source.indexOf(start), source.in
 
 test('annual Plan Selected is recorded before the chosen payment checkout starts', () => {
   assert.match(body('const handleSelectCard', 'const handleSelectBitcoin'), /trackPlanSelected\(annualOfferDetails\)/)
-  assert.match(body('const handleConfirmAnnualClaim', 'const handlePlanBack'), /trackCheckoutInitiated\(annualOffer\.offer, 'stripe'\)/)
-  assert.match(body('const handleConfirmAnnualClaim', 'const handlePlanBack'), /trackCheckoutInitiated\(annualOffer\.offer, 'btcpay'\)/)
+  // Checkout Initiated is recorded by the shared payment starter, which runs
+  // after the method click (Plan Selected) and after Billing activation.
+  assert.match(body('const startAnnualPayment', 'const handleSelectPaid'), /trackCheckoutInitiated\(annualOffer\.offer, 'stripe'\)/)
+  assert.match(body('const startAnnualPayment', 'const handleSelectPaid'), /trackCheckoutInitiated\(annualOffer\.offer, 'btcpay'\)/)
+  assert.match(body('const handleSelectPaid', 'const handleSelectCrypto'), /await startAnnualPayment\(claim\)/)
+  assert.match(body('const handleSelectCrypto', 'const handleConfirmAnnualClaim'), /await startAnnualPayment\(claim\)/)
   assert.doesNotMatch(source, /trackPlanSelected\('monthly'\)/)
 })

--- a/scripts/check-annual-billing-v2-contract.mjs
+++ b/scripts/check-annual-billing-v2-contract.mjs
@@ -14,6 +14,7 @@ const CLIENT_FILE = 'apps/web/app/lib/billing-v2.ts'
 const AUTH_STORE_FILE = 'apps/web/app/stores/use-auth-store.ts'
 const PAYMENT_PANEL_FILE = 'apps/web/app/components/payment-choice-panel.tsx'
 const SIGNUP_PAGE_FILE = 'apps/web/app/(auth)/signup/page.tsx'
+const SIGNUP_TERMS_FILE = 'apps/web/app/(auth)/signup/components/annual-confirmation-summary.tsx'
 const PENDING_PAYMENT_FILE = 'apps/web/app/(auth)/signup/pending-payment/page.tsx'
 const OFFER_PRESENTATION_FILE = 'apps/web/app/lib/annual-offer-presentation.ts'
 const PUBLIC_ANALYTICS_FILE = 'apps/web/app/lib/public-analytics.ts'
@@ -182,8 +183,32 @@ export function checkAnnualBillingV2Contract(root = process.cwd()) {
   const presentation = readFileSync(resolve(root, OFFER_PRESENTATION_FILE), 'utf8')
   const analytics = readFileSync(resolve(root, PUBLIC_ANALYTICS_FILE), 'utf8')
   for (const source of [signup, paymentPanel]) {
-    assert(source.includes('annualOfferPlanLabel') && source.includes('annualOfferAnnualLabel') && source.includes('annualOfferRenewalCopy'), 'Public annual UI must derive class, amount, and renewal copy from the canonical offer')
+    assert(source.includes('annualOfferPlanLabel') && source.includes('annualOfferAnnualLabel'), 'Public annual UI must derive class and amount from the canonical offer')
     assert(source.includes("isAnnualOfferProviderAvailable") && source.includes("'stripe'") && source.includes("'btcpay'"), 'Public annual UI must gate Stripe and BTCPay with canonical offer providers')
+  }
+  assert(paymentPanel.includes('annualOfferRenewalCopy'), 'Authenticated annual UI must derive renewal copy from the canonical offer')
+  // Signup now puts validated disclosure terms beside the form/QR, rather than
+  // repeating offer-only annual wording on the initial trial-choice screen.
+  const signupTree = ts.createSourceFile('signup.tsx', signup, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const termsTree = ts.createSourceFile('terms.tsx', functionBlock(readFileSync(resolve(root, SIGNUP_TERMS_FILE), 'utf8'), 'AnnualTermsSummary'), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX)
+  const suppliedDisclosures = new Set()
+  const readDisclosureFields = new Set()
+  const visitSignup = (node) => {
+    if (ts.isJsxSelfClosingElement(node) && node.tagName.getText(signupTree) === 'AnnualTermsSummary') {
+      const attribute = node.attributes.properties.find((item) => ts.isJsxAttribute(item) && item.name.getText(signupTree) === 'disclosure')
+      if (attribute?.initializer && ts.isJsxExpression(attribute.initializer) && attribute.initializer.expression) suppliedDisclosures.add(attribute.initializer.expression.getText(signupTree))
+    }
+    ts.forEachChild(node, visitSignup)
+  }
+  const visitTerms = (node) => {
+    if (ts.isPropertyAccessExpression(node) && node.expression.getText(termsTree) === 'disclosure') readDisclosureFields.add(node.name.text)
+    ts.forEachChild(node, visitTerms)
+  }
+  visitSignup(signupTree)
+  visitTerms(termsTree)
+  assert(suppliedDisclosures.has('disclosure') && suppliedDisclosures.has('cardDisclosure'), 'Signup terms must render the validated disclosure for card and Bitcoin')
+  for (const field of ['kind', 'firstChargeAmountMinor', 'firstChargeAt', 'autoRenew', 'renewalAmountMinor', 'refundWindowDays']) {
+    assert(readDisclosureFields.has(field), `Signup terms must derive ${field} from the validated disclosure`)
   }
   assert(signup.includes('annualOffer={annualOffer}'), 'Signup must pass the signed annual offer through StepChoosePlan')
   checkPendingPaymentRecovery(pendingPayment)

--- a/scripts/check-annual-billing-v2-contract.test.mjs
+++ b/scripts/check-annual-billing-v2-contract.test.mjs
@@ -6,6 +6,8 @@ import { dirname, join } from 'node:path'
 import { checkAnnualBillingV2Contract } from './check-annual-billing-v2-contract.mjs'
 
 const pendingPath = 'apps/web/app/(auth)/signup/pending-payment/page.tsx'
+const signupPath = 'apps/web/app/(auth)/signup/page.tsx'
+const termsPath = 'apps/web/app/(auth)/signup/components/annual-confirmation-summary.tsx'
 const files = [
   'contracts/annual-only-billing-v2.schema.sha256',
   'contracts/annual-only-billing-v2.schema.json',
@@ -13,20 +15,18 @@ const files = [
   'apps/web/app/stores/use-auth-store.ts',
   'apps/web/app/components/payment-choice-panel.tsx',
   'apps/web/app/(auth)/signup/page.tsx',
+  termsPath,
   pendingPath,
   'apps/web/app/lib/annual-offer-presentation.ts',
   'apps/web/app/lib/public-analytics.ts',
 ]
 
-function withPendingMutation(from, to, check) {
+function withSourceMutation(path, mutate, check) {
   const root = mkdtempSync(join(tmpdir(), 'annual-contract-'))
   try {
     for (const file of files) {
       let source = readFileSync(file, 'utf8')
-      if (file === pendingPath) {
-        assert.ok(source.includes(from), 'mutation must change actual source')
-        source = source.replace(from, to)
-      }
+      if (file === path) source = mutate(source)
       mkdirSync(dirname(join(root, file)), { recursive: true })
       writeFileSync(join(root, file), source)
     }
@@ -34,9 +34,36 @@ function withPendingMutation(from, to, check) {
   } finally { rmSync(root, { recursive: true, force: true }) }
 }
 
+function withPendingMutation(from, to, check) {
+  withSourceMutation(pendingPath, (source) => {
+    assert.ok(source.includes(from), 'mutation must change actual source')
+    return source.replace(from, to)
+  }, check)
+}
+
 test('the public annual client, persistence, and authenticated UI stay compatible with the pinned closed v2 wire contract', () => {
   assert.doesNotThrow(() => checkAnnualBillingV2Contract())
 })
+
+for (const field of ['kind', 'firstChargeAmountMinor', 'firstChargeAt', 'autoRenew', 'renewalAmountMinor', 'refundWindowDays']) {
+  test(`rejects signup terms that replace disclosure ${field} with fixed copy`, () => {
+    withSourceMutation(termsPath, (source) => {
+      const from = `disclosure.${field}`
+      assert.ok(source.includes(from))
+      return source.replaceAll(from, 'null') + `\n// ${from}\n`
+    }, (root) => assert.throws(() => checkAnnualBillingV2Contract(root), /Signup terms must derive/))
+  })
+}
+
+for (const disclosure of ['disclosure', 'cardDisclosure']) {
+  test(`rejects removing the rendered ${disclosure} terms even with a source comment`, () => {
+    withSourceMutation(signupPath, (source) => {
+      const from = `<AnnualTermsSummary disclosure={${disclosure}} />`
+      assert.ok(source.includes(from))
+      return source.replaceAll(from, '<span />') + `\n// ${from}\n`
+    }, (root) => assert.throws(() => checkAnnualBillingV2Contract(root), /Signup terms must render/))
+  })
+}
 
 const mutations = [
   ['generic closed releases authority', "setState('unknown')", "useAuthStore.getState().clearPendingSignupPaymentRecovery(recovery); setState('unknown')"],


### PR DESCRIPTION
## Summary
- Update the original email tab after successful verification in another tab, scoped to the current verification request.
- Present 7-day and 30-day trial choices without annual pricing on the initial choice screen.
- Take the no-card trial directly to the password-loss acknowledgement before account creation, without asking twice.
- Open the Stripe form or Bitcoin QR/address directly after payment-method selection, retaining concise price and charge/renewal terms.
- Simplify payment-method copy and show Monero only as a disabled coming-soon placeholder.
- Preserve existing payment recovery, duplicate-attempt protections and self-hosted signup.

## Verification
- Web tests: 1,191 passed, 4 skipped across 81 files.
- Web type-check, lint and build passed. Build retains a trace-copy ENOENT warning for the root app client-reference manifest; this is not packaged runtime acceptance.
- Billing-copy checks: 14 tests passed; plan-selection contract passed.
- Added request-scoped cross-tab confirmation and acknowledgement-before-creation regressions; updated direct-payment/history/recovery tests.
- The confirmed waiting tab no longer registers an unnecessary leave-page warning; active signup/payment tabs retain it.
- Annual public handshake and mutation-negative checks passed after updating the obsolete terms-location guard.
- Exact-head review gate and CI passed for `c709d88108eb36c0c55e3353dc6c93c95765fc18`.
- Trusted preview run 34387840234 succeeded. Served signup page/layout JavaScript and both loaded CSS files match artifact 10118577557 byte-for-byte.

## Remaining gates
- Real email cross-tab, account creation, fresh login and Stripe/Bitcoin acceptance remain unverified on this candidate. Limited fixture browser smoke is not live signup/payment acceptance.
- Preview deployment-identity returns 503 with an empty image revision label; matching static assets establish frontend artifact equality, not complete server identity.
- Low-priority follow-up: add an individual Bitcoin-panel deletion mutation to the source guard; the current implementation displays the terms correctly.
- No production deployment is included or authorized by this PR.
