### PR TITLE
fix(notes): isolate pending actions across account changes

### DIFF
--- a/apps/web/app/stores/__tests__/use-note-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-note-store.test.ts
@@ -428,6 +428,59 @@ describe('useNoteStore', () => {
       errorSpy.mockRestore()
     })
 
+    // The boundary is crossed while the action still awaits the core import;
+    // the next account then signs in with the same lower store, so only the
+    // action's own guard can keep the old account's input away from it.
+    it('create never hands the old account\'s draft to the lower store once the account changed during the import', async () => {
+      const createItem = vi.fn(async () => 'b-created')
+      etebase({ createItem })
+
+      const result = useNoteStore.getState().createNote({ title: 'A', content: 'Account A body' })
+      boundaries.replacement.cross()
+      etebase({ createItem })
+
+      await expect(result).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      expect(createItem).not.toHaveBeenCalled()
+      expect(useNoteStore.getState().notes).toEqual([OTHER_ACCOUNT_NOTE])
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    })
+
+    it('update never hands the old account\'s edit to the lower store once the account changed during the import', async () => {
+      const updateItem = vi.fn(async () => 'queued' as const)
+      etebase({ updateItem, itemCache: new Map() })
+      useNoteStore.setState({ notes: [note('note-1', { content: 'Account A body' })] })
+
+      const result = useNoteStore.getState().updateNote('note-1', { content: 'Account A edit' })
+      boundaries.replacement.cross()
+      etebase({ updateItem, itemCache: new Map() })
+
+      await expect(result).resolves.toBe(false)
+      expect(updateItem).not.toHaveBeenCalled()
+      expect(useNoteStore.getState().notes).toEqual([OTHER_ACCOUNT_NOTE])
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    })
+
+    it('move never hands the old account\'s note to the lower store once the account changed during the import', async () => {
+      const moveItem = vi.fn(async () => 'note-moved')
+      etebase({ moveItem, itemCache: new Map([['note-1', {}]]) })
+      useNotebookStore.setState({
+        lists: [
+          { id: 'notes-1', name: 'Notes', color: '#fff', visible: true, accessLevel: 1 },
+          { id: 'notes-2', name: 'Work', color: '#00f', visible: true, accessLevel: 2 },
+        ],
+      })
+      useNoteStore.setState({ notes: [note('note-1', { content: 'Account A body' })] })
+
+      const result = useNoteStore.getState().moveNote('note-1', 'notes-2')
+      boundaries.replacement.cross()
+      etebase({ moveItem, itemCache: new Map([['note-1', {}]]) })
+
+      await expect(result).resolves.toBeNull()
+      expect(moveItem).not.toHaveBeenCalled()
+      expect(useNoteStore.getState().notes).toEqual([OTHER_ACCOUNT_NOTE])
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+    })
+
     it('still restores a note and reports the failure when the same account\'s delete throws', async () => {
       const original = note('note-1')
       const pending = deferred<'remote' | false>()

--- a/apps/web/app/stores/__tests__/use-note-store.test.ts
+++ b/apps/web/app/stores/__tests__/use-note-store.test.ts
@@ -4,9 +4,58 @@ import { useNoteStore } from '../use-note-store'
 import { useEtebaseStore } from '../use-etebase-store'
 import { useNotebookStore } from '../use-notebook-store'
 import { useAuthStore } from '../use-auth-store'
+import { AccountBoundaryChangedError, bumpAccountEpoch } from '@/app/lib/account-epoch'
 
 const toastMock = vi.hoisted(() => ({ showErrorToast: vi.fn() }))
 vi.mock('@/app/stores/use-toast-store', () => toastMock)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/**
+ * Account boundaries as the auth store crosses them: logout bumps the epoch
+ * and clears account state; replacement then loads the next account's notes.
+ */
+const OTHER_ACCOUNT_NOTE: Note = {
+  id: 'b-note',
+  uid: 'b-note',
+  title: 'B',
+  content: 'Account B body',
+  notebookId: 'b-notes',
+  created_at: new Date(0),
+  updated_at: new Date(0),
+}
+const boundaries = {
+  logout: { cross: () => {
+    bumpAccountEpoch()
+    useNoteStore.setState({ notes: [] })
+    useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+  }, notesAfter: [] as Note[] },
+  replacement: { cross: () => {
+    bumpAccountEpoch()
+    useEtebaseStore.setState(useEtebaseStore.getInitialState(), true)
+    useNoteStore.setState({ notes: [OTHER_ACCOUNT_NOTE] })
+  }, notesAfter: [OTHER_ACCOUNT_NOTE] },
+}
+type Boundary = keyof typeof boundaries
+type Completion = 'success' | 'false' | 'throw' | 'boundary'
+const staleCases = (Object.keys(boundaries) as Boundary[]).flatMap((boundary) => (
+  (['success', 'false', 'throw', 'boundary'] as Completion[]).map((completion) => [boundary, completion] as const)
+))
+
+function settle<T>(pending: ReturnType<typeof deferred<T>>, completion: Completion, success: T, failure: T) {
+  if (completion === 'success') pending.resolve(success)
+  else if (completion === 'false') pending.resolve(failure)
+  else if (completion === 'throw') pending.reject(new Error('boom'))
+  else pending.reject(new AccountBoundaryChangedError())
+}
 
 function note(id: string, overrides: Partial<Note> = {}): Note {
   return {
@@ -296,6 +345,104 @@ describe('useNoteStore', () => {
       await expect(useNoteStore.getState().moveNote('missing', 'notes-2')).resolves.toBeNull()
       await expect(useNoteStore.getState().moveNote('note-1', 'notes-1')).resolves.toBe('note-1')
       expect(moveItem).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('account boundary while an action is in flight', () => {
+    it.each(staleCases)('delete never republishes the note after %s (%s)', async (boundary, completion) => {
+      const pending = deferred<'remote' | false>()
+      etebase({ deleteItem: vi.fn(() => pending.promise), itemCache: new Map([['note-1', {}]]) })
+      useNoteStore.setState({ notes: [note('note-1', { content: 'Account A body' })] })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = useNoteStore.getState().deleteNote('note-1')
+      boundaries[boundary].cross()
+      settle(pending, completion, 'remote', false)
+
+      await expect(result).resolves.toBe(false)
+      expect(useNoteStore.getState().notes).toEqual(boundaries[boundary].notesAfter)
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+      expect(errorSpy).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it.each(staleCases)('create rejects quietly without publishing after %s (%s)', async (boundary, completion) => {
+      const pending = deferred<string | null>()
+      const createItem = vi.fn(() => pending.promise)
+      etebase({ createItem })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = useNoteStore.getState().createNote({ title: 'A', content: 'Account A body' })
+      await vi.waitFor(() => expect(createItem).toHaveBeenCalled())
+      boundaries[boundary].cross()
+      settle(pending, completion, 'a-note', null)
+
+      await expect(result).rejects.toBeInstanceOf(AccountBoundaryChangedError)
+      expect(useNoteStore.getState().notes).toEqual(boundaries[boundary].notesAfter)
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+      expect(errorSpy).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it.each(staleCases)('move leaves the current store alone after %s (%s)', async (boundary, completion) => {
+      const pending = deferred<string | null>()
+      const moveItem = vi.fn(() => pending.promise)
+      etebase({ moveItem, itemCache: new Map([['note-1', {}]]) })
+      useNotebookStore.setState({
+        lists: [
+          { id: 'notes-1', name: 'Notes', color: '#fff', visible: true, accessLevel: 1 },
+          { id: 'notes-2', name: 'Work', color: '#00f', visible: true, accessLevel: 2 },
+        ],
+      })
+      useNoteStore.setState({ notes: [note('note-1', { content: 'Account A body' })] })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = useNoteStore.getState().moveNote('note-1', 'notes-2')
+      await vi.waitFor(() => expect(moveItem).toHaveBeenCalled())
+      boundaries[boundary].cross()
+      settle(pending, completion, 'note-moved', null)
+
+      await expect(result).resolves.toBeNull()
+      expect(useNoteStore.getState().notes).toEqual(boundaries[boundary].notesAfter)
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+      expect(errorSpy).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it.each(staleCases)('update reports nothing saved and stays quiet after %s (%s)', async (boundary, completion) => {
+      const pending = deferred<'remote' | false>()
+      const updateItem = vi.fn(() => pending.promise)
+      etebase({ updateItem, itemCache: new Map([['note-1', {}]]) })
+      useNoteStore.setState({ notes: [note('note-1')] })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = useNoteStore.getState().updateNote('note-1', { content: 'Account A edit' })
+      await vi.waitFor(() => expect(updateItem).toHaveBeenCalled())
+      boundaries[boundary].cross()
+      settle(pending, completion, 'remote', false)
+
+      await expect(result).resolves.toBe(false)
+      expect(useNoteStore.getState().notes).toEqual(boundaries[boundary].notesAfter)
+      expect(toastMock.showErrorToast).not.toHaveBeenCalled()
+      expect(errorSpy).not.toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+
+    it('still restores a note and reports the failure when the same account\'s delete throws', async () => {
+      const original = note('note-1')
+      const pending = deferred<'remote' | false>()
+      etebase({ deleteItem: vi.fn(() => pending.promise), itemCache: new Map([['note-1', {}]]) })
+      useNoteStore.setState({ notes: [original] })
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = useNoteStore.getState().deleteNote('note-1')
+      expect(useNoteStore.getState().notes).toEqual([])
+      pending.reject(new Error('boom'))
+
+      await expect(result).resolves.toBe(false)
+      expect(useNoteStore.getState().notes).toEqual([original])
+      expect(toastMock.showErrorToast).toHaveBeenCalledWith('Failed to delete note. Please try again.')
+      errorSpy.mockRestore()
     })
   })
 

--- a/apps/web/app/stores/use-note-store.ts
+++ b/apps/web/app/stores/use-note-store.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand'
 import type { Note, SyncStatus } from '@silentsuite/core'
 import { useEtebaseStore } from '@/app/stores/use-etebase-store'
 import { useAuthStore } from '@/app/stores/use-auth-store'
+import { AccountBoundaryChangedError, getAccountEpoch, isCurrentAccountEpoch } from '@/app/lib/account-epoch'
 import { getSafeErrorDetails } from '@/app/lib/privacy-safe-errors'
 import { showErrorToast } from '@/app/stores/use-toast-store'
 import { canWriteNotebook, newNoteNotebook, useNotebookStore } from '@/app/stores/use-notebook-store'
@@ -20,17 +21,29 @@ interface NoteState {
   syncStatus: SyncStatus
 }
 
+/**
+ * Every action captures the account epoch before its first await. Once logout
+ * or an account switch moves the epoch on, a late result belongs to the old
+ * account: it is never written into the store and never reported to the user.
+ */
 interface NoteActions {
-  /** Creates the note in Etebase first and only then adds it locally; throws if that fails. */
+  /**
+   * Creates the note in Etebase first and only then adds it locally; throws if
+   * that fails, or quietly with AccountBoundaryChangedError if the account changed.
+   */
   createNote: (note?: NewNote) => Promise<Note>
   /** Resolves true once the change is saved remotely or queued for offline replay. */
   updateNote: (id: string, patch: Partial<Pick<Note, 'title' | 'content'>>) => Promise<boolean>
-  /** Resolves false (and restores the note) when the server delete fails. */
+  /**
+   * Resolves false (and restores the note) when the server delete fails, and
+   * false without restoring anything when the account changed meanwhile.
+   */
   deleteNote: (id: string) => Promise<boolean>
   /**
    * Moves a note to another notebook. An Etebase item belongs to one
    * collection, so the note is recreated there and removed from its old
-   * notebook. Resolves with the note's new id, or null when nothing moved.
+   * notebook. Resolves with the note's new id, or null when nothing moved
+   * or the account changed meanwhile.
    */
   moveNote: (id: string, notebookId: string) => Promise<string | null>
   canWriteNote: (note: Note) => boolean
@@ -66,6 +79,7 @@ export const useNoteStore = create<NoteState & NoteActions>()(
 
       // The list only ever shows notes that already have an Etebase item UID,
       // so there is no window in which an entry exists but cannot be saved.
+      const accountEpoch = getAccountEpoch()
       const etebase = useEtebaseStore.getState()
       let itemUid: string | null = null
       try {
@@ -74,9 +88,13 @@ export const useNoteStore = create<NoteState & NoteActions>()(
           ? await etebase.createItem('notes', draft.content, undefined, notebookId, noteToItemMeta(draft))
           : null
       } catch (err) {
+        if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) {
+          throw new AccountBoundaryChangedError()
+        }
         console.error('[note-store] Failed to sync new note to Etebase', getSafeErrorDetails(err))
         showErrorToast('Failed to save note. Please try again.')
       }
+      if (!isCurrentAccountEpoch(accountEpoch)) throw new AccountBoundaryChangedError()
       // The etebase store already reported why the item was not created.
       if (!itemUid) throw new Error('Note could not be saved.')
 
@@ -90,6 +108,7 @@ export const useNoteStore = create<NoteState & NoteActions>()(
       const existing = get().notes.find((n) => n.id === id)
       if (!existing || !get().canWriteNote(existing)) return false
 
+      const accountEpoch = getAccountEpoch()
       const updated: Note = { ...existing, ...patch, updated_at: new Date() }
       set((state) => ({ notes: state.notes.map((n) => (n.id === id ? updated : n)) }))
 
@@ -108,8 +127,9 @@ export const useNoteStore = create<NoteState & NoteActions>()(
           // edit by UID under its notebook instead of dropping it.
           collectionUid: existing.notebookId,
         })
-        return outcome !== false
+        return isCurrentAccountEpoch(accountEpoch) && outcome !== false
       } catch (err) {
+        if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
         console.error('[note-store] Failed to sync note update to Etebase', getSafeErrorDetails(err))
         showErrorToast('Failed to save note. Please try again.')
         return false
@@ -121,6 +141,7 @@ export const useNoteStore = create<NoteState & NoteActions>()(
       const note = get().notes.find((n) => n.id === id)
       if (!note || !get().canWriteNote(note)) return false
 
+      const accountEpoch = getAccountEpoch()
       set((state) => ({ notes: state.notes.filter((n) => n.id !== id) }))
 
       const etebase = useEtebaseStore.getState()
@@ -129,13 +150,16 @@ export const useNoteStore = create<NoteState & NoteActions>()(
       try {
         // The notebook lets the store queue the delete by UID when no item is in memory.
         const outcome = await etebase.deleteItem('notes', id, { collectionUid: note.notebookId })
+        if (!isCurrentAccountEpoch(accountEpoch)) return false
         if (outcome !== false) return true
       } catch (err) {
+        if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return false
         console.error('[note-store] Failed to sync note deletion to Etebase', getSafeErrorDetails(err))
         showErrorToast('Failed to delete note. Please try again.')
       }
 
-      // The server still has the note; put it back.
+      // The server still has the note; put it back, but never into another account's list.
+      if (!isCurrentAccountEpoch(accountEpoch)) return false
       set((state) => (state.notes.some((n) => n.id === id) ? state : { notes: [...state.notes, note] }))
       return false
     },
@@ -148,6 +172,7 @@ export const useNoteStore = create<NoteState & NoteActions>()(
       const target = useNotebookStore.getState().lists.find((list) => list.id === notebookId)
       if (!target || !canWriteNotebook(target)) return null
 
+      const accountEpoch = getAccountEpoch()
       const etebase = useEtebaseStore.getState()
       if (!etebase.account || !etebase.itemCache.has(id)) return null
 
@@ -155,12 +180,13 @@ export const useNoteStore = create<NoteState & NoteActions>()(
         const { noteToItemMeta } = await import('@silentsuite/core')
         // A move is not an edit: the title and last-edit time travel with the note.
         const movedId = await etebase.moveItem('notes', id, existing.content, notebookId, existing.notebookId, noteToItemMeta(existing))
-        if (!movedId) return null
+        if (!movedId || !isCurrentAccountEpoch(accountEpoch)) return null
         set((state) => ({
           notes: state.notes.map((n) => (n.id === id ? { ...existing, id: movedId, uid: movedId, notebookId } : n)),
         }))
         return movedId
       } catch (err) {
+        if (!isCurrentAccountEpoch(accountEpoch) || err instanceof AccountBoundaryChangedError) return null
         console.error('[note-store] Failed to move note', getSafeErrorDetails(err))
         showErrorToast('Failed to move note. Please try again.')
         return null

--- a/apps/web/app/stores/use-note-store.ts
+++ b/apps/web/app/stores/use-note-store.ts
@@ -80,10 +80,12 @@ export const useNoteStore = create<NoteState & NoteActions>()(
       // The list only ever shows notes that already have an Etebase item UID,
       // so there is no window in which an entry exists but cannot be saved.
       const accountEpoch = getAccountEpoch()
-      const etebase = useEtebaseStore.getState()
       let itemUid: string | null = null
       try {
         const { noteToItemMeta } = await import('@silentsuite/core')
+        // Check before the lower store sees anything: a late call would run as the next account.
+        if (!isCurrentAccountEpoch(accountEpoch)) throw new AccountBoundaryChangedError()
+        const etebase = useEtebaseStore.getState()
         itemUid = etebase.account
           ? await etebase.createItem('notes', draft.content, undefined, notebookId, noteToItemMeta(draft))
           : null
@@ -112,11 +114,13 @@ export const useNoteStore = create<NoteState & NoteActions>()(
       const updated: Note = { ...existing, ...patch, updated_at: new Date() }
       set((state) => ({ notes: state.notes.map((n) => (n.id === id ? updated : n)) }))
 
-      const etebase = useEtebaseStore.getState()
-      if (!etebase.account) return false
+      if (!useEtebaseStore.getState().account) return false
 
       try {
         const { noteToItemMeta } = await import('@silentsuite/core')
+        // Check before the lower store sees anything: a late call would run as the next account.
+        if (!isCurrentAccountEpoch(accountEpoch)) return false
+        const etebase = useEtebaseStore.getState()
         const outcome = await etebase.updateItem('notes', id, updated.content, {
           meta: noteToItemMeta(updated),
           // Offline edits keep their body and title in the encrypted local
@@ -173,11 +177,14 @@ export const useNoteStore = create<NoteState & NoteActions>()(
       if (!target || !canWriteNotebook(target)) return null
 
       const accountEpoch = getAccountEpoch()
-      const etebase = useEtebaseStore.getState()
-      if (!etebase.account || !etebase.itemCache.has(id)) return null
+      const { account, itemCache } = useEtebaseStore.getState()
+      if (!account || !itemCache.has(id)) return null
 
       try {
         const { noteToItemMeta } = await import('@silentsuite/core')
+        // Check before the lower store sees anything: a late call would run as the next account.
+        if (!isCurrentAccountEpoch(accountEpoch)) return null
+        const etebase = useEtebaseStore.getState()
         // A move is not an edit: the title and last-edit time travel with the note.
         const movedId = await etebase.moveItem('notes', id, existing.content, notebookId, existing.notebookId, noteToItemMeta(existing))
         if (!movedId || !isCurrentAccountEpoch(accountEpoch)) return null


### PR DESCRIPTION
## Summary
Discard pending Notes action results when logout or an account change invalidates the action. Guard asynchronous preparation before invoking mutations, and suppress stale completion notifications. Preserve same-account deletion rollback and existing write permissions.

## Verification
Adds deferred completion and pre-mutation boundary regression coverage for create, update, delete and move. Full web tests and type checking pass locally. Independent review completed; required CI must pass before integration.

Follow-up to #731, before production deployment. Notes remains an experimental, default-off feature.