### PR TITLE
feat(bridge): keep loopback dashboard alongside remote DAV

### DIFF
--- a/apps/docs/user-guide/apps/dav-bridge.md
+++ b/apps/docs/user-guide/apps/dav-bridge.md
@@ -111,32 +111,92 @@ silentsuite-bridge --setup-macos-apple-accounts
 Then trust the generated localhost certificate in **Keychain Access** with **Trust > Secure Sockets Layer (SSL)** set to **Always Trust**, restart the bridge, and use the `https://` DAV URLs shown in the dashboard.
 
 ::: warning HTTPS is all-or-nothing for one bridge profile
-Enabling bridge SSL changes the single local DAV listener from HTTP to HTTPS. Existing Thunderbird, Evolution, or KDE clients configured with `http://localhost:37358/` must be updated to the dashboard's `https://` URL and may need to trust the same localhost certificate. Running simultaneous HTTP and HTTPS listeners is not part of this bridge mode.
+Enabling bridge SSL switches every configured listener (loopback and remote) from HTTP to HTTPS. Existing Thunderbird, Evolution, or KDE clients configured with `http://localhost:37358/` must be updated to the dashboard's `https://` URL and may need to trust the same localhost certificate. Running simultaneous HTTP and HTTPS listeners is not part of this bridge mode. For a remote listener, the remote IP or hostname must also be in the certificate's SANs (see the Remote DAV Access section).
 :::
 
 For detailed Apple setup fields and troubleshooting, see [macOS Calendar & Contacts](./macos.md).
 
 ## Remote DAV Access (Tailscale / Private Networks)
 
-An explicit non-loopback bind exposes the Bridge's CalDAV and CardDAV endpoints
-to the configured private network. It does **not** expose the SilentSuite
-dashboard: the unauthenticated dashboard is disabled for the entire remote
-bind. To use the dashboard again, run the Bridge with a loopback bind on the
-Bridge host and open it from that host.
+The Bridge listens on the addresses you configure in `SILENTSUITE_SERVER_HOSTS`
+(as a comma-separated `host:port` list). Each entry is a *requested* listener;
+only the entries that actually bind become *bound* listeners you can dial.
+The dashboard Network card and the `/.web/api/status` JSON show both lists so
+you can tell requested-but-unbound entries from real endpoints.
+
+### Loopback is special
+
+The unauthenticated Bridge dashboard is served **only** on a listener whose
+bound address is a numeric loopback literal (`127.0.0.1` or `::1`). The
+dashboard gate checks three bridge-owned facts stamped into every request:
+the bound listener address, the accepted local socket address, and the peer
+address. All three must be loopback. A `0.0.0.0` / `::` wildcard bind is
+never treated as loopback even for a connection from `127.0.0.1`, because the
+bound address is the wildcard, not a loopback literal. The dashboard is
+therefore denied on wildcard and remote listeners regardless of where the
+request originates — there is no "local connection" exception for the
+dashboard. To use the dashboard, run the Bridge with a loopback entry and
+open it from the Bridge host.
+
+DAV endpoints have no such restriction: any bound listener (loopback,
+wildcard, or remote) serves CalDAV/CardDAV to clients that can reach it.
+A wildcard bind (`0.0.0.0` / `::`) serves DAV on every interface, but it
+is not a dialable client URL itself — clients reach it via the host's
+actual IP address. This is how a remote private-network bind is meant to
+be used.
+
+### Mixed loopback + remote (recommended for Tailscale)
+
+To keep the dashboard usable on the Bridge host while exposing DAV to a
+private network, configure both a loopback and a remote entry in
+`SILENTSUITE_SERVER_HOSTS`:
+
+```bash
+SILENTSUITE_SERVER_HOSTS=127.0.0.1:37358,100.64.10.20:37358 \
+SILENTSUITE_ALLOW_REMOTE=1 silentsuite-bridge
+```
+
+The loopback entry serves the dashboard and DAV on the Bridge host; the
+remote entry serves DAV only to the private network. The dashboard URL and
+the per-account DAV URLs the tray shows always prefer the bound loopback
+listener, so copying a DAV URL gives you the safe local endpoint by
+default. A remote-only bind (no loopback entry) makes the tray show the
+bound remote literal with its configured port for DAV — never a wildcard,
+never an unbound `LISTEN_ADDRESS:LISTEN_PORT`. The dashboard itself is not
+served on a remote-only bind, so its Network card is only visible when a
+loopback listener is also configured and you open the dashboard from the
+Bridge host.
+
+### Remote DAV clients
 
 `127.0.0.1` and `localhost` always refer to the device making the request. A
-DAV client on another Tailscale or private-network device must therefore use
-the Bridge host's private IP address, MagicDNS name, or another approved private
-hostname instead. Do not expose the Bridge listener to the public internet.
+DAV client on another Tailscale or private-network device must use the
+Bridge host's private IP address, MagicDNS name, or another approved private
+hostname — not `localhost`. Do not expose the Bridge listener to the public
+internet.
 
-When HTTPS is enabled, the exact IP address or hostname used by the DAV client
-must be present in the certificate's Subject Alternative Names (SANs). Do not
-bypass certificate verification. Certificate support for explicit Tailscale
-IPs and MagicDNS names is tracked in [#518](https://github.com/silent-suite/silentsuite/issues/518).
+When HTTPS is enabled, the exact IP address or hostname used by the DAV
+client must be present in the certificate's Subject Alternative Names
+(SANs). Do not bypass certificate verification. The auto-generated localhost
+certificate from `--setup-macos-apple-accounts` covers `localhost`,
+`127.0.0.1`, and `::1` only; an explicit Tailscale IP or MagicDNS name is
+not in that SAN set and must be added to a custom certificate. Certificate
+support for explicit Tailscale IPs and MagicDNS names is tracked in
+[#518](https://github.com/silent-suite/silentsuite/issues/518).
 
-Opening a remote listener in a browser can show `Radicale works!` or a similar
-generic Radicale status response. That confirms that the DAV listener is
-reachable; it is not the SilentSuite dashboard.
+Opening a remote or wildcard listener in a browser can show `Radicale
+works!` or a similar generic Radicale status response. That confirms the
+DAV listener is reachable; it is not the SilentSuite dashboard.
+
+### Platform note on the 127/8 loopback range
+
+`127.0.0.1` is the normal loopback address and is what the Bridge uses by
+default. The whole `127.0.0.0/8` range is loopback on Linux, but the Bridge
+treats only numeric loopback literals as dashboard-eligible and the
+generated localhost certificate covers `127.0.0.1` (not every `127.x.x.x`
+address). Use `127.0.0.1` unless you have a specific reason to use another
+loopback address, and add that address to your certificate SANs when TLS is
+on.
 
 ## Multi-Account Use
 
@@ -229,8 +289,10 @@ SILENTSUITE_LISTEN_ADDRESS=::1 SILENTSUITE_LISTEN_PORT=45123 silentsuite-bridge 
 
 - With nothing exported, no `"network"` object is written and the bridge keeps `127.0.0.1:37358`.
 - A non-loopback address without `SILENTSUITE_ALLOW_REMOTE=1` is refused before anything is
-  written. The permission is persisted together with the bind, and the dashboard stays
-  disabled on remote binds.
+  written. The permission is persisted together with the bind. The dashboard is served
+  only on bound loopback listeners; a remote-only profile has no dashboard, while a mixed
+  `SILENTSUITE_SERVER_HOSTS` profile (loopback + remote) keeps the dashboard on the
+  loopback entry and serves DAV on both.
 - Nothing else from the environment (server URL, data directory, log file, SSL paths,
   credentials) is ever persisted by this command.
 - Running `--install-autostart` again merges newly exported variables over the retained
@@ -321,7 +383,7 @@ Uninstalling the local Bridge only removes the desktop sync helper from this com
 | `SILENTSUITE_LISTEN_ADDRESS` | `127.0.0.1` | IP address to listen on (persisted by `--install-autostart` when exported) |
 | `SILENTSUITE_LISTEN_PORT` | `37358` | Port to listen on (persisted by `--install-autostart` when exported) |
 | `SILENTSUITE_SERVER_HOSTS` | listen address and port | Radicale `host:port` list (persisted by `--install-autostart` when exported) |
-| `SILENTSUITE_ALLOW_REMOTE` | unset | Required for a non-loopback bind; disables the dashboard (persisted by `--install-autostart` when exported) |
+| `SILENTSUITE_ALLOW_REMOTE` | unset | Required for any non-loopback bind (in `SILENTSUITE_LISTEN_ADDRESS` or `SILENTSUITE_SERVER_HOSTS`); the dashboard is served only on bound loopback listeners, so a remote-only profile has no dashboard (persisted by `--install-autostart` when exported) |
 | `SILENTSUITE_DATA_DIR` | Platform-specific | Data storage location (not supported with `--install-autostart`) |
 | `SILENTSUITE_SYNC_INTERVAL` | `900` (15 min) | Sync interval in seconds |
 | `SILENTSUITE_LOG_LEVEL` | `INFO` | Log level (DEBUG, INFO, WARNING, ERROR) |
@@ -418,7 +480,7 @@ when you prefer a fresh download).
 
 ### Bridge won't start
 
-On the default localhost bind, the bridge can start before an account is configured so you can log in through `http://localhost:37358/`. If you intentionally configured a remote/non-loopback bind, the dashboard is disabled for safety and you must add an account first with:
+On the default localhost bind, the bridge can start before an account is configured so you can log in through `http://localhost:37358/`. If you configured a remote-only bind (no loopback entry in `SILENTSUITE_SERVER_HOSTS`), the dashboard is not served on any listener; add an account first with:
 
 ```bash
 silentsuite-bridge --login

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -2,7 +2,7 @@
 
 Local E2EE CalDAV/CardDAV sync daemon for SilentSuite.
 
-Connects to `server.silentsuite.io` by default, or your configured self-hosted server, via the Etebase protocol. It decrypts/encrypts data locally and exposes CalDAV/CardDAV endpoints on `localhost:37358` for supported desktop clients, including Thunderbird, Calendar and Contacts on macOS, GNOME Calendar and Evolution, KDE Kontact, and Outlook on Windows.
+Connects to `server.silentsuite.io` by default, or your configured self-hosted server, via the Etebase protocol. It decrypts/encrypts data locally and exposes CalDAV/CardDAV endpoints on `localhost:37358` by default for supported desktop clients, including Thunderbird, Calendar and Contacts on macOS, GNOME Calendar and Evolution, KDE Kontact, and Outlook on Windows. The unauthenticated dashboard is served only on a bound loopback listener; see the [DAV bridge guide](https://docs.silentsuite.io/user-guide/apps/dav-bridge) for mixed loopback + remote `SILENTSUITE_SERVER_HOSTS` recipes and the requested-vs-bound distinction.
 
 ## Account Commands
 
@@ -36,7 +36,7 @@ silentsuite-bridge --setup-macos-apple-accounts
 
 On macOS, this persists bridge SSL settings, opens the certificate for Keychain, and prints the Advanced account setup fields. Trust the certificate in Keychain with **Secure Sockets Layer (SSL)** set to **Always Trust**, restart the bridge, then use the dashboard's `https://localhost:37358/your@example.com/` DAV URL.
 
-Enabling bridge SSL changes the whole single listener to HTTPS. Existing HTTP clients using the same bridge profile must switch to `https://` and trust the localhost certificate. The bridge does not expose simultaneous HTTP and HTTPS listeners in this mode.
+Enabling bridge SSL switches every configured listener (loopback and remote) to HTTPS. Existing HTTP clients using the same bridge profile must switch to `https://` and trust the localhost certificate (and, for a remote listener, the remote IP/hostname must be in the certificate's SANs). The bridge does not expose simultaneous HTTP and HTTPS listeners in this mode.
 
 Advanced/headless configuration keys:
 
@@ -64,7 +64,7 @@ SILENTSUITE_LISTEN_PORT=45123 silentsuite-bridge --install-autostart
 
 Semantics:
 
-- A non-loopback bind without `SILENTSUITE_ALLOW_REMOTE=1` is refused before anything is written. Permission is persisted alongside the bind so the clean-environment restart is validated too. The dashboard stays disabled on remote binds.
+- A non-loopback bind without `SILENTSUITE_ALLOW_REMOTE=1` is refused before anything is written. Permission is persisted alongside the bind so the clean-environment restart is validated too. The dashboard is served only on bound loopback listeners: a remote-only profile has no dashboard, while a mixed `SILENTSUITE_SERVER_HOSTS` profile (loopback + remote) keeps the dashboard on the loopback entry and serves DAV on both. The Bridge never starts an automatic local listener that you did not configure.
 - Reinstalling merges newly exported variables over the retained profile; values you do not export again are kept. `--remove-autostart` removes the entry but keeps the profile. To reset, delete the `"network"` object from `settings.json`.
 - `--remove-autostart` runs before the profile is validated, so it still works when `settings.json` holds an invalid `"network"` object. On Linux/macOS it exits non-zero and keeps the entry for a retry when systemd/launchd does not confirm the stop/unload. On Windows it only deletes the sign-in Run entry; a bridge that is already running is not stopped.
 - Every write to `settings.json` (network profile, sync interval, SSL settings) is atomic (temp file + replace, then a directory sync on Linux/macOS). A failure before the replace leaves the existing `settings.json` unchanged; if only the directory sync fails, the command says the new content is visible but not confirmed durable. A `settings.json` that is not a JSON object is refused rather than overwritten.

--- a/bridge/silentsuite-bridge.spec
+++ b/bridge/silentsuite-bridge.spec
@@ -198,6 +198,7 @@ a = Analysis(
         "silentsuite_bridge.radicale.rights",
         "silentsuite_bridge.radicale.creds",
         "silentsuite_bridge.radicale.etesync_cache",
+        "silentsuite_bridge.radicale.server",
         "silentsuite_bridge.web",
         "silentsuite_bridge.web.__init__",
 

--- a/bridge/src/silentsuite_bridge/__main__.py
+++ b/bridge/src/silentsuite_bridge/__main__.py
@@ -129,7 +129,50 @@ def effective_dav_scheme() -> str:
     return "https" if config.SSL_ENABLED else "http"
 
 
+def _print_requested_listeners() -> None:
+    """Print requested listener table before any listener is bound."""
+    records = config.parse_server_hosts(config.SERVER_HOSTS)
+    if not records:
+        return
+    print("Requested listeners:")
+    for r in records:
+        host = r["host"]
+        port = r["port"]
+        kind = r["kind"]
+        if kind == "loopback":
+            role = "DAV and dashboard"
+        elif kind == "wildcard":
+            role = "bind address, DAV only, dashboard denied"
+        else:
+            role = "remote DAV only"
+        label = f"{host}:{port}" if port else host
+        print(f"  {label} ({kind} — {role})")
+
+
 def _dashboard_url():
+    """Return the loopback listener dashboard URL.
+
+    Resolution order:
+    1. Registry bound loopback URL (authoritative when the bridge is running).
+    2. Requested loopback URL, but ONLY when the registry has never been
+       started (genuine pre-start authentication/standalone mode). Once serving
+       has been attempted, a missing bound URL means the loopback listener
+       failed to bind or was stopped — never fall back to an unbound requested
+       address.
+    3. None when serving was attempted/stopped and no loopback bound.
+    """
+    from .radicale.server import get_registry
+
+    registry = get_registry()
+    registry_url = registry.dashboard_url(config.SSL_ENABLED)
+    if registry_url is not None:
+        return registry_url
+    # Only fall back to requested URL before serving has ever been attempted.
+    if registry.is_started or registry.is_stopped:
+        return None
+    requested = config.requested_dashboard_listener()
+    if requested:
+        return config.listener_base_url(requested["host"], requested["port"]) + "/"
     return f"{config.local_base_url()}/"
 
 
@@ -154,18 +197,36 @@ def check_credentials(open_browser=True):
     creds = Credentials()
     users = creds.list_users()
 
+    # Print requested listeners before any early exit
+    _print_requested_listeners()
+
     if not users:
         if config.is_dashboard_enabled():
             dashboard_url = _dashboard_url()
             logger.info("No users configured; starting bridge dashboard setup")
             print("\nNo account configured yet. Open the bridge dashboard to sign in:")
-            print(f"  {dashboard_url}\n")
+            print(f"  {dashboard_url}")
+            print("  (URL confirmed when the listener binds)\n")
             if open_browser:
                 _open_dashboard_later(dashboard_url)
             return True
 
+        # No loopback listener configured: print hint before early exit
+        hint = config.loopback_listener_hint()
+        if hint:
+            print(
+                "\nNo account configured and no loopback listener is configured for"
+                " the dashboard.\nSet SILENTSUITE_SERVER_HOSTS to include a loopback"
+                " address, e.g.:"
+            )
+            print(f"  SILENTSUITE_SERVER_HOSTS={hint}\n")
+        else:
+            print(
+                "\nNo account configured and no loopback listener is configured for"
+                " the dashboard.\n"
+            )
+
         logger.error("No users configured and bridge dashboard is disabled")
-        print("\nNo account configured and the bridge dashboard is disabled for this bind.")
         print("Run `silentsuite-bridge --login` or `silentsuite-bridge --manual-login` first.\n")
         return False
 
@@ -584,11 +645,17 @@ def run_server():
                 "Remote bridge bind enabled by SILENTSUITE_ALLOW_REMOTE=1. "
                 "DAV traffic is plaintext HTTP unless protected by your own proxy/VPN."
             )
-        logger.warning(
-            "Remote listener exposes DAV endpoints only; the bridge dashboard is "
-            "disabled for this bind. Use a loopback bind on the Bridge host to "
-            "access the dashboard."
-        )
+        if config.is_dashboard_enabled():
+            logger.warning(
+                "Dashboard is served on the loopback listener only;"
+                " remote listeners expose DAV endpoints only."
+            )
+        else:
+            logger.warning(
+                "Remote listener exposes DAV endpoints only; the bridge dashboard is "
+                "disabled for this bind. Use a loopback bind on the Bridge host to "
+                "access the dashboard."
+            )
     logger.info("Etebase server configured")
     logger.info("Bridge data directory configured")
     logger.info("CalDAV/CardDAV scheme: %s", config.dav_scheme())
@@ -613,31 +680,129 @@ def run_server():
         sys.exit(1)
 
 
-def _serve_radicale_with_bridge_application(configuration) -> None:
-    """Run Radicale once with the Bridge's narrowly compatible application.
+def _serve_radicale_with_bridge_application(configuration, shutdown_socket=None) -> None:
+    """Run Radicale once with the Bridge's adapted server stack.
 
-    Radicale 3.2.3 constructs its module-global ``Application`` internally.
-    Keep the temporary replacement single-process, non-reentrant, and
-    ownership-aware so another caller cannot have its replacement overwritten.
+    Radicale 3.2.3 reads Application, RequestHandler, ParallelHTTPServer, and
+    ParallelHTTPSServer as module globals at call time (see serve() lines
+    266-310).  This wrapper replaces all four with bridge-owned subclasses,
+    resets the ListenerRegistry, and passes ``shutdown_socket`` through to
+    serve().  On return / exception / KeyboardInterrupt all four globals are
+    restored and the registry is marked stopped.
+
+    tray.quit() terminates the process with ``os._exit(0)`` and is outside
+    these guarantees.
     """
     from radicale import server as radicale_server
     from radicale.app import Application as RadicaleApplication
 
     from .radicale.application import Application as BridgeApplication
+    from .radicale.server import (
+        BridgeRequestHandlerMixin,
+        _build_bridge_http_server_class,
+        _build_bridge_https_server_class,
+        get_pinned_originals,
+        get_registry,
+        print_resolution_failed,
+    )
+
+    registry = get_registry()
+    # Only a registry this invocation actually started is marked stopped on
+    # exit; a rejected entry state must not turn a never-started registry
+    # into a stopped one.
+    registry_started = False
 
     if not _RADICALE_SERVER_APPLICATION_LOCK.acquire(blocking=False):
         raise RuntimeError("Radicale server application injection is already active")
     try:
-        if radicale_server.Application is not RadicaleApplication:
-            raise RuntimeError("Unexpected Radicale server Application entry state")
-        expected_application = radicale_server.Application
+        # --- validate upstream identity against pinned originals (module-import-time) ---
+        originals = get_pinned_originals()
+        for name, pinned in originals.items():
+            current = getattr(radicale_server, name, None)
+            if current is not pinned:
+                raise RuntimeError(
+                    f"Unexpected Radicale server {name} entry state: pinned original replaced"
+                )
+
+        # --- reset the registry AFTER lock + identity validation ---
+        registry.reset()
+        registry_started = True
+
+        # --- build and inject bridge-owned classes ---
+        BridgeHTTP = _build_bridge_http_server_class(
+            originals["ParallelHTTPServer"], registry,
+        )
+        BridgeHTTPS = _build_bridge_https_server_class(
+            originals["ParallelHTTPSServer"], registry,
+        )
+
+        # BridgeRequestHandlerMixin FIRST so its get_environ() runs (MRO depth-first).
+        class _BridgeRequestHandler(BridgeRequestHandlerMixin, originals["RequestHandler"]):
+            pass
+
         radicale_server.Application = BridgeApplication
+        radicale_server.RequestHandler = _BridgeRequestHandler
+        radicale_server.ParallelHTTPServer = BridgeHTTP
+        radicale_server.ParallelHTTPSServer = BridgeHTTPS
+
+        # Record what we installed so we only restore our own replacements.
+        _installed = {
+            "Application": BridgeApplication,
+            "RequestHandler": _BridgeRequestHandler,
+            "ParallelHTTPServer": BridgeHTTP,
+            "ParallelHTTPSServer": BridgeHTTPS,
+        }
+
+        # Narrow resolution-failure observer: swap radicale_server.socket to a
+        # module-local proxy that delegates every attribute to the real stdlib
+        # socket module but overrides getaddrinfo for this one module reference
+        # only. radicale_server.socket IS the stdlib socket module (same
+        # object), so assigning radicale_server.socket.getaddrinfo would
+        # globally replace socket.getaddrinfo for every thread/importer. The
+        # proxy avoids that: only the radicale.server module global is swapped,
+        # and the real socket module is never mutated, so sync/auth/HTTP
+        # threads and every other importer of ``socket`` keep the real
+        # getaddrinfo. Radicale's serve() reads ``socket`` as its own module
+        # global, so the proxy is the only reference that observes resolution
+        # failures. Restored in the same finally block as the four globals.
+        import types as _types
+
+        _captured_socket = radicale_server.socket
+        _original_getaddrinfo = _captured_socket.getaddrinfo
+
+        def _observing_getaddrinfo(host, port, *args, **kwargs):
+            try:
+                return _original_getaddrinfo(host, port, *args, **kwargs)
+            except OSError:
+                registry.record_failed()
+                print_resolution_failed(f"{host}:{port}")
+                raise
+
+        class _ObservingSocketProxy(_types.ModuleType):
+            def __getattr__(self, name):
+                return getattr(_captured_socket, name)
+
+        _socket_proxy = _ObservingSocketProxy(_captured_socket.__name__)
+        _socket_proxy.getaddrinfo = _observing_getaddrinfo
+        radicale_server.socket = _socket_proxy
+
         try:
-            radicale_server.serve(configuration)
+            radicale_server.serve(configuration, shutdown_socket=shutdown_socket)
         finally:
-            if radicale_server.Application is BridgeApplication:
-                radicale_server.Application = expected_application
+            # --- restore the module-local socket proxy (ownership-aware) ---
+            if radicale_server.socket is _socket_proxy:
+                radicale_server.socket = _captured_socket
+            # --- restore every slot we own, but ONLY if it still holds our replacement ---
+            for name, original in originals.items():
+                current = getattr(radicale_server, name)
+                if current is _installed.get(name):
+                    setattr(radicale_server, name, original)
     finally:
+        # Mark the registry stopped BEFORE releasing the lifecycle lock so a
+        # second invocation that acquires the lock cannot reset and start a
+        # fresh registry that this invocation then marks stopped.
+        if registry_started:
+            registry.mark_stopped()
         _RADICALE_SERVER_APPLICATION_LOCK.release()
 
 
@@ -713,7 +878,8 @@ def main():
         print("  SILENTSUITE_LISTEN_ADDRESS   Listen address (default: 127.0.0.1)")
         print("  SILENTSUITE_LISTEN_PORT      Listen port (default: 37358)")
         print("  SILENTSUITE_SERVER_HOSTS     Radicale host specs (default: listen address:port)")
-        print("  SILENTSUITE_ALLOW_REMOTE     Allow non-loopback bind and disable dashboard")
+        print("  SILENTSUITE_ALLOW_REMOTE     Allow non-loopback bind; the dashboard is served")
+        print("                              only on explicitly configured loopback listeners")
         print("  (Environment overrides the persisted settings.json network profile.)")
         print("  SILENTSUITE_DATA_DIR         Data directory path (not supported with --install-autostart)")
         print("  SILENTSUITE_LOG_LEVEL        Log level (default: INFO)")

--- a/bridge/src/silentsuite_bridge/auth_browser.py
+++ b/bridge/src/silentsuite_bridge/auth_browser.py
@@ -636,17 +636,62 @@ class AuthCallbackHandler(http.server.BaseHTTPRequestHandler):
             if not email:
                 self.send_error(404)
                 return
-            bridge_url = f"{config.local_base_url()}/{email}/"
+            # Use the registry's bound listeners for the DAV URL, preferring
+            # loopback and falling back to a bound remote literal. Only before
+            # serving has been attempted do we fall back to the configured
+            # listener; after serving with no usable bound listener we show
+            # an explicit unavailable note instead of a fabricated address.
+            from .radicale.server import get_registry
+
+            registry = get_registry()
+            base = registry.dav_base_url(config.SSL_ENABLED)
+            if base is not None:
+                bridge_url = f"{base}/{email}/"
+            elif registry.is_started or registry.is_stopped:
+                bridge_url = "DAV URL unavailable: no usable listener is bound."
+            else:
+                base = config.local_base_url()
+                bridge_url = f"{base}/{email}/"
             if config.is_dashboard_enabled():
-                dashboard_url = f"{config.local_base_url()}/"
-                dashboard_bookmark = (
-                    '<div class="bookmark-box">&#11088; Bookmark '
-                    f'<a href="{html_mod.escape(dashboard_url)}">{html_mod.escape(dashboard_url)}</a> '
-                    "to find these details later</div>"
-                )
+                from .radicale.server import get_registry
+
+                registry = get_registry()
+                registry_url = registry.dashboard_url(config.SSL_ENABLED)
+                if registry_url is not None:
+                    dashboard_url = registry_url
+                    dashboard_bookmark = (
+                        '<div class="bookmark-box">&#11088; Bookmark '
+                        f'<a href="{html_mod.escape(dashboard_url)}">{html_mod.escape(dashboard_url)}</a> '
+                        "to find these details later</div>"
+                    )
+                elif registry.is_started or registry.is_stopped:
+                    # Serving was attempted but no loopback bound — do not
+                    # advertise an unbound requested URL.
+                    dashboard_url = ""
+                    dashboard_bookmark = (
+                        '<div class="bookmark-box">'
+                        "Dashboard is not configured or not bound on a loopback listener."
+                        "</div>"
+                    )
+                else:
+                    requested = config.requested_dashboard_listener()
+                    dashboard_url = (
+                        config.listener_base_url(requested["host"], requested["port"]) + "/"
+                        if requested
+                        else f"{config.local_base_url()}/"
+                    )
+                    dashboard_bookmark = (
+                        '<div class="bookmark-box">&#11088; Bookmark '
+                        f'<a href="{html_mod.escape(dashboard_url)}">{html_mod.escape(dashboard_url)}</a> '
+                        "to find these details later</div>"
+                    )
             else:
                 dashboard_url = ""
-                dashboard_bookmark = '<div class="bookmark-box">Dashboard is disabled for remote bridge binds.</div>'
+                dashboard_bookmark = (
+                    '<div class="bookmark-box">'
+                    "Dashboard is not configured or not bound on a loopback listener."
+                    "</div>"
+                )
 
             page = SUCCESS_PAGE_HTML
             page = page.replace("USER_EMAIL", html_mod.escape(email))
@@ -812,9 +857,31 @@ def browser_login(running_bridge=False):
         print()
         print("  Etebase server configured.")
         if config.is_dashboard_enabled():
-            print("  Dashboard will be available on the configured local listener.")
+            from .radicale.server import get_registry
+
+            registry = get_registry()
+            registry_url = registry.dashboard_url(config.SSL_ENABLED)
+            if registry_url is not None:
+                print(f"  Dashboard available on the loopback listener: {registry_url}")
+            elif registry.is_started or registry.is_stopped:
+                print(
+                    "  Dashboard is not bound on a loopback listener; "
+                    "check SILENTSUITE_SERVER_HOSTS for a loopback entry."
+                )
+            else:
+                requested = config.requested_dashboard_listener()
+                if requested:
+                    url = config.listener_base_url(requested["host"], requested["port"]) + "/"
+                    print(f"  Dashboard will be available on the configured loopback listener: {url}")
+                else:
+                    print("  Dashboard will be available on the configured local listener.")
         else:
-            print("  Dashboard is disabled for remote bridge binds.")
+            # No loopback entry in SILENTSUITE_SERVER_HOSTS: the dashboard is
+            # never served on wildcard or remote listeners.
+            print(
+                "  Dashboard is not configured on a loopback listener; "
+                "add a loopback entry to SILENTSUITE_SERVER_HOSTS to use it."
+            )
         print("  CalDAV/CardDAV account configured.")
         print(f"\n  Full setup guides: https://docs.silentsuite.io/user-guide/apps/dav-bridge\n")
 

--- a/bridge/src/silentsuite_bridge/config.py
+++ b/bridge/src/silentsuite_bridge/config.py
@@ -435,9 +435,216 @@ def is_remote_bind_configured() -> bool:
     return bool(remote_bind_reasons())
 
 
+def is_wildcard_host(host: str) -> bool:
+    """Return true for hosts that bind on all interfaces (0.0.0.0, ::, *, empty).
+
+    Numeric unspecified addresses (``0.0.0.0``, ``::``) are also recognized
+    through ``ip_address()`` so expanded forms are classified correctly.
+    """
+    stripped = host.strip()
+    if stripped in {"", "0.0.0.0", "::", "*"}:
+        return True
+    try:
+        return ip_address(stripped).is_unspecified
+    except ValueError:
+        return False
+
+
+def is_loopback_literal(host: str) -> bool:
+    """Return true only for a numeric loopback IP, not localhost."""
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def parse_server_hosts(server_hosts: str) -> list[dict]:
+    """Parse SERVER_HOSTS into records (host, port, kind).
+
+    ``kind`` is one of ``loopback``, ``wildcard``, ``remote``, ``invalid``.
+    Uses ``_split_host_spec`` first, falls back to ``_extract_host`` for
+    lenient env input, and classifies unparseable entries as ``invalid``.
+    An entry whose strict parse fails keeps its invalid classification and
+    is never fabricated into a valid default-port listener.
+    """
+    records: list[dict] = []
+    for spec in server_hosts.split(","):
+        spec = spec.strip()
+        if not spec:
+            continue
+        try:
+            host, port = _split_host_spec(spec, "SILENTSUITE_SERVER_HOSTS")
+        except (NetworkProfileError, ValueError):
+            # Strict parse failed: classify as invalid. Do NOT fabricate a
+            # valid default-port listener from a malformed entry.
+            records.append({"host": spec, "port": 0, "kind": "invalid"})
+            continue
+        records.append({"host": host, "port": port, "kind": _host_kind(host)})
+    return records
+
+
+def _host_kind(host: str) -> str:
+    """Classify a host string as loopback, wildcard, or remote."""
+    if is_loopback_literal(host) or host.lower() == "localhost":
+        return "loopback"
+    if is_wildcard_host(host):
+        return "wildcard"
+    return "remote"
+
+
+def requested_loopback_listeners() -> list[dict]:
+    """Return only loopback records from the current SERVER_HOSTS."""
+    return [r for r in parse_server_hosts(SERVER_HOSTS) if r["kind"] == "loopback"]
+
+
+def requested_remote_listeners() -> list[dict]:
+    """Return only remote (non-loopback, non-wildcard) records from SERVER_HOSTS."""
+    return [r for r in parse_server_hosts(SERVER_HOSTS) if r["kind"] == "remote"]
+
+
+def requested_dashboard_listener() -> dict | None:
+    """Return the first loopback record from SERVER_HOSTS, or None."""
+    for r in parse_server_hosts(SERVER_HOSTS):
+        if r["kind"] == "loopback":
+            return r
+    return None
+
+
+def listener_base_url(host: str, port: int) -> str:
+    """Build ``scheme://host:port`` for a given listener, honoring SSL_ENABLED."""
+    scheme = "https" if SSL_ENABLED else "http"
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"{scheme}://{host}:{port}"
+
+
 def is_dashboard_enabled() -> bool:
-    """The dashboard is unauthenticated today, so disable it on remote binds."""
-    return not is_remote_bind_configured()
+    """True when at least one loopback record exists; wildcard-only stays false."""
+    return len(requested_loopback_listeners()) > 0
+
+
+def loopback_listener_hint() -> str | None:
+    """Return a safe hint string: current specs + suggested 127.0.0.1:<port>.
+
+    Port is LISTEN_PORT if free, else LISTEN_PORT+1 upward, skipping ports
+    already used by any existing spec whose family is IPv4, IPv4 wildcard, or
+    unknown (hostname). Unknown-family hostname entries are treated
+    conservatively: their ports are reserved so the hint never suggests a
+    loopback listener on a port a hostname entry already uses.
+    """
+    existing_hosts = SERVER_HOSTS
+    used_ports: set[int] = set()
+    for r in parse_server_hosts(existing_hosts):
+        port = r.get("port", 0)
+        if not port or port <= 0:
+            continue
+        host = r["host"]
+        family = _address_family_of(host, r["kind"])
+        # Reserve IPv4 literal ports, IPv4 wildcard ports, and unknown-family
+        # (hostname) ports. IPv6-only ports are NOT reserved because the
+        # suggested 127.0.0.1 listener is IPv4 and Radicale sets IPV6_V6ONLY.
+        if family == "ipv4":
+            used_ports.add(port)
+        elif family is None and r["kind"] not in ("invalid",):
+            # Unknown family (hostname): reserve conservatively.
+            used_ports.add(port)
+
+    candidate = LISTEN_PORT
+    while candidate <= 65535:
+        if candidate not in used_ports:
+            break
+        candidate += 1
+    if candidate > 65535:
+        return None
+    return f"{existing_hosts},127.0.0.1:{candidate}"
+
+
+def _is_ip(host: str) -> bool:
+    try:
+        ip_address(host)
+        return True
+    except ValueError:
+        return False
+
+
+def _address_family_of(host: str, kind: str) -> str | None:
+    """Return 'ipv4', 'ipv6', or None for a listener host."""
+    if kind == "wildcard":
+        # Recognize expanded unspecified addresses through ip_address().
+        stripped = host.strip()
+        if stripped in ("", "*", "0.0.0.0"):
+            return "ipv4"
+        if stripped == "::":
+            return "ipv6"
+        try:
+            addr = ip_address(stripped)
+            return "ipv4" if addr.version == 4 else "ipv6"
+        except ValueError:
+            return None
+    try:
+        return "ipv4" if ip_address(host).version == 4 else "ipv6"
+    except ValueError:
+        return None
+
+
+def _normalised_listener_key(host: str, port: int) -> str:
+    """Return a stable key for deduplication: canonical IP + port."""
+    try:
+        canonical = str(ip_address(host.strip()))
+    except ValueError:
+        canonical = host.strip().lower()
+    return f"{canonical}:{port}"
+
+
+def listener_conflicts() -> list[str]:
+    """Return conflict descriptions for duplicate or wildcard-over-literal entries.
+
+    Detects: same-family same-port wildcard-versus-literal conflicts, and
+    exact duplicates.  Invalid entries are excluded.  Keys are structured
+    ``(family, canonical_host, port)`` tuples — never colon-joined strings —
+    because IPv6 literals contain colons and a textual key would misparse.
+    """
+    records = parse_server_hosts(SERVER_HOSTS)
+    conflicts: list[str] = []
+    # (family, canonical_host, port) -> record
+    seen: dict[tuple, dict] = {}
+
+    for r in records:
+        if r["kind"] == "invalid" or not r["port"] or r["port"] <= 0:
+            continue
+        host = r["host"]
+        port = r["port"]
+        family = _address_family_of(host, r["kind"])
+        if family is None:
+            continue
+        canonical_host = str(ip_address(host)) if _is_ip(host) else host.lower()
+        key = (family, canonical_host, port)
+
+        if key in seen:
+            existing = seen[key]
+            conflicts.append(
+                f"duplicate listener {existing['host']}:{existing['port']}"
+                f" and {host}:{port}"
+            )
+            continue
+        seen[key] = r
+
+    # Wildcard vs literal same-family same-port: structured tuple comparison,
+    # no textual splitting of colon-bearing IPv6 addresses.
+    wildcard_keys = [key for key, entry in seen.items() if entry["kind"] == "wildcard"]
+    for key_a in wildcard_keys:
+        family_a, _host_a, port_a = key_a
+        entry_a = seen[key_a]
+        for key_b, entry_b in seen.items():
+            if key_b == key_a:
+                continue
+            family_b, _host_b, port_b = key_b
+            if family_a == family_b and port_a == port_b:
+                conflicts.append(
+                    f"wildcard {entry_a['host']}:{entry_a['port']} conflicts with literal"
+                    f" {entry_b['host']}:{entry_b['port']}"
+                )
+    return conflicts
 
 
 def _remote_bind_error(reasons: list[str]) -> NetworkConfigError:
@@ -453,9 +660,18 @@ def validate_network_config() -> None:
 
     An invalid persisted profile (or malformed environment port) is rejected
     first so a corrupted settings.json can never widen the bind.
+    Listener conflicts are also rejected.
     """
     if NETWORK_PROFILE_ERROR:
-        raise NetworkProfileError(f"SilentSuite Bridge network configuration is invalid: {NETWORK_PROFILE_ERROR}")
+        raise NetworkProfileError(
+            f"SilentSuite Bridge network configuration is invalid: {NETWORK_PROFILE_ERROR}"
+        )
+    conflicts = listener_conflicts()
+    if conflicts:
+        raise NetworkConfigError(
+            "SilentSuite Bridge network configuration conflict in SILENTSUITE_SERVER_HOSTS; "
+            "check for duplicate or wildcard-over-literal entries"
+        )
     reasons = remote_bind_reasons()
     if reasons and not ALLOW_REMOTE:
         raise _remote_bind_error(reasons)

--- a/bridge/src/silentsuite_bridge/radicale/application.py
+++ b/bridge/src/silentsuite_bridge/radicale/application.py
@@ -87,6 +87,10 @@ class _DavDiagnosticRedactionFilter(logging.Filter):
                 record.msg = template
             elif template.startswith("Listening on "):
                 record.msg = "Radicale listener started"
+            elif template.startswith("cannot create server socket on "):
+                record.msg = "Radicale listener bind failed"
+            elif template.startswith("cannot retrieve IPv4 or IPv6 address of "):
+                record.msg = "Radicale listener address resolution failed"
             elif record.exc_info or "during request" in template:
                 record.msg = _safe_exception_diagnostic(record.exc_info)
             elif record.levelno >= logging.ERROR:

--- a/bridge/src/silentsuite_bridge/radicale/server.py
+++ b/bridge/src/silentsuite_bridge/radicale/server.py
@@ -1,0 +1,381 @@
+"""SilentSuite Bridge Radicale server adapters.
+
+ListenerRegistry, bridge-owned server classes, and a request handler that
+stamps loopback evidence into the WSGI environ so the dashboard gate can
+authorize requests with bridge-owned facts: bound address, accepted local
+address, and peer address.
+"""
+
+import logging
+import ssl
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+# ---------- Pinned originals captured once at module import ----------
+# _assert_upstream uses these; never captured per serve call.
+
+import radicale.server as _rs
+
+_PINNED_ORIGINALS = {
+    "Application": _rs.Application,
+    "RequestHandler": _rs.RequestHandler,
+    "ParallelHTTPServer": _rs.ParallelHTTPServer,
+    "ParallelHTTPSServer": _rs.ParallelHTTPSServer,
+}
+
+
+def get_pinned_originals():
+    return dict(_PINNED_ORIGINALS)
+
+
+# ---------- evidence object ----------
+
+class _ListenerEvidence:
+    """Frozen evidence object stamped into WSGI environ for dashboard auth.
+
+    Fields are set once at construction and cannot be reassigned: ``__slots__``
+    plus ``__setattr__``/``__delattr__`` guards make the object effectively
+    immutable so a lookalike mutable object cannot satisfy the gate by having
+    its fields rewritten after the type check.
+    """
+
+    __slots__ = ("listener", "accepted_local", "peer", "ssl")
+
+    def __init__(
+        self,
+        *,
+        listener: tuple,
+        accepted_local: tuple,
+        peer: str,
+        ssl: bool,
+    ) -> None:
+        object.__setattr__(self, "listener", listener)
+        object.__setattr__(self, "accepted_local", accepted_local)
+        object.__setattr__(self, "peer", peer)
+        object.__setattr__(self, "ssl", ssl)
+
+    def __setattr__(self, name, value):  # noqa: D401 - invariant guard
+        raise AttributeError("ListenerEvidence is immutable")
+
+    def __delattr__(self, name):  # noqa: D401 - invariant guard
+        raise AttributeError("ListenerEvidence is immutable")
+
+
+# ---------- registry with lifecycle ----------
+
+class ListenerRegistry:
+    """Lock-protected lifecycle-scoped record of bound and failed listeners.
+
+    States:
+      - NEVER  (__init__)
+      - STARTED (reset() called)
+      - STOPPED (mark_stopped() called; URLs become None)
+    """
+
+    _NEVER = 0
+    _STARTED = 1
+    _STOPPED = 2
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._bound: list[dict] = []
+        self._failed_count = 0
+        self._state = self._NEVER
+        self._listeners: list = []
+
+    # -- change notification --
+
+    def add_listener(self, callback) -> None:
+        """Register a callable invoked after every lifecycle or bind change.
+
+        Callbacks run synchronously on the thread that changed the registry
+        (the serving thread during bind, the wrapper on stop) and outside the
+        registry lock, so a callback may read the registry. No thread is
+        created. Exceptions are logged in bounded form and never propagate
+        into the serve loop.
+        """
+        with self._lock:
+            self._listeners.append(callback)
+
+    def remove_listener(self, callback) -> None:
+        with self._lock:
+            self._listeners = [cb for cb in self._listeners if cb is not callback]
+
+    def _notify(self) -> None:
+        with self._lock:
+            callbacks = list(self._listeners)
+        for callback in callbacks:
+            try:
+                callback()
+            except Exception as exc:
+                logger.warning(
+                    "Listener registry callback failed (%s)", type(exc).__name__
+                )
+
+    # -- lifecycle --
+
+    def reset(self) -> None:
+        with self._lock:
+            self._bound.clear()
+            self._failed_count = 0
+            self._state = self._STARTED
+        self._notify()
+
+    def mark_stopped(self) -> None:
+        with self._lock:
+            self._state = self._STOPPED
+        self._notify()
+
+    @property
+    def is_started(self) -> bool:
+        with self._lock:
+            return self._state == self._STARTED
+
+    @property
+    def is_stopped(self) -> bool:
+        with self._lock:
+            return self._state == self._STOPPED
+
+    # -- recording --
+
+    def record_bound(self, server_address: tuple, family, ssl: bool) -> None:
+        # server_address on IPv6 may be a 4-tuple (host, port, flowinfo, scope_id)
+        host = server_address[0]
+        port = server_address[1]
+        with self._lock:
+            self._bound.append(
+                {"host": host, "port": port, "family": family, "ssl": ssl}
+            )
+        self._notify()
+
+    def record_failed(self) -> None:
+        with self._lock:
+            self._failed_count += 1
+        self._notify()
+
+    # -- querying --
+
+    def bound_listeners(self) -> list[dict]:
+        with self._lock:
+            return list(self._bound)
+
+    def failed_count(self) -> int:
+        with self._lock:
+            return self._failed_count
+
+    def dashboard_url(self, ssl_enabled: bool) -> str | None:
+        with self._lock:
+            if self._state != self._STARTED:
+                return None
+            for entry in self._bound:
+                if _is_loopback_literal(entry["host"]):
+                    scheme = "https" if entry.get("ssl", ssl_enabled) else "http"
+                    host = entry["host"]
+                    if ":" in host and not host.startswith("["):
+                        host = f"[{host}]"
+                    return f"{scheme}://{host}:{entry['port']}/"
+        return None
+
+    def dav_base_url(self, ssl_enabled: bool) -> str | None:
+        """Return a bound DAV base URL (scheme://host:port), or None.
+
+        Prefers a loopback listener (so DAV URLs point at the same safe
+        endpoint as the dashboard). When no loopback bound, returns the first
+        non-wildcard bound remote literal so DAV clients on a private network
+        get a usable literal endpoint. Wildcard binds are never returned: a
+        client cannot dial ``0.0.0.0`` or ``::``. Returns None when serving
+        has not started, was stopped, or no usable listener bound.
+        """
+        with self._lock:
+            if self._state != self._STARTED:
+                return None
+            # Prefer loopback.
+            for entry in self._bound:
+                if _is_loopback_literal(entry["host"]):
+                    return _entry_base_url(entry, ssl_enabled)
+            # Then any non-wildcard remote literal.
+            for entry in self._bound:
+                if not _is_wildcard(entry["host"]):
+                    return _entry_base_url(entry, ssl_enabled)
+        return None
+
+
+_module_registry = ListenerRegistry()
+
+
+def get_registry() -> ListenerRegistry:
+    return _module_registry
+
+
+# ---------- helpers ----------
+
+def _is_loopback_literal(host: str) -> bool:
+    """Return true only for a numeric loopback IP (no hostname, no wildcard)."""
+    from ipaddress import ip_address
+
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_wildcard(host: str) -> bool:
+    return host.strip() in {"", "0.0.0.0", "::", "*"}
+
+
+def _entry_base_url(entry: dict, ssl_enabled: bool) -> str:
+    """Build ``scheme://host:port`` from a registry bound-listener entry."""
+    scheme = "https" if entry.get("ssl", ssl_enabled) else "http"
+    host = entry["host"]
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"{scheme}://{host}:{entry['port']}"
+
+
+# ---------- marker classes ----------
+
+class _BridgeServerTrait:
+    """Shared marker for both bridge HTTP and HTTPS server subclasses."""
+
+
+# ---------- server builders ----------
+
+def _build_bridge_http_server_class(upstream_class, registry: ListenerRegistry):
+    """Create a bridge HTTP server subclass.
+
+    The upstream constructor (which performs ``server_bind``) is wrapped in a
+    try/except so that an occupied port, activation failure, or any other
+    ``OSError``/``RuntimeError`` from construction records a failure and
+    re-raises so Radicale's bind loop continues to the next address (upstream
+    catches ``OSError`` only; a ``RuntimeError`` propagates out of serve()).
+    Recording happens around the constructor, not after it, because a failed
+    constructor never populates ``server_address``. The ``address`` argument
+    holds the requested host:port passed to the constructor, so the
+    "Listener not bound:" line uses the requested address even though the
+    constructor failed before binding.
+    """
+
+    class _BridgeServer(upstream_class, _BridgeServerTrait):
+        def __init__(self, configuration, family, address, handler_class):
+            try:
+                super().__init__(configuration, family, address, handler_class)
+            except (OSError, RuntimeError):
+                registry.record_failed()
+                print_listener_not_bound(
+                    f"{address[0]}:{address[1]}", "HTTP",
+                )
+                raise
+            # After full construction: server_address is populated.
+            registry.record_bound(self.server_address, self.address_family, ssl=False)
+            _print_bound(self.server_address, ssl=False)
+
+    return _BridgeServer
+
+
+def _build_bridge_https_server_class(upstream_class, registry: ListenerRegistry):
+    """Create a bridge HTTPS server subclass.
+
+    Same constructor-failure handling as the HTTP subclass; TLS constructor
+    failures (missing/unreadable cert/key, SSL context errors) are recorded
+    and re-raised. Upstream catches ``OSError`` only; a ``RuntimeError`` from
+    the TLS constructor propagates out of serve() rather than continuing the
+    bind loop.
+    """
+
+    class _BridgeHTTPSServer(upstream_class, _BridgeServerTrait):
+        def __init__(self, configuration, family, address, handler_class):
+            try:
+                super().__init__(configuration, family, address, handler_class)
+            except (OSError, RuntimeError):
+                registry.record_failed()
+                print_listener_not_bound(
+                    f"{address[0]}:{address[1]}", "HTTPS",
+                )
+                raise
+            registry.record_bound(self.server_address, self.address_family, ssl=True)
+            _print_bound(self.server_address, ssl=True)
+
+    return _BridgeHTTPSServer
+
+
+def _print_bound(server_address: tuple, ssl: bool) -> None:
+    """Print one stdout Listening: line with role and dashboard status.
+
+    server_address may be a 4-tuple on IPv6; we use [:2].
+    """
+    host = server_address[0]
+    port = server_address[1]
+    scheme = "https" if ssl else "http"
+    host_display = f"[{host}]" if (":" in host and not host.startswith("[")) else host
+
+    if _is_loopback_literal(host):
+        print(
+            f"Listening: {scheme}://{host_display}:{port}"
+            " (DAV and dashboard, loopback only)"
+        )
+    elif _is_wildcard(host):
+        print(
+            f"Listening: {host_display}:{port}"
+            " (bind address, DAV only, dashboard denied; not a client URL)"
+        )
+    else:
+        print(
+            f"Listening: {host_display}:{port}"
+            " (remote DAV only, dashboard denied)"
+        )
+
+
+def print_listener_not_bound(spec: str, kind: str) -> None:
+    """Print one stdout Listener not bound: line."""
+    print(f"Listener not bound: {spec} ({kind})")
+
+
+def print_resolution_failed(spec: str) -> None:
+    """Print one stdout resolution-failure line."""
+    print(f"Listener address resolution failed: {spec}")
+
+
+# ---------- request handler mixin ----------
+
+class BridgeRequestHandlerMixin:
+    """Stamps loopback evidence into the WSGI environ.
+
+    MUST be placed BEFORE the upstream RequestHandler in the MRO so its
+    get_environ() is called first and the stamp is present.
+    """
+
+    def get_environ(self):
+        environ = super().get_environ()
+        server = getattr(self, "server", None)
+        is_bridge = isinstance(server, _BridgeServerTrait)
+        if not is_bridge:
+            return environ
+        try:
+            listener = self.server.server_address[:2]
+            accepted = self.request.getsockname()[:2]
+            peer = self.client_address[0]
+
+            # Strip IPv6 zone suffixes
+            listener_host = listener[0]
+            accepted_host = accepted[0]
+            if isinstance(listener_host, str) and "%" in listener_host:
+                listener_host = listener_host.split("%", 1)[0]
+                listener = (listener_host, listener[1])
+            if isinstance(accepted_host, str) and "%" in accepted_host:
+                accepted_host = accepted_host.split("%", 1)[0]
+                accepted = (accepted_host, accepted[1])
+            if isinstance(peer, str) and "%" in peer:
+                peer = peer.split("%", 1)[0]
+
+            ssl_on = isinstance(self.connection, ssl.SSLSocket)
+            environ["silentsuite_bridge.evidence"] = _ListenerEvidence(
+                listener=listener,
+                accepted_local=accepted,
+                peer=peer,
+                ssl=ssl_on,
+            )
+        except OSError:
+            pass
+        return environ

--- a/bridge/src/silentsuite_bridge/tray.py
+++ b/bridge/src/silentsuite_bridge/tray.py
@@ -49,12 +49,48 @@ COLOR_GRAY = "#666666"
 
 
 def _dashboard_url():
-    """Return the configured local dashboard URL."""
-    return f"{config.local_base_url()}/"
+    """Return the dashboard URL from the registry, or None when not bound.
+
+    Falls back to the requested URL only before serving has been attempted
+    (tray built before the server starts). Once serving was attempted/stopped,
+    a missing bound URL means no loopback listener is bound — return None so
+    the tray shows a disabled item.
+    """
+    from .radicale.server import get_registry
+
+    registry = get_registry()
+    registry_url = registry.dashboard_url(config.SSL_ENABLED)
+    if registry_url is not None:
+        return registry_url
+    # Only fall back to requested URL before serving has ever been attempted.
+    if registry.is_started or registry.is_stopped:
+        return None
+    requested = config.requested_dashboard_listener()
+    if requested:
+        return config.listener_base_url(requested["host"], requested["port"]) + "/"
+    return None
 
 
 def _account_dav_url(email):
-    """Return the configured local DAV URL for one account."""
+    """Return the DAV URL for one account from a bound listener.
+
+    Uses the registry's bound listeners when available, preferring loopback
+    (so the copied URL matches the safe dashboard endpoint) and falling back
+    to a bound remote literal when no loopback is bound. Falls back to the
+    configured LISTEN_ADDRESS/LISTEN_PORT only before serving has been
+    attempted. Once serving was attempted/stopped with no usable listener
+    bound, returns None so callers can handle the absence explicitly rather
+    than advertising an unbound requested address.
+    """
+    from .radicale.server import get_registry
+
+    registry = get_registry()
+    base = registry.dav_base_url(config.SSL_ENABLED)
+    if base is not None:
+        return f"{base}/{email}/"
+    # Only fall back to requested URL before serving has ever been attempted.
+    if registry.is_started or registry.is_stopped:
+        return None
     return f"{config.local_base_url()}/{email}/"
 
 
@@ -105,9 +141,44 @@ class BridgeTray:
         self._error = None
         self._icon = None
         self._running = False
+        # The tray starts before the server binds (run_server starts it
+        # first), so the menu must follow the listener registry: every bind,
+        # bind failure, or stop asks pystray to re-render the menu. The hook
+        # runs synchronously on the thread that changed the registry; no
+        # thread is owned by the tray for this.
+        from .radicale.server import get_registry
+
+        get_registry().add_listener(self._on_registry_change)
+
+    def _on_registry_change(self):
+        """Re-render the menu after a listener registry change.
+
+        ``Icon.update_menu()`` is pystray's documented call for a menu whose
+        callable ``text``/``enabled`` values changed. Before ``run()`` has
+        created the icon there is nothing to refresh; the menu built in
+        ``run()`` reads the registry at that point.
+        """
+        icon = self._icon
+        if icon is None:
+            return
+        try:
+            icon.update_menu()
+        except Exception as e:
+            logger.debug("Tray menu refresh failed (%s)", bounded_exception_class(e))
 
     def _build_menu(self):
-        """Build the tray menu."""
+        """Build the tray menu.
+
+        Dashboard and DAV URLs are resolved at click time, not at menu-build
+        time, so a menu built before the server binds (or while a previous
+        registry state was active) never opens or copies a stale URL. The
+        callbacks defer to ``_dashboard_url()`` / ``_account_dav_url()`` which
+        read the live registry on every invocation. The dashboard item's
+        ``text`` and ``enabled`` values are callables that pystray evaluates
+        whenever it renders the menu, and ``_on_registry_change`` asks for a
+        re-render on every registry change, so the label and availability
+        follow the bound state instead of a pre-start snapshot.
+        """
         accounts = _get_accounts()
 
         status_text = {
@@ -120,17 +191,23 @@ class BridgeTray:
         if accounts:
             account_items = []
             for email in accounts:
-                dav_url = _account_dav_url(email)
+                # Resolve the DAV URL at click time so a stale pre-start menu
+                # never copies a URL that is no longer valid.
+                def _copy_dav(_icon=None, _item=None, _email=email):
+                    url = _account_dav_url(_email)
+                    if url is not None:
+                        self._copy_to_clipboard(url)
+
                 account_items.append(pystray.MenuItem(
                     email,
                     pystray.Menu(
                         pystray.MenuItem(
                             "Copy CalDAV URL",
-                            lambda _icon=None, _item=None, url=dav_url: self._copy_to_clipboard(url),
+                            _copy_dav,
                         ),
                         pystray.MenuItem(
                             "Copy CardDAV URL",
-                            lambda _icon=None, _item=None, url=dav_url: self._copy_to_clipboard(url),
+                            _copy_dav,
                         ),
                     ),
                 ))
@@ -138,6 +215,29 @@ class BridgeTray:
             account_items = [
                 pystray.MenuItem("No accounts configured", None, enabled=False),
             ]
+
+        # Dashboard label and availability are evaluated by pystray each time
+        # the menu is rendered (callable text/enabled), and the click handler
+        # re-resolves the URL and no-ops if it is None, so an old menu cannot
+        # open a stale dashboard URL after the listener state changed.
+        def _dashboard_text(_item=None):
+            if _dashboard_url() is not None:
+                return "Open Dashboard"
+            return "Dashboard not bound on a loopback listener"
+
+        def _dashboard_enabled(_item=None):
+            return _dashboard_url() is not None
+
+        def _open_dashboard(_icon=None, _item=None):
+            url = _dashboard_url()
+            if url is not None:
+                webbrowser.open(url)
+
+        dashboard_item = pystray.MenuItem(
+            _dashboard_text,
+            _open_dashboard,
+            enabled=_dashboard_enabled,
+        )
 
         return pystray.Menu(
             pystray.MenuItem(
@@ -153,10 +253,7 @@ class BridgeTray:
             pystray.Menu.SEPARATOR,
             *account_items,
             pystray.Menu.SEPARATOR,
-            pystray.MenuItem(
-                "Open Dashboard",
-                lambda _icon=None, _item=None: webbrowser.open(_dashboard_url()),
-            ),
+            dashboard_item,
             pystray.MenuItem(
                 "Add / Re-authenticate Account",
                 lambda _icon=None, _item=None: self._reauthenticate(),

--- a/bridge/src/silentsuite_bridge/web/__init__.py
+++ b/bridge/src/silentsuite_bridge/web/__init__.py
@@ -228,32 +228,245 @@ def _create_sync_request():
 # Localhost Host allowlist for defense-in-depth against DNS-rebinding and
 # cross-origin attacks on the dashboard (SEC-R7.4). The dashboard is
 # loopback-only by default, so only localhost variants are accepted.
+#
+# As of #720 the Host check is replaced by a strict evidence gate that
+# validates the bound listener, accepted local address, and peer.  The
+# Host authority is still validated against the listener port to defeat
+# port-smuggling.
 
 
-def _has_valid_host(environ):
-    """Check that the Host header matches a localhost variant.
+def _trusted_loopback_evidence(environ) -> bool:
+    """Return true only when bridge-owned evidence proves a loopback peer.
 
-    Handles IPv4 (127.0.0.1:port), IPv6 ([::1]:port, [::1]), and bare
-    hostnames (localhost) correctly by stripping the port first.
+    Requires: evidence present and the internal ``_ListenerEvidence`` type,
+    ``listener`` and ``accepted_local`` are 2-tuples of (str, int) where the
+    ints are non-bool ports in range, ``peer`` is a str, the listener address
+    is a loopback literal, the accepted_local address is loopback and its
+    port equals the listener port (the request was accepted on the same
+    listener that bound it), the peer is a numeric loopback address, and
+    ``REMOTE_ADDR`` equals peer. ``ssl`` must be a bool. Malformed or
+    untrusted values deny rather than raise — including an uninitialized
+    evidence object created via ``object.__new__`` that bypasses
+    ``__init__`` (all slots are unset).
     """
-    raw = environ.get("HTTP_HOST", "")
-    # Strip port: split on the last colon only (IPv6 has colons in the address).
-    # For bracketed IPv6 like [::1]:37358, extract between [ and ].
+    from ipaddress import ip_address
+
+    from ..radicale.server import _ListenerEvidence
+
+    evidence = environ.get("silentsuite_bridge.evidence")
+    if evidence is None:
+        return False
+
+    # Reject any lookalike object: only the private frozen type is trusted.
+    if not isinstance(evidence, _ListenerEvidence):
+        return False
+
+    # Reject an uninitialized evidence created via object.__new__ that
+    # bypasses __init__: accessing a slot that was never set raises
+    # AttributeError, which we treat as untrusted rather than fatal.
+    try:
+        listener = evidence.listener
+        accepted_local = evidence.accepted_local
+        peer = evidence.peer
+        evidence_ssl = evidence.ssl
+    except AttributeError:
+        return False
+
+    # Defensive shape check before dereferencing.
+    if not (isinstance(listener, tuple) and len(listener) == 2):
+        return False
+    if not (isinstance(accepted_local, tuple) and len(accepted_local) == 2):
+        return False
+    if not isinstance(peer, str):
+        return False
+    if not isinstance(evidence_ssl, bool):
+        return False
+
+    listener_host, listener_port = listener
+    accepted_host, accepted_port = accepted_local
+
+    # Hosts must be strings.
+    if not isinstance(listener_host, str) or not isinstance(accepted_host, str):
+        return False
+
+    # Ports must be ints, not bools (bool is a subclass of int), and in range.
+    if isinstance(listener_port, bool) or not isinstance(listener_port, int):
+        return False
+    if isinstance(accepted_port, bool) or not isinstance(accepted_port, int):
+        return False
+    if not (1 <= listener_port <= 65535) or not (1 <= accepted_port <= 65535):
+        return False
+
+    # Accepted-local port must equal the listener port: the request was
+    # accepted on the same listener that bound it.
+    if accepted_port != listener_port:
+        return False
+
+    remote_addr = environ.get("REMOTE_ADDR", "")
+
+    # Listener must be a loopback literal (never wildcard, never remote)
+    try:
+        if not ip_address(listener_host).is_loopback:
+            return False
+    except (ValueError, TypeError):
+        return False
+
+    # Accepted local must be loopback
+    try:
+        if not ip_address(accepted_host).is_loopback:
+            return False
+    except (ValueError, TypeError):
+        return False
+
+    # Peer must be numeric loopback
+    try:
+        if not ip_address(peer).is_loopback:
+            return False
+    except (ValueError, TypeError):
+        return False
+
+    # REMOTE_ADDR must equal peer
+    if remote_addr != peer:
+        return False
+
+    return True
+
+
+def _parse_host_authority(raw: str) -> tuple[str | None, int | None]:
+    """Parse a Host header strictly; returns (host, port) or (None, None).
+
+    Accepts only: ``localhost`` (exact, lowercase), numeric IPv4 loopback
+    (127/8), or numeric IPv6 loopback (::1).  Rejects all other IP literals,
+    hostnames, IPv4-mapped IPv6, bracketed non-IPv6, zone ids, commas,
+    whitespace anywhere (never stripped: a padded authority is rejected, not
+    normalised), and malformed ports.  Brackets are required for IPv6,
+    forbidden for IPv4.
+    """
+    from ipaddress import ip_address, IPv6Address
+    if not raw or not isinstance(raw, str):
+        return None, None
+    if "," in raw or "%" in raw or any(ch.isspace() for ch in raw):
+        return None, None
+
+    host: str | None = None
+    port: int | None = None
+
     if raw.startswith("["):
-        # IPv6 with port: [::1]:37358 or IPv6 without port: [::1]
-        bracket_end = raw.find("]")
-        if bracket_end > 0:
-            host = raw[1:bracket_end]
+        end = raw.find("]")
+        if end <= 1:
+            return None, None
+        host = raw[1:end]
+        rest = raw[end + 1:]
+        if rest == "":
+            port = None
+        elif rest.startswith(":"):
+            port = _parse_host_port(rest[1:])
+            if port is None:
+                return None, None
         else:
-            host = ""
+            return None, None
+        # Must be an IPv6 literal — no localhost or IPv4 in brackets
+        try:
+            addr = ip_address(host)
+        except ValueError:
+            return None, None
+        if not isinstance(addr, IPv6Address):
+            return None, None
+        if addr.ipv4_mapped is not None:
+            return None, None
+        if not addr.is_loopback:
+            return None, None
+        host_lower = str(addr)  # canonical form
     else:
-        # IPv4 or hostname, possibly with :port
-        host = raw.rsplit(":", 1)[0] if ":" in raw else raw
-    return host in {"localhost", "127.0.0.1", "::1"}
+        colon_count = raw.count(":")
+        if colon_count > 1:
+            return None, None  # bare IPv6
+        if colon_count == 1:
+            host, port_str = raw.rsplit(":", 1)
+            port = _parse_host_port(port_str)
+            if port is None:
+                return None, None
+        else:
+            host = raw
+            port = None
+        if host is None or not host:
+            return None, None
+        host_lower = host
+        if host == "localhost":
+            pass
+        else:
+            try:
+                addr = ip_address(host)
+            except ValueError:
+                return None, None
+            if not addr.is_loopback:
+                return None, None
+            if isinstance(addr, IPv6Address):
+                if addr.ipv4_mapped is not None:
+                    return None, None
+            host_lower = str(addr)  # canonical form
+
+    return host_lower, port
 
 
-def _host_error():
-    return _json_response(403, {"error": "Dashboard access denied: non-local Host header"})
+def _parse_host_port(port_str: str) -> int | None:
+    """Parse a port string: 1-5 ASCII digits, 1..65535."""
+    if not port_str or len(port_str) > 5 or not port_str.isascii() or not port_str.isdigit():
+        return None
+    p = int(port_str)
+    if not 1 <= p <= 65535:
+        return None
+    return p
+
+
+def _dashboard_not_found() -> tuple:
+    """Return a plain 404 matching Radicale's disabled-web-module response."""
+    return (404, {}, b"Not found")
+
+
+# Throttled warning: emit at most once per process lifetime per denial reason.
+_warned_evidence_missing = False
+_warned_authority = False
+
+
+def _check_dashboard_access(environ) -> tuple | None:
+    """Return None if access is granted, or a denial WSGI response tuple."""
+    global _warned_evidence_missing, _warned_authority
+
+    # 1. Evidence gate — evidence must exist, be the internal frozen type, and
+    #    prove a loopback peer. _trusted_loopback_evidence performs the
+    #    type/shape validation so malformed/lookalike objects deny (404) rather
+    #    than raise.
+    evidence = environ.get("silentsuite_bridge.evidence")
+    if evidence is None or not _trusted_loopback_evidence(environ):
+        if not _warned_evidence_missing:
+            logger.warning("Dashboard request denied: missing or untrusted loopback evidence")
+            _warned_evidence_missing = True
+        return _dashboard_not_found()
+
+    # 2. Host authority check
+    raw = environ.get("HTTP_HOST", "")
+    host, port = _parse_host_authority(raw)
+    listener_port = evidence.listener[1]
+
+    if host is None:
+        if not _warned_authority:
+            logger.warning("Dashboard request denied: invalid Host authority")
+            _warned_authority = True
+        return _dashboard_not_found()
+
+    # Port must match listener port, or when absent default 80/443
+    expected_port = port
+    if expected_port is None:
+        expected_port = 443 if evidence.ssl else 80
+
+    if expected_port != listener_port:
+        if not _warned_authority:
+            logger.warning("Dashboard request denied: Host port mismatch")
+            _warned_authority = True
+        return _dashboard_not_found()
+
+    return None
 
 
 def _csrf_error():
@@ -804,6 +1017,11 @@ DASHBOARD_HTML = """<!DOCTYPE html>
             </div>
 
             <div class="url-section">
+                <h3>Network</h3>
+                {{NETWORK_CARD}}
+            </div>
+
+            <div class="url-section">
                 <div class="section-title-row">
                     <h3>Configured Accounts</h3>
                     <button id="addAccountBtn" class="account-action-btn primary">Add / Re-authenticate Account</button>
@@ -1149,6 +1367,116 @@ DASHBOARD_HTML = """<!DOCTYPE html>
 </html>"""
 
 
+def _render_network_card() -> str:
+    """Render the Network card as escaped HTML.
+
+    Shows requested AND bound listeners separately even on partial failures,
+    with a scheme-qualified client URL for each non-wildcard bound literal
+    (respecting per-entry SSL). Wildcard binds are bind-only with no dialable
+    URL. The source rule names the three bridge-owned facts (bound listener,
+    accepted local address, peer) the dashboard gate checks.
+    """
+    from ..radicale.server import get_registry
+
+    registry = get_registry()
+    bound = registry.bound_listeners()
+    requested = config.parse_server_hosts(config.SERVER_HOSTS)
+    parts = []
+
+    # Requested listeners — always shown, even when some bound.
+    if requested:
+        parts.append('<div style="margin-bottom:6px;color:#ccc;">Requested listeners:</div>')
+        for r in requested:
+            host = html.escape(str(r["host"]))
+            port = r["port"]
+            kind = r["kind"]
+            if kind == "loopback":
+                role = "DAV and dashboard"
+            elif kind == "wildcard":
+                role = "bind address, DAV only"
+            elif kind == "invalid":
+                role = "not parseable, will not bind"
+            else:
+                role = "remote DAV only"
+            display_host = f"[{host}]" if ":" in host and not host.startswith("[") else host
+            label = f"{display_host}:{port}" if port else host
+            parts.append(
+                f'<div class="url-box">'
+                f'<div><label>{label} ({kind} — {role}; requested, not yet confirmed bound)</label></div>'
+                f'</div>'
+            )
+
+    # Bound listeners — shown separately, with a dialable scheme URL for
+    # each non-wildcard literal.
+    if bound:
+        parts.append('<div style="margin:6px 0;color:#ccc;">Bound listeners:</div>')
+        for b in bound:
+            host = html.escape(str(b["host"]))
+            port = b["port"]
+            ssl_on = bool(b.get("ssl", False))
+            scheme = "https" if ssl_on else "http"
+            ssl_flag = " (TLS)" if ssl_on else ""
+            display_host = b["host"]
+            if ":" in display_host and not display_host.startswith("["):
+                display_host = f"[{display_host}]"
+            if config.is_loopback_literal(b["host"]):
+                role = "DAV and dashboard"
+                url = f"{scheme}://{display_host}:{port}/"
+                parts.append(
+                    f'<div class="url-box">'
+                    f'<div><label>{host}:{port}{ssl_flag} — {role}</label></div>'
+                    f'<div><code>{html.escape(url)}</code></div>'
+                    f'</div>'
+                )
+            elif config.is_wildcard_host(b["host"]):
+                role = (
+                    "bind address, DAV only (not a client URL; DAV clients use "
+                    f"{scheme}://&lt;this host's concrete address&gt;:{port}/)"
+                )
+                parts.append(
+                    f'<div class="url-box">'
+                    f'<div><label>{host}:{port}{ssl_flag} — {role}</label></div>'
+                    f'</div>'
+                )
+            else:
+                role = "remote DAV only"
+                url = f"{scheme}://{display_host}:{port}/"
+                parts.append(
+                    f'<div class="url-box">'
+                    f'<div><label>{host}:{port}{ssl_flag} — {role}</label></div>'
+                    f'<div><code>{html.escape(url)}</code></div>'
+                    f'</div>'
+                )
+    elif requested:
+        parts.append(
+            '<div style="margin:6px 0;color:#888;">No listeners bound yet.</div>'
+        )
+    else:
+        parts.append('<div style="color:#888;">No listeners configured</div>')
+
+    failed = registry.failed_count()
+    if failed:
+        parts.append(
+            f'<div style="margin-top:6px;color:#ff8a8a;">'
+            f'{failed} listener(s) failed to bind'
+            f'</div>'
+        )
+
+    parts.append(
+        '<div style="margin-top:8px;font-size:12px;color:#666;">'
+        'Source rule: the dashboard answers only when bridge-owned evidence proves '
+        'the request arrived on a bound loopback listener (never a wildcard or '
+        'remote bind), was accepted on a loopback local address on that '
+        'listener\'s port, and came from a loopback peer matching REMOTE_ADDR. '
+        'The Host header must then be a strict loopback authority whose port '
+        'matches the listener, and mutating requests must also carry the CSRF '
+        'token. Anything else gets a plain 404. Append /&lt;account email&gt;/ to a '
+        'bound endpoint above for that account\'s CalDAV/CardDAV URL.'
+        '</div>'
+    )
+    return "\n".join(parts)
+
+
 def _render_dashboard():
     """Render the dashboard HTML with current status."""
     from .. import __version__
@@ -1159,7 +1487,22 @@ def _render_dashboard():
     creds = Credentials()
     users = creds.list_users()
 
-    base_url = config.local_base_url(config.LISTEN_ADDRESS)
+    # Use the registry's bound listeners for DAV URLs when available,
+    # preferring loopback and falling back to a bound remote literal when no
+    # loopback bound. Only before serving has been attempted do we fall back to
+    # the configured LISTEN_ADDRESS/LISTEN_PORT. Once serving was
+    # attempted/stopped with no usable listener bound, DAV URLs are not
+    # advertised (the dashboard gate would deny them anyway).
+    from ..radicale.server import get_registry
+
+    registry = get_registry()
+    base_url = registry.dav_base_url(config.SSL_ENABLED)
+    if base_url is None:
+        if registry.is_started or registry.is_stopped:
+            # No usable bound listener after serving was attempted.
+            base_url = None
+        else:
+            base_url = config.local_base_url(config.LISTEN_ADDRESS)
 
     with _bridge_status_lock:
         state = _bridge_status["state"]
@@ -1218,9 +1561,33 @@ def _render_dashboard():
         login_copy = "Sign in with your SilentSuite account. Existing accounts stay configured; signing in again refreshes credentials for that account."
         account_html = ""
         for index, user in enumerate(users):
-            dav_url = f"{base_url}/{user}/"
-            server_url = creds.get_server_url(user)
+            # url_id is assigned for EVERY account before any branch so the
+            # successful-bind branch (which uses it in the copy button) cannot
+            # raise UnboundLocalError when base_url is not None.
             url_id = f"davUrl{index}"
+            if base_url is not None:
+                dav_url = f"{base_url}/{user}/"
+                dav_url_html = (
+                    '<div class="url-box">'
+                    '<div>'
+                    '<label>CalDAV/CardDAV URL</label>'
+                    f'<code id="{url_id}">{esc(dav_url)}</code>'
+                    '</div>'
+                    f'<button class="copy-btn" onclick="copy(event, \'{url_id}\')">Copy</button>'
+                    '</div>'
+                    '<div style="font-size:12px;color:#f59e0b;margin-top:6px;">For calendar/contact apps only. Copy it into your app &mdash; do not open it in a web browser, which can expose your password in the address bar.</div>'
+                )
+            else:
+                dav_url = ""
+                dav_url_html = (
+                    '<div class="url-box">'
+                    '<div>'
+                    '<label>CalDAV/CardDAV URL</label>'
+                    '<code>DAV URL unavailable: no usable listener is bound. Check the network card above.</code>'
+                    '</div>'
+                    '</div>'
+                )
+            server_url = creds.get_server_url(user)
             fingerprint = _account_fingerprint(creds, user)
             fingerprint_id = f"accountFingerprint{index}"
             if fingerprint:
@@ -1262,14 +1629,7 @@ def _render_dashboard():
                 f'<h4>{esc(user)}</h4>'
                 f'<div class="account-meta">Server: <code>{esc(server_url)}</code></div>'
                 f'{fingerprint_html}'
-                '<div class="url-box">'
-                '<div>'
-                '<label>CalDAV/CardDAV URL</label>'
-                f'<code id="{url_id}">{esc(dav_url)}</code>'
-                '</div>'
-                f'<button class="copy-btn" onclick="copy(event, \'{url_id}\')">Copy</button>'
-                '</div>'
-                '<div style="font-size:12px;color:#f59e0b;margin-top:6px;">For calendar/contact apps only. Copy it into your app &mdash; do not open it in a web browser, which can expose your password in the address bar.</div>'
+                f'{dav_url_html}'
                 f'{ssl_note}'
                 '<div class="account-actions">'
                 f'<button class="account-action-btn" data-account="{account_attr}" '
@@ -1315,8 +1675,71 @@ def _render_dashboard():
         interval_display = f"{interval} sec"
     page = page.replace("{{SYNC_INTERVAL}}", str(interval))
     page = page.replace("{{SYNC_INTERVAL_DISPLAY}}", esc(interval_display))
+    page = page.replace("{{NETWORK_CARD}}", _render_network_card())
 
     return page
+
+
+def _network_card() -> dict:
+    """Return network listener info for the dashboard status API.
+
+    Includes requested AND bound listeners separately, with a
+    scheme-qualified ``url`` for each non-wildcard bound literal (respecting
+    per-entry SSL). Wildcard binds have ``url: null`` (not a dialable
+    endpoint). The rule names the three bridge-owned facts the gate checks.
+    """
+    from ..radicale.server import get_registry
+
+    registry = get_registry()
+    requested = config.parse_server_hosts(config.SERVER_HOSTS)
+    bound = registry.bound_listeners()
+    dashboard_url = registry.dashboard_url(config.SSL_ENABLED)
+
+    requested_summary = [
+        {"host": r["host"], "port": r["port"], "kind": r["kind"]}
+        for r in requested
+    ]
+
+    def _bound_entry(b: dict) -> dict:
+        host = b["host"]
+        ssl_on = bool(b.get("ssl", False))
+        scheme = "https" if ssl_on else "http"
+        if config.is_loopback_literal(host):
+            role = "DAV and dashboard"
+        elif config.is_wildcard_host(host):
+            role = "DAV only (bind address, not a client URL)"
+        else:
+            role = "DAV only (remote)"
+        display_host = host
+        if ":" in display_host and not display_host.startswith("["):
+            display_host = f"[{display_host}]"
+        url = None if config.is_wildcard_host(host) else f"{scheme}://{display_host}:{b['port']}/"
+        return {
+            "host": host,
+            "port": b["port"],
+            "ssl": ssl_on,
+            "role": role,
+            "url": url,
+        }
+
+    bound_summary = [_bound_entry(b) for b in bound]
+
+    return {
+        "requested": requested_summary,
+        "bound": bound_summary,
+        "failed_count": registry.failed_count(),
+        "dashboard_url": dashboard_url,
+        "rule": (
+            "Dashboard is served only when bridge-owned evidence proves the "
+            "request arrived on a bound loopback listener (never wildcard or "
+            "remote), was accepted on a loopback local address on that "
+            "listener's port, and came from a loopback peer matching "
+            "REMOTE_ADDR; the Host header must be a strict loopback authority "
+            "whose port matches the listener, and mutating requests must carry "
+            "the CSRF token. Anything else is a plain 404."
+        ),
+        "account_path_pattern": "/<email>/",
+    }
 
 
 class Web(BaseWeb):
@@ -1327,9 +1750,10 @@ class Web(BaseWeb):
 
     def get(self, environ, base_prefix, path, user):
         """Serve the dashboard for Radicale's web endpoint."""
-        # SEC-R7.4: Reject non-local Host headers before any processing.
-        if not _has_valid_host(environ):
-            return _host_error()
+        # #720 loopback evidence gate — evidence, then Host, then CSRF
+        denial = _check_dashboard_access(environ)
+        if denial is not None:
+            return denial
 
         if path in ("", "/", "/.web", "/.web/"):
             html = _render_dashboard()
@@ -1349,6 +1773,7 @@ class Web(BaseWeb):
                 )
             data = {
                 "status": status,
+                "network": _network_card(),
                 "log": list(_sync_log)[:20],
             }
             return (
@@ -1461,10 +1886,10 @@ class Web(BaseWeb):
 
     def post(self, environ, base_prefix, path, user):
         """Handle POST requests for API endpoints."""
-        # SEC-R7.4: Reject non-local Host headers before any processing.
-        # Defense-in-depth against DNS-rebinding when ALLOW_REMOTE is enabled.
-        if not _has_valid_host(environ):
-            return _host_error()
+        # #720 loopback evidence gate — evidence, then Host, then CSRF
+        denial = _check_dashboard_access(environ)
+        if denial is not None:
+            return denial
 
         # Trigger immediate sync
         if path == "/.web/api/sync":

--- a/bridge/tests/conftest.py
+++ b/bridge/tests/conftest.py
@@ -21,6 +21,51 @@ from silentsuite_bridge.local_cache import db, models
 
 
 # ---------------------------------------------------------------------------
+# Listener registry isolation
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def fresh_registry(monkeypatch):
+    """Isolate the global ListenerRegistry per test.
+
+    The registry in ``silentsuite_bridge.radicale.server`` is a module-level
+    singleton; a test that drives the real serve wrapper (and calls
+    ``mark_stopped``) would leak the STOPPED state into later tests by
+    filename ordering, breaking render/auth assertions that expect the
+    NEVER state. This fixture swaps the singleton for a fresh
+    ``ListenerRegistry`` and patches ``get_registry`` in every module that
+    imports it (web, tray, auth_browser, __main__) so the function-local
+    ``from ... import get_registry`` rebinds resolve to the fresh instance.
+    """
+    from silentsuite_bridge.radicale import server as server_module
+    from silentsuite_bridge.radicale.server import ListenerRegistry
+
+    fresh = ListenerRegistry()
+    monkeypatch.setattr(server_module, "_module_registry", fresh, raising=False)
+    # Patch get_registry at its definition site so every ``from ... import
+    # get_registry`` rebind sees the fresh-returning function.
+    monkeypatch.setattr(
+        server_module, "get_registry", lambda: fresh, raising=False
+    )
+    # Modules that already bound ``get_registry`` at import time need the
+    # attribute on their own module too, since ``from m import f`` captures
+    # the reference once.
+    for mod_name in (
+        "silentsuite_bridge.web",
+        "silentsuite_bridge.tray",
+        "silentsuite_bridge.auth_browser",
+        "silentsuite_bridge.__main__",
+    ):
+        try:
+            mod = sys.modules.get(mod_name)
+        except Exception:
+            mod = None
+        if mod is not None and hasattr(mod, "get_registry"):
+            monkeypatch.setattr(mod, "get_registry", lambda: fresh, raising=False)
+    yield fresh
+
+
+# ---------------------------------------------------------------------------
 # In-memory SQLite database
 # ---------------------------------------------------------------------------
 

--- a/bridge/tests/test_auth_browser_csrf.py
+++ b/bridge/tests/test_auth_browser_csrf.py
@@ -285,6 +285,40 @@ def test_success_page_uses_https_bridge_urls_when_ssl_enabled():
     assert "http://127.0.0.1:37358/" not in body
 
 
+def test_success_page_running_bridge_builds_bookmark_for_bound_url(fresh_registry):
+    """Regression: when the bridge is running with a bound loopback listener,
+    the success page must build the dashboard bookmark for the bound URL (not
+    leave dashboard_bookmark unbound). This covers the normal running-bridge
+    path, not only the standalone pre-start case."""
+    from silentsuite_bridge import config
+
+    with patch.object(config, "LISTEN_ADDRESS", "127.0.0.1"), \
+         patch.object(config, "LISTEN_PORT", 37358), \
+         patch.object(config, "SSL_ENABLED", False):
+        fresh_registry.reset()
+        fresh_registry.record_bound(("127.0.0.1", 37358), None, ssl=False)
+
+        server = http.server.HTTPServer(("127.0.0.1", 0), AuthCallbackHandler)
+        server.csrf_token = "expected-token"
+        server.authenticated_email = "alice@example.com"
+        thread = threading.Thread(target=server.handle_request)
+        thread.start()
+        try:
+            status, body = _get_auth_path(server, "/success")
+        finally:
+            server.server_close()
+            thread.join(timeout=5)
+
+    assert status == 200
+    # The bound dashboard URL appears in the page.
+    assert "http://127.0.0.1:37358/" in body
+    # The bookmark box is rendered (not the "not bound" fallback).
+    assert "bookmark-box" in body
+    assert "Dashboard is not configured or not bound" not in body
+    # The bound DAV URL is shown.
+    assert "http://127.0.0.1:37358/alice@example.com/" in body
+
+
 def test_browser_login_completion_does_not_print_account_or_server_values(capsys):
     server = MagicMock()
     event = MagicMock()

--- a/bridge/tests/test_auth_browser_csrf.py
+++ b/bridge/tests/test_auth_browser_csrf.py
@@ -340,14 +340,19 @@ def test_browser_login_completion_does_not_print_account_or_server_values(capsys
     ):
         assert browser_login(running_bridge=True) == "alice@example.com"
 
-    output = capsys.readouterr().out
-    from silentsuite_bridge import config
+        # Compute the expected URL while the SSL_ENABLED patch is still active:
+        # listener_base_url() reads config.SSL_ENABLED at call time, so building
+        # it after the patch exits would yield http:// while the output is https://.
+        from silentsuite_bridge import config
 
-    requested = config.requested_dashboard_listener()
-    assert requested is not None
-    assert requested["kind"] == "loopback"
-    expected_url = config.listener_base_url(requested["host"], requested["port"]) + "/"
-    assert expected_url.startswith(("http://127.0.0.1:", "https://127.0.0.1:", "http://[::1]:", "https://[::1]:"))
+        requested = config.requested_dashboard_listener()
+        assert requested is not None
+        assert requested["kind"] == "loopback"
+        expected_url = config.listener_base_url(requested["host"], requested["port"]) + "/"
+
+    output = capsys.readouterr().out
+
+    assert expected_url.startswith(("https://127.0.0.1:", "https://[::1]:"))
     assert "private-server.example.invalid" not in expected_url
     # Not-yet-bound path: requested loopback URL, not the bound-listener line.
     assert (

--- a/bridge/tests/test_auth_browser_csrf.py
+++ b/bridge/tests/test_auth_browser_csrf.py
@@ -341,7 +341,20 @@ def test_browser_login_completion_does_not_print_account_or_server_values(capsys
         assert browser_login(running_bridge=True) == "alice@example.com"
 
     output = capsys.readouterr().out
-    assert "Dashboard will be available on the configured local listener." in output
+    from silentsuite_bridge import config
+
+    requested = config.requested_dashboard_listener()
+    assert requested is not None
+    assert requested["kind"] == "loopback"
+    expected_url = config.listener_base_url(requested["host"], requested["port"]) + "/"
+    assert expected_url.startswith(("http://127.0.0.1:", "https://127.0.0.1:", "http://[::1]:", "https://[::1]:"))
+    assert "private-server.example.invalid" not in expected_url
+    # Not-yet-bound path: requested loopback URL, not the bound-listener line.
+    assert (
+        f"Dashboard will be available on the configured loopback listener: {expected_url}"
+        in output
+    )
+    assert "Dashboard available on the loopback listener:" not in output
     assert "CalDAV/CardDAV account configured." in output
     assert "alice@example.com" not in output
     assert "https://private-server.example.invalid" not in output

--- a/bridge/tests/test_autostart_clean_shell_cli.py
+++ b/bridge/tests/test_autostart_clean_shell_cli.py
@@ -70,6 +70,19 @@ CLI_CASES = [
         },
         id="fresh-install-no-env-no-pinning",
     ),
+    pytest.param(
+        {"SILENTSUITE_SERVER_HOSTS": "127.0.0.1:45123,0.0.0.0:45124", "SILENTSUITE_ALLOW_REMOTE": "1"},
+        {
+            "exit": 0,
+            "network": {"serverHosts": "127.0.0.1:45123,0.0.0.0:45124", "allowRemote": True},
+            "address": "127.0.0.1",
+            "port": 37358,
+            "radicale_hosts": [["127.0.0.1", 45123], ["0.0.0.0", 45124]],
+            "dashboard": True,
+            "web": "silentsuite_bridge.web",
+        },
+        id="mixed-loopback-wildcard-with-permission",
+    ),
 ]
 
 # Base-compatible probe: no reference to helpers introduced by the fix.

--- a/bridge/tests/test_config.py
+++ b/bridge/tests/test_config.py
@@ -457,3 +457,203 @@ class TestSslSettingsPersistence:
             config.DATA_DIR = original_data
             config.SSL_ENABLED = original_ssl
             restore_config(monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# Listener parsing and conflict tests for #720
+# ---------------------------------------------------------------------------
+
+
+class TestParseServerHosts:
+    def test_parse_loopback_and_remote(self, monkeypatch):
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="127.0.0.1:37358,192.0.2.10:37358",
+        )
+        try:
+            records = cfg.parse_server_hosts(cfg.SERVER_HOSTS)
+            assert records == [
+                {"host": "127.0.0.1", "port": 37358, "kind": "loopback"},
+                {"host": "192.0.2.10", "port": 37358, "kind": "remote"},
+            ]
+            assert cfg.requested_loopback_listeners() == [records[0]]
+            assert cfg.is_dashboard_enabled() is True
+        finally:
+            restore_config(monkeypatch)
+
+    def test_wildcard_only_disables_dashboard(self, monkeypatch):
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="0.0.0.0:37358",
+            SILENTSUITE_ALLOW_REMOTE="1",
+        )
+        try:
+            assert cfg.is_dashboard_enabled() is False
+            assert cfg.requested_loopback_listeners() == []
+            records = cfg.parse_server_hosts(cfg.SERVER_HOSTS)
+            assert records[0]["kind"] == "wildcard"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_wildcard_ipv4_literal_same_port_conflict(self, monkeypatch):
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="0.0.0.0:37358,127.0.0.1:37358",
+        )
+        try:
+            conflicts = cfg.listener_conflicts()
+            assert len(conflicts) >= 1
+        finally:
+            restore_config(monkeypatch)
+
+    def test_wildcard_ipv6_literal_different_family_ok(self, monkeypatch):
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="[::]:37358,127.0.0.1:37358",
+        )
+        try:
+            conflicts = cfg.listener_conflicts()
+            assert conflicts == []
+        finally:
+            restore_config(monkeypatch)
+
+    def test_loopback_listener_hint_avoids_used_ports(self, monkeypatch):
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="0.0.0.0:37358",
+        )
+        try:
+            hint = cfg.loopback_listener_hint()
+            assert hint is not None
+            assert "127.0.0.1:" in hint
+            # Must not suggest the already-used port
+            assert ":37358,127" not in hint or hint.startswith("0.0.0.0:37358,127")
+            suggested_port = int(hint.rsplit(":", 1)[1])
+            assert suggested_port != 37358
+        finally:
+            restore_config(monkeypatch)
+
+    def test_wildcard_ipv6_literal_same_family_conflict(self, monkeypatch):
+        """An expanded IPv6 wildcard (::) and an IPv6 loopback literal on the
+        same port are a same-family wildcard-over-literal conflict."""
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="[::]:37358,[::1]:37358",
+        )
+        try:
+            conflicts = cfg.listener_conflicts()
+            assert len(conflicts) >= 1, (
+                f"Expected IPv6 wildcard/literal same-family conflict, got {conflicts}"
+            )
+        finally:
+            restore_config(monkeypatch)
+
+    def test_wildcard_ipv6_expanded_form_same_family_conflict(self, monkeypatch):
+        """The expanded unspecified IPv6 form (e.g. 0:0:0:0:0:0:0:0) is
+        recognized as a wildcard and conflicts with an IPv6 literal on the
+        same port."""
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="[0:0:0:0:0:0:0:0]:37358,[::1]:37358",
+            SILENTSUITE_ALLOW_REMOTE="1",
+        )
+        try:
+            conflicts = cfg.listener_conflicts()
+            assert len(conflicts) >= 1, (
+                f"Expected expanded-form IPv6 wildcard conflict, got {conflicts}"
+            )
+        finally:
+            restore_config(monkeypatch)
+
+    def test_malformed_port_retains_invalid_classification(self, monkeypatch):
+        """A malformed port keeps the invalid classification and is never
+        fabricated into a valid default-port listener."""
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="127.0.0.1:notaport",
+        )
+        try:
+            records = cfg.parse_server_hosts(cfg.SERVER_HOSTS)
+            assert len(records) == 1
+            assert records[0]["kind"] == "invalid"
+            assert records[0]["port"] == 0
+        finally:
+            restore_config(monkeypatch)
+
+    def test_wildcard_over_literal_same_family_fails_closed_without_echoing_values(self, monkeypatch):
+        """0.0.0.0:P beside 127.0.0.1:P is refused at validation, naming the
+        variable but never echoing the address or port."""
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="0.0.0.0:37358,127.0.0.1:37358",
+            SILENTSUITE_ALLOW_REMOTE="1",
+        )
+        try:
+            with pytest.raises(cfg.NetworkConfigError, match="SILENTSUITE_SERVER_HOSTS") as excinfo:
+                cfg.validate_network_config()
+            message = str(excinfo.value)
+            assert "0.0.0.0" not in message
+            assert "127.0.0.1" not in message
+            assert "37358" not in message
+        finally:
+            restore_config(monkeypatch)
+
+    def test_ipv6_wildcard_beside_ipv4_loopback_same_port_starts(self, monkeypatch):
+        """[::]:P with 127.0.0.1:P is not a conflict (IPV6_V6ONLY keeps the
+        families apart) and keeps the dashboard on the loopback entry."""
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="[::]:37358,127.0.0.1:37358",
+            SILENTSUITE_ALLOW_REMOTE="1",
+        )
+        try:
+            cfg.validate_network_config()
+            assert cfg.is_dashboard_enabled() is True
+            assert cfg.requested_dashboard_listener() == {
+                "host": "127.0.0.1", "port": 37358, "kind": "loopback",
+            }
+        finally:
+            restore_config(monkeypatch)
+
+    def test_wildcard_only_hint_is_exact_next_port(self, monkeypatch):
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="0.0.0.0:37358",
+            SILENTSUITE_ALLOW_REMOTE="1",
+        )
+        try:
+            assert cfg.loopback_listener_hint() == "0.0.0.0:37358,127.0.0.1:37359"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_ipv6_wildcard_does_not_reserve_ipv4_hint_port(self, monkeypatch):
+        """An IPv6-only wildcard on LISTEN_PORT leaves that port free for the
+        suggested IPv4 loopback listener."""
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="[::]:37358",
+            SILENTSUITE_ALLOW_REMOTE="1",
+        )
+        try:
+            assert cfg.loopback_listener_hint() == "[::]:37358,127.0.0.1:37358"
+        finally:
+            restore_config(monkeypatch)
+
+    def test_unknown_family_hint_reserves_port(self, monkeypatch):
+        """A hostname entry (unknown family) reserves its port so the
+        loopback hint never suggests a 127.0.0.1 listener on a port a
+        hostname entry already uses."""
+        cfg = reload_config_with_env(
+            monkeypatch,
+            SILENTSUITE_SERVER_HOSTS="myhost.example:37358",
+            SILENTSUITE_ALLOW_REMOTE="1",
+        )
+        try:
+            hint = cfg.loopback_listener_hint()
+            assert hint is not None
+            suggested_port = int(hint.rsplit(":", 1)[1])
+            assert suggested_port != 37358, (
+                "hint must not suggest the hostname entry's port"
+            )
+        finally:
+            restore_config(monkeypatch)

--- a/bridge/tests/test_listener_isolation.py
+++ b/bridge/tests/test_listener_isolation.py
@@ -1,0 +1,1104 @@
+"""Listener isolation and evidence-gate integration tests for #720.
+
+Linux full-suite wired tests using the production serve wrapper, shutdown
+via socketpair, and assertion of real socket binding behaviour. These tests
+exercise the actual security properties: wildcard/remote dashboard denial,
+IPv6 loopback serving, missing-evidence negative control, partial-bind
+failure recording, registry lifecycle, restoration, and lock handoff
+concurrency.
+"""
+
+import contextlib
+import logging
+import os
+import socket
+import ssl
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import radicale.server as radicale_server_module
+from silentsuite_bridge import __main__ as bridge_main
+from silentsuite_bridge import config
+from silentsuite_bridge.radicale.server import get_registry
+
+# Only run these tests on Linux where the full socket suite is available.
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Wired socket tests are Linux-only")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _free_port_ipv6() -> int:
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+        s.bind(("::1", 0))
+        return s.getsockname()[1]
+
+
+def _build_configuration(hosts: str):
+    """Build a Radicale configuration that won't fail on missing certs etc."""
+    from radicale.config import DEFAULT_CONFIG_SCHEMA, Configuration
+
+    configuration = Configuration(DEFAULT_CONFIG_SCHEMA)
+    configuration.update(
+        {
+            "server": {"hosts": hosts},
+            "auth": {"type": "silentsuite_bridge.radicale.auth"},
+            "storage": {"type": "silentsuite_bridge.radicale.storage"},
+            "rights": {"type": "silentsuite_bridge.radicale.rights"},
+            "web": {"type": "silentsuite_bridge.web"},
+            "logging": {"level": "debug"},
+        },
+        source="test",
+        privileged=True,
+    )
+    return configuration
+
+
+@contextlib.contextmanager
+def _serve_with_hosts(hosts: str, allow_remote: bool = False, monkeypatch=None):
+    """Run the production serve wrapper with given SERVER_HOSTS.
+
+    Yields (registry, thread). On exit, closes the shutdown socket and joins
+    the thread. Propagates any error from the serving thread.
+    """
+    if monkeypatch is not None:
+        monkeypatch.setattr(config, "SERVER_HOSTS", hosts)
+        monkeypatch.setattr(config, "ALLOW_REMOTE", allow_remote)
+    else:
+        config.SERVER_HOSTS = hosts
+        config.ALLOW_REMOTE = allow_remote
+
+    registry = get_registry()
+    registry.reset()
+
+    configuration = _build_configuration(hosts)
+
+    a, b = socket.socketpair()
+    thread_errors: list = []
+
+    def _run():
+        try:
+            bridge_main._serve_radicale_with_bridge_application(
+                configuration, shutdown_socket=a,
+            )
+        except Exception as exc:
+            thread_errors.append(exc)
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+
+    # Wait for at least one listener to bind or a failure to record
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        if registry.bound_listeners() or registry.failed_count():
+            break
+        time.sleep(0.05)
+
+    try:
+        yield registry, t
+    finally:
+        b.close()
+        t.join(timeout=10)
+        assert not t.is_alive(), "serving thread did not terminate within 10s"
+        # Close both socketpair ends: 'a' is passed into serve() and may still
+        # be open; closing it here ensures no fd leak and deterministic teardown.
+        with contextlib.suppress(OSError):
+            a.close()
+        if thread_errors:
+            raise thread_errors[0]
+
+
+def _http_get(host: str, port: int, path: str = "/", timeout: float = 5.0) -> tuple[int, bytes]:
+    import http.client
+
+    conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        return resp.status, resp.read()
+    finally:
+        conn.close()
+
+
+def _http_post(host: str, port: int, path: str, body: bytes, headers: dict | None = None,
+               timeout: float = 5.0) -> tuple[int, bytes]:
+    import http.client
+
+    conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    try:
+        hdrs = headers or {}
+        conn.request("POST", path, body=body, headers=hdrs)
+        resp = conn.getresponse()
+        return resp.status, resp.read()
+    finally:
+        conn.close()
+
+
+def _http_propfind(host: str, port: int, path: str = "/", timeout: float = 5.0) -> int:
+    import http.client
+
+    conn = http.client.HTTPConnection(host, port, timeout=timeout)
+    try:
+        conn.request("PROPFIND", path)
+        resp = conn.getresponse()
+        resp.read()
+        return resp.status
+    finally:
+        conn.close()
+
+
+def _https_get(host: str, port: int, path: str = "/", timeout: float = 5.0) -> tuple[int, bytes]:
+    import http.client
+
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    conn = http.client.HTTPSConnection(host, port, timeout=timeout, context=ctx)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        return resp.status, resp.read()
+    finally:
+        conn.close()
+
+
+def _own_non_loopback_ipv4() -> str | None:
+    """Return the runner's own non-loopback IPv4 address, or None."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+    except OSError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorFailureOutput:
+    """Regression for the NameError where the constructor-failure path called
+    ``_print_listener_not_bound`` (which did not exist) instead of
+    ``print_listener_not_bound``. A failed bind must record the failure and
+    print the 'Listener not bound:' line, not raise NameError."""
+
+    def test_http_constructor_failure_prints_not_bound_and_records(self, monkeypatch, capsys):
+        from silentsuite_bridge.radicale.server import (
+            ListenerRegistry, _build_bridge_http_server_class,
+        )
+
+        registry = ListenerRegistry()
+        registry.reset()
+
+        class _FailingUpstream:
+            def __init__(self, configuration, family, address, handler_class):
+                raise OSError("address already in use")
+
+        BridgeHTTP = _build_bridge_http_server_class(_FailingUpstream, registry)
+
+        with pytest.raises(OSError, match="address already in use"):
+            BridgeHTTP(object(), socket.AF_INET, ("127.0.0.1", 45123), None)
+
+        assert registry.failed_count() == 1
+        captured = capsys.readouterr()
+        assert "Listener not bound: 127.0.0.1:45123 (HTTP)" in captured.out, (
+            f"Expected HTTP 'Listener not bound:' stdout line, got: {captured.out}"
+        )
+
+    def test_https_constructor_failure_prints_not_bound_and_records(self, monkeypatch, capsys):
+        from silentsuite_bridge.radicale.server import (
+            ListenerRegistry, _build_bridge_https_server_class,
+        )
+
+        registry = ListenerRegistry()
+        registry.reset()
+
+        class _FailingUpstream:
+            def __init__(self, configuration, family, address, handler_class):
+                raise RuntimeError("SSL context error")
+
+        BridgeHTTPS = _build_bridge_https_server_class(_FailingUpstream, registry)
+
+        with pytest.raises(RuntimeError, match="SSL context error"):
+            BridgeHTTPS(object(), socket.AF_INET, ("127.0.0.1", 45124), None)
+
+        assert registry.failed_count() == 1
+        captured = capsys.readouterr()
+        assert "Listener not bound: 127.0.0.1:45124 (HTTPS)" in captured.out, (
+            f"Expected HTTPS 'Listener not bound:' stdout line, got: {captured.out}"
+        )
+
+
+class TestWildcardDenial:
+    def test_wildcard_listener_denies_dashboard_while_dav_is_alive(self, monkeypatch):
+        """Wildcard-bound listener returns 404 for /.web, 401 for PROPFIND /."""
+        P1 = _free_port()
+        P2 = _free_port()
+        with _serve_with_hosts(
+            f"127.0.0.1:{P1},0.0.0.0:{P2}",
+            allow_remote=True,
+            monkeypatch=monkeypatch,
+        ) as (registry, thread):
+            # Wait for both to bind
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                if len(registry.bound_listeners()) >= 2:
+                    break
+                time.sleep(0.05)
+            assert len(registry.bound_listeners()) >= 2, "Expected two bound listeners"
+
+            status, body = _http_get("127.0.0.1", P1, "/.web")
+            assert status == 200, f"Loopback listener should serve dashboard, got {status}"
+
+            status2, body2 = _http_get("127.0.0.1", P2, "/.web")
+            assert status2 == 404, f"Wildcard listener should deny dashboard, got {status2}"
+
+            # Prove wildcard DAV is alive
+            dav_status = _http_propfind("127.0.0.1", P2, "/")
+            assert dav_status == 401, f"Wildcard DAV should respond 401, got {dav_status}"
+
+    def test_wildcard_post_with_valid_csrf_denied_before_side_effect(self, monkeypatch):
+        """POST with a valid CSRF token to a wildcard listener is denied (404)
+        and never reaches the settings handler — verified with a mutation spy.
+        Uses a valid loopback Host header (127.0.0.1:P2) and valid CSRF so the
+        only thing that can deny the request is the evidence gate, not a
+        Host/CSRF mismatch. An allowed control on the loopback listener proves
+        the route and spy are wired, so a 404 on the wildcard cannot be explained
+        by a deleted source gate or an unwired spy."""
+        P1 = _free_port()
+        P2 = _free_port()
+        from silentsuite_bridge.web import _dashboard_csrf_token
+
+        # Mutation spy: records any settings write. Must stay empty for the
+        # wildcard request and be touched exactly once for the loopback control.
+        settings_calls: list = []
+        monkeypatch.setattr(
+            config, "save_settings",
+            lambda *a, **k: settings_calls.append(a) or None,
+        )
+
+        with _serve_with_hosts(
+            f"127.0.0.1:{P1},0.0.0.0:{P2}",
+            allow_remote=True,
+            monkeypatch=monkeypatch,
+        ) as (registry, thread):
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                if len(registry.bound_listeners()) >= 2:
+                    break
+                time.sleep(0.05)
+
+            assert len(registry.bound_listeners()) >= 2, "Expected two bound listeners"
+
+            body = b'{"syncInterval":60}'
+            headers = {
+                "Content-Type": "application/json",
+                "X-SilentSuite-CSRF": _dashboard_csrf_token,
+                # Valid loopback Host matching the wildcard listener port —
+                # the only deny path left is the evidence gate.
+                "Host": f"127.0.0.1:{P2}",
+            }
+            status, resp_body = _http_post("127.0.0.1", P2, "/.web/api/settings", body, headers)
+            assert status == 404, f"Wildcard POST should be denied by evidence gate, got {status}"
+            assert settings_calls == [], "Wildcard POST must not reach the settings handler"
+
+            # Allowed control on the loopback listener: same body/CSRF/Host
+            # pattern against the loopback listener must reach the handler
+            # and write settings, proving the route and spy are wired.
+            control_headers = {
+                "Content-Type": "application/json",
+                "X-SilentSuite-CSRF": _dashboard_csrf_token,
+                "Host": f"127.0.0.1:{P1}",
+            }
+            c_status, _ = _http_post("127.0.0.1", P1, "/.web/api/settings", body, control_headers)
+            assert c_status == 200, f"Loopback control POST should succeed, got {c_status}"
+            assert len(settings_calls) == 1, (
+                f"Loopback control should reach the settings handler exactly once, "
+                f"got {len(settings_calls)}"
+            )
+
+
+class TestNonLoopbackPeer:
+    def test_non_loopback_peer_denies_dashboard(self, monkeypatch):
+        """A request to a remote-bound listener from a non-loopback peer
+        returns 404. Skipped when no non-loopback address is available."""
+        own_ip = _own_non_loopback_ipv4()
+        if own_ip is None:
+            pytest.skip("No non-loopback IPv4 address available")
+
+        P = _free_port()
+        with _serve_with_hosts(
+            f"127.0.0.1:{_free_port()},{own_ip}:{P}",
+            allow_remote=True,
+            monkeypatch=monkeypatch,
+        ) as (registry, thread):
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                if len(registry.bound_listeners()) >= 2:
+                    break
+                time.sleep(0.05)
+
+            status, body = _http_get(own_ip, P, "/.web")
+            assert status == 404, f"Remote peer should be denied dashboard, got {status}"
+
+    def test_remote_post_with_valid_host_no_side_effect(self, monkeypatch):
+        """A POST to a real non-loopback remote listener with a valid loopback
+        Host header and valid CSRF is denied (404) and never reaches the
+        settings handler — the evidence gate denies on the bound remote
+        listener regardless of the Host header. Skipped without a non-loopback
+        address."""
+        own_ip = _own_non_loopback_ipv4()
+        if own_ip is None:
+            pytest.skip("No non-loopback IPv4 address available")
+
+        from silentsuite_bridge.web import _dashboard_csrf_token
+
+        settings_calls: list = []
+        monkeypatch.setattr(
+            config, "save_settings",
+            lambda *a, **k: settings_calls.append(a) or None,
+        )
+
+        P_remote = _free_port()
+        P_loopback = _free_port()
+        with _serve_with_hosts(
+            f"127.0.0.1:{P_loopback},{own_ip}:{P_remote}",
+            allow_remote=True,
+            monkeypatch=monkeypatch,
+        ) as (registry, thread):
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                if len(registry.bound_listeners()) >= 2:
+                    break
+                time.sleep(0.05)
+
+            body = b'{"syncInterval":60}'
+            headers = {
+                "Content-Type": "application/json",
+                "X-SilentSuite-CSRF": _dashboard_csrf_token,
+                # Valid loopback Host — the deny must come from the evidence
+                # gate (bound listener is remote), not a Host mismatch.
+                "Host": f"127.0.0.1:{P_remote}",
+            }
+            status, _ = _http_post(own_ip, P_remote, "/.web/api/settings", body, headers)
+            assert status == 404, (
+                f"Remote POST should be denied by evidence gate, got {status}"
+            )
+            assert settings_calls == [], "Remote POST must not reach the settings handler"
+
+
+class TestIPv6:
+    @pytest.mark.skipif(not hasattr(socket, "AF_INET6"), reason="IPv6 not available")
+    def test_ipv6_loopback_serves_dashboard(self, monkeypatch):
+        """A real HTTP request to [::1]:P serves the dashboard (200)."""
+        try:
+            port = _free_port_ipv6()
+        except OSError:
+            pytest.skip("IPv6 loopback not available")
+
+        with _serve_with_hosts(
+            f"[::1]:{port}",
+            monkeypatch=monkeypatch,
+        ) as (registry, thread):
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                if registry.bound_listeners():
+                    break
+                time.sleep(0.05)
+
+            assert registry.bound_listeners(), "Expected at least one bound listener"
+            status, body = _http_get("::1", port, "/.web")
+            assert status == 200, f"IPv6 loopback should serve dashboard, got {status}"
+
+    @pytest.mark.skipif(not hasattr(socket, "AF_INET6"), reason="IPv6 not available")
+    def test_ipv6_wildcard_denies_dashboard(self, monkeypatch):
+        """[::]:P denies the dashboard even for a loopback peer."""
+        try:
+            # Get a port that's free for both ::1 and ::
+            with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+                s.bind(("::", 0))
+                port = s.getsockname()[1]
+        except OSError:
+            pytest.skip("IPv6 wildcard bind not available")
+
+        with _serve_with_hosts(
+            f"127.0.0.1:{_free_port()},[::]:{port}",
+            allow_remote=True,
+            monkeypatch=monkeypatch,
+        ) as (registry, thread):
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                if len(registry.bound_listeners()) >= 2:
+                    break
+                time.sleep(0.05)
+
+            assert len(registry.bound_listeners()) >= 2, "Expected two bound listeners"
+            status, body = _http_get("::1", port, "/.web")
+            assert status == 404, f"IPv6 wildcard should deny dashboard, got {status}"
+
+
+class TestMissingEvidenceControl:
+    def test_upstream_handler_without_evidence_returns_404(self, monkeypatch):
+        """Run the production wrapper but with only Application injected
+        (upstream handler, no bridge evidence stamp) and assert 127.0.0.1
+        returns 404. This proves fail-closed and that the passing case
+        depends on the stamp.
+
+        We inject only the bridge Application and leave the upstream
+        RequestHandler/server classes, so no evidence is stamped.
+        """
+        from radicale import server as radicale_server
+        from radicale.app import Application as RadicaleApplication
+
+        from silentsuite_bridge.radicale.application import Application as BridgeApplication
+
+        P = _free_port()
+        if monkeypatch is not None:
+            monkeypatch.setattr(config, "SERVER_HOSTS", f"127.0.0.1:{P}")
+            monkeypatch.setattr(config, "ALLOW_REMOTE", False)
+        else:
+            config.SERVER_HOSTS = f"127.0.0.1:{P}"
+            config.ALLOW_REMOTE = False
+
+        configuration = _build_configuration(f"127.0.0.1:{P}")
+        a, b = socket.socketpair()
+        thread_errors: list = []
+
+        # Inject ONLY the Application, leave upstream RequestHandler/servers.
+        if not bridge_main._RADICALE_SERVER_APPLICATION_LOCK.acquire(blocking=False):
+            raise RuntimeError("lock already active")
+        try:
+            radicale_server.Application = BridgeApplication
+            try:
+                def _run():
+                    try:
+                        radicale_server.serve(configuration, shutdown_socket=a)
+                    except Exception as exc:
+                        thread_errors.append(exc)
+
+                t = threading.Thread(target=_run, daemon=True)
+                t.start()
+
+                deadline = time.monotonic() + 10.0
+                while time.monotonic() < deadline:
+                    # No registry to check; just wait for the socket to accept
+                    try:
+                        with socket.create_connection(("127.0.0.1", P), timeout=1):
+                            break
+                    except OSError:
+                        time.sleep(0.05)
+
+                status, body = _http_get("127.0.0.1", P, "/.web")
+                assert status == 404, (
+                    f"Upstream handler without evidence should return 404, got {status}"
+                )
+            finally:
+                b.close()
+                t.join(timeout=10)
+                assert not t.is_alive(), "serving thread did not terminate"
+                with contextlib.suppress(OSError):
+                    a.close()
+                # Restore Application if it still holds ours
+                if radicale_server.Application is BridgeApplication:
+                    radicale_server.Application = RadicaleApplication
+        finally:
+            bridge_main._RADICALE_SERVER_APPLICATION_LOCK.release()
+
+        if thread_errors:
+            raise thread_errors[0]
+
+
+class TestPartialBind:
+    def test_partial_bind_reports_one_bound_one_failed(self, monkeypatch, capsys, caplog):
+        """Pre-occupy one port, assert registry records one bound + one failed,
+        stdout has one Listening: and one Listener not bound: line, and the
+        logger contains the redacted bind-failure message with no address or
+        port from the failed entry."""
+        P5 = _free_port()
+        P6 = _free_port()
+        blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        blocker.bind(("127.0.0.1", P5))
+        blocker.listen(1)
+        try:
+            # DEBUG on the radicale logger: the bind loop also emits DEBUG
+            # lines carrying the address, and the redaction filter must
+            # rewrite every one of them, not only the WARNING.
+            with caplog.at_level(logging.DEBUG, logger="radicale"):
+                with _serve_with_hosts(
+                    f"127.0.0.1:{P5},127.0.0.1:{P6}",
+                    monkeypatch=monkeypatch,
+                ) as (registry, thread):
+                    deadline = time.monotonic() + 10.0
+                    while time.monotonic() < deadline:
+                        if registry.failed_count() >= 1 and len(registry.bound_listeners()) >= 1:
+                            break
+                        time.sleep(0.05)
+
+                    bound = registry.bound_listeners()
+                    assert len(bound) == 1, f"Expected exactly one bound listener, got {len(bound)}"
+                    assert registry.failed_count() == 1, (
+                        f"Expected exactly one failed, got {registry.failed_count()}"
+                    )
+        finally:
+            blocker.close()
+
+        captured = capsys.readouterr()
+        assert captured.out.count("Listening:") == 1, (
+            f"Expected one Listening: line, got: {captured.out}"
+        )
+        assert "Listener not bound:" in captured.out, (
+            f"Expected a Listener not bound: line, got: {captured.out}"
+        )
+
+        # Privacy contract: upstream's "cannot create server socket on
+        # '<host:port>': <error>" WARNING is rewritten by the production
+        # _DavDiagnosticRedactionFilter (installed on the radicale logger when
+        # silentsuite_bridge.radicale.application is imported) to the exact
+        # address-free template. The raw template must never reach a handler,
+        # and no record from any logger may carry the requested host or either
+        # port. The operator-facing address lives only on stdout.
+        radicale_messages = [
+            rec.getMessage() for rec in caplog.records if rec.name.startswith("radicale")
+        ]
+        assert "Radicale listener bind failed" in radicale_messages, (
+            f"Expected the redacted bind-failure record, got: {radicale_messages}"
+        )
+        assert "Radicale listener started" in radicale_messages
+        assert not any("cannot create server socket" in m for m in radicale_messages), (
+            f"Raw upstream bind-failure text leaked: {radicale_messages}"
+        )
+        radicale_text = " ".join(radicale_messages)
+        for private in ("127.0.0.1", str(P5), str(P6)):
+            assert private not in radicale_text, (
+                f"Address material {private!r} leaked into the radicale log: {radicale_text}"
+            )
+
+
+class TestResolutionFailure:
+    def test_resolution_failure_increments_failed_count_without_global_socket_mutation(
+        self, monkeypatch, capsys, caplog,
+    ):
+        """A hostname that cannot resolve increments failed_count and prints
+        the resolution-failure line, while a healthy loopback listener still
+        binds. The test patches getaddrinfo narrowly for the exact nonexistent
+        hostname so it is deterministic and does not depend on external DNS.
+
+        Regression for the scope bug: the observing wrapper must NOT mutate
+        the stdlib socket module. We assert ``socket.getaddrinfo`` is the
+        original callable throughout serving and that an unrelated DNS failure
+        during serving is not recorded by the bridge observer.
+        """
+        import socket as stdlib_socket
+
+        real_gai = stdlib_socket.getaddrinfo
+
+        def _scoped_gai(host, port, *args, **kwargs):
+            if host == "nonexistent.invalid":
+                raise stdlib_socket.gaierror(
+                    stdlib_socket.EAI_NONAME, "Name or service not known"
+                )
+            return real_gai(host, port, *args, **kwargs)
+
+        # Patch the real socket module narrowly for the nonexistent hostname
+        # only. The bridge proxy delegates to this, so the observer fires for
+        # nonexistent.invalid but real lookups (127.0.0.1) still succeed.
+        monkeypatch.setattr(stdlib_socket, "getaddrinfo", _scoped_gai)
+
+        P_healthy = _free_port()
+        captured_during = {}
+
+        with caplog.at_level(logging.DEBUG, logger="radicale"):
+            with _serve_with_hosts(
+                f"127.0.0.1:{P_healthy},nonexistent.invalid:12345",
+                monkeypatch=monkeypatch,
+            ) as (registry, thread):
+                deadline = time.monotonic() + 10.0
+                while time.monotonic() < deadline:
+                    if (
+                        registry.failed_count() >= 1
+                        and len(registry.bound_listeners()) >= 1
+                    ):
+                        break
+                    time.sleep(0.05)
+
+                # The stdlib socket.getaddrinfo must be the real callable
+                # while serving is active (the proxy swaps only the
+                # radicale.server module global, never the socket module).
+                captured_during["gai"] = stdlib_socket.getaddrinfo
+                assert stdlib_socket.getaddrinfo is _scoped_gai, (
+                    "stdlib socket.getaddrinfo must not be replaced by the "
+                    "bridge observer"
+                )
+
+                assert registry.failed_count() >= 1, (
+                    "Resolution failure must be recorded; got failed_count=0"
+                )
+                bound = registry.bound_listeners()
+                assert len(bound) == 1, (
+                    f"Expected exactly the healthy loopback listener bound, "
+                    f"got {bound}"
+                )
+                assert bound[0]["host"] == "127.0.0.1"
+
+        captured = capsys.readouterr()
+        assert "Listener address resolution failed:" in captured.out, (
+            f"Expected resolution-failure stdout line, got: {captured.out}"
+        )
+        # Privacy contract for the DNS path: upstream's "cannot retrieve IPv4
+        # or IPv6 address of '<host:port>': <error>" WARNING must reach the
+        # handler only as the exact redacted template, and the hostname and
+        # port must be absent from every captured record. The stdout line is
+        # the only place the requested spec appears.
+        radicale_messages = [
+            rec.getMessage() for rec in caplog.records if rec.name.startswith("radicale")
+        ]
+        assert "Radicale listener address resolution failed" in radicale_messages, (
+            f"Expected the redacted resolution-failure record, got: {radicale_messages}"
+        )
+        assert not any("cannot retrieve" in m for m in radicale_messages), (
+            f"Raw upstream resolution-failure text leaked: {radicale_messages}"
+        )
+        radicale_text = " ".join(radicale_messages)
+        for private in ("nonexistent.invalid", "12345", "127.0.0.1", str(P_healthy)):
+            assert private not in radicale_text, (
+                f"Address material {private!r} leaked into the radicale log: {radicale_text}"
+            )
+        # After serve exits, the radicale.server module global is restored to
+        # the real socket module; the stdlib socket module was never mutated.
+        assert radicale_server_module.socket is stdlib_socket, (
+            "radicale.server.socket must be restored to the real socket module"
+        )
+
+    def test_unrelated_dns_failure_not_recorded_by_bridge_observer(
+        self, monkeypatch,
+    ):
+        """A DNS failure for a hostname the bridge is NOT configured to serve
+        must not increment the bridge registry's failed_count. The observer
+        only fires for hostnames Radicale passes to getaddrinfo during serve().
+        The unrelated failure must actually raise through the real stdlib path
+        (asserted with pytest.raises), not be swallowed by try/except pass.
+        The resolver is patched narrowly for that exact name so the failure is
+        deterministic and never depends on external DNS.
+        """
+        import socket as stdlib_socket
+
+        real_gai = stdlib_socket.getaddrinfo
+        unrelated = "totally-unrelated-nonexistent.invalid"
+
+        def _scoped_gai(host, port, *args, **kwargs):
+            if host == unrelated:
+                raise stdlib_socket.gaierror(
+                    stdlib_socket.EAI_NONAME, "Name or service not known"
+                )
+            return real_gai(host, port, *args, **kwargs)
+
+        monkeypatch.setattr(stdlib_socket, "getaddrinfo", _scoped_gai)
+
+        P = _free_port()
+        with _serve_with_hosts(
+            f"127.0.0.1:{P}", monkeypatch=monkeypatch,
+        ) as (registry, thread):
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                if registry.bound_listeners():
+                    break
+                time.sleep(0.05)
+
+            assert registry.bound_listeners(), "Expected a bound listener"
+            failed_before = registry.failed_count()
+
+            # Trigger the unrelated DNS failure through the stdlib module
+            # (not the radicale.server proxy) and assert it actually raises.
+            with pytest.raises(stdlib_socket.gaierror):
+                stdlib_socket.getaddrinfo(unrelated, 80)
+
+            assert registry.failed_count() == failed_before, (
+                "Unrelated DNS failure must not be recorded by the bridge "
+                "observer"
+            )
+
+    def test_resolution_only_hosts_raise_no_servers_started_deterministically(
+        self, monkeypatch, capsys,
+    ):
+        """When every configured host fails to resolve, upstream raises
+        RuntimeError('No servers started'). The harness propagates it, so the
+        test expects the error explicitly, then inspects the registry/stdout.
+        Deterministic via a narrowly patched resolver for the exact hostname.
+        """
+        import socket as stdlib_socket
+
+        real_gai = stdlib_socket.getaddrinfo
+
+        def _scoped_gai(host, port, *args, **kwargs):
+            if host == "nonexistent.invalid":
+                raise stdlib_socket.gaierror(
+                    stdlib_socket.EAI_NONAME, "Name or service not known"
+                )
+            return real_gai(host, port, *args, **kwargs)
+
+        monkeypatch.setattr(stdlib_socket, "getaddrinfo", _scoped_gai)
+
+        P = _free_port()
+        with pytest.raises(RuntimeError, match="No servers started"):
+            with _serve_with_hosts(
+                f"nonexistent.invalid:12345",
+                monkeypatch=monkeypatch,
+            ) as (registry, thread):
+                pass  # serve exits before yielding control
+
+        # The registry recorded the failure and stdout printed the line.
+        # (The registry was marked stopped when the error propagated.)
+        registry = get_registry()
+        assert registry.is_stopped
+        captured = capsys.readouterr()
+        assert "Listener address resolution failed:" in captured.out, (
+            f"Expected resolution-failure stdout line, got: {captured.out}"
+        )
+
+
+class TestRegistryLifecycle:
+    def test_registry_stops_after_serve_exits(self, monkeypatch):
+        """Registry returns None dashboard URL after serve exits."""
+        P = _free_port()
+        with _serve_with_hosts(
+            f"127.0.0.1:{P}", monkeypatch=monkeypatch,
+        ) as (registry, thread):
+            deadline = time.monotonic() + 10.0
+            while time.monotonic() < deadline:
+                if registry.bound_listeners():
+                    break
+                time.sleep(0.05)
+
+            assert registry.dashboard_url(False) is not None
+            assert registry.is_started
+
+        # After the context exits (b closed, thread joined):
+        assert registry.is_stopped
+        assert registry.dashboard_url(False) is None
+
+    def test_registry_never_started_returns_none(self):
+        """Never-started registry returns None for dashboard URL."""
+        from silentsuite_bridge.radicale.server import ListenerRegistry
+
+        r = ListenerRegistry()
+        assert r.dashboard_url(False) is None
+
+
+class TestRestoration:
+    def test_globals_restored_after_serve_exits(self, monkeypatch):
+        """All four radicale.server globals are restored to pinned originals."""
+        import radicale.server as rad_server
+
+        from silentsuite_bridge.radicale.server import get_pinned_originals
+
+        P = _free_port()
+        originals_before = get_pinned_originals()
+        with _serve_with_hosts(
+            f"127.0.0.1:{P}", monkeypatch=monkeypatch,
+        ):
+            pass  # context exit closes and joins
+
+        for name, pinned in originals_before.items():
+            current = getattr(rad_server, name, None)
+            assert current is pinned, (
+                f"radicale.server.{name} was not restored: expected {pinned}, got {current}"
+            )
+
+    def test_getaddrinfo_restored_after_serve_exits(self, monkeypatch):
+        """The module-local socket proxy is restored after serve exits: the
+        radicale.server module global points back at the real socket module
+        and the real socket module's getaddrinfo was never replaced."""
+        import radicale.server as rad_server
+
+        original_gai = socket.getaddrinfo
+        P = _free_port()
+        with _serve_with_hosts(
+            f"127.0.0.1:{P}", monkeypatch=monkeypatch,
+        ):
+            pass  # context exit closes and joins
+
+        assert socket.getaddrinfo is original_gai, (
+            "stdlib socket.getaddrinfo was replaced during serve and not "
+            "restored — the observer must never mutate the socket module"
+        )
+        assert rad_server.socket is socket, (
+            "radicale.server.socket must be restored to the real socket module"
+        )
+
+    def test_globals_restored_after_injected_exception(self, monkeypatch):
+        """An exception from serve() still restores all four globals."""
+        import radicale.server as rad_server
+
+        from silentsuite_bridge.radicale.server import get_pinned_originals
+
+        def boom(_configuration, shutdown_socket=None):
+            raise RuntimeError("injected failure")
+
+        monkeypatch.setattr(rad_server, "serve", boom)
+        originals_before = get_pinned_originals()
+
+        with pytest.raises(RuntimeError, match="injected failure"):
+            bridge_main._serve_radicale_with_bridge_application(object())
+
+        for name, pinned in originals_before.items():
+            current = getattr(rad_server, name, None)
+            assert current is pinned, f"{name} not restored after exception"
+
+
+class _ReleaseObservingLock:
+    """Stand-in for the lifecycle lock that records the registry state at the
+    instant ``release()`` is entered.
+
+    This is the deterministic regression for the stop-after-unlock ordering:
+    the wrapper must have marked the registry stopped BEFORE it releases the
+    lock. Under the old order (release, then mark_stopped) the recorded value
+    is False; no thread timing is involved.
+    """
+
+    def __init__(self, registry):
+        self._inner = threading.Lock()
+        self._registry = registry
+        self.stopped_at_release: list[bool] = []
+        self.release_hook = None
+
+    def acquire(self, blocking=True, timeout=-1):
+        return self._inner.acquire(blocking, timeout)
+
+    def release(self):
+        self.stopped_at_release.append(self._registry.is_stopped)
+        self._inner.release()
+        hook, self.release_hook = self.release_hook, None
+        if hook is not None:
+            hook()
+
+
+class TestLockHandoff:
+    def test_registry_is_stopped_at_the_instant_the_lock_is_released(self, monkeypatch):
+        """Ordering regression with no thread timing: the state observed from
+        inside the lock's ``release()`` must already be stopped. The old
+        stop-after-unlock order records False here."""
+        import radicale.server as radicale_server
+
+        registry = get_registry()
+        observing = _ReleaseObservingLock(registry)
+        monkeypatch.setattr(bridge_main, "_RADICALE_SERVER_APPLICATION_LOCK", observing)
+        monkeypatch.setattr(radicale_server, "serve", lambda *a, **k: None)
+
+        bridge_main._serve_radicale_with_bridge_application(
+            _build_configuration(f"127.0.0.1:{_free_port()}"),
+        )
+
+        assert observing.stopped_at_release == [True], (
+            "registry must be marked stopped before the lifecycle lock is released"
+        )
+        assert registry.is_stopped
+
+    def test_lifecycle_handoff_under_contention(self, monkeypatch):
+        """Real handoff: while one invocation holds the lifecycle lock inside
+        serve(), a second invocation is rejected and does not reset the
+        holder's registry. At the holder's release the registry is already
+        stopped, and the successor that acquires the lock from the release
+        hook (the exact window the old order raced in) sees a freshly started
+        registry throughout its own serve() call.
+        """
+        import radicale.server as radicale_server
+
+        registry = get_registry()
+        observing = _ReleaseObservingLock(registry)
+        monkeypatch.setattr(bridge_main, "_RADICALE_SERVER_APPLICATION_LOCK", observing)
+
+        entered_serve = threading.Event()
+        release_serve = threading.Event()
+        successor_states: list[tuple[bool, bool]] = []
+
+        def _hold_serve(_configuration, shutdown_socket=None):
+            entered_serve.set()
+            # Park until the test releases us, holding the lifecycle lock.
+            assert release_serve.wait(timeout=10), "holder was not released"
+
+        def _successor_serve(_configuration, shutdown_socket=None):
+            successor_states.append((registry.is_started, registry.is_stopped))
+
+        monkeypatch.setattr(radicale_server, "serve", _hold_serve)
+
+        P = _free_port()
+        holder_errors: list = []
+
+        def _hold():
+            try:
+                bridge_main._serve_radicale_with_bridge_application(
+                    _build_configuration(f"127.0.0.1:{P}"),
+                )
+            except BaseException as exc:
+                holder_errors.append(exc)
+
+        def _run_successor():
+            # Runs on the holder thread immediately after its lock release,
+            # i.e. inside the window where the old order still had
+            # mark_stopped() pending.
+            monkeypatch.setattr(radicale_server, "serve", _successor_serve)
+            bridge_main._serve_radicale_with_bridge_application(
+                _build_configuration(f"127.0.0.1:{P}"),
+            )
+
+        observing.release_hook = _run_successor
+
+        holder = threading.Thread(target=_hold, daemon=True)
+        holder.start()
+        # Wait until the holder is inside serve() (lock held).
+        assert entered_serve.wait(timeout=10), "holder never entered serve"
+        assert registry.is_started
+
+        # Second invocation must be rejected while the holder holds the lock
+        # and must leave the holder's registry running.
+        with pytest.raises(RuntimeError, match="already active"):
+            bridge_main._serve_radicale_with_bridge_application(
+                _build_configuration(f"127.0.0.1:{P}"),
+            )
+        assert registry.is_started
+        assert observing.stopped_at_release == []
+
+        # Release the holder; it restores globals, marks the registry stopped,
+        # releases the lock, and the hook runs the successor in that window.
+        release_serve.set()
+        holder.join(timeout=10)
+        assert not holder.is_alive(), "holder thread did not terminate"
+        assert holder_errors == [], f"holder errors: {holder_errors}"
+
+        # Holder release saw stopped; successor release saw stopped too.
+        assert observing.stopped_at_release == [True, True]
+        # The successor's serve() ran on a freshly started registry that the
+        # holder's shutdown did not stomp on.
+        assert successor_states == [(True, False)]
+        assert registry.is_stopped
+
+
+class TestTlsWired:
+    def test_https_serves_dashboard_on_loopback(self, monkeypatch, tmp_path):
+        """Optional TLS wired case: generate a localhost certificate, assert
+        the HTTPS server subclass is used and the dashboard is served on
+        https://127.0.0.1:P. Gated on openssl being available."""
+        if not _has_openssl():
+            pytest.skip("openssl not available for certificate generation")
+
+        cert_path, key_path = _generate_localhost_certificate(tmp_path)
+        P = _free_port()
+
+        monkeypatch.setattr(config, "SERVER_HOSTS", f"127.0.0.1:{P}")
+        monkeypatch.setattr(config, "ALLOW_REMOTE", False)
+        monkeypatch.setattr(config, "SSL_ENABLED", True)
+        monkeypatch.setattr(config, "SSL_CERT_FILE", str(cert_path))
+        monkeypatch.setattr(config, "SSL_KEY_FILE", str(key_path))
+
+        # Build config with ssl enabled
+        from radicale.config import DEFAULT_CONFIG_SCHEMA, Configuration
+
+        configuration = Configuration(DEFAULT_CONFIG_SCHEMA)
+        configuration.update(
+            {
+                "server": {
+                    "hosts": f"127.0.0.1:{P}",
+                    "ssl": "True",
+                    "certificate": str(cert_path),
+                    "key": str(key_path),
+                },
+                "auth": {"type": "silentsuite_bridge.radicale.auth"},
+                "storage": {"type": "silentsuite_bridge.radicale.storage"},
+                "rights": {"type": "silentsuite_bridge.radicale.rights"},
+                "web": {"type": "silentsuite_bridge.web"},
+                "logging": {"level": "debug"},
+            },
+            source="test",
+            privileged=True,
+        )
+
+        registry = get_registry()
+        registry.reset()
+        a, b = socket.socketpair()
+        thread_errors: list = []
+
+        def _run():
+            try:
+                bridge_main._serve_radicale_with_bridge_application(
+                    configuration, shutdown_socket=a,
+                )
+            except Exception as exc:
+                thread_errors.append(exc)
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if registry.bound_listeners():
+                break
+            time.sleep(0.05)
+
+        try:
+            assert registry.bound_listeners(), "Expected a bound HTTPS listener"
+            bound = registry.bound_listeners()[0]
+            assert bound.get("ssl") is True, "Bound listener should record ssl=True"
+
+            dashboard_url = registry.dashboard_url(True)
+            assert dashboard_url is not None, "Expected a dashboard URL"
+            assert dashboard_url.startswith("https://"), (
+                f"Dashboard URL should be https://, got {dashboard_url}"
+            )
+
+            status, body = _https_get("127.0.0.1", P, "/.web")
+            assert status == 200, f"HTTPS loopback should serve dashboard, got {status}"
+        finally:
+            b.close()
+            t.join(timeout=10)
+            assert not t.is_alive(), "HTTPS serving thread did not terminate"
+            with contextlib.suppress(OSError):
+                a.close()
+
+        if thread_errors:
+            raise thread_errors[0]
+
+
+# ---------------------------------------------------------------------------
+# TLS helpers
+# ---------------------------------------------------------------------------
+
+
+def _has_openssl() -> bool:
+    import shutil
+
+    return shutil.which("openssl") is not None
+
+
+def _generate_localhost_certificate(tmp_path: Path) -> tuple[Path, Path]:
+    """Generate a self-signed localhost certificate using openssl."""
+    cert = tmp_path / "localhost-cert.pem"
+    key = tmp_path / "localhost-key.pem"
+    subj = "/CN=localhost"
+    alt = "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1"
+    subprocess.run(
+        [
+            "openssl", "req", "-x509", "-newkey", "rsa:2048",
+            "-keyout", str(key), "-out", str(cert),
+            "-days", "1", "-nodes", "-subj", subj,
+            "-addext", alt,
+        ],
+        check=True,
+        capture_output=True,
+        timeout=30,
+    )
+    return cert, key

--- a/bridge/tests/test_main_startup.py
+++ b/bridge/tests/test_main_startup.py
@@ -243,9 +243,62 @@ def test_check_credentials_blocks_no_accounts_when_dashboard_disabled(tmp_path, 
     assert bridge_main.check_credentials(open_browser=False) is False
 
     output = capsys.readouterr().out
-    assert "dashboard is disabled" in output
+    assert "no loopback listener is configured for" in output
     assert "--login" in output
     assert "--manual-login" in output
+
+
+def test_check_credentials_prints_requested_report_and_hint_before_early_exit(
+    tmp_path, monkeypatch, capsys, caplog,
+):
+    """Wildcard-only profile with no account: the requested-listener report
+    and the exact loopback hint print before the early exit, run_server is
+    never reached, and none of it reaches the logger."""
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    monkeypatch.setattr(config, "SERVER_HOSTS", "0.0.0.0:37358")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "ALLOW_REMOTE", True)
+    monkeypatch.setattr(
+        bridge_main,
+        "run_server",
+        MagicMock(side_effect=AssertionError("run_server must not run without an account")),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=bridge_main.logger.name):
+        assert bridge_main.check_credentials(open_browser=False) is False
+
+    output = capsys.readouterr().out
+    assert "Requested listeners:" in output
+    assert "0.0.0.0:37358 (wildcard" in output
+    assert "SILENTSUITE_SERVER_HOSTS=0.0.0.0:37358,127.0.0.1:37359" in output
+    assert output.index("Requested listeners:") < output.index("SILENTSUITE_SERVER_HOSTS=")
+    assert output.index("SILENTSUITE_SERVER_HOSTS=") < output.index("--login")
+    assert "0.0.0.0" not in caplog.text
+    assert "37358" not in caplog.text
+    bridge_main.run_server.assert_not_called()
+
+
+def test_check_credentials_mixed_hosts_reports_requested_dashboard_url_as_unconfirmed(
+    tmp_path, monkeypatch, capsys,
+):
+    """Mixed loopback + remote profile with no account: the requested loopback
+    URL is printed with the requested-not-bound caveat, and the remote entry
+    is listed as requested remote DAV only."""
+    monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+    monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:45123,192.0.2.10:45123")
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "ALLOW_REMOTE", True)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    assert bridge_main.check_credentials(open_browser=False) is True
+
+    output = capsys.readouterr().out
+    assert "127.0.0.1:45123 (loopback" in output
+    assert "192.0.2.10:45123 (remote" in output
+    assert "http://127.0.0.1:45123/" in output
+    assert "http://127.0.0.1:37358/" not in output
+    assert "confirmed when the listener binds" in output
 
 
 def test_headless_zero_account_startup_resumes_cleanup_before_exit(monkeypatch):
@@ -282,16 +335,27 @@ def test_check_credentials_prints_https_dashboard_url_when_ssl_enabled(tmp_path,
 
 
 def test_dashboard_url_uses_http_when_ssl_disabled(monkeypatch):
+    from silentsuite_bridge.radicale.server import get_registry
+
     monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
     monkeypatch.setattr(config, "LISTEN_PORT", 37358)
     monkeypatch.setattr(config, "SSL_ENABLED", False)
+    # Ensure the registry is in the never-started state so the pre-start
+    # fallback path is exercised (a prior wired test may have left it
+    # stopped). monkeypatch undoes this after the test.
+    registry = get_registry()
+    monkeypatch.setattr(registry, "_state", registry._NEVER)
     assert bridge_main._dashboard_url() == "http://127.0.0.1:37358/"
 
 
 def test_dashboard_url_uses_https_when_ssl_enabled(monkeypatch):
+    from silentsuite_bridge.radicale.server import get_registry
+
     monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
     monkeypatch.setattr(config, "LISTEN_PORT", 37358)
     monkeypatch.setattr(config, "SSL_ENABLED", True)
+    registry = get_registry()
+    monkeypatch.setattr(registry, "_state", registry._NEVER)
     assert bridge_main._dashboard_url() == "https://127.0.0.1:37358/"
 
 
@@ -365,7 +429,7 @@ def test_main_missing_ssl_file_exits_cleanly_without_traceback(monkeypatch, tmp_
 def _run_server_until_keyboard_interrupt(monkeypatch):
     from radicale import server as radicale_server
 
-    def stop_server(_configuration):
+    def stop_server(_configuration, shutdown_socket=None):
         raise KeyboardInterrupt
 
     monkeypatch.setattr(bridge_main, "_initial_status_check", lambda: None)
@@ -380,7 +444,7 @@ def test_server_application_injection_restores_upstream_application(monkeypatch,
     from radicale import server as radicale_server
     from radicale.app import Application as RadicaleApplication
 
-    def serve(_configuration):
+    def serve(_configuration, shutdown_socket=None):
         assert radicale_server.Application is BridgeApplication
         if outcome is not None:
             raise outcome
@@ -397,7 +461,7 @@ def test_server_application_injection_restores_upstream_application(monkeypatch,
 def test_server_application_injection_rejects_nested_entry(monkeypatch):
     from radicale import server as radicale_server
 
-    def serve(_configuration):
+    def serve(_configuration, shutdown_socket=None):
         with pytest.raises(RuntimeError, match="already active"):
             bridge_main._serve_radicale_with_bridge_application(object())
 
@@ -414,7 +478,7 @@ def test_server_application_injection_rejects_real_two_thread_contention(monkeyp
     serve_barrier = threading.Barrier(2)
     holder_errors = []
 
-    def serve(_configuration):
+    def serve(_configuration, shutdown_socket=None):
         assert radicale_server.Application is BridgeApplication
         entered_serve.set()
         serve_barrier.wait()
@@ -466,7 +530,7 @@ def test_server_application_injection_does_not_overwrite_third_party_replacement
     replacement = object()
     monkeypatch.setattr(radicale_server, "Application", radicale_server.Application)
 
-    def serve(_configuration):
+    def serve(_configuration, shutdown_socket=None):
         radicale_server.Application = replacement
 
     monkeypatch.setattr(radicale_server, "serve", serve)

--- a/bridge/tests/test_network_profile.py
+++ b/bridge/tests/test_network_profile.py
@@ -880,3 +880,25 @@ def test_cli_install_autostart_denies_remote_bind_before_any_write(settings_file
     err = capsys.readouterr().err
     assert "SILENTSUITE_ALLOW_REMOTE=1" in err
     assert "0.0.0.0" not in err
+
+
+# ---------------------------------------------------------------------------
+# Mixed-hosts regression for #720
+# ---------------------------------------------------------------------------
+
+
+def test_persisted_mixed_hosts_with_permission_loads_web_module(settings_file, monkeypatch):
+    """127.0.0.1:37358,203.0.113.7:37358 with allowRemote=true loads web module."""
+    write_settings(
+        settings_file,
+        {
+            "network": {
+                "serverHosts": "127.0.0.1:37358,203.0.113.7:37358",
+                "allowRemote": True,
+            }
+        },
+    )
+    config.load_settings()
+    config.validate_network_config()
+    assert config.is_dashboard_enabled() is True
+    assert bridge_main.build_radicale_configuration().get("web", "type") == "silentsuite_bridge.web"

--- a/bridge/tests/test_tray_urls.py
+++ b/bridge/tests/test_tray_urls.py
@@ -1,7 +1,10 @@
 """Tests for scheme-aware DAV and dashboard URLs in tray actions."""
 
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from silentsuite_bridge import config, tray
 
@@ -14,20 +17,37 @@ class FakeMenu:
 
 
 class FakeMenuItem:
+    """Mirror pystray.MenuItem: ``text`` and ``enabled`` may be callables
+    taking the item, evaluated whenever the property is read."""
+
     def __init__(self, text, action, **kwargs):
-        self.text = text
+        self._text = text
         self.action = action
         self.kwargs = kwargs
+
+    @property
+    def text(self):
+        return self._text(self) if callable(self._text) else self._text
+
+    @property
+    def enabled(self):
+        value = self.kwargs.get("enabled", True)
+        return value(self) if callable(value) else value
 
 
 def _menu_item(menu, text):
     return next(item for item in menu.items if isinstance(item, FakeMenuItem) and item.text == text)
 
 
-def test_tray_url_helpers_follow_ssl_config(monkeypatch):
+# The autouse ``fresh_registry`` fixture in conftest.py provides an isolated
+# ListenerRegistry for every test; tests request it by name to drive state.
+
+
+def test_tray_url_helpers_follow_ssl_config(monkeypatch, fresh_registry):
     monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
     monkeypatch.setattr(config, "LISTEN_PORT", 37358)
     monkeypatch.setattr(config, "SSL_ENABLED", False)
+    # Registry never started: requested-address fallback applies.
     assert tray._dashboard_url() == "http://127.0.0.1:37358/"
     assert tray._account_dav_url("alice@example.com") == "http://127.0.0.1:37358/alice@example.com/"
 
@@ -36,7 +56,71 @@ def test_tray_url_helpers_follow_ssl_config(monkeypatch):
     assert tray._account_dav_url("alice@example.com") == "https://127.0.0.1:37358/alice@example.com/"
 
 
-def test_https_tray_actions_copy_and_open_configured_urls(monkeypatch):
+def test_dav_url_uses_bound_loopback_once_serving_started(monkeypatch, fresh_registry):
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    fresh_registry.reset()
+    fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=False)
+    assert tray._account_dav_url("alice@example.com") == "http://127.0.0.1:45123/alice@example.com/"
+
+
+def test_dav_url_prefers_loopback_over_bound_remote(monkeypatch, fresh_registry):
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    fresh_registry.reset()
+    # Remote listed first; loopback must win.
+    fresh_registry.record_bound(("192.0.2.10", 45200), None, ssl=False)
+    fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=False)
+    assert tray._account_dav_url("alice@example.com") == "http://127.0.0.1:45123/alice@example.com/"
+
+
+def test_dav_url_falls_back_to_bound_remote_literal_without_loopback(monkeypatch, fresh_registry):
+    """Remote-only bind: the copied URL is the actual bound remote literal
+    with its custom port, never LISTEN_ADDRESS:LISTEN_PORT."""
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    fresh_registry.reset()
+    fresh_registry.record_bound(("192.0.2.10", 45200), None, ssl=False)
+    assert tray._account_dav_url("alice@example.com") == "http://192.0.2.10:45200/alice@example.com/"
+
+
+def test_dav_url_never_returns_wildcard_bind(monkeypatch, fresh_registry):
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    fresh_registry.reset()
+    fresh_registry.record_bound(("0.0.0.0", 37358), None, ssl=False)
+    assert tray._account_dav_url("alice@example.com") is None
+
+
+def test_dav_url_returns_none_after_serving_attempted_without_listener(monkeypatch, fresh_registry):
+    """After serving was attempted/stopped with no usable bound listener,
+    no URL may claim an unbound LISTEN_ADDRESS:LISTEN_PORT."""
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    fresh_registry.reset()
+    # Serving attempted and exited with zero listeners bound.
+    fresh_registry.mark_stopped()
+
+    assert tray._account_dav_url("alice@example.com") is None
+    assert tray._dashboard_url() is None
+
+
+def test_dav_url_https_scheme_from_bound_ssl_listener(monkeypatch, fresh_registry):
+    monkeypatch.setattr(config, "SSL_ENABLED", True)
+
+    fresh_registry.reset()
+    fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=True)
+    assert tray._account_dav_url("alice@example.com") == "https://127.0.0.1:45123/alice@example.com/"
+
+
+def test_https_tray_actions_copy_and_open_configured_urls(monkeypatch, fresh_registry):
     monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
     monkeypatch.setattr(tray, "pystray", SimpleNamespace(Menu=FakeMenu, MenuItem=FakeMenuItem))
     monkeypatch.setattr(tray, "_get_accounts", lambda: ["alice@example.com"])
@@ -65,3 +149,232 @@ def test_https_tray_actions_copy_and_open_configured_urls(monkeypatch):
         ((expected_dav,), {}),
     ]
     open_browser.assert_called_once_with("https://127.0.0.1:37358/")
+
+
+def test_tray_dashboard_disabled_when_no_loopback_bound(monkeypatch, fresh_registry):
+    """When no loopback listener is bound, tray shows disabled item."""
+    monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
+    fake_pystray = type(sys)("pystray")
+    fake_pystray.Menu = FakeMenu
+    fake_pystray.MenuItem = FakeMenuItem
+    monkeypatch.setattr(tray, "pystray", fake_pystray)
+    monkeypatch.setattr(tray, "_get_accounts", lambda: ["alice@example.com"])
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    # Remote-only bind: dashboard disabled, DAV URL is the bound remote literal.
+    fresh_registry.reset()
+    fresh_registry.record_bound(("192.0.2.10", 45200), None, ssl=False)
+
+    manager = tray.BridgeTray()
+    menu = manager._build_menu()
+    item = _menu_item(menu, "Dashboard not bound on a loopback listener")
+    assert item.enabled is False
+
+    account_item = _menu_item(menu, "alice@example.com")
+    copy_caldav = _menu_item(account_item.action, "Copy CalDAV URL")
+    manager._copy_to_clipboard = MagicMock()
+    copy_caldav.action("icon", "item")
+    manager._copy_to_clipboard.assert_called_once_with(
+        "http://192.0.2.10:45200/alice@example.com/"
+    )
+
+
+def test_tray_account_shows_unavailable_when_no_listener_bound(monkeypatch, fresh_registry):
+    """Serving stopped with zero usable listeners: the copy callbacks resolve
+    the URL at click time and no-op (do not copy a fabricated local URL) when
+    no usable listener is bound."""
+    monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
+    fake_pystray = type(sys)("pystray")
+    fake_pystray.Menu = FakeMenu
+    fake_pystray.MenuItem = FakeMenuItem
+    monkeypatch.setattr(tray, "pystray", fake_pystray)
+    monkeypatch.setattr(tray, "_get_accounts", lambda: ["alice@example.com"])
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    fresh_registry.reset()
+    fresh_registry.mark_stopped()
+
+    manager = tray.BridgeTray()
+    menu = manager._build_menu()
+    account_item = _menu_item(menu, "alice@example.com")
+    copy_caldav = _menu_item(account_item.action, "Copy CalDAV URL")
+    manager._copy_to_clipboard = MagicMock()
+    copy_caldav.action("icon", "item")
+    manager._copy_to_clipboard.assert_not_called()
+
+
+def test_tray_menu_built_pre_start_uses_live_url_after_registry_changes(monkeypatch, fresh_registry):
+    """Regression for stale pre-start URL snapshot: a menu built before the
+    server binds must, when its callbacks are invoked AFTER the registry moves
+    to a running loopback bind, open/copy the live bound URL — not the pre-start
+    requested fallback."""
+    monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
+    fake_pystray = type(sys)("pystray")
+    fake_pystray.Menu = FakeMenu
+    fake_pystray.MenuItem = FakeMenuItem
+    monkeypatch.setattr(tray, "pystray", fake_pystray)
+    monkeypatch.setattr(tray, "_get_accounts", lambda: ["alice@example.com"])
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    # Build the menu pre-start (registry NEVER state).
+    manager = tray.BridgeTray()
+    menu = manager._build_menu()
+    open_dashboard = _menu_item(menu, "Open Dashboard")
+    account_item = _menu_item(menu, "alice@example.com")
+    copy_caldav = _menu_item(account_item.action, "Copy CalDAV URL")
+
+    # Now the server binds a loopback listener on a DIFFERENT port.
+    fresh_registry.reset()
+    fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=False)
+
+    open_browser = MagicMock()
+    monkeypatch.setattr(tray.webbrowser, "open", open_browser)
+    manager._copy_to_clipboard = MagicMock()
+
+    # Invoking the stale menu's callbacks must use the LIVE bound URL, not the
+    # pre-start 127.0.0.1:37358 fallback.
+    open_dashboard.action("icon", "item")
+    open_browser.assert_called_once_with("http://127.0.0.1:45123/")
+
+    copy_caldav.action("icon", "item")
+    manager._copy_to_clipboard.assert_called_once_with(
+        "http://127.0.0.1:45123/alice@example.com/"
+    )
+
+
+def test_tray_menu_built_with_loopback_no_ops_after_registry_stops(monkeypatch, fresh_registry):
+    """A menu built while a loopback listener was bound must, when invoked
+    AFTER the registry is stopped, NOT open or copy the now-stale URL."""
+    monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
+    fake_pystray = type(sys)("pystray")
+    fake_pystray.Menu = FakeMenu
+    fake_pystray.MenuItem = FakeMenuItem
+    monkeypatch.setattr(tray, "pystray", fake_pystray)
+    monkeypatch.setattr(tray, "_get_accounts", lambda: ["alice@example.com"])
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    # Build the menu while a loopback listener is bound.
+    fresh_registry.reset()
+    fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=False)
+    manager = tray.BridgeTray()
+    menu = manager._build_menu()
+    open_dashboard = _menu_item(menu, "Open Dashboard")
+    account_item = _menu_item(menu, "alice@example.com")
+    copy_caldav = _menu_item(account_item.action, "Copy CalDAV URL")
+
+    # Server stops; no usable listener bound.
+    fresh_registry.mark_stopped()
+
+    open_browser = MagicMock()
+    monkeypatch.setattr(tray.webbrowser, "open", open_browser)
+    manager._copy_to_clipboard = MagicMock()
+
+    open_dashboard.action("icon", "item")
+    open_browser.assert_not_called()
+
+    copy_caldav.action("icon", "item")
+    manager._copy_to_clipboard.assert_not_called()
+
+
+def test_tray_menu_built_pre_start_no_ops_after_remote_only_bind(monkeypatch, fresh_registry):
+    """A menu built pre-start must, after the server binds remote-only (no
+    loopback), NOT open a stale dashboard URL (dashboard is denied) but still
+    copy the live bound remote DAV URL."""
+    monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
+    fake_pystray = type(sys)("pystray")
+    fake_pystray.Menu = FakeMenu
+    fake_pystray.MenuItem = FakeMenuItem
+    monkeypatch.setattr(tray, "pystray", fake_pystray)
+    monkeypatch.setattr(tray, "_get_accounts", lambda: ["alice@example.com"])
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    # Build the menu pre-start (dashboard item enabled via requested fallback).
+    manager = tray.BridgeTray()
+    menu = manager._build_menu()
+    open_dashboard = _menu_item(menu, "Open Dashboard")
+    account_item = _menu_item(menu, "alice@example.com")
+    copy_caldav = _menu_item(account_item.action, "Copy CalDAV URL")
+
+    # Server binds remote-only; no loopback → dashboard URL is None.
+    fresh_registry.reset()
+    fresh_registry.record_bound(("192.0.2.10", 45200), None, ssl=False)
+
+    open_browser = MagicMock()
+    monkeypatch.setattr(tray.webbrowser, "open", open_browser)
+    manager._copy_to_clipboard = MagicMock()
+
+    open_dashboard.action("icon", "item")
+    open_browser.assert_not_called()
+
+    copy_caldav.action("icon", "item")
+    manager._copy_to_clipboard.assert_called_once_with(
+        "http://192.0.2.10:45200/alice@example.com/"
+    )
+
+
+def test_tray_dashboard_item_text_and_enabled_follow_registry_without_rebuild(monkeypatch, fresh_registry):
+    """The dashboard item's label and enabled state are live: the same menu
+    object built pre-start must report the bound state after the registry
+    changes, exactly as pystray re-evaluates callable text/enabled on render."""
+    monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
+    fake_pystray = type(sys)("pystray")
+    fake_pystray.Menu = FakeMenu
+    fake_pystray.MenuItem = FakeMenuItem
+    monkeypatch.setattr(tray, "pystray", fake_pystray)
+    monkeypatch.setattr(tray, "_get_accounts", lambda: [])
+    monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+    monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+    monkeypatch.setattr(config, "SSL_ENABLED", False)
+
+    manager = tray.BridgeTray()
+    menu = manager._build_menu()
+    item = _menu_item(menu, "Open Dashboard")
+    assert item.enabled is True
+
+    # Serving starts and only a remote listener binds: same item, now disabled.
+    fresh_registry.reset()
+    fresh_registry.record_bound(("192.0.2.10", 45200), None, ssl=False)
+    assert item.text == "Dashboard not bound on a loopback listener"
+    assert item.enabled is False
+
+    # The loopback listener binds: same item, enabled again.
+    fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=False)
+    assert item.text == "Open Dashboard"
+    assert item.enabled is True
+
+    # Serving stops: disabled without any rebuild.
+    fresh_registry.mark_stopped()
+    assert item.text == "Dashboard not bound on a loopback listener"
+    assert item.enabled is False
+
+
+def test_tray_registry_changes_request_menu_refresh_on_the_changing_thread(monkeypatch, fresh_registry):
+    """Every registry change asks pystray to re-render the menu via
+    ``Icon.update_menu`` on the calling thread; a failing refresh never
+    propagates into the serving path."""
+    monkeypatch.setattr(tray, "TRAY_AVAILABLE", True)
+    manager = tray.BridgeTray()
+
+    # No icon yet (run() not called): changes are a no-op, not an error.
+    fresh_registry.reset()
+
+    icon = SimpleNamespace(update_menu=MagicMock())
+    manager._icon = icon
+    fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=False)
+    fresh_registry.record_failed()
+    fresh_registry.mark_stopped()
+    assert icon.update_menu.call_count == 3
+
+    icon.update_menu.side_effect = RuntimeError("backend gone")
+    fresh_registry.reset()  # must not raise
+    assert fresh_registry.is_started

--- a/bridge/tests/test_web_dashboard.py
+++ b/bridge/tests/test_web_dashboard.py
@@ -36,19 +36,49 @@ NODE = shutil.which("node")
 _LOCAL_HOST = "localhost:37358"
 
 
+def _stamped_environ(listener_host="127.0.0.1", listener_port=37358,
+                     accepted_host="127.0.0.1", peer="127.0.0.1",
+                     ssl=False, **extra):
+    """Build a WSGI environ dict with trusted loopback evidence.
+
+    accepted_local uses the same port as the bound listener (the request is
+    accepted on the listener that bound it); the evidence gate requires the
+    accepted-local port to equal the listener port.
+    """
+    from silentsuite_bridge.radicale.server import _ListenerEvidence
+
+    evidence = _ListenerEvidence(
+        listener=(listener_host, listener_port),
+        accepted_local=(accepted_host, listener_port),
+        peer=peer,
+        ssl=ssl,
+    )
+    host_authority = f"[{listener_host}]" if ":" in listener_host else listener_host
+    environ = {
+        "HTTP_HOST": f"{host_authority}:{listener_port}",
+        "REMOTE_ADDR": peer,
+        "silentsuite_bridge.evidence": evidence,
+    }
+    environ.update(extra)
+    return environ
+
+
 def _get_environ(host=_LOCAL_HOST):
-    environ = {}
-    if host is not None:
+    environ = _stamped_environ()
+    if host is None:
+        environ.pop("HTTP_HOST", None)
+    elif host != "127.0.0.1:37358":
         environ["HTTP_HOST"] = host
     return environ
 
 
 def _post_environ(body=b"", csrf_token=None, host=_LOCAL_HOST):
-    environ = {
-        "CONTENT_LENGTH": str(len(body)),
-        "wsgi.input": io.BytesIO(body),
-    }
-    if host is not None:
+    environ = _stamped_environ()
+    environ["CONTENT_LENGTH"] = str(len(body))
+    environ["wsgi.input"] = io.BytesIO(body)
+    if host is None:
+        environ.pop("HTTP_HOST", None)
+    elif host != "127.0.0.1:37358":
         environ["HTTP_HOST"] = host
     if csrf_token is not None:
         environ["HTTP_X_SILENTSUITE_CSRF"] = csrf_token
@@ -77,9 +107,8 @@ def _wsgi_response(app, method, path):
         "REQUEST_METHOD": method,
         "PATH_INFO": path,
         "SCRIPT_NAME": "",
-        # SEC-R7.4: the dashboard rejects non-local Host headers, so requests
-        # routed through the full WSGI stack must carry a localhost Host header.
-        "HTTP_HOST": "127.0.0.1:37358",
+        # #720: dashboard requires loopback evidence in WSGI environ
+        **{k: v for k, v in _stamped_environ(listener_host="127.0.0.1", listener_port=37358).items()},
         "SERVER_NAME": "127.0.0.1",
         "SERVER_PORT": "37358",
         "SERVER_PROTOCOL": "HTTP/1.1",
@@ -384,7 +413,8 @@ def test_web_compat_route_serves_dashboard(path, tmp_path, monkeypatch):
 @pytest.mark.parametrize("path", ["/", "/.web", "/.web/api/status"])
 def test_dashboard_get_rejects_non_local_host(path, tmp_path, monkeypatch):
     # SEC-R7.4: a non-local Host header (DNS-rebinding / cross-origin) is
-    # rejected before any dashboard processing.
+    # rejected before any dashboard processing. Denial returns a plain 404
+    # matching Radicale's disabled-web-module response, not a JSON 403.
     monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
     web = Web.__new__(Web)
 
@@ -392,14 +422,14 @@ def test_dashboard_get_rejects_non_local_host(path, tmp_path, monkeypatch):
         _get_environ(host="evil.example.com"), "", path, None
     )
 
-    assert status == 403
-    assert headers["Content-Type"] == "application/json"
-    assert "non-local Host" in json.loads(body)["error"]
+    assert status == 404
+    assert headers == {}
+    assert body == b"Not found"
 
 
 def test_dashboard_post_rejects_non_local_host():
     # SEC-R7.4: non-local Host headers are rejected on mutating endpoints
-    # before CSRF validation or body parsing.
+    # before CSRF validation or body parsing. Denial is a plain 404.
     web = Web.__new__(Web)
 
     status, headers, body = web.post(
@@ -409,9 +439,9 @@ def test_dashboard_post_rejects_non_local_host():
         None,
     )
 
-    assert status == 403
-    assert headers["Content-Type"] == "application/json"
-    assert "non-local Host" in json.loads(body)["error"]
+    assert status == 404
+    assert headers == {}
+    assert body == b"Not found"
 
 
 def test_radicale_root_redirect_terminates_at_dashboard(tmp_path, monkeypatch):
@@ -1619,3 +1649,529 @@ def test_dashboard_update_interval_serializes_overlapping_saves_and_cancels_stal
     assert repeated["snapshots"]["final"]["requests"] == ['{"syncInterval":300}']
     assert repeated["snapshots"]["final"]["status"] == "Saved"
     assert repeated["snapshots"]["final"]["disabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Evidence-gate tests for #720
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceGate:
+    """Unit tests for the evidence gate in _check_dashboard_access."""
+
+    def test_missing_evidence_denies_on_loopback_config(self, monkeypatch):
+        """No evidence object → 404 even with valid Host."""
+        monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:37358")
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = {"HTTP_HOST": "127.0.0.1:37358", "REMOTE_ADDR": "127.0.0.1"}
+        result = _check_dashboard_access(environ)
+        assert result is not None
+        assert result[0] == 404
+
+    def test_trusted_loopback_evidence_passes(self, monkeypatch):
+        """Valid evidence + loopback Host + matching port → None (access granted)."""
+        monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:37358")
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ()
+        result = _check_dashboard_access(environ)
+        assert result is None
+
+    def test_wildcard_listener_evidence_denies(self, monkeypatch):
+        """Listener address is 0.0.0.0 → denied even with loopback peer."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(listener_host="0.0.0.0")
+        result = _check_dashboard_access(environ)
+        assert result is not None
+        assert result[0] == 404
+
+    def test_remote_listener_evidence_denies(self, monkeypatch):
+        """Listener address is remote → denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(listener_host="192.0.2.10")
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_non_loopback_peer_denies(self, monkeypatch):
+        """Peer is not loopback → denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(peer="192.168.1.1")
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_peer_remot_addr_mismatch_denies(self, monkeypatch):
+        """Peer != REMOTE_ADDR → denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ()
+        environ["REMOTE_ADDR"] = "127.0.0.2"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_ipv4_mapped_loopback_denied(self, monkeypatch):
+        """IPv4-mapped IPv6 loopback rejected by Host authority."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ()
+        environ["HTTP_HOST"] = "[::ffff:127.0.0.1]:37358"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_non_loopback_host_denied(self, monkeypatch):
+        """Non-loopback Host literal denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ()
+        environ["HTTP_HOST"] = "192.168.1.1:37358"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_port_mismatch_denied(self, monkeypatch):
+        """Host port != listener port → denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(listener_port=37358)
+        environ["HTTP_HOST"] = "127.0.0.1:37359"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_comma_in_host_denied(self, monkeypatch):
+        """Comma-smuggled host denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ()
+        environ["HTTP_HOST"] = "localhost,evil:37358"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_zone_id_denied(self, monkeypatch):
+        """Zone id in host denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ()
+        environ["HTTP_HOST"] = "[::1%eth0]:37358"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_bracketed_ipv4_denied(self, monkeypatch):
+        """Bracketed IPv4 denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ()
+        environ["HTTP_HOST"] = "[127.0.0.1]:37358"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_127_0_0_0_accepted(self, monkeypatch):
+        """127.0.0.0 is a valid 127/8 loopback literal and is accepted."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(listener_host="127.0.0.0")
+        environ["HTTP_HOST"] = "127.0.0.0:37358"
+        result = _check_dashboard_access(environ)
+        assert result is None
+
+    def test_localhost_without_port_denied_on_non_80(self, monkeypatch):
+        """localhost without port is denied when listener port is not 80."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(listener_port=37358)
+        environ["HTTP_HOST"] = "localhost"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_ipv6_loopback_bracketed_accepted(self, monkeypatch):
+        """[::1]:P is a valid IPv6 loopback Host and is accepted."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(listener_host="::1", listener_port=37358)
+        environ["HTTP_HOST"] = "[::1]:37358"
+        result = _check_dashboard_access(environ)
+        assert result is None
+
+    def test_ipv6_bracketed_junk_after_host_denied(self, monkeypatch):
+        """[::1]junk:P is denied (junk after closing bracket)."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(listener_host="::1", listener_port=37358)
+        environ["HTTP_HOST"] = "[::1]junk:37358"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    def test_127_1_short_form_denied(self, monkeypatch):
+        """127.1 is not a valid IP literal and is denied."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ()
+        environ["HTTP_HOST"] = "127.1:37358"
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            " 127.0.0.1:37358",
+            "127.0.0.1:37358 ",
+            "127.0.0.1 :37358",
+            "127.0.0.1: 37358",
+            "localhost\t:37358",
+            "[::1] :37358",
+            "\t[::1]:37358",
+        ],
+    )
+    def test_whitespace_in_host_authority_denied_not_stripped(self, host):
+        """Whitespace anywhere in the Host authority is rejected outright;
+        the parser must never strip it into a valid authority."""
+        from silentsuite_bridge.web import _check_dashboard_access, _parse_host_authority
+
+        assert _parse_host_authority(host) == (None, None)
+        environ = _stamped_environ(listener_host="::1" if "::1" in host else "127.0.0.1")
+        environ["HTTP_HOST"] = host
+        result = _check_dashboard_access(environ)
+        assert result is not None
+        assert result[0] == 404
+
+    def test_localhost_must_be_exact_lowercase(self):
+        """Only the exact ``localhost`` token is accepted; case variants are
+        not normalised into it."""
+        from silentsuite_bridge.web import _parse_host_authority
+
+        assert _parse_host_authority("localhost:37358") == ("localhost", 37358)
+        assert _parse_host_authority("LOCALHOST:37358") == (None, None)
+        assert _parse_host_authority("Localhost:37358") == (None, None)
+
+    def test_lookalike_evidence_object_denied(self, monkeypatch):
+        """A duck-typed lookalike object is rejected by the type check."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        lookalike = type("Fake", (), {})()
+        lookalike.listener = ("127.0.0.1", 37358)
+        lookalike.accepted_local = ("127.0.0.1", 0)
+        lookalike.peer = "127.0.0.1"
+        lookalike.ssl = False
+        environ = {
+            "HTTP_HOST": "127.0.0.1:37358",
+            "REMOTE_ADDR": "127.0.0.1",
+            "silentsuite_bridge.evidence": lookalike,
+        }
+        result = _check_dashboard_access(environ)
+        assert result is not None
+        assert result[0] == 404
+
+    def test_malformed_evidence_tuple_denied(self, monkeypatch):
+        """A real _ListenerEvidence with a malformed listener tuple is denied."""
+        from silentsuite_bridge.radicale.server import _ListenerEvidence
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        bad = _ListenerEvidence(
+            listener=("127.0.0.1",),  # 1-tuple, not 2
+            accepted_local=("127.0.0.1", 0),
+            peer="127.0.0.1",
+            ssl=False,
+        )
+        environ = {
+            "HTTP_HOST": "127.0.0.1:37358",
+            "REMOTE_ADDR": "127.0.0.1",
+            "silentsuite_bridge.evidence": bad,
+        }
+        result = _check_dashboard_access(environ)
+        assert result is not None
+        assert result[0] == 404
+
+    def test_evidence_is_immutable(self, monkeypatch):
+        """_ListenerEvidence fields cannot be reassigned after construction."""
+        from silentsuite_bridge.radicale.server import _ListenerEvidence
+
+        ev = _ListenerEvidence(
+            listener=("127.0.0.1", 37358),
+            accepted_local=("127.0.0.1", 0),
+            peer="127.0.0.1",
+            ssl=False,
+        )
+        with pytest.raises(AttributeError):
+            ev.peer = "10.0.0.1"
+        with pytest.raises(AttributeError):
+            del ev.peer
+
+    def test_valid_csrf_from_denied_source_never_reaches_handler(self, monkeypatch):
+        """Even with valid CSRF token, denied evidence prevents handler access."""
+        monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:37358")
+        from silentsuite_bridge.web import Web as WebClass
+
+        from radicale.config import DEFAULT_CONFIG_SCHEMA, Configuration
+
+        cfg = Configuration(DEFAULT_CONFIG_SCHEMA)
+        web = WebClass(cfg)
+
+        # Build environ with valid CSRF but NO evidence
+        environ = {
+            "HTTP_HOST": "127.0.0.1:37358",
+            "REMOTE_ADDR": "127.0.0.1",
+            "HTTP_X_SILENTSUITE_CSRF": _dashboard_csrf_token,
+            "CONTENT_LENGTH": "2",
+            "wsgi.input": io.BytesIO(b"{}"),
+        }
+        status, headers, body = web.post(environ, "", "/.web/api/sync", None)
+        assert status == 404, f"Expected 404 denial, got {status}"
+
+    def test_forwarded_header_ignored(self, monkeypatch):
+        """X-Forwarded-For is ignored; REMOTE_ADDR must match evidence peer."""
+        from silentsuite_bridge.web import _check_dashboard_access
+
+        environ = _stamped_environ(peer="127.0.0.1")
+        environ["HTTP_X_FORWARDED_FOR"] = "127.0.0.1"
+        environ["REMOTE_ADDR"] = "10.0.0.1"  # mismatched to evidence
+        result = _check_dashboard_access(environ)
+        assert result is not None
+
+
+class TestEvidenceShapeContract:
+    """Validate the evidence gate's full shape contract: str addresses,
+    integer non-bool ports in range, bool ssl, accepted-local port equals
+    listener port, and rejection of malformed/uninitialized evidence without
+    crashes."""
+
+    def test_valid_loopback_evidence_accepted(self):
+        from silentsuite_bridge.web import _trusted_loopback_evidence
+
+        environ = _stamped_environ(listener_port=37358)
+        assert _trusted_loopback_evidence(environ) is True
+
+    def test_accepted_port_must_equal_listener_port(self):
+        from silentsuite_bridge.web import _trusted_loopback_evidence
+        from silentsuite_bridge.radicale.server import _ListenerEvidence
+
+        # Accepted on a different port than the listener bound.
+        evidence = _ListenerEvidence(
+            listener=("127.0.0.1", 37358),
+            accepted_local=("127.0.0.1", 9999),
+            peer="127.0.0.1",
+            ssl=False,
+        )
+        environ = {"REMOTE_ADDR": "127.0.0.1", "silentsuite_bridge.evidence": evidence}
+        assert _trusted_loopback_evidence(environ) is False
+
+    def test_bool_port_rejected(self):
+        from silentsuite_bridge.web import _trusted_loopback_evidence
+        from silentsuite_bridge.radicale.server import _ListenerEvidence
+
+        # bool is a subclass of int but must be rejected as a port.
+        evidence = _ListenerEvidence(
+            listener=("127.0.0.1", True),
+            accepted_local=("127.0.0.1", True),
+            peer="127.0.0.1",
+            ssl=False,
+        )
+        environ = {"REMOTE_ADDR": "127.0.0.1", "silentsuite_bridge.evidence": evidence}
+        assert _trusted_loopback_evidence(environ) is False
+
+    def test_out_of_range_port_rejected(self):
+        from silentsuite_bridge.web import _trusted_loopback_evidence
+        from silentsuite_bridge.radicale.server import _ListenerEvidence
+
+        evidence = _ListenerEvidence(
+            listener=("127.0.0.1", 0),
+            accepted_local=("127.0.0.1", 0),
+            peer="127.0.0.1",
+            ssl=False,
+        )
+        environ = {"REMOTE_ADDR": "127.0.0.1", "silentsuite_bridge.evidence": evidence}
+        assert _trusted_loopback_evidence(environ) is False
+
+    def test_non_bool_ssl_rejected(self):
+        from silentsuite_bridge.web import _trusted_loopback_evidence
+        from silentsuite_bridge.radicale.server import _ListenerEvidence
+
+        evidence = _ListenerEvidence(
+            listener=("127.0.0.1", 37358),
+            accepted_local=("127.0.0.1", 37358),
+            peer="127.0.0.1",
+            ssl="yes",  # not a bool
+        )
+        environ = {"REMOTE_ADDR": "127.0.0.1", "silentsuite_bridge.evidence": evidence}
+        assert _trusted_loopback_evidence(environ) is False
+
+    def test_non_str_host_rejected(self):
+        from silentsuite_bridge.web import _trusted_loopback_evidence
+        from silentsuite_bridge.radicale.server import _ListenerEvidence
+
+        evidence = _ListenerEvidence(
+            listener=(127001, 37358),  # int host, not str
+            accepted_local=("127.0.0.1", 37358),
+            peer="127.0.0.1",
+            ssl=False,
+        )
+        environ = {"REMOTE_ADDR": "127.0.0.1", "silentsuite_bridge.evidence": evidence}
+        assert _trusted_loopback_evidence(environ) is False
+
+    def test_uninitialized_evidence_via_object_new_rejected(self):
+        """An evidence object created via object.__new__ that bypasses
+        __init__ has unset slots; the gate must reject it without crashing."""
+        from silentsuite_bridge.web import _trusted_loopback_evidence
+        from silentsuite_bridge.radicale.server import _ListenerEvidence
+
+        evidence = object.__new__(_ListenerEvidence)
+        environ = {"REMOTE_ADDR": "127.0.0.1", "silentsuite_bridge.evidence": evidence}
+        assert _trusted_loopback_evidence(environ) is False
+
+    def test_lookalike_object_rejected(self):
+        from silentsuite_bridge.web import _trusted_loopback_evidence
+
+        class FakeEvidence:
+            listener = ("127.0.0.1", 37358)
+            accepted_local = ("127.0.0.1", 37358)
+            peer = "127.0.0.1"
+            ssl = False
+
+        environ = {
+            "REMOTE_ADDR": "127.0.0.1",
+            "silentsuite_bridge.evidence": FakeEvidence(),
+        }
+        assert _trusted_loopback_evidence(environ) is False
+
+
+class TestNetworkCard:
+    """Requested vs bound rendering, per-listener client endpoints, and the
+    status API ``network`` object."""
+
+    def _partial_failure(self, monkeypatch, fresh_registry):
+        # Requested: loopback + remote + wildcard. Bound: loopback + wildcard.
+        # The remote entry failed to bind.
+        monkeypatch.setattr(
+            config, "SERVER_HOSTS", "127.0.0.1:45123,192.0.2.10:45123,0.0.0.0:45124",
+        )
+        monkeypatch.setattr(config, "SSL_ENABLED", False)
+        fresh_registry.reset()
+        fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=False)
+        fresh_registry.record_failed()
+        fresh_registry.record_bound(("0.0.0.0", 45124), None, ssl=False)
+
+    def test_card_shows_requested_and_bound_separately_on_partial_failure(
+        self, monkeypatch, fresh_registry,
+    ):
+        self._partial_failure(monkeypatch, fresh_registry)
+
+        card = web_module._render_network_card()
+
+        assert "Requested listeners:" in card
+        assert "Bound listeners:" in card
+        # The failed remote entry stays visible as requested, never as bound.
+        assert "192.0.2.10:45123 (remote" in card
+        assert "http://192.0.2.10" not in card
+        # Bound loopback literal gets a dialable scheme URL.
+        assert "http://127.0.0.1:45123/" in card
+        # Wildcard bind is bind-only: no dialable URL for 0.0.0.0.
+        assert "http://0.0.0.0" not in card
+        assert "not a client URL" in card
+        assert "1 listener(s) failed to bind" in card
+        # Source rule names all three facts plus the Host and CSRF gates.
+        for phrase in ("bound loopback listener", "accepted", "peer", "Host", "CSRF"):
+            assert phrase in card
+
+    def test_status_api_network_has_scheme_urls_and_null_for_wildcard(
+        self, monkeypatch, fresh_registry,
+    ):
+        self._partial_failure(monkeypatch, fresh_registry)
+
+        data = web_module._network_card()
+
+        assert data["requested"] == [
+            {"host": "127.0.0.1", "port": 45123, "kind": "loopback"},
+            {"host": "192.0.2.10", "port": 45123, "kind": "remote"},
+            {"host": "0.0.0.0", "port": 45124, "kind": "wildcard"},
+        ]
+        bound = {(b["host"], b["port"]): b for b in data["bound"]}
+        assert set(bound) == {("127.0.0.1", 45123), ("0.0.0.0", 45124)}
+        assert bound[("127.0.0.1", 45123)]["url"] == "http://127.0.0.1:45123/"
+        assert bound[("127.0.0.1", 45123)]["role"] == "DAV and dashboard"
+        assert bound[("0.0.0.0", 45124)]["url"] is None
+        assert data["failed_count"] == 1
+        assert data["dashboard_url"] == "http://127.0.0.1:45123/"
+        assert data["account_path_pattern"] == "/<email>/"
+        assert "CSRF" in data["rule"]
+
+    def test_bound_remote_tls_listener_has_https_url_and_no_dashboard(
+        self, monkeypatch, fresh_registry,
+    ):
+        """Loopback failed, remote bound with TLS: the remote endpoint is a
+        usable https URL for DAV clients, the dashboard URL is None."""
+        monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:45123,192.0.2.10:45200")
+        monkeypatch.setattr(config, "SSL_ENABLED", True)
+        fresh_registry.reset()
+        fresh_registry.record_failed()
+        fresh_registry.record_bound(("192.0.2.10", 45200), None, ssl=True)
+
+        data = web_module._network_card()
+
+        assert data["dashboard_url"] is None
+        assert data["bound"] == [
+            {
+                "host": "192.0.2.10",
+                "port": 45200,
+                "ssl": True,
+                "role": "DAV only (remote)",
+                "url": "https://192.0.2.10:45200/",
+            }
+        ]
+        card = web_module._render_network_card()
+        assert "https://192.0.2.10:45200/" in card
+        assert "(TLS)" in card
+
+    def test_ipv6_loopback_endpoint_is_bracketed(self, monkeypatch, fresh_registry):
+        monkeypatch.setattr(config, "SERVER_HOSTS", "[::1]:45123")
+        monkeypatch.setattr(config, "SSL_ENABLED", False)
+        fresh_registry.reset()
+        fresh_registry.record_bound(("::1", 45123, 0, 0), None, ssl=False)
+
+        data = web_module._network_card()
+        assert data["bound"][0]["url"] == "http://[::1]:45123/"
+        assert data["dashboard_url"] == "http://[::1]:45123/"
+        card = web_module._render_network_card()
+        assert "[::1]:45123" in card
+        assert "http://[::1]:45123/" in card
+
+    def test_status_endpoint_includes_network(self, monkeypatch, fresh_registry):
+        self._partial_failure(monkeypatch, fresh_registry)
+        web = Web.__new__(Web)
+
+        status, headers, body = web.get(_get_environ(), "", "/.web/api/status", None)
+
+        assert status == 200
+        payload = json.loads(body)
+        assert payload["network"]["failed_count"] == 1
+        assert payload["network"]["dashboard_url"] == "http://127.0.0.1:45123/"
+        assert [b["url"] for b in payload["network"]["bound"]] == [
+            "http://127.0.0.1:45123/", None,
+        ]
+
+    def test_account_dav_url_uses_bound_listener_and_is_unavailable_after_stop(
+        self, tmp_path, monkeypatch, fresh_registry,
+    ):
+        """Account cards pair the path pattern with the bound listener, and
+        stop advertising an address once serving ended with nothing bound."""
+        monkeypatch.setattr(config, "CREDS_FILE", str(tmp_path / "creds.json"))
+        monkeypatch.setattr(config, "LISTEN_ADDRESS", "127.0.0.1")
+        monkeypatch.setattr(config, "LISTEN_PORT", 37358)
+        monkeypatch.setattr(config, "SERVER_HOSTS", "127.0.0.1:45123")
+        monkeypatch.setattr(config, "SSL_ENABLED", False)
+        monkeypatch.setattr(web_module, "_account_fingerprint", lambda _c, _u: None)
+        creds = Credentials()
+        creds.set_etebase("alice@example.com", "alice-session", "https://server.test")
+        creds.save()
+
+        fresh_registry.reset()
+        fresh_registry.record_bound(("127.0.0.1", 45123), None, ssl=False)
+        page = _render_dashboard()
+        assert "http://127.0.0.1:45123/alice@example.com/" in page
+        assert "http://127.0.0.1:37358/alice@example.com/" not in page
+        assert 'id="davUrl0"' in page
+
+        fresh_registry.mark_stopped()
+        page = _render_dashboard()
+        assert "DAV URL unavailable" in page
+        assert "/alice@example.com/" not in page
+        assert 'id="davUrl0"' not in page


### PR DESCRIPTION
## Summary
- Keep a loopback-only dashboard available alongside explicitly configured remote DAV listeners.
- Validate dashboard requests against trusted listener, accepted-socket and peer evidence, with Host and CSRF protections.
- Report successful binds and usable dashboard URLs separately from requested configuration and listener failures.
- Keep listener address detail off non-interactive output unless explicitly opted in; preserve interactive and dashboard detail.
- Open only a bound loopback dashboard at startup and detach completed browser callbacks.
- Update browser login, tray behavior and documentation; add listener-isolation, redirected-output and lifecycle regression coverage.

Refs #720.

## Verification
Exact candidate: `94b6d0f2ac07178623bfa7c2d14e5b797d3f9083`.
- https://github.com/silent-suite/silentsuite/actions/runs/34756190635: 947 passed, two skipped; Linux executable build and --version/--help smoke passed.
- Windows installer/docs and CLI smoke checks passed; macOS network-profile/autostart tests passed at this head.
- Independent security/correctness review gate complete, including the output-policy and callback-lifecycle corrections.
- Packaged/native dashboard, certificate trust, and real-client DAV acceptance remain separate outstanding checks. CI smoke is not real-client acceptance.
- Documented default remains 127.0.0.1. Explicit alternative loopback addresses require platform and certificate compatibility.

No release publication or deployment is included. This branch does not include the separate deletion-convergence candidate in #736.
