### PR TITLE
fix(bridge): preserve DAV tokens across cache refreshes

### DIFF
--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -608,6 +608,48 @@ def record_dav_change(
         return revision
 
 
+def reanchor_dav_state(cache_col, previous_state_hash):
+    """Carry current-revision DAV proofs across a non-DAV-visible cache write.
+
+    Ordinary writers such as the collection-envelope refresh and the upload
+    acknowledgement rewrite hashed envelope bytes or dirty/new flags without
+    changing anything a DAV client can observe. Without this step every such
+    write looks identical to an unledgered downgrade-era mutation, the token
+    chain breaks, and the next REPORT from a client holding an older token is
+    answered with ``valid-sync-token`` instead of the pending deltas (including
+    the literal 404 for a remotely deleted href).
+
+    Only proofs whose stored hash equals ``previous_state_hash`` are moved to
+    the post-write hash. Anything else stays unproven, so the integrity guard
+    in ``Collection.sync`` keeps failing closed. Must run inside the writer's
+    own transaction. Returns True when at least one proof was re-anchored.
+    """
+    current_col = models.CollectionEntity.get_by_id(cache_col.id)
+    state_hash = dav_collection_state_hash(current_col)
+    if state_hash == previous_state_hash:
+        return False
+    revision = current_col.dav_revision
+    moved = (
+        models.DavRevision.update(state_hash=state_hash)
+        .where(
+            (models.DavRevision.collection == current_col)
+            & (models.DavRevision.revision == revision)
+            & (models.DavRevision.state_hash == previous_state_hash)
+        )
+        .execute()
+    )
+    moved += (
+        models.DavSyncToken.update(state_hash=state_hash)
+        .where(
+            (models.DavSyncToken.collection == current_col)
+            & (models.DavSyncToken.revision == revision)
+            & (models.DavSyncToken.state_hash == previous_state_hash)
+        )
+        .execute()
+    )
+    return moved > 0
+
+
 class StorageException(Exception):
     pass
 
@@ -896,6 +938,13 @@ class Etebase:
                             local_user=self.user,
                             uid=col.uid,
                         )
+                        previous_state_hash = None
+                    else:
+                        # Envelope refresh: hashed bytes change, DAV view does
+                        # not. Keep retained client tokens provable.
+                        previous_state_hash = dav_collection_state_hash(
+                            collection
+                        )
                     collection.eb_col = col_mgr.cache_save(col)
                     collection.stoken = col.stoken
                     collection.deleted = col.deleted
@@ -908,6 +957,8 @@ class Etebase:
                             models.CollectionEntity.deleted,
                         ]
                     )
+                    if previous_state_hash is not None:
+                        reanchor_dav_state(collection, previous_state_hash)
                     if collection.deleted:
                         models.DavUnresolvedItem.delete().where(
                             models.DavUnresolvedItem.collection == collection
@@ -982,6 +1033,7 @@ class Etebase:
                 with self._mutation_session_guard():
                     with db.database_proxy.atomic("IMMEDIATE"):
                         self._assert_session_current()
+                        previous_state_hash = dav_collection_state_hash(collection)
                         (
                             models.CollectionEntity.update(dirty=False, new=False)
                             .where(
@@ -993,6 +1045,7 @@ class Etebase:
                             )
                             .execute()
                         )
+                        reanchor_dav_state(collection, previous_state_hash)
 
     def sync_collection(self, uid):
         """Sync a single collection (push then pull)."""
@@ -1075,6 +1128,7 @@ class Etebase:
                 if cache_item.remote_uid is None:
                     cache_item.remote_uid = item.uid
                     cache_item.save(only=[models.ItemEntity.remote_uid])
+                    reanchor_dav_state(cache_col, previous_state_hash)
                 if resolve_unresolved:
                     models.DavUnresolvedItem.delete().where(
                         (models.DavUnresolvedItem.collection == cache_col)
@@ -1386,10 +1440,17 @@ class Etebase:
                     len(items_data),
                 )
 
+                applied = deletions = unresolved = 0
                 with self._mutation_session_guard():
                     with db.database_proxy.atomic("IMMEDIATE"):
                         for item in items_data:
-                            self._apply_pulled_item(cache_col, col, item_mgr, item)
+                            if self._apply_pulled_item(
+                                cache_col, col, item_mgr, item
+                            ):
+                                applied += 1
+                                deletions += 1 if item.deleted else 0
+                            else:
+                                unresolved += 1
 
                         done = item_list.done
                         stoken = item_list.stoken
@@ -1399,6 +1460,15 @@ class Etebase:
                             .where(models.CollectionEntity.id == cache_col.id)
                             .execute()
                         )
+                if items_data:
+                    # Aggregate counts only: no hrefs, identifiers or content.
+                    logger.info(
+                        "PULL collection: applied %d changes (%d deletions), "
+                        "%d unresolved",
+                        applied,
+                        deletions,
+                        unresolved,
+                    )
 
     def _collection_dirty_get(self, collection):
         quarantined_local_items = models.DavUnresolvedItem.select(
@@ -1442,6 +1512,9 @@ class Etebase:
                 with self._mutation_session_guard():
                     with db.database_proxy.atomic("IMMEDIATE"):
                         self._assert_session_current()
+                        # Acknowledgement rewrites envelopes and clears flags
+                        # without a DAV-visible change; keep tokens provable.
+                        previous_state_hash = dav_collection_state_hash(cache_col)
                         for original, item in zip(original_rows, chunk_items):
                             item_id, original_envelope, original_dirty, original_new = original
                             uploaded_envelope = item_mgr.cache_save(item)
@@ -1459,6 +1532,7 @@ class Etebase:
                                 )
                                 .execute()
                             )
+                        reanchor_dav_state(cache_col, previous_state_hash)
 
     # --- CRUD operations ---
 
@@ -1525,6 +1599,7 @@ class Collection:
             current_cache = models.CollectionEntity.get_by_id(self.cache_col.id)
             if current_cache.deleted:
                 raise RuntimeError("collection is unavailable")
+            previous_state_hash = dav_collection_state_hash(current_cache)
             current_col = self.col_mgr.cache_load(current_cache.eb_col)
             meta = dict(current_col.meta)
             meta.update(update_info)
@@ -1537,6 +1612,9 @@ class Collection:
                     models.CollectionEntity.dirty,
                 ]
             )
+            # Collection metadata is not part of the item sync-collection
+            # delta; keep retained item tokens provable.
+            reanchor_dav_state(current_cache, previous_state_hash)
             self.cache_col = current_cache
             self.col = current_col
 

--- a/bridge/src/silentsuite_bridge/local_cache/__init__.py
+++ b/bridge/src/silentsuite_bridge/local_cache/__init__.py
@@ -1134,7 +1134,7 @@ class Etebase:
                         (models.DavUnresolvedItem.collection == cache_col)
                         & (models.DavUnresolvedItem.local_item == cache_item)
                     ).execute()
-                return True
+                return "preserved"
 
             cache_item.remote_uid = item.uid
             cache_item.eb_item = item_mgr.cache_save(item)
@@ -1313,6 +1313,7 @@ class Etebase:
                         & (models.ItemEntity.remote_uid == item.uid)
                         & (models.ItemEntity.id != unresolved.local_item_id)
                     )
+                    previous_state_hash = dav_collection_state_hash(cache_col)
                     if (
                         local_item is not None
                         and conflict is not None
@@ -1329,6 +1330,7 @@ class Etebase:
                             ]
                         )
                         current_unresolved.delete_instance()
+                        reanchor_dav_state(cache_col, previous_state_hash)
                         continue
                     if (
                         local_item is not None
@@ -1348,6 +1350,22 @@ class Etebase:
                             ]
                         )
                         current_unresolved.delete_instance()
+                        href_mapper = models.HrefMapper.get_or_none(
+                            models.HrefMapper.content == local_item
+                        )
+                        if href_mapper is not None:
+                            # Envelope replacement can change the DAV ETag.
+                            record_dav_change(
+                                cache_col,
+                                href_mapper.href,
+                                previous_state_hash=previous_state_hash,
+                                etag=getattr(replacement, "etag", None),
+                                deleted=local_item.deleted,
+                            )
+                        else:
+                            models.DavSyncToken.delete().where(
+                                models.DavSyncToken.collection == cache_col
+                            ).execute()
                         continue
                     if local_item is None or conflict is not None:
                         current_unresolved.reason = "legacy_duplicate"
@@ -1363,9 +1381,9 @@ class Etebase:
                         if local_item.remote_uid is None:
                             local_item.remote_uid = item.uid
                             local_item.save(only=[models.ItemEntity.remote_uid])
+                            reanchor_dav_state(cache_col, previous_state_hash)
                         current_unresolved.delete_instance()
                         continue
-                    previous_state_hash = dav_collection_state_hash(cache_col)
                     local_item.remote_uid = item.uid
                     local_item.eb_item = remote_envelope
                     local_item.deleted = item.deleted
@@ -1440,17 +1458,23 @@ class Etebase:
                     len(items_data),
                 )
 
-                applied = deletions = unresolved = 0
+                applied = tombstones_applied = preserved_local_intent = (
+                    page_quarantined
+                ) = 0
                 with self._mutation_session_guard():
                     with db.database_proxy.atomic("IMMEDIATE"):
                         for item in items_data:
-                            if self._apply_pulled_item(
+                            outcome = self._apply_pulled_item(
                                 cache_col, col, item_mgr, item
-                            ):
+                            )
+                            if outcome == "preserved":
+                                preserved_local_intent += 1
+                            elif outcome:
                                 applied += 1
-                                deletions += 1 if item.deleted else 0
+                                if item.deleted:
+                                    tombstones_applied += 1
                             else:
-                                unresolved += 1
+                                page_quarantined += 1
 
                         done = item_list.done
                         stoken = item_list.stoken
@@ -1463,11 +1487,13 @@ class Etebase:
                 if items_data:
                     # Aggregate counts only: no hrefs, identifiers or content.
                     logger.info(
-                        "PULL collection: applied %d changes (%d deletions), "
-                        "%d unresolved",
+                        "PULL collection: applied %d remote records "
+                        "(%d tombstones), %d preserved local intent, "
+                        "%d page-quarantined",
                         applied,
-                        deletions,
-                        unresolved,
+                        tombstones_applied,
+                        preserved_local_intent,
+                        page_quarantined,
                     )
 
     def _collection_dirty_get(self, collection):

--- a/bridge/src/silentsuite_bridge/radicale/storage.py
+++ b/bridge/src/silentsuite_bridge/radicale/storage.py
@@ -698,6 +698,8 @@ class Collection(BaseCollection):
             DavSyncToken.delete().where(
                 DavSyncToken.collection == self.collection.cache_col
             ).execute()
+            # Bounded category only: never the token, href or collection.
+            logger.warning("DAV sync history invalidated (state_mismatch)")
             if old_token:
                 return _INVALID_SYNC_HISTORY
             current_token_row = None
@@ -727,6 +729,7 @@ class Collection(BaseCollection):
             & (DavSyncToken.token == old_token_value)
         )
         if token_row is None or token_row.revision > revision:
+            logger.info("DAV sync token unknown; client must full-resync")
             raise ValueError("unknown sync token")
         if old_token == token:
             return token, []
@@ -741,6 +744,7 @@ class Collection(BaseCollection):
         )
         expected_revisions = revision - token_row.revision
         if len(changed_revisions) != expected_revisions:
+            logger.warning("DAV sync history invalidated (coverage_gap)")
             raise ValueError("unknown sync token")
         proven_state_hash = token_row.state_hash
         for change in changed_revisions:
@@ -751,14 +755,21 @@ class Collection(BaseCollection):
                 DavSyncToken.delete().where(
                     DavSyncToken.collection == self.collection.cache_col
                 ).execute()
+                logger.warning("DAV sync history invalidated (chain_break)")
                 return _INVALID_SYNC_HISTORY
             proven_state_hash = change.state_hash
         if proven_state_hash != state_hash:
             DavSyncToken.delete().where(
                 DavSyncToken.collection == self.collection.cache_col
             ).execute()
+            logger.warning("DAV sync history invalidated (chain_tail_mismatch)")
             return _INVALID_SYNC_HISTORY
         changed_hrefs = sorted({change.href for change in changed_revisions})
+        logger.info(
+            "DAV sync delta served: %d changed hrefs across %d revisions",
+            len(changed_hrefs),
+            len(changed_revisions),
+        )
         return token, changed_hrefs
 
     def _sanitize_href_mappings(self):

--- a/bridge/tests/test_carddav_remote_delete_convergence.py
+++ b/bridge/tests/test_carddav_remote_delete_convergence.py
@@ -15,6 +15,7 @@ import pytest
 import vobject
 from playhouse.sqlite_ext import SqliteExtDatabase
 
+from silentsuite_bridge import __main__ as bridge_main
 from silentsuite_bridge import config
 from silentsuite_bridge import local_cache as local_cache_module
 from silentsuite_bridge.local_cache import Etebase, db, models
@@ -258,6 +259,25 @@ def _report(app, token=None):
     return status, responses, root.findtext(f"{DAV}sync-token")
 
 
+def _production_logging_boundary(monkeypatch):
+    """Apply the Bridge's real dependency log boundary under DEBUG capture.
+
+    ``caplog.set_level(DEBUG)`` raises the root logger, so peewee would emit
+    SQL parameters (hrefs, tokens) that production never logs: the Bridge's
+    ``configure_logging`` pins dependency loggers above CRITICAL regardless of
+    the product level. Exercise that function rather than re-listing the
+    loggers here, and restore every touched level at teardown.
+    """
+    for name in ("peewee", "etebase", "requests", "urllib3", "httpx", "httpcore"):
+        dependency_logger = logging.getLogger(name)
+        monkeypatch.setattr(dependency_logger, "level", dependency_logger.level)
+    monkeypatch.setattr(config, "LOG_FILE", None)
+    # Same precedent as test_main_startup: keep pytest's capture handler as the
+    # only root handler instead of letting basicConfig add a stderr handler.
+    monkeypatch.setattr(logging, "basicConfig", MagicMock())
+    bridge_main.configure_logging()
+
+
 def _cache_col(user):
     return models.CollectionEntity.get(
         (models.CollectionEntity.local_user == user)
@@ -277,6 +297,7 @@ def test_remote_deletion_survives_collection_refresh_and_reports_404(
     tombstone_meta,
 ):
     caplog.set_level(logging.DEBUG)
+    _production_logging_boundary(monkeypatch)
     app, database, user, remote, _direct = _bridge(tmp_path, monkeypatch)
     service = _service(database, user, remote)
     contact_a, contact_b = _seed(remote, service)
@@ -378,6 +399,7 @@ def test_local_create_token_survives_upload_acknowledgement(
     caplog,
 ):
     caplog.set_level(logging.DEBUG)
+    _production_logging_boundary(monkeypatch)
     app, database, user, remote, direct_storage = _bridge(tmp_path, monkeypatch)
     service = _service(database, user, remote)
     _seed(remote, service)
@@ -437,7 +459,15 @@ def test_unproven_mutation_after_refresh_still_fails_closed(
         (models.ItemEntity.collection == cache_col)
         & (models.ItemEntity.remote_uid == "remote-b")
     )
-    row.eb_item = b"downgrade-era-mutation"
+    # Faithful old-writer mutation: a valid, loadable envelope for the same
+    # remote item with different content, written without advancing the ledger.
+    stale_b = _remote_item(
+        "remote-b",
+        _vcard("contact-b", "Contact B Stale Writer"),
+        meta={"name": "contact-b", "dav_href": "contact-b.vcf"},
+        etag="etag-b-stale",
+    )
+    row.eb_item = remote.store.save(stale_b)
     row.save(only=[models.ItemEntity.eb_item])
 
     direct_collection = Collection(direct_storage, f"/{USERNAME}/{COLLECTION_UID}")

--- a/bridge/tests/test_carddav_remote_delete_convergence.py
+++ b/bridge/tests/test_carddav_remote_delete_convergence.py
@@ -1,0 +1,452 @@
+"""Vertical CardDAV regression: remote deletion must survive ordinary cache writers.
+
+Drives the real ``local_cache.Etebase`` sync service (mocked SDK managers with a
+round-trip cache store) and the real Radicale WSGI application. It proves that a
+collection-envelope refresh or an upload acknowledgement, which change hashed
+cache bytes/flags without any DAV-visible change, do not break the sync-token
+chain and hide a remote tombstone behind ``valid-sync-token``.
+"""
+import logging
+import xml.etree.ElementTree as ET
+from collections import deque
+from unittest.mock import MagicMock
+
+import pytest
+import vobject
+from playhouse.sqlite_ext import SqliteExtDatabase
+
+from silentsuite_bridge import config
+from silentsuite_bridge import local_cache as local_cache_module
+from silentsuite_bridge.local_cache import Etebase, db, models
+from silentsuite_bridge.radicale import storage as bridge_storage
+from silentsuite_bridge.radicale.storage import Collection
+from tests.test_macos_dav_discovery import (
+    DAV,
+    USERNAME,
+    _application,
+    _basic_auth,
+    _request,
+)
+
+SYNC_REPORT = b"""<?xml version="1.0" encoding="utf-8"?>
+<d:sync-collection xmlns:d="DAV:">
+  <d:sync-token>{token}</d:sync-token>
+  <d:sync-level>1</d:sync-level>
+  <d:prop><d:getetag /></d:prop>
+</d:sync-collection>
+"""
+COLLECTION_UID = "contacts"
+HOSTILE_NAME = "../private-remote-name/../hostile-secret"
+HOSTILE_HREF = "../../private-hostile-href.vcf"
+
+
+def _vcard(uid, fn):
+    return (
+        "BEGIN:VCARD\r\nVERSION:3.0\r\n"
+        f"UID:{uid}\r\nFN:{fn}\r\nN:{fn};;;;\r\nEND:VCARD\r\n"
+    )
+
+
+class _CacheStore:
+    """Round-trip ``cache_save``/``cache_load`` keyed by object identity.
+
+    Re-saving a *different* SDK object (a refreshed collection envelope, a
+    tombstone) yields different bytes, exactly like a real envelope refresh.
+    """
+
+    def __init__(self):
+        self._objects = {}
+
+    def save(self, obj):
+        key = id(obj)
+        self._objects[key] = obj
+        return key.to_bytes(8, "big")
+
+    def load(self, blob):
+        return self._objects[int.from_bytes(bytes(blob), "big")]
+
+
+def _remote_item(uid, content, *, meta, deleted=False, etag):
+    item = MagicMock()
+    item.uid = uid
+    item.content = content.encode()
+    item.deleted = deleted
+    item.etag = etag
+    item.meta = dict(meta)
+
+    def delete():
+        item.deleted = True
+
+    item.delete.side_effect = delete
+    return item
+
+
+def _remote_collection(stoken):
+    collection = MagicMock()
+    collection.uid = COLLECTION_UID
+    collection.stoken = stoken
+    collection.deleted = False
+    collection.meta = {"name": "Contacts"}
+    collection.collection_type = "etebase.vcard"
+    collection.access_level = 0
+    return collection
+
+
+class _RemoteAccount:
+    """Scripted Etebase managers: queued list pages, idle pages afterwards."""
+
+    def __init__(self):
+        self.store = _CacheStore()
+        self.col_mgr = MagicMock()
+        self.item_mgr = MagicMock()
+        self.col_mgr.cache_save.side_effect = self.store.save
+        self.col_mgr.cache_load.side_effect = self.store.load
+        self.col_mgr.get_item_manager.return_value = self.item_mgr
+        self.item_mgr.cache_save.side_effect = self.store.save
+        self.item_mgr.cache_load.side_effect = self.store.load
+        self.item_mgr.create.side_effect = self._create
+        self.collection_pages = deque()
+        self.item_pages = deque()
+        self.col_mgr.list.side_effect = lambda *_args: self._next(
+            self.collection_pages, memberships=True
+        )
+        self.item_mgr.list.side_effect = lambda *_args: self._next(
+            self.item_pages
+        )
+        self.created = []
+
+    def _next(self, pages, *, memberships=False):
+        if pages:
+            return pages.popleft()
+        page = MagicMock(data=[], done=True, stoken="idle")
+        if memberships:
+            page.removed_memberships = []
+        return page
+
+    def _create(self, meta, content):
+        item = _remote_item(
+            f"remote-local-{len(self.created)}",
+            content.decode(),
+            meta=meta,
+            etag=f"etag-local-{len(self.created)}",
+        )
+        self.created.append(item)
+        return item
+
+    def queue_collection_page(self, *collections, stoken):
+        self.collection_pages.append(
+            MagicMock(
+                data=list(collections),
+                removed_memberships=[],
+                done=True,
+                stoken=stoken,
+            )
+        )
+
+    def queue_item_page(self, *items, stoken):
+        self.item_pages.append(
+            MagicMock(data=list(items), done=True, stoken=stoken)
+        )
+
+
+def _service(database, user, remote):
+    account = MagicMock()
+    account.get_collection_manager.return_value = remote.col_mgr
+    service = Etebase.__new__(Etebase)
+    service.etebase = account
+    service.username = user.username
+    service._database = database
+    service.stored_session = "fake"
+    service.user = user
+    return service
+
+
+def _bridge(tmp_path, monkeypatch):
+    app = _application(tmp_path, monkeypatch)
+    database = SqliteExtDatabase(
+        config.DATABASE_FILE,
+        pragmas={"foreign_keys": 1},
+    )
+    db.database_proxy.initialize(database)
+    database.create_tables(
+        [
+            models.Config,
+            models.User,
+            models.CollectionEntity,
+            models.ItemEntity,
+            models.HrefMapper,
+            models.DavChange,
+            models.DavRevision,
+            models.DavSyncToken,
+            models.DavUnresolvedItem,
+            models.SchemaMigration,
+        ]
+    )
+    models.Config.create(db_version=1)
+    user = models.User.create(username=USERNAME)
+    remote = _RemoteAccount()
+
+    def cached_collection(uid):
+        return local_cache_module.Collection(
+            remote.col_mgr,
+            models.CollectionEntity.get(
+                (models.CollectionEntity.local_user == user)
+                & (models.CollectionEntity.uid == uid)
+            ),
+        )
+
+    etesync = MagicMock()
+    etesync.get.side_effect = cached_collection
+    etesync.list.side_effect = lambda: [cached_collection(COLLECTION_UID)]
+    context = MagicMock()
+    context.__enter__.return_value = (etesync, False)
+    context.__exit__.return_value = False
+    monkeypatch.setattr(
+        bridge_storage,
+        "etesync_for_user",
+        lambda _user, **_kwargs: context,
+    )
+    direct_storage = MagicMock()
+    direct_storage.etesync = etesync
+    return app, database, user, remote, direct_storage
+
+
+def _seed(remote, service):
+    contact_a = _remote_item(
+        "remote-a",
+        _vcard("contact-a", "Contact A"),
+        meta={"name": "contact-a", "dav_href": "contact-a.vcf"},
+        etag="etag-a-1",
+    )
+    contact_b = _remote_item(
+        "remote-b",
+        _vcard("contact-b", "Contact B"),
+        meta={"name": "contact-b", "dav_href": "contact-b.vcf"},
+        etag="etag-b-1",
+    )
+    remote.queue_collection_page(_remote_collection("col-1"), stoken="list-1")
+    remote.queue_item_page(contact_a, contact_b, stoken="items-1")
+    service.sync()
+    return contact_a, contact_b
+
+
+def _report(app, token=None):
+    body = SYNC_REPORT.replace(b"{token}", (token or "").encode())
+    status, _headers, response_body = _request(
+        app,
+        f"/{USERNAME}/{COLLECTION_UID}/",
+        method="REPORT",
+        body=body,
+        depth="1",
+        auth=_basic_auth(),
+    )
+    if status != "207 Multi-Status":
+        return status, {}, None
+    root = ET.fromstring(response_body)
+    responses = {}
+    for response in root.findall(f"{DAV}response"):
+        href = response.findtext(f"{DAV}href", "").rsplit("/", 1)[-1]
+        direct_status = response.findtext(f"{DAV}status")
+        if direct_status is not None:
+            responses[href] = (direct_status, None)
+            continue
+        propstat = response.find(f"{DAV}propstat")
+        responses[href] = (
+            propstat.findtext(f"{DAV}status"),
+            propstat.findtext(f"{DAV}prop/{DAV}getetag"),
+        )
+    return status, responses, root.findtext(f"{DAV}sync-token")
+
+
+def _cache_col(user):
+    return models.CollectionEntity.get(
+        (models.CollectionEntity.local_user == user)
+        & (models.CollectionEntity.uid == COLLECTION_UID)
+    )
+
+
+@pytest.mark.parametrize("tombstone_meta", [
+    pytest.param({"name": "contact-a", "dav_href": "contact-a.vcf"}, id="named"),
+    pytest.param({}, id="nameless"),
+    pytest.param({"name": HOSTILE_NAME, "dav_href": HOSTILE_HREF}, id="hostile"),
+])
+def test_remote_deletion_survives_collection_refresh_and_reports_404(
+    tmp_path,
+    monkeypatch,
+    caplog,
+    tombstone_meta,
+):
+    caplog.set_level(logging.DEBUG)
+    app, database, user, remote, _direct = _bridge(tmp_path, monkeypatch)
+    service = _service(database, user, remote)
+    contact_a, contact_b = _seed(remote, service)
+
+    status, responses, token_1 = _report(app)
+    assert status == "207 Multi-Status"
+    assert set(responses) == {"contact-a.vcf", "contact-b.vcf"}
+    assert token_1
+    cache_col = _cache_col(user)
+    revision_before = cache_col.dav_revision
+
+    # Another device deleted A, updated B and created C. The collection's
+    # stoken advanced, so the next collection-list page refreshes the cached
+    # collection envelope before the item pull applies the tombstone.
+    tombstone_a = _remote_item(
+        "remote-a", "", meta=tombstone_meta, deleted=True, etag="etag-a-1"
+    )
+    updated_b = _remote_item(
+        "remote-b",
+        _vcard("contact-b", "Contact B Updated"),
+        meta={"name": "contact-b", "dav_href": "contact-b.vcf"},
+        etag="etag-b-2",
+    )
+    created_c = _remote_item(
+        "remote-c",
+        _vcard("contact-c", "Contact C"),
+        meta={"name": "contact-c", "dav_href": "contact-c.vcf"},
+        etag="etag-c-1",
+    )
+    remote.queue_collection_page(_remote_collection("col-2"), stoken="list-2")
+    remote.queue_item_page(tombstone_a, updated_b, created_c, stoken="items-2")
+    service.sync()
+
+    cache_col = _cache_col(user)
+    assert cache_col.dav_revision == revision_before + 3
+    rows_a = list(
+        models.ItemEntity.select().where(
+            (models.ItemEntity.collection == cache_col)
+            & (models.ItemEntity.remote_uid == "remote-a")
+        )
+    )
+    assert len(rows_a) == 1 and rows_a[0].deleted
+    assert models.ItemEntity.select().where(
+        models.ItemEntity.collection == cache_col
+    ).count() == 3
+    assert models.DavUnresolvedItem.select().count() == 0
+
+    # The client that still holds token_1 must learn about the deletion as a
+    # literal 404 on the original href, not lose its token to valid-sync-token.
+    status, responses, token_2 = _report(app, token_1)
+    assert status == "207 Multi-Status"
+    assert responses["contact-a.vcf"] == ("HTTP/1.1 404 Not Found", None)
+    assert responses["contact-b.vcf"] == ("HTTP/1.1 200 OK", '"etag-b-2"')
+    assert responses["contact-c.vcf"] == ("HTTP/1.1 200 OK", '"etag-c-1"')
+    assert token_2 and token_2 != token_1
+
+    tokens = {
+        row.token: row
+        for row in models.DavSyncToken.select().where(
+            models.DavSyncToken.collection == cache_col
+        )
+    }
+    prefix = "http://radicale.org/ns/sync/"
+    assert token_1[len(prefix):] in tokens
+    assert token_2[len(prefix):] in tokens
+    assert tokens[token_2[len(prefix):]].revision == cache_col.dav_revision
+    assert models.DavRevision.select().where(
+        models.DavRevision.collection == cache_col
+    ).count() == cache_col.dav_revision
+
+    # Restart / sibling instance: retained tokens stay valid and idempotent.
+    restarted = _service(database, models.User.get_by_id(user.id), remote)
+    restarted.sync()
+    status, responses, token_3 = _report(app, token_2)
+    assert status == "207 Multi-Status"
+    assert responses == {}
+    assert token_3 == token_2
+    status, responses, _token = _report(app, token_1)
+    assert status == "207 Multi-Status"
+    assert responses["contact-a.vcf"] == ("HTTP/1.1 404 Not Found", None)
+    status, responses, _token = _report(app)
+    assert status == "207 Multi-Status"
+    assert set(responses) == {"contact-b.vcf", "contact-c.vcf"}
+
+    # Privacy: no token value, href, hostile metadata or account path in logs.
+    assert token_1[len(prefix):] not in caplog.text
+    assert token_2[len(prefix):] not in caplog.text
+    assert HOSTILE_NAME not in caplog.text
+    assert "private-hostile-href" not in caplog.text
+    assert "private-remote-name" not in caplog.text
+    assert "contact-a.vcf" not in caplog.text
+    assert USERNAME not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+def test_local_create_token_survives_upload_acknowledgement(
+    tmp_path,
+    monkeypatch,
+    caplog,
+):
+    caplog.set_level(logging.DEBUG)
+    app, database, user, remote, direct_storage = _bridge(tmp_path, monkeypatch)
+    service = _service(database, user, remote)
+    _seed(remote, service)
+    status, _responses, token_1 = _report(app)
+    assert status == "207 Multi-Status"
+
+    # A macOS client creates a contact through the Bridge.
+    local_item = MagicMock()
+    local_item.vobject_item = vobject.readOne(_vcard("contact-local", "Local C"))
+    direct_collection = Collection(direct_storage, f"/{USERNAME}/{COLLECTION_UID}")
+    direct_collection.upload("contact-local.vcf", local_item)
+    status, responses, token_2 = _report(app, token_1)
+    assert status == "207 Multi-Status"
+    assert responses == {"contact-local.vcf": ("HTTP/1.1 200 OK", '"etag-local-0"')}
+    assert token_2 != token_1
+
+    # Background sync pushes it (acknowledgement clears dirty/new and re-saves
+    # the envelope) and the pull echoes the same item back.
+    created = remote.created[0]
+    remote.queue_item_page(created, stoken="items-2")
+    service.sync()
+    cache_col = _cache_col(user)
+    local_row = models.ItemEntity.get(
+        (models.ItemEntity.collection == cache_col)
+        & (models.ItemEntity.remote_uid == created.uid)
+    )
+    assert not local_row.dirty and not local_row.new
+
+    status, responses, token_3 = _report(app, token_2)
+    assert status == "207 Multi-Status"
+    assert responses == {"contact-local.vcf": ("HTTP/1.1 200 OK", '"etag-local-0"')}
+    assert token_3 != token_2
+    status, responses, token_4 = _report(app, token_1)
+    assert status == "207 Multi-Status"
+    assert responses == {"contact-local.vcf": ("HTTP/1.1 200 OK", '"etag-local-0"')}
+    assert token_4 == token_3
+    assert "contact-local" not in caplog.text
+    assert USERNAME not in caplog.text
+
+
+def test_unproven_mutation_after_refresh_still_fails_closed(
+    tmp_path,
+    monkeypatch,
+):
+    app, database, user, remote, direct_storage = _bridge(tmp_path, monkeypatch)
+    service = _service(database, user, remote)
+    _seed(remote, service)
+    status, _responses, token_1 = _report(app)
+    assert status == "207 Multi-Status"
+
+    # Legitimate envelope refresh, then a downgrade-era writer mutates an item
+    # without a ledger row. The integrity guard must still reject the token.
+    remote.queue_collection_page(_remote_collection("col-2"), stoken="list-2")
+    service.sync()
+    cache_col = _cache_col(user)
+    row = models.ItemEntity.get(
+        (models.ItemEntity.collection == cache_col)
+        & (models.ItemEntity.remote_uid == "remote-b")
+    )
+    row.eb_item = b"downgrade-era-mutation"
+    row.save(only=[models.ItemEntity.eb_item])
+
+    direct_collection = Collection(direct_storage, f"/{USERNAME}/{COLLECTION_UID}")
+    with pytest.raises(ValueError, match="unknown sync token"):
+        direct_collection.sync(token_1)
+    assert models.DavSyncToken.select().count() == 0
+    status, _responses, _token = _report(app, token_1)
+    assert status != "207 Multi-Status"
+    status, responses, replacement = _report(app)
+    assert status == "207 Multi-Status"
+    assert replacement != token_1
+    assert set(responses) == {"contact-a.vcf", "contact-b.vcf"}

--- a/bridge/tests/test_carddav_remote_delete_convergence.py
+++ b/bridge/tests/test_carddav_remote_delete_convergence.py
@@ -501,3 +501,216 @@ def test_unproven_mutation_after_refresh_still_fails_closed(
     assert status == "207 Multi-Status"
     assert replacement != token_1
     assert set(responses) == {"contact-a.vcf", "contact-b.vcf"}
+
+
+def test_unproven_mutation_before_refresh_still_fails_closed(
+    tmp_path,
+    monkeypatch,
+):
+    app, database, user, remote, direct_storage = _bridge(tmp_path, monkeypatch)
+    service = _service(database, user, remote)
+    _seed(remote, service)
+    status, _responses, token_1 = _report(app)
+    assert status == "207 Multi-Status"
+
+    cache_col = _cache_col(user)
+    row = models.ItemEntity.get(
+        (models.ItemEntity.collection == cache_col)
+        & (models.ItemEntity.remote_uid == "remote-b")
+    )
+    stale_b = _remote_item(
+        "remote-b",
+        _vcard("contact-b", "Contact B Stale Writer"),
+        meta={"name": "contact-b", "dav_href": "contact-b.vcf"},
+        etag="etag-b-stale",
+    )
+    row.eb_item = remote.store.save(stale_b)
+    row.save(only=[models.ItemEntity.eb_item])
+
+    remote.queue_collection_page(_remote_collection("col-2"), stoken="list-2")
+    service.sync()
+
+    direct_collection = Collection(direct_storage, f"/{USERNAME}/{COLLECTION_UID}")
+    with pytest.raises(ValueError, match="unknown sync token"):
+        direct_collection.sync(token_1)
+    assert models.DavSyncToken.select().count() == 0
+    status, responses, replacement = _report(app)
+    assert status == "207 Multi-Status"
+    assert replacement != token_1
+    assert set(responses) == {"contact-a.vcf", "contact-b.vcf"}
+
+
+def _inject_deleted_duplicate(user, remote):
+    cache_col = _cache_col(user)
+    deleted_item = _remote_item(
+        "remote-b",
+        "",
+        meta={"name": "contact-duplicate"},
+        deleted=True,
+        etag="etag-dup-deleted",
+    )
+    pending = models.ItemEntity.create(
+        collection=cache_col,
+        uid="contact-duplicate",
+        eb_item=remote.store.save(deleted_item),
+        deleted=True,
+        dirty=True,
+        new=True,
+    )
+    models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="legacy-cache:pending",
+        eb_item=remote.store.save(deleted_item),
+        deleted=True,
+        reason="legacy_duplicate",
+        local_item=pending,
+    )
+    return pending
+
+
+def _inject_attached_dirty_new(user, remote):
+    cache_col = _cache_col(user)
+    pending_remote = _remote_item(
+        "remote-pending",
+        _vcard("contact-pending", "Pending"),
+        meta={"name": "contact-pending", "dav_href": "contact-pending.vcf"},
+        etag="etag-pending-1",
+    )
+    pending = models.ItemEntity.create(
+        collection=cache_col,
+        uid="contact-pending",
+        eb_item=remote.store.save(pending_remote),
+        dirty=True,
+        new=True,
+    )
+    models.HrefMapper.create(content=pending, href="contact-pending.vcf")
+    models.DavUnresolvedItem.create(
+        collection=cache_col,
+        remote_uid="legacy-cache:pending",
+        eb_item=remote.store.save(pending_remote),
+        reason="legacy_corrupt",
+        local_item=pending,
+    )
+    return pending
+
+
+def _recover_idle_then_unrelated_deletion_reports_404(
+    app,
+    user,
+    remote,
+    service,
+    token_1,
+    live_hrefs,
+):
+    cache_col = _cache_col(user)
+    revision_before = cache_col.dav_revision
+    service.pull_collection(COLLECTION_UID)
+    cache_col = _cache_col(user)
+    assert cache_col.dav_revision == revision_before
+    assert models.DavUnresolvedItem.select().count() == 0
+
+    status, responses, token_idle = _report(app, token_1)
+    assert status == "207 Multi-Status"
+    assert responses == {}
+    assert token_idle == token_1
+
+    status, responses, token_same_revision = _report(app)
+    assert status == "207 Multi-Status"
+    assert set(responses) == live_hrefs
+    assert token_same_revision == token_1
+
+    tombstone_a = _remote_item(
+        "remote-a",
+        "",
+        meta={"name": "contact-a", "dav_href": "contact-a.vcf"},
+        deleted=True,
+        etag="etag-a-1",
+    )
+    remote.queue_item_page(tombstone_a, stoken="items-tombstone")
+    service.pull_collection(COLLECTION_UID)
+
+    status, responses, token_2 = _report(app, token_1)
+    assert status == "207 Multi-Status"
+    assert responses["contact-a.vcf"] == ("HTTP/1.1 404 Not Found", None)
+    assert token_2 and token_2 != token_1
+
+    status, responses, token_from_prior = _report(app, token_same_revision)
+    assert status == "207 Multi-Status"
+    assert responses["contact-a.vcf"] == ("HTTP/1.1 404 Not Found", None)
+    assert token_from_prior == token_2
+
+    prefix = "http://radicale.org/ns/sync/"
+    cache_col = _cache_col(user)
+    tokens = {
+        row.token: row
+        for row in models.DavSyncToken.select().where(
+            models.DavSyncToken.collection == cache_col
+        )
+    }
+    assert token_1[len(prefix):] in tokens
+    assert token_2[len(prefix):] in tokens
+    assert tokens[token_1[len(prefix):]].revision == revision_before
+    assert tokens[token_2[len(prefix):]].revision == cache_col.dav_revision
+    assert cache_col.dav_revision == revision_before + 1
+
+
+def test_deleted_duplicate_recovery_keeps_token_through_idle_page_and_later_404(
+    tmp_path,
+    monkeypatch,
+):
+    app, database, user, remote, _direct = _bridge(tmp_path, monkeypatch)
+    service = _service(database, user, remote)
+    _seed(remote, service)
+    pending = _inject_deleted_duplicate(user, remote)
+
+    status, responses, token_1 = _report(app)
+    assert status == "207 Multi-Status"
+    assert set(responses) == {"contact-a.vcf", "contact-b.vcf"}
+    assert token_1
+    assert models.DavUnresolvedItem.select().count() == 1
+
+    _recover_idle_then_unrelated_deletion_reports_404(
+        app,
+        user,
+        remote,
+        service,
+        token_1,
+        {"contact-a.vcf", "contact-b.vcf"},
+    )
+    resolved = models.ItemEntity.get_by_id(pending.id)
+    assert resolved.deleted is True
+    assert resolved.dirty is False
+    assert resolved.new is False
+
+
+def test_attached_dirty_new_recovery_keeps_token_through_idle_page_and_later_404(
+    tmp_path,
+    monkeypatch,
+):
+    app, database, user, remote, _direct = _bridge(tmp_path, monkeypatch)
+    service = _service(database, user, remote)
+    _seed(remote, service)
+    pending = _inject_attached_dirty_new(user, remote)
+
+    status, responses, token_1 = _report(app)
+    assert status == "207 Multi-Status"
+    assert set(responses) == {
+        "contact-a.vcf",
+        "contact-b.vcf",
+        "contact-pending.vcf",
+    }
+    assert token_1
+    assert models.DavUnresolvedItem.select().count() == 1
+
+    _recover_idle_then_unrelated_deletion_reports_404(
+        app,
+        user,
+        remote,
+        service,
+        token_1,
+        {"contact-a.vcf", "contact-b.vcf", "contact-pending.vcf"},
+    )
+    recovered = models.ItemEntity.get_by_id(pending.id)
+    assert recovered.remote_uid == "remote-pending"
+    assert recovered.dirty is True
+    assert recovered.new is True

--- a/bridge/tests/test_carddav_remote_delete_convergence.py
+++ b/bridge/tests/test_carddav_remote_delete_convergence.py
@@ -363,10 +363,31 @@ def test_remote_deletion_survives_collection_refresh_and_reports_404(
     prefix = "http://radicale.org/ns/sync/"
     assert token_1[len(prefix):] in tokens
     assert token_2[len(prefix):] in tokens
-    assert tokens[token_2[len(prefix):]].revision == cache_col.dav_revision
-    assert models.DavRevision.select().where(
-        models.DavRevision.collection == cache_col
-    ).count() == cache_col.dav_revision
+    token_1_row = tokens[token_1[len(prefix):]]
+    token_2_row = tokens[token_2[len(prefix):]]
+    assert token_1_row.revision == revision_before
+    assert token_2_row.revision == cache_col.dav_revision
+    # `_prune_sync_history` drops ledger rows at or before the oldest
+    # retained token. Seed revisions are not needed to serve deltas from
+    # token_1; the retained interval is (oldest_token, current].
+    retained = list(
+        models.DavRevision.select()
+        .where(models.DavRevision.collection == cache_col)
+        .order_by(models.DavRevision.revision)
+    )
+    assert [row.revision for row in retained] == list(
+        range(token_1_row.revision + 1, cache_col.dav_revision + 1)
+    )
+    assert [(row.href, row.deleted, row.etag) for row in retained] == [
+        ("contact-a.vcf", True, "etag-a-1"),
+        ("contact-b.vcf", False, "etag-b-2"),
+        ("contact-c.vcf", False, "etag-c-1"),
+    ]
+    proven = token_1_row.state_hash
+    for change in retained:
+        assert change.previous_state_hash == proven
+        proven = change.state_hash
+    assert proven == token_2_row.state_hash
 
     # Restart / sibling instance: retained tokens stay valid and idempotent.
     restarted = _service(database, models.User.get_by_id(user.id), remote)

--- a/bridge/tests/test_carddav_sync.py
+++ b/bridge/tests/test_carddav_sync.py
@@ -221,13 +221,18 @@ def test_reanchor_second_proof_update_rolls_back_cache_mutation(
 ):
     collection = _carddav_collection(mem_db, user)
     cache_col = collection.collection.cache_col
+    # `_prune_sync_history` drops ledger rows at or before the oldest
+    # retained token. A token at the current revision would prune the
+    # current DavRevision; keep an older token, then a later ledgered
+    # change, then the current token so the current proof still exists.
+    older_token, _ = collection.sync(None)
     record_dav_change(
         cache_col,
         "contact-1.vcf",
         previous_state_hash=local_cache_module.dav_collection_state_hash(cache_col),
         etag="etag-1",
     )
-    token, _ = collection.sync(None)
+    token, _ = collection.sync(older_token)
     cache_col = CollectionEntity.get_by_id(cache_col.id)
     cache_item = ItemEntity.get(uid="contact-1")
     previous_hash = local_cache_module.dav_collection_state_hash(cache_col)

--- a/bridge/tests/test_carddav_sync.py
+++ b/bridge/tests/test_carddav_sync.py
@@ -10,7 +10,7 @@ import vobject
 
 from silentsuite_bridge import config
 from silentsuite_bridge import local_cache as local_cache_module
-from silentsuite_bridge.local_cache import record_dav_change
+from silentsuite_bridge.local_cache import db, record_dav_change, reanchor_dav_state
 from silentsuite_bridge.local_cache.models import (
     CollectionEntity,
     DavRevision,
@@ -214,6 +214,61 @@ def test_mapper_replacement_invalidates_token_and_full_inventory_drops_old_href(
     assert replacement_token != old_token
     assert list(replacement_hrefs) == ["shared-contact.vcf"]
     assert "contact-1.vcf" not in replacement_hrefs
+
+
+def test_reanchor_second_proof_update_rolls_back_cache_mutation(
+    mem_db, user, monkeypatch
+):
+    collection = _carddav_collection(mem_db, user)
+    cache_col = collection.collection.cache_col
+    record_dav_change(
+        cache_col,
+        "contact-1.vcf",
+        previous_state_hash=local_cache_module.dav_collection_state_hash(cache_col),
+        etag="etag-1",
+    )
+    token, _ = collection.sync(None)
+    cache_col = CollectionEntity.get_by_id(cache_col.id)
+    cache_item = ItemEntity.get(uid="contact-1")
+    previous_hash = local_cache_module.dav_collection_state_hash(cache_col)
+    revision_row = DavRevision.get(
+        (DavRevision.collection == cache_col)
+        & (DavRevision.revision == cache_col.dav_revision)
+    )
+    token_row = DavSyncToken.get(token=token.rsplit("/", 1)[-1])
+    assert revision_row.state_hash == previous_hash
+    assert token_row.state_hash == previous_hash
+
+    original_update = DavSyncToken.update
+
+    def fail_token_proof(*args, **kwargs):
+        query = original_update(*args, **kwargs)
+
+        def fail_execute(*_args, **_kwargs):
+            raise RuntimeError("injected token proof failure")
+
+        query.execute = fail_execute
+        return query
+
+    monkeypatch.setattr(DavSyncToken, "update", fail_token_proof)
+
+    with pytest.raises(RuntimeError, match="injected token proof failure"):
+        with db.database_proxy.atomic("IMMEDIATE"):
+            cache_item.dirty = True
+            cache_item.save(only=[ItemEntity.dirty])
+            reanchor_dav_state(cache_col, previous_hash)
+
+    persisted = ItemEntity.get_by_id(cache_item.id)
+    assert persisted.dirty is False
+    assert persisted.eb_item == b"encrypted-item"
+    assert DavRevision.get_by_id(revision_row.id).state_hash == previous_hash
+    assert DavSyncToken.get_by_id(token_row.id).state_hash == previous_hash
+    assert (
+        local_cache_module.dav_collection_state_hash(
+            CollectionEntity.get_by_id(cache_col.id)
+        )
+        == previous_hash
+    )
 
 
 def test_later_ledger_change_cannot_hide_prior_unledgered_mutation(mem_db, user):

--- a/bridge/tests/test_collection_list_sync.py
+++ b/bridge/tests/test_collection_list_sync.py
@@ -25,6 +25,7 @@ def _database(path):
             models.ItemEntity,
             models.HrefMapper,
             models.DavChange,
+            models.DavRevision,
             models.DavSyncToken,
             models.DavUnresolvedItem,
             models.SchemaMigration,

--- a/bridge/tests/test_local_cache.py
+++ b/bridge/tests/test_local_cache.py
@@ -955,6 +955,8 @@ class TestSyncLogic:
 
         logs = caplog.text
         assert "fetched 1 items" in logs
+        assert "preserved local intent" in logs
+        assert "page-quarantined" in logs
         assert "private-collection-uid" not in logs
         assert "private-etebase-item-uid" not in logs
         assert "private-local-item-uid" not in logs
@@ -1694,7 +1696,11 @@ def test_dirty_new_legacy_duplicate_is_forked_before_push(mem_db, user):
         content=b"edited-content",
         deleted=False,
     )
-    forked_remote = MagicMock(uid="fresh-remote-item", deleted=False)
+    forked_remote = MagicMock(
+        uid="fresh-remote-item",
+        deleted=False,
+        etag="etag-forked",
+    )
     item_mgr = MagicMock()
     item_mgr.cache_load.side_effect = lambda envelope: {
         b"owner-envelope": owner_remote,
@@ -1733,6 +1739,10 @@ def test_dirty_new_legacy_duplicate_is_forked_before_push(mem_db, user):
     assert recovered.new is True
     assert models.DavUnresolvedItem.select().count() == 0
     assert list(etebase._collection_dirty_get(cache_col)) == [recovered]
+    change = models.DavRevision.get(collection=cache_col)
+    assert change.href == "contact-2.vcf"
+    assert change.deleted is False
+    assert change.etag == "etag-forked"
     item_mgr.create.assert_called_once_with(
         {"name": "contact-2"},
         b"edited-content",
@@ -2917,7 +2927,7 @@ def test_remote_pull_cannot_overwrite_newer_dirty_local_item(mem_db, user):
         MagicMock(collection_type="etebase.vcard"),
         item_mgr,
         remote_item,
-    ) is True
+    ) == "preserved"
 
     persisted = ItemEntity.get_by_id(cache_item.id)
     assert persisted.eb_item == b"newer-local-write"


### PR DESCRIPTION
## Summary
- Preserve retained DAV sync proofs across ordinary collection-cache refreshes and upload acknowledgements.
- Keep fail-closed invalidation for unledgered cache mutations.
- Add bounded sync diagnostics and regression coverage for remote contact deletion, upload acknowledgement, retained history, restart and privacy.

## Scope
Bridge cache writes, DAV revision/token proof handling and regression tests only. No schema migration, account reset, autostart change or dashboard change.

## Verification
- Baseline run 34691793621 on unchanged production source: four intended regressions failed with 403 instead of 207; 796 passed, two skipped.
- Candidate run https://github.com/silent-suite/silentsuite/actions/runs/34693736231 at 0d14cbb2486a07d6d133243c60a877a69daad9f1: 800 passed, two skipped.
- Linux executable build and --version/--help smoke passed.
- Independent review pending. Real-client and packaged synchronization acceptance remain unverified. No release publication included.
