### PR TITLE
fix(android): stop dashboard startup recovery loop

### DIFF
--- a/android/app/src/androidTest/java/io/silentsuite/sync/ui/PostLoginSetupRuntimeTest.kt
+++ b/android/app/src/androidTest/java/io/silentsuite/sync/ui/PostLoginSetupRuntimeTest.kt
@@ -250,6 +250,16 @@ class PostLoginSetupRuntimeTest {
         val previousPermissionRequestOverride = AccountActivity.permissionRequestOverride
         var dashboardPermissionRequests = 0
         var scenario: ActivityScenario<AccountActivity>?=null
+        val registryPreferences = context.getSharedPreferences(
+            "account_creation_registry", android.content.Context.MODE_PRIVATE,
+        )
+        val previousRegistry = registryPreferences.getString("rows", null)
+        fun restoreRegistry() {
+            val editor = registryPreferences.edit()
+            if (previousRegistry == null) editor.remove("rows") else editor.putString("rows", previousRegistry)
+            check(editor.commit())
+        }
+        var dashboardMonitor: android.app.Instrumentation.ActivityMonitor? = null
         try {
             check(
                 notificationPreferences.edit()
@@ -295,7 +305,84 @@ class PostLoginSetupRuntimeTest {
             assertEquals(target.name, exactDashboard.title.toString())
             assertEquals(1, dashboardPermissionRequests)
             org.junit.Assert.assertTrue(exactDashboard.findViewById<android.view.View>(R.id.drawer_layout).isShown)
+
+            // A real production bootstrap failure must not cycle back to the dashboard.
+            // Block unexpected dashboard launches so the broken version fails boundedly.
+            instrumentation.runOnMainSync { exactDashboard.finish() }
+            check(registryPreferences.edit().putString("rows", "invalid-registry").commit())
+            App.postLoginBootstrapSucceeded = io.silentsuite.sync.ui.setup.PostLoginSetupMigration.bootstrap(context)
+            org.junit.Assert.assertFalse(App.postLoginBootstrapSucceeded)
+            dashboardMonitor = instrumentation.addMonitor(AccountActivity::class.java.name, null, true)
+            ActivityScenario.launch<PostLoginSetupActivity>(
+                PostLoginSetupActivity.newIntent(context, target, "target-generation"),
+            ).use { recovery ->
+                repeat(2) {
+                    recovery.onActivity { activity ->
+                        assertEquals(
+                            activity.getString(R.string.post_login_bootstrap_failed_title),
+                            activity.findViewById<android.widget.TextView>(R.id.setup_title).text.toString(),
+                        )
+                        org.junit.Assert.assertTrue(activity.findViewById<android.widget.Button>(R.id.setup_retry_inventory).isShown)
+                        org.junit.Assert.assertFalse(activity.findViewById<android.widget.Button>(R.id.setup_remove_incomplete).isShown)
+                        org.junit.Assert.assertFalse(activity.findViewById<android.widget.Button>(R.id.setup_done).isShown)
+                        org.junit.Assert.assertFalse(activity.findViewById<View>(R.id.setup_stepper).isShown)
+                    }
+                    recovery.recreate()
+                }
+                assertEquals(0, requireNotNull(dashboardMonitor).hits)
+                recovery.onActivity { activity ->
+                    activity.findViewById<android.widget.Button>(R.id.setup_retry_inventory).performClick()
+                }
+                val failureDeadline = android.os.SystemClock.uptimeMillis() + 5_000
+                var retryFinished = false
+                while (!retryFinished && android.os.SystemClock.uptimeMillis() < failureDeadline) {
+                    recovery.onActivity { activity ->
+                        retryFinished = activity.findViewById<android.widget.Button>(R.id.setup_retry_inventory).isEnabled
+                    }
+                    if (!retryFinished) android.os.SystemClock.sleep(25)
+                }
+                org.junit.Assert.assertTrue("Failed startup retry did not settle", retryFinished)
+                org.junit.Assert.assertFalse(App.postLoginBootstrapSucceeded)
+                assertEquals(0, requireNotNull(dashboardMonitor).hits)
+                assertEquals(PostLoginSetupState.COMPLETE, AccountSettings.setupState(manager, target, true))
+                assertEquals(PostLoginSetupState.COMPLETE, AccountSettings.setupState(manager, sibling, true))
+                assertEquals("target-generation", manager.getUserData(target, AccountSettings.KEY_CREATION_ID))
+                assertEquals("sibling-generation", manager.getUserData(sibling, AccountSettings.KEY_CREATION_ID))
+                assertEquals(target, ActiveAccountManager.getActiveAccount(context))
+
+                // Remove only the injected fixture fault. Retry must execute the real
+                // bootstrap and return to the exact dashboard without resetting setup.
+                restoreRegistry()
+                instrumentation.removeMonitor(requireNotNull(dashboardMonitor))
+                dashboardMonitor = null
+                recovery.onActivity { activity ->
+                    activity.findViewById<android.widget.Button>(R.id.setup_retry_inventory).performClick()
+                }
+                val recoveryDeadline = android.os.SystemClock.uptimeMillis() + 5_000
+                var recoveredDashboard: AccountActivity? = null
+                while (recoveredDashboard == null && android.os.SystemClock.uptimeMillis() < recoveryDeadline) {
+                    instrumentation.runOnMainSync {
+                        recoveredDashboard = ActivityLifecycleMonitorRegistry.getInstance()
+                            .getActivitiesInStage(Stage.RESUMED)
+                            .filterIsInstance<AccountActivity>()
+                            .singleOrNull()
+                            ?.takeIf { it.title.toString() == target.name }
+                    }
+                    if (recoveredDashboard == null) android.os.SystemClock.sleep(25)
+                }
+                org.junit.Assert.assertTrue(App.postLoginBootstrapSucceeded)
+                instrumentation.runOnMainSync {
+                    val recovered = requireNotNull(recoveredDashboard) { "Startup retry did not restore the exact dashboard" }
+                    org.junit.Assert.assertTrue(recovered.findViewById<View>(R.id.drawer_layout).isShown)
+                    recovered.finish()
+                }
+                assertEquals(PostLoginSetupState.COMPLETE, AccountSettings.setupState(manager, target, true))
+                assertEquals(PostLoginSetupState.COMPLETE, AccountSettings.setupState(manager, sibling, true))
+                assertEquals(target, ActiveAccountManager.getActiveAccount(context))
+            }
         } finally {
+            dashboardMonitor?.let(instrumentation::removeMonitor)
+            restoreRegistry()
             runCatching { scenario?.close() }
             AccountActivity.permissionRequestOverride = previousPermissionRequestOverride
             AccountActivity.AccountInfoViewModel.accountLoaderOverride = null

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupActivity.kt
@@ -157,6 +157,7 @@ class PostLoginSetupActivity : BaseActivity() {
             resumeSetupWork()
         }
         model.bootstrapRunning.observe(this) {
+            // Emits only for an explicit startup retry (start/finish), never on plain launch.
             // A successful retry may have reconciled a row/registry that was unreadable
             // during onCreate. Refresh its retained work owner before resuming effects.
             if (App.postLoginBootstrapSucceeded) initializeOwnedWork()

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupActivity.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupActivity.kt
@@ -95,24 +95,7 @@ class PostLoginSetupActivity : BaseActivity() {
             return
         }
 
-        val creationId = accountCreationId
-        if (creationId != null) {
-            val record = registry().get(account.type, account.name)
-            val ownsRecovery = AccountCreationRegistry.owns(record, creationId)
-            val rowExists = account in accountManager.getAccountsByType(App.accountType)
-            val durableState = state()
-            when {
-                !rowExists && ownsRecovery ->
-                    model.initializeRecovery(account, creationId)
-                rowExists &&
-                    (durableState == PostLoginSetupState.CREATING ||
-                        durableState == PostLoginSetupState.RECOVERY_REQUIRED) &&
-                    ownsRecovery ->
-                    model.initializeRecovery(account, creationId)
-                exactAccount() != null && (record == null || ownsRecovery) ->
-                    model.initialize(account)
-            }
-        }
+        initializeOwnedWork()
 
         setContentView(R.layout.activity_post_login_setup)
         applySetupActionBarInsets(findViewById(R.id.setup_action_bar))
@@ -148,6 +131,13 @@ class PostLoginSetupActivity : BaseActivity() {
             submit(PostLoginSetupOrchestrator.UserDecision.REMOVE_INCOMPLETE)
         }
         findViewById<Button>(R.id.setup_retry_inventory).setOnClickListener {
+            if (!App.postLoginBootstrapSucceeded) {
+                val creationId = accountCreationId ?: return@setOnClickListener
+                if (exactAccount() == null) return@setOnClickListener
+                model.clearUserDecision()
+                model.retryBootstrap(account, creationId)
+                return@setOnClickListener
+            }
             if (
                 SetupContinuationPolicy.permits(
                     state(),
@@ -166,6 +156,13 @@ class PostLoginSetupActivity : BaseActivity() {
             render()
             resumeSetupWork()
         }
+        model.bootstrapRunning.observe(this) {
+            // A successful retry may have reconciled a row/registry that was unreadable
+            // during onCreate. Refresh its retained work owner before resuming effects.
+            if (App.postLoginBootstrapSucceeded) initializeOwnedWork()
+            render()
+            resumeSetupWork()
+        }
         model.recoveryRemoval.observe(this) { removal ->
             render()
             if (
@@ -177,6 +174,25 @@ class PostLoginSetupActivity : BaseActivity() {
             }
         }
         render()
+    }
+
+    private fun initializeOwnedWork() {
+        val creationId = accountCreationId ?: return
+        val record = registry().get(account.type, account.name)
+        val ownsRecovery = AccountCreationRegistry.owns(record, creationId)
+        val rowExists = account in accountManager.getAccountsByType(App.accountType)
+        val durableState = state()
+        when {
+            !rowExists && ownsRecovery ->
+                model.initializeRecovery(account, creationId)
+            rowExists &&
+                (durableState == PostLoginSetupState.CREATING ||
+                    durableState == PostLoginSetupState.RECOVERY_REQUIRED) &&
+                ownsRecovery ->
+                model.initializeRecovery(account, creationId)
+            exactAccount() != null && (record == null || ownsRecovery) ->
+                model.initialize(account)
+        }
     }
 
     override fun onResume() {
@@ -210,10 +226,11 @@ class PostLoginSetupActivity : BaseActivity() {
         return PostLoginSetupOrchestrator.Input(
             state = state(),
             ownership = ownership,
+            bootstrapSucceeded = App.postLoginBootstrapSucceeded,
             syncConfiguration = model.syncConfigurationOutcome(),
             inventory = model.inventoryOutcome,
             userDecision = model.pendingUserDecision(),
-            permissions = if (ownership == PostLoginSetupOrchestrator.Ownership.EXACT) {
+            permissions = if (App.postLoginBootstrapSucceeded && ownership == PostLoginSetupOrchestrator.Ownership.EXACT) {
                 permissionEvidence()
             } else {
                 emptyMap()
@@ -288,6 +305,7 @@ class PostLoginSetupActivity : BaseActivity() {
                 model.inventoryAndCreate(applicationContext, account, accountCreationId)
                 false
             }
+            PostLoginSetupOrchestrator.Decision.ShowBootstrapFailure,
             PostLoginSetupOrchestrator.Decision.WaitForInventory,
             PostLoginSetupOrchestrator.Decision.ShowInventoryRecovery,
             PostLoginSetupOrchestrator.Decision.AwaitIntegrationDecision,
@@ -591,6 +609,15 @@ class PostLoginSetupActivity : BaseActivity() {
     }
 
     private fun render() {
+        if (!App.postLoginBootstrapSucceeded) {
+            renderBootstrapFailure()
+            return
+        }
+        findViewById<View>(R.id.setup_stepper).visibility = View.VISIBLE
+        findViewById<Button>(R.id.setup_retry_inventory).apply {
+            setText(R.string.post_login_setup_retry_inventory)
+            isEnabled = true
+        }
         val current = state()
         val permissions =
             if (::accountManager.isInitialized && ownership() ==
@@ -695,6 +722,29 @@ class PostLoginSetupActivity : BaseActivity() {
         )
         findViewById<View>(R.id.setup_action_bar).visibility =
             visible(actionButtons.any { it.visibility == View.VISIBLE })
+    }
+
+    /** Startup failure is not incomplete-account recovery: never offer account removal. */
+    private fun renderBootstrapFailure() {
+        findViewById<TextView>(R.id.setup_title).setText(R.string.post_login_bootstrap_failed_title)
+        findViewById<TextView>(R.id.setup_body).setText(R.string.post_login_bootstrap_failed_body)
+        listOf(
+            R.id.setup_stepper,
+            R.id.setup_integration_details,
+            R.id.setup_status,
+            R.id.setup_done,
+            R.id.setup_continue_limited,
+            R.id.setup_skip_integrations,
+            R.id.setup_remove_incomplete,
+        ).forEach { findViewById<View>(it).visibility = View.GONE }
+        val exact = exactAccount() != null
+        findViewById<Button>(R.id.setup_retry_inventory).apply {
+            setText(R.string.retry)
+            visibility = visible(exact)
+            isEnabled = model.bootstrapRunning.value != true
+        }
+        findViewById<View>(R.id.setup_resolve_ambiguity).visibility = visible(!exact)
+        findViewById<View>(R.id.setup_action_bar).visibility = View.VISIBLE
     }
 
     private fun applySetupActionBarInsets(actionBar: View) =

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupOrchestrator.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupOrchestrator.kt
@@ -58,6 +58,7 @@ object PostLoginSetupOrchestrator {
     data class Input(
         val state: PostLoginSetupState,
         val ownership: Ownership,
+        val bootstrapSucceeded: Boolean,
         val syncConfiguration: SyncConfigurationOutcome = SyncConfigurationOutcome.NOT_STARTED,
         val inventory: InventoryOutcome = InventoryOutcome.NOT_STARTED,
         val userDecision: UserDecision = UserDecision.NONE,
@@ -66,6 +67,7 @@ object PostLoginSetupOrchestrator {
     )
 
     sealed class Decision {
+        object ShowBootstrapFailure : Decision()
         object RequireRecovery : Decision()
         object ConfigureAndroidSync : Decision()
         object ShowSyncConfigurationFailure : Decision()
@@ -93,6 +95,9 @@ object PostLoginSetupOrchestrator {
     }
 
     fun decide(input: Input): Decision {
+        // A saved COMPLETE row does not prove that this process finished startup.
+        // Withhold even cleanup effects until ownership reconciliation has succeeded.
+        if (!input.bootstrapSucceeded) return Decision.ShowBootstrapFailure
         when (input.ownership) {
             Ownership.MISSING_GENERATION,
             Ownership.GENERATION_MISMATCH -> return Decision.ResolveInAndroidSettings

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupViewModel.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupViewModel.kt
@@ -12,6 +12,7 @@ import com.etebase.client.CollectionAccessLevel
 import com.etebase.client.FetchOptions
 import com.etebase.client.ItemMetadata
 import io.silentsuite.sync.AccountSettings
+import io.silentsuite.sync.App
 import io.silentsuite.sync.Constants
 import io.silentsuite.sync.EtebaseLocalCache
 import io.silentsuite.sync.HttpClient
@@ -54,6 +55,7 @@ class PostLoginSetupViewModel(application: Application) : AndroidViewModel(appli
     }
 
     val collections = MutableLiveData<CollectionsResult>()
+    val bootstrapRunning = MutableLiveData(false)
     val recoveryRemoval = MutableLiveData<RecoveryRemovalCoordinator.State>()
     private var initializedAccount: Account? = null
     private var started = false
@@ -92,6 +94,34 @@ class PostLoginSetupViewModel(application: Application) : AndroidViewModel(appli
         if (initializedAccount == account) return
         check(initializedAccount == null) { "PostLoginSetupViewModel cannot be reused for another account" }
         initializedAccount = account
+    }
+
+    /** Explicit, single-flight startup retry retained across Activity recreation. */
+    fun retryBootstrap(account: Account, creationId: String) {
+        if (bootstrapRunning.value == true) return
+        val context = getApplication<Application>().applicationContext
+        val manager = AccountManager.get(context)
+        if (ExactAccountRouting.validate(account, creationId, App.accountType, manager) == null) return
+        bootstrapRunning.value = true
+        viewModelScope.launch {
+            try {
+                val succeeded = withContext(Dispatchers.IO) {
+                    if (ExactAccountRouting.validate(account, creationId, App.accountType, manager) == null) {
+                        false
+                    } else {
+                        PostLoginSetupMigration.bootstrap(context)
+                    }
+                }
+                App.postLoginBootstrapSucceeded = succeeded
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (_: Exception) {
+                // Startup diagnostics must not expose account or session exception details.
+                App.postLoginBootstrapSucceeded = false
+            } finally {
+                bootstrapRunning.value = false
+            }
+        }
     }
 
     /** Retained application-context owner; no Activity is retained by platform callbacks. */

--- a/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupViewModel.kt
+++ b/android/app/src/main/java/io/silentsuite/sync/ui/setup/PostLoginSetupViewModel.kt
@@ -55,7 +55,11 @@ class PostLoginSetupViewModel(application: Application) : AndroidViewModel(appli
     }
 
     val collections = MutableLiveData<CollectionsResult>()
-    val bootstrapRunning = MutableLiveData(false)
+    /**
+     * Deliberately unset until an explicit startup retry begins: a seeded value would dispatch at
+     * STARTED and add a second drain to every ordinary launch before the onResume drain.
+     */
+    val bootstrapRunning = MutableLiveData<Boolean>()
     val recoveryRemoval = MutableLiveData<RecoveryRemovalCoordinator.State>()
     private var initializedAccount: Account? = null
     private var started = false

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -633,6 +633,8 @@
     <string name="post_login_account_created_body">Your account is safe on this device. SilentSuite is configuring Android sync.</string>
     <string name="post_login_sync_configuration_failed_title">Android sync setup could not finish</string>
     <string name="post_login_sync_configuration_failed_body">Your account is safe. Try configuring Android sync again.</string>
+    <string name="post_login_bootstrap_failed_title">SilentSuite could not finish starting</string>
+    <string name="post_login_bootstrap_failed_body">Try the startup checks again. You do not need to remove your account or clear app data.</string>
     <string name="post_login_collections_title">Preparing your encrypted collections…</string>
     <string name="post_login_collections_body">Checking your calendars, contacts, and tasks.</string>
     <string name="post_login_collections_failed_title">Collections could not be prepared</string>

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/PostLoginSetupLifecycleTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/PostLoginSetupLifecycleTest.kt
@@ -62,6 +62,7 @@ class PostLoginSetupLifecycleTest {
         PostLoginSetupOrchestrator.Input(
             state = state,
             ownership = PostLoginSetupOrchestrator.Ownership.EXACT,
+            bootstrapSucceeded = true,
             syncConfiguration = sync,
             inventory = inventory,
             userDecision = userDecision,

--- a/android/app/src/test/java/io/silentsuite/sync/ui/setup/PostLoginSetupOrchestratorTest.kt
+++ b/android/app/src/test/java/io/silentsuite/sync/ui/setup/PostLoginSetupOrchestratorTest.kt
@@ -16,6 +16,31 @@ class PostLoginSetupOrchestratorTest {
     private val none = PostLoginSetupOrchestrator.UserDecision.NONE
 
     @Test
+    fun `failed startup never redirects or mutates any saved setup state`() {
+        PostLoginSetupState.values().forEach { state ->
+            PostLoginSetupOrchestrator.Ownership.values().forEach { ownership ->
+                PostLoginSetupOrchestrator.UserDecision.values().forEach { userDecision ->
+                    assertEquals(
+                        PostLoginSetupOrchestrator.Decision.ShowBootstrapFailure,
+                        decide(
+                            state = state,
+                            ownership = ownership,
+                            bootstrapSucceeded = false,
+                            userDecision = userDecision,
+                            initialSyncRequestId = "pending-request",
+                        ),
+                    )
+                }
+            }
+        }
+        // The same durable COMPLETE row opens normally once startup really succeeds.
+        assertEquals(
+            PostLoginSetupOrchestrator.Decision.OpenDashboard,
+            decide(state = PostLoginSetupState.COMPLETE, bootstrapSucceeded = true),
+        )
+    }
+
+    @Test
     fun `every durable state has one cold-start decision`() {
         val expected = mapOf(
             PostLoginSetupState.CREATING to
@@ -361,6 +386,7 @@ class PostLoginSetupOrchestratorTest {
     private fun decide(
         state: PostLoginSetupState,
         ownership: PostLoginSetupOrchestrator.Ownership = exact,
+        bootstrapSucceeded: Boolean = true,
         syncConfiguration: PostLoginSetupOrchestrator.SyncConfigurationOutcome =
             PostLoginSetupOrchestrator.SyncConfigurationOutcome.NOT_STARTED,
         inventory: PostLoginSetupOrchestrator.InventoryOutcome = notStarted,
@@ -375,6 +401,7 @@ class PostLoginSetupOrchestratorTest {
             PostLoginSetupOrchestrator.Input(
                 state = state,
                 ownership = ownership,
+                bootstrapSucceeded = bootstrapSucceeded,
                 syncConfiguration = syncConfiguration,
                 inventory = inventory,
                 userDecision = userDecision,


### PR DESCRIPTION
## Summary
- Stop an already-configured account cycling between the dashboard and setup when the startup migration fails.
- Render a visible recovery state with an explicit Retry action instead of launching the dashboard again.
- Preserve account data and completed setup state while startup recovery remains blocked.
- Extend setup decision/lifecycle coverage and the existing exact-account runtime journey to exercise failure, recreation, failed retry and successful recovery.

Related to #728. This addresses a source-confirmed startup loop; it is not yet established as the cause of the reported device's blank screen. Keep the issue open pending incident validation.

## Verification
- Independent code review approved the correction and the integration-only revalidation approved refreshed head `e263d9261ef2bbcf2fcba4b00df36e39da91e435`, with no medium-or-higher findings.
- Focused source-wiring checks and XML parsing passed; these are static checks only.
- [Fresh integration Android CI passed](https://github.com/silent-suite/silentsuite/actions/runs/34683230547): compilation, lint, Python source contracts, unsigned APK/AAB packaging and privacy scans. [General CI](https://github.com/silent-suite/silentsuite/actions/runs/34683230546) also passed on the same head.
- Fresh-head XML verifies 249 JVM tests passed with no skips or failures, plus 258 instrumentation executions across all six API 21/35/36 shards. The recovery journey and existing crash-cut regression both passed on all three API levels; producer identities and XML hashes were verified.
- No local Android or Python test execution; no release or reporter outreach.
- Refreshed against `main` at `40830f5041183f667f014e439f1d37c4b31a63bd`; the complete Android patch is byte-identical to the reviewed candidate. Merged after all gates passed as `b2a1d44e377e47ffd426a3f56dfc51f1e507044f`; the merged tree exactly matches the reviewed and tested tree. No release or issue closure is included.

### CI-driven correction
The initial candidate's existing crash-cut test failed on API 21, 35 and 36 because the new observer's initial value added an extra setup drain. The recovery journey itself passed on all three API lanes. The correction leaves the observer unset until an explicit Retry; it does not weaken tests, selectors or assertions. Fresh exact-head CI verified both journeys pass.

## Scope and residual risk
Android startup/setup UI and regression tests only. No sync-engine, account deletion, signing, release, server or hosted-service changes. Runtime validation on the reporter's device remains outstanding. The retry deliberately remains fail-closed when the underlying startup failure persists.
